### PR TITLE
DARC1 regularization

### DIFF
--- a/include/lbann/layers/regularizers/darc1.hpp
+++ b/include/lbann/layers/regularizers/darc1.hpp
@@ -1,0 +1,191 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_darc1 .cpp .hpp - DARC1 implementation
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_REGULARIZER_DARC1_HPP_INCLUDED
+#define LBANN_LAYER_REGULARIZER_DARC1_HPP_INCLUDED
+
+#include "lbann/layers/regularizers/regularizer.hpp"
+
+namespace lbann {
+
+template <data_layout T_layout>
+class darc1 : public regularizer_layer {
+ public:
+
+  darc1(int index,
+          lbann_comm *comm,
+          double scaling_factor) :
+    regularizer_layer(index, comm),
+    m_scaling_factor(scaling_factor),
+    m_max_row(0) {
+    initialize_distributed_matrices();
+  }
+
+  darc1(const darc1& other) :
+    regularizer_layer(other),
+    m_scaling_factor(other.m_scaling_factor),
+    m_max_row(other.m_max_row) {
+    m_row_norms = other.m_row_norms->Copy();
+  }
+
+  darc1& operator=(const darc1& other) {
+    regularizer_layer::operator=(other);
+    m_scaling_factor = other.m_scaling_factor;
+    m_max_row = other.m_max_row;
+    if (m_row_norms) {
+      delete m_row_norms;
+    }
+    m_row_norms = other.m_row_norms->Copy();
+    return *this;
+  }
+
+  ~darc1() {
+    delete m_row_norms;
+  }
+
+  darc1* copy() const { return new darc1(*this); }
+
+  std::string get_type() const { return "darc1"; }
+
+  std::string get_description() const {
+    return " darc1 scaling_factor: " + std::to_string(m_scaling_factor) 
+           + " dataLayout: " + get_data_layout_string(get_data_layout());
+  }
+
+  virtual inline void initialize_distributed_matrices();
+  virtual data_layout get_data_layout() const { return T_layout; }
+
+ protected:
+
+  void setup_data() {
+    regularizer_layer::setup_data();
+    El::Zeros(*m_row_norms, this->m_num_neurons, 1);
+  }
+
+  void fp_compute() {
+
+    // Forward prop does not affect activations
+    El::LockedView(*this->m_activations_v, *this->m_prev_activations);
+
+    // Compute DARC1 regularization term
+    if (m_scaling_factor != DataType(0)) {
+
+      // Get local matrices
+      const Mat& activations_local = this->m_activations_v->LockedMatrix();
+      Mat& row_norms_local = m_row_norms->Matrix();
+      const int local_height = activations_local.Height();
+      const int local_width = activations_local.Width();
+
+      // Compute row-wise 1-norms
+      El::Zero(row_norms_local);
+      const int block_size = std::max((int) (64 / sizeof(DataType)), 1);
+      #pragma omp parallel for
+      for (int block_start = 0;
+           block_start < local_height;
+           block_start += block_size) {
+        const int block_end = std::min(block_start + block_size,
+                                       local_height);
+        for (int col = 0; col < local_width; ++col) {
+          for (int row = block_start; row < block_end; ++row) {
+            row_norms_local(row, 0) += std::fabs(activations_local(row, col));
+          }
+        }
+      }
+      El::AllReduce(m_row_norms->Matrix(),
+                    m_row_norms->RedundantComm(),
+                    El::mpi::SUM);
+      
+      // Get row with largest 1-norm
+      auto max_row_norm = El::VectorMaxAbsLoc(*m_row_norms);
+      m_max_row = max_row_norm.index;
+
+      // Apply DARC1 regularization term to objective function
+      const int mini_batch_size = this->m_activations_v->Width();
+      const DataType regularization_term = (m_scaling_factor / mini_batch_size
+                                            * max_row_norm.value);
+      this->m_neural_network_model->m_obj_fn->add_to_value(regularization_term);
+
+    }
+  }
+
+  void bp_compute() {
+
+    // Copy previous error signal
+    El::Copy(*this->m_prev_error_signal, *this->m_error_signal_v);
+    
+    // Apply gradient from DARC1 regularization term
+    if (m_scaling_factor != DataType(0)
+        && m_error_signal_v->IsLocalRow(m_max_row)) {
+
+      // Get local matrices
+      const Mat& activations_local = this->m_activations_v->LockedMatrix();
+      Mat& error_signal_local = this->m_error_signal_v->Matrix();
+      const int local_width = error_signal_local.Width();
+
+      // Apply DARC1 regularization gradient
+      const int mini_batch_size = this->m_activations_v->Width();
+      const DataType gradient_term = m_scaling_factor / mini_batch_size;
+      const int row = this->m_error_signal_v->LocalRow(m_max_row);
+      #pragma omp parallel for
+      for (int col = 0; col < local_width; ++col) {
+        const DataType activations_entry = activations_local(row, col);
+        DataType& error_signal_entry = error_signal_local(row, col);
+        if (activations_entry > DataType(0)) {
+          error_signal_entry += gradient_term;
+        }
+        if (activations_entry < DataType(0)) {
+          error_signal_entry -= gradient_term;
+        }
+      }
+      
+    }
+
+  }
+
+  /** Scaling factor for DARC1 regularization term. */
+  DataType m_scaling_factor;
+  /** Activation matrix row with maximum 1-norm. */
+  int m_max_row;
+  /** 1-norms for rows of the activation matrix. */
+  AbsDistMat *m_row_norms;
+
+};
+
+template<> inline void darc1<data_layout::MODEL_PARALLEL>::initialize_distributed_matrices() {
+  regularizer_layer::initialize_distributed_matrices<data_layout::MODEL_PARALLEL>();
+  m_row_norms = new RowSumMat(m_comm->get_model_grid());
+}
+
+template<> inline void darc1<data_layout::DATA_PARALLEL>::initialize_distributed_matrices() {
+  regularizer_layer::initialize_distributed_matrices<data_layout::DATA_PARALLEL>();
+  m_row_norms = new StarMat(m_comm->get_model_grid());
+}
+
+}  // namespace lbann
+
+#endif  // LBANN_LAYER_REGULARIZER_DARC1_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -71,6 +71,7 @@
 #include "lbann/layers/regularizers/dropout.hpp"
 #include "lbann/layers/regularizers/selu_dropout.hpp"
 #include "lbann/layers/regularizers/batch_normalization.hpp"
+#include "lbann/layers/regularizers/darc1.hpp"
 
 /// I/O Layers
 #include "lbann/layers/io/input/input_layer_distributed_minibatch.hpp"

--- a/model_zoo/models/resnet50/model_resnet50_darc1.prototext
+++ b/model_zoo/models/resnet50/model_resnet50_darc1.prototext
@@ -1,0 +1,2292 @@
+model {
+  name: "dag_model"
+  objective_function: "cross_entropy"
+  metric {
+    categorical_accuracy {
+    }
+  }
+  metric {
+    top_k_categorical_accuracy {
+      top_k: 5
+    }
+  }
+  data_layout: "data_parallel"
+  mini_batch_size: 256
+  block_size: 256
+  num_epochs: 10
+  num_parallel_readers: 0
+  procs_per_model: 0
+  use_cudnn: true
+  num_gpus: -1
+
+  ###################################################
+  # Callbacks
+  ###################################################
+  callback {
+    print {
+      interval: 1
+    }
+  }
+  callback {
+    timer {
+    }
+  }
+  callback {
+    summary {
+      dir: "."
+      batch_interval: 1
+      mat_interval: 25
+    }
+  }
+#  callback {
+#    imcomm {
+#      intermodel_comm_method: "normal"
+#      layers: ""
+#    }
+#  }
+
+  ###################################################
+  # Layers
+  ###################################################
+
+  # conv1
+  layer {
+    parents: ""
+    name: "data"
+    children: "conv1"
+    data_layout: "data_parallel"
+    input_partitioned_minibatch {
+    }
+  }
+  layer {
+    parents: "data"
+    name: "conv1"
+    children: "bn_conv1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 7
+      conv_pads_i: 3
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "conv1"
+    name: "bn_conv1"
+    children: "conv1_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn_conv1"
+    name: "conv1_relu"
+    children: "pool1"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "conv1_relu"
+    name: "pool1"
+    children: "res2a_split"
+    data_layout: "data_parallel"
+    pooling {
+      num_dims: 2
+      pool_dims_i: 3
+      pool_pads_i: 0
+      pool_strides_i: 2
+      pool_mode: "max"
+    }
+  }
+
+  # res2a
+  layer {
+    parents: "pool1"
+    name: "res2a_split"
+    children: "res2a_branch1 res2a_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res2a_split"
+    name: "res2a_branch1"
+    children: "bn2a_branch1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2a_branch1"
+    name: "bn2a_branch1"
+    children: "res2a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res2a_split"
+    name: "res2a_branch2a"
+    children: "bn2a_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2a_branch2a"
+    name: "bn2a_branch2a"
+    children: "res2a_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2a_branch2a"
+    name: "res2a_branch2a_relu"
+    children: "res2a_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2a_branch2a_relu"
+    name: "res2a_branch2b"
+    children: "bn2a_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2a_branch2b"
+    name: "bn2a_branch2b"
+    children: "res2a_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2a_branch2b"
+    name: "res2a_branch2b_relu"
+    children: "res2a_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2a_branch2b_relu"
+    name: "res2a_branch2c"
+    children: "bn2a_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2a_branch2c"
+    name: "bn2a_branch2c"
+    children: "res2a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2a_branch1 bn2a_branch2c"
+    name: "res2a"
+    children: "res2a_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res2a"
+    name: "res2a_relu"
+    children: "res2b_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res2b
+  layer {
+    parents: "res2a_relu"
+    name: "res2b_split"
+    children: "res2b res2b_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res2b_split"
+    name: "res2b_branch2a"
+    children: "bn2b_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2b_branch2a"
+    name: "bn2b_branch2a"
+    children: "res2b_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2b_branch2a"
+    name: "res2b_branch2a_relu"
+    children: "res2b_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2b_branch2a_relu"
+    name: "res2b_branch2b"
+    children: "bn2b_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2b_branch2b"
+    name: "bn2b_branch2b"
+    children: "res2b_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2b_branch2b"
+    name: "res2b_branch2b_relu"
+    children: "res2b_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2b_branch2b_relu"
+    name: "res2b_branch2c"
+    children: "bn2b_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2b_branch2c"
+    name: "bn2b_branch2c"
+    children: "res2b"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res2b_split bn2b_branch2c"
+    name: "res2b"
+    children: "res2b_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res2b"
+    name: "res2b_relu"
+    children: "res2c_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res2c
+  layer {
+    parents: "res2b_relu"
+    name: "res2c_split"
+    children: "res2c res2c_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res2c_split"
+    name: "res2c_branch2a"
+    children: "bn2c_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2c_branch2a"
+    name: "bn2c_branch2a"
+    children: "res2c_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2c_branch2a"
+    name: "res2c_branch2a_relu"
+    children: "res2c_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2c_branch2a_relu"
+    name: "res2c_branch2b"
+    children: "bn2c_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 64
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2c_branch2b"
+    name: "bn2c_branch2b"
+    children: "res2c_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn2c_branch2b"
+    name: "res2c_branch2b_relu"
+    children: "res2c_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res2c_branch2b_relu"
+    name: "res2c_branch2c"
+    children: "bn2c_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res2c_branch2c"
+    name: "bn2c_branch2c"
+    children: "res2c"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res2c_split bn2c_branch2c"
+    name: "res2c"
+    children: "res2c_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res2c"
+    name: "res2c_relu"
+    children: "res3a_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res3a
+  layer {
+    parents: "res2c_relu"
+    name: "res3a_split"
+    children: "res3a_branch1 res3a_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res3a_split"
+    name: "res3a_branch1"
+    children: "bn3a_branch1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3a_branch1"
+    name: "bn3a_branch1"
+    children: "res3a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res3a_split"
+    name: "res3a_branch2a"
+    children: "bn3a_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3a_branch2a"
+    name: "bn3a_branch2a"
+    children: "res3a_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3a_branch2a"
+    name: "res3a_branch2a_relu"
+    children: "res3a_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3a_branch2a_relu"
+    name: "res3a_branch2b"
+    children: "bn3a_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3a_branch2b"
+    name: "bn3a_branch2b"
+    children: "res3a_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3a_branch2b"
+    name: "res3a_branch2b_relu"
+    children: "res3a_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3a_branch2b_relu"
+    name: "res3a_branch2c"
+    children: "bn3a_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3a_branch2c"
+    name: "bn3a_branch2c"
+    children: "res3a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3a_branch1 bn3a_branch2c"
+    name: "res3a"
+    children: "res3a_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res3a"
+    name: "res3a_relu"
+    children: "res3b_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res3b
+  layer {
+    parents: "res3a_relu"
+    name: "res3b_split"
+    children: "res3b res3b_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res3b_split"
+    name: "res3b_branch2a"
+    children: "bn3b_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3b_branch2a"
+    name: "bn3b_branch2a"
+    children: "res3b_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3b_branch2a"
+    name: "res3b_branch2a_relu"
+    children: "res3b_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3b_branch2a_relu"
+    name: "res3b_branch2b"
+    children: "bn3b_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3b_branch2b"
+    name: "bn3b_branch2b"
+    children: "res3b_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3b_branch2b"
+    name: "res3b_branch2b_relu"
+    children: "res3b_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3b_branch2b_relu"
+    name: "res3b_branch2c"
+    children: "bn3b_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3b_branch2c"
+    name: "bn3b_branch2c"
+    children: "res3b"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res3b_split bn3b_branch2c"
+    name: "res3b"
+    children: "res3b_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res3b"
+    name: "res3b_relu"
+    children: "res3c_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res3c
+  layer {
+    parents: "res3b_relu"
+    name: "res3c_split"
+    children: "res3c res3c_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res3c_split"
+    name: "res3c_branch2a"
+    children: "bn3c_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3c_branch2a"
+    name: "bn3c_branch2a"
+    children: "res3c_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3c_branch2a"
+    name: "res3c_branch2a_relu"
+    children: "res3c_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3c_branch2a_relu"
+    name: "res3c_branch2b"
+    children: "bn3c_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3c_branch2b"
+    name: "bn3c_branch2b"
+    children: "res3c_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3c_branch2b"
+    name: "res3c_branch2b_relu"
+    children: "res3c_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3c_branch2b_relu"
+    name: "res3c_branch2c"
+    children: "bn3c_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3c_branch2c"
+    name: "bn3c_branch2c"
+    children: "res3c"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res3c_split bn3c_branch2c"
+    name: "res3c"
+    children: "res3c_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res3c"
+    name: "res3c_relu"
+    children: "res3d_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  
+  # res3d
+  layer {
+    parents: "res3c_relu"
+    name: "res3d_split"
+    children: "res3d res3d_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res3d_split"
+    name: "res3d_branch2a"
+    children: "bn3d_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3d_branch2a"
+    name: "bn3d_branch2a"
+    children: "res3d_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3d_branch2a"
+    name: "res3d_branch2a_relu"
+    children: "res3d_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3d_branch2a_relu"
+    name: "res3d_branch2b"
+    children: "bn3d_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 128
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3d_branch2b"
+    name: "bn3d_branch2b"
+    children: "res3d_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn3d_branch2b"
+    name: "res3d_branch2b_relu"
+    children: "res3d_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res3d_branch2b_relu"
+    name: "res3d_branch2c"
+    children: "bn3d_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res3d_branch2c"
+    name: "bn3d_branch2c"
+    children: "res3d"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res3d_split bn3d_branch2c"
+    name: "res3d"
+    children: "res3d_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res3d"
+    name: "res3d_relu"
+    children: "res4a_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4a
+  layer {
+    parents: "res3d_relu"
+    name: "res4a_split"
+    children: "res4a_branch1 res4a_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4a_split"
+    name: "res4a_branch1"
+    children: "bn4a_branch1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4a_branch1"
+    name: "bn4a_branch1"
+    children: "res4a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4a_split"
+    name: "res4a_branch2a"
+    children: "bn4a_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4a_branch2a"
+    name: "bn4a_branch2a"
+    children: "res4a_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4a_branch2a"
+    name: "res4a_branch2a_relu"
+    children: "res4a_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4a_branch2a_relu"
+    name: "res4a_branch2b"
+    children: "bn4a_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4a_branch2b"
+    name: "bn4a_branch2b"
+    children: "res4a_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4a_branch2b"
+    name: "res4a_branch2b_relu"
+    children: "res4a_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4a_branch2b_relu"
+    name: "res4a_branch2c"
+    children: "bn4a_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4a_branch2c"
+    name: "bn4a_branch2c"
+    children: "res4a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4a_branch1 bn4a_branch2c"
+    name: "res4a"
+    children: "res4a_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4a"
+    name: "res4a_relu"
+    children: "res4b_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4b
+  layer {
+    parents: "res4a_relu"
+    name: "res4b_split"
+    children: "res4b res4b_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4b_split"
+    name: "res4b_branch2a"
+    children: "bn4b_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4b_branch2a"
+    name: "bn4b_branch2a"
+    children: "res4b_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4b_branch2a"
+    name: "res4b_branch2a_relu"
+    children: "res4b_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4b_branch2a_relu"
+    name: "res4b_branch2b"
+    children: "bn4b_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4b_branch2b"
+    name: "bn4b_branch2b"
+    children: "res4b_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4b_branch2b"
+    name: "res4b_branch2b_relu"
+    children: "res4b_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4b_branch2b_relu"
+    name: "res4b_branch2c"
+    children: "bn4b_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4b_branch2c"
+    name: "bn4b_branch2c"
+    children: "res4b"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4b_split bn4b_branch2c"
+    name: "res4b"
+    children: "res4b_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4b"
+    name: "res4b_relu"
+    children: "res4c_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4c
+  layer {
+    parents: "res4b_relu"
+    name: "res4c_split"
+    children: "res4c res4c_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4c_split"
+    name: "res4c_branch2a"
+    children: "bn4c_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4c_branch2a"
+    name: "bn4c_branch2a"
+    children: "res4c_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4c_branch2a"
+    name: "res4c_branch2a_relu"
+    children: "res4c_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4c_branch2a_relu"
+    name: "res4c_branch2b"
+    children: "bn4c_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4c_branch2b"
+    name: "bn4c_branch2b"
+    children: "res4c_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4c_branch2b"
+    name: "res4c_branch2b_relu"
+    children: "res4c_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4c_branch2b_relu"
+    name: "res4c_branch2c"
+    children: "bn4c_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4c_branch2c"
+    name: "bn4c_branch2c"
+    children: "res4c"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4c_split bn4c_branch2c"
+    name: "res4c"
+    children: "res4c_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4c"
+    name: "res4c_relu"
+    children: "res4d_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4d
+  layer {
+    parents: "res4c_relu"
+    name: "res4d_split"
+    children: "res4d res4d_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4d_split"
+    name: "res4d_branch2a"
+    children: "bn4d_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4d_branch2a"
+    name: "bn4d_branch2a"
+    children: "res4d_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4d_branch2a"
+    name: "res4d_branch2a_relu"
+    children: "res4d_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4d_branch2a_relu"
+    name: "res4d_branch2b"
+    children: "bn4d_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4d_branch2b"
+    name: "bn4d_branch2b"
+    children: "res4d_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4d_branch2b"
+    name: "res4d_branch2b_relu"
+    children: "res4d_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4d_branch2b_relu"
+    name: "res4d_branch2c"
+    children: "bn4d_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4d_branch2c"
+    name: "bn4d_branch2c"
+    children: "res4d"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4d_split bn4d_branch2c"
+    name: "res4d"
+    children: "res4d_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4d"
+    name: "res4d_relu"
+    children: "res4e_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4e
+  layer {
+    parents: "res4d_relu"
+    name: "res4e_split"
+    children: "res4e res4e_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4e_split"
+    name: "res4e_branch2a"
+    children: "bn4e_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4e_branch2a"
+    name: "bn4e_branch2a"
+    children: "res4e_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4e_branch2a"
+    name: "res4e_branch2a_relu"
+    children: "res4e_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4e_branch2a_relu"
+    name: "res4e_branch2b"
+    children: "bn4e_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4e_branch2b"
+    name: "bn4e_branch2b"
+    children: "res4e_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4e_branch2b"
+    name: "res4e_branch2b_relu"
+    children: "res4e_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4e_branch2b_relu"
+    name: "res4e_branch2c"
+    children: "bn4e_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4e_branch2c"
+    name: "bn4e_branch2c"
+    children: "res4e"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4e_split bn4e_branch2c"
+    name: "res4e"
+    children: "res4e_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4e"
+    name: "res4e_relu"
+    children: "res4f_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res4f
+  layer {
+    parents: "res4e_relu"
+    name: "res4f_split"
+    children: "res4f res4f_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res4f_split"
+    name: "res4f_branch2a"
+    children: "bn4f_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4f_branch2a"
+    name: "bn4f_branch2a"
+    children: "res4f_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4f_branch2a"
+    name: "res4f_branch2a_relu"
+    children: "res4f_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4f_branch2a_relu"
+    name: "res4f_branch2b"
+    children: "bn4f_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4f_branch2b"
+    name: "bn4f_branch2b"
+    children: "res4f_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn4f_branch2b"
+    name: "res4f_branch2b_relu"
+    children: "res4f_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res4f_branch2b_relu"
+    name: "res4f_branch2c"
+    children: "bn4f_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 1024
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res4f_branch2c"
+    name: "bn4f_branch2c"
+    children: "res4f"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res4f_split bn4f_branch2c"
+    name: "res4f"
+    children: "res4f_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res4f"
+    name: "res4f_relu"
+    children: "res5a_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res5a
+  layer {
+    parents: "res4f_relu"
+    name: "res5a_split"
+    children: "res5a_branch1 res5a_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res5a_split"
+    name: "res5a_branch1"
+    children: "bn5a_branch1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 2048
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5a_branch1"
+    name: "bn5a_branch1"
+    children: "res5a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res5a_split"
+    name: "res5a_branch2a"
+    children: "bn5a_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 2
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5a_branch2a"
+    name: "bn5a_branch2a"
+    children: "res5a_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5a_branch2a"
+    name: "res5a_branch2a_relu"
+    children: "res5a_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5a_branch2a_relu"
+    name: "res5a_branch2b"
+    children: "bn5a_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5a_branch2b"
+    name: "bn5a_branch2b"
+    children: "res5a_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5a_branch2b"
+    name: "res5a_branch2b_relu"
+    children: "res5a_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5a_branch2b_relu"
+    name: "res5a_branch2c"
+    children: "bn5a_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 2048
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5a_branch2c"
+    name: "bn5a_branch2c"
+    children: "res5a"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5a_branch1 bn5a_branch2c"
+    name: "res5a"
+    children: "res5a_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res5a"
+    name: "res5a_relu"
+    children: "res5b_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  
+  # res5b
+  layer {
+    parents: "res5a_relu"
+    name: "res5b_split"
+    children: "res5b res5b_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res5b_split"
+    name: "res5b_branch2a"
+    children: "bn5b_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5b_branch2a"
+    name: "bn5b_branch2a"
+    children: "res5b_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5b_branch2a"
+    name: "res5b_branch2a_relu"
+    children: "res5b_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5b_branch2a_relu"
+    name: "res5b_branch2b"
+    children: "bn5b_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5b_branch2b"
+    name: "bn5b_branch2b"
+    children: "res5b_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5b_branch2b"
+    name: "res5b_branch2b_relu"
+    children: "res5b_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5b_branch2b_relu"
+    name: "res5b_branch2c"
+    children: "bn5b_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 2048
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5b_branch2c"
+    name: "bn5b_branch2c"
+    children: "res5b"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res5b_split bn5b_branch2c"
+    name: "res5b"
+    children: "res5b_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res5b"
+    name: "res5b_relu"
+    children: "res5c_split"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # res5c
+  layer {
+    parents: "res5b_relu"
+    name: "res5c_split"
+    children: "res5c res5c_branch2a"
+    data_layout: "data_parallel"
+    split {
+    }
+  }
+  layer {
+    parents: "res5c_split"
+    name: "res5c_branch2a"
+    children: "bn5c_branch2a"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5c_branch2a"
+    name: "bn5c_branch2a"
+    children: "res5c_branch2a_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5c_branch2a"
+    name: "res5c_branch2a_relu"
+    children: "res5c_branch2b"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5c_branch2a_relu"
+    name: "res5c_branch2b"
+    children: "bn5c_branch2b"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 512
+      conv_dims_i: 3
+      conv_pads_i: 1
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5c_branch2b"
+    name: "bn5c_branch2b"
+    children: "res5c_branch2b_relu"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "bn5c_branch2b"
+    name: "res5c_branch2b_relu"
+    children: "res5c_branch2c"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+  layer {
+    parents: "res5c_branch2b_relu"
+    name: "res5c_branch2c"
+    children: "bn5c_branch2c"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 2
+      num_output_channels: 2048
+      conv_dims_i: 1
+      conv_pads_i: 0
+      conv_strides_i: 1
+      weight_initialization: "he_normal"
+      has_bias: false
+      l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "res5c_branch2c"
+    name: "bn5c_branch2c"
+    children: "res5c"
+    data_layout: "data_parallel"
+    batch_normalization {
+      decay: 0.9
+      scale_init: 1.0
+      bias_init: 0.0
+      epsilon: 1e-5
+    }
+  }
+  layer {
+    parents: "res5c_split bn5c_branch2c"
+    name: "res5c"
+    children: "res5c_relu"
+    data_layout: "data_parallel"
+    sum {
+    }
+  }
+  layer {
+    parents: "res5c"
+    name: "res5c_relu"
+    children: "pool5"
+    data_layout: "data_parallel"
+    relu {
+    }
+  }
+
+  # Inference
+  layer {
+    parents: "res5c_relu"
+    name: "pool5"
+    children: "fc1000"
+    data_layout: "data_parallel"
+    pooling {
+      num_dims: 2
+      pool_dims_i: 8
+      pool_pads_i: 0
+      pool_strides_i: 1
+      pool_mode: "average"
+    }
+  }
+  layer {
+    parents: "pool5"
+    name: "fc1000"
+    children: "darc1"
+    data_layout: "model_parallel"
+    fully_connected {
+    num_neurons: 1000
+    weight_initialization: "he_normal"
+    has_bias: false
+    l2_regularization_factor: 1e-4
+    }
+  }
+  layer {
+    parents: "fc1000"
+    name: "darc1"
+    children: "prob"
+    data_layout: "model_parallel"
+    darc1 {
+      scaling_factor: 0.064
+    }
+  }
+  layer {
+    parents: "darc1"
+    name: "prob"
+    children: "target"
+    data_layout: "model_parallel"
+    softmax {
+    }
+  }
+  layer {
+    parents: "prob"
+    name: "target"
+    children: ""
+    data_layout: "data_parallel"
+    target_partitioned_minibatch {
+      shared_data_reader: true
+    }
+  }
+
+}

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -357,6 +357,7 @@ message Layer {
    LocalResponseNormalization local_response_normalization = 20;
    Dropout dropout = 21;
    SeluDropout selu_dropout = 229;
+   Darc1 darc1 = 230;
 
    // activation Layers
    Softmax softmax = 200;
@@ -434,6 +435,10 @@ message LocalResponseNormalization {
 
 message Dropout {
   double keep_prob = 2;  //default: 0.5
+}
+
+message Darc1 {
+  double scaling_factor = 1;  //default: 0.064
 }
 
 //////////////////

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -722,6 +722,26 @@ void add_layers(
     }
 
     //////////////////////////////////////////////////////////////////
+    // LAYER: darc1
+    //////////////////////////////////////////////////////////////////
+    else if (layer.has_darc1()) {
+      const lbann_data::Darc1& ell = layer.darc1();
+      if (dl == data_layout::MODEL_PARALLEL) {
+        d = new darc1<data_layout::MODEL_PARALLEL>(
+          layer_id,
+          comm,
+          ell.scaling_factor()
+        );
+      } else {
+        d = new darc1<data_layout::DATA_PARALLEL>(
+          layer_id,
+          comm,
+          ell.scaling_factor()
+        );
+      }
+    }
+
+    //////////////////////////////////////////////////////////////////
     // LAYER: selu (activation)
     //////////////////////////////////////////////////////////////////
     else if (layer.has_selu()) {


### PR DESCRIPTION
This is an implementation of the DARC1 regularization described in "Generalization in Deep Learning" by Kawaguchi, Kaelbling, and Bengio (2017). Preliminary experiments with Resnet-50 on ILSVRC2012 do not show any improvement over the baseline, although results are tentative.

### First 10 image classes of ILSVRC2012
Each line shows the average over 5 runs. 10% of training set was held out as a validation set. Solid line uses DARC1 and dotted line is baseline.

<img src="https://user-images.githubusercontent.com/4406448/31788415-75f6b16c-b4c3-11e7-97a7-57bb1fadd0be.png" width="400" height="346" />

### Entirety of ILSVRC2012
Solid line uses DARC1 and dotted line is baseline. 10% of training set was held out as a validation set.

<img src="https://user-images.githubusercontent.com/4406448/31788440-8591fab4-b4c3-11e7-9cd7-ea7ac4d023b5.png" width="400" height="346" />

Note that this model has not been run to convergence, so it is possible DARC1 achieves something in that regime. In addition, I just used the hyperparameter from the paper, so hyperparameter tuning could yield some result.