### PR TITLE
Add hwloc to link libraries for lbann

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,9 @@ if(LBANN_HAS_LBANN_PROTO)
   target_link_libraries(lbann LbannProto)
 endif()
 
+# LBANN also requires HWLOC. This seems sufficient for now.
+target_link_libraries(lbann hwloc)
+
 ################################################################
 # Install LBANN
 ################################################################


### PR DESCRIPTION
this could be made more robust (in the traditional "FindHwloc.cmake"
sense) if desired. but this was sufficient for my test.