### PR TITLE
Fixes to Pearson correlation metric

### DIFF
--- a/include/lbann/metrics/categorical_accuracy.hpp
+++ b/include/lbann/metrics/categorical_accuracy.hpp
@@ -62,9 +62,12 @@ class categorical_accuracy_metric : public metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  DataType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  double evaluate_compute(const AbsDistMat& prediction,
+                          const AbsDistMat& ground_truth) override;
 
  private:
 

--- a/include/lbann/metrics/mean_absolute_deviation.hpp
+++ b/include/lbann/metrics/mean_absolute_deviation.hpp
@@ -57,9 +57,12 @@ class mean_absolute_deviation_metric : public metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  DataType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  double evaluate_compute(const AbsDistMat& prediction,
+                          const AbsDistMat& ground_truth) override;
 
 };
 

--- a/include/lbann/metrics/mean_squared_error.hpp
+++ b/include/lbann/metrics/mean_squared_error.hpp
@@ -57,9 +57,12 @@ class mean_squared_error_metric : public metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  DataType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  double evaluate_compute(const AbsDistMat& prediction,
+                          const AbsDistMat& ground_truth) override;
 
 };
 

--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -42,7 +42,7 @@ class target_layer;
 /** Metric statistics. */
 struct metric_statistics {
   /** Sum of metric values. */
-  DataType m_sum;
+  double m_sum;
   /** Number of samples. */
   int m_num_samples;
   /** Default constructor. */
@@ -58,12 +58,12 @@ struct metric_statistics {
   /** Destructor. */
   ~metric_statistics() = default;
   /** Add metric value to statistics. */
-  void add_value(DataType value, int num_samples = 1);
+  void add_value(double value, int num_samples = 1);
   /** Get mean metric value.
    *  If mini-batch sizes are not identical, the mean is over the
    *  sample values rather than over the mini-batch mean values.
    */
-  DataType get_mean() const;
+  double get_mean() const;
   /** Get number of samples. */
   int get_num_samples() const { return m_num_samples; }
   /** Reset statistics. */
@@ -115,7 +115,7 @@ class metric {
   virtual void setup(model& m);
   
   /** Evaluate the metric value. */
-  DataType evaluate(execution_mode mode);
+  double evaluate(execution_mode mode);
 
   /** Clear all statistics. */
   void reset_statistics() { m_statistics.clear(); }
@@ -126,7 +126,7 @@ class metric {
    *  If mini-batch sizes are not identical, the mean is over the
    *  sample values rather than over the mini-batch mean values.
    */
-  DataType get_mean_value(execution_mode mode) const;
+  double get_mean_value(execution_mode mode) const;
   /** Get number of samples for statistics. */
   int get_statistics_num_samples(execution_mode mode) const;
 
@@ -147,9 +147,12 @@ class metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  virtual DataType evaluate_compute(const AbsDistMat& prediction,
-                                    const AbsDistMat& ground_truth) = 0;
+  /** Computation to evaluate the metric function.
+   *  This should return the sum of metric values across the
+   *  mini-batch, not the mean value.
+   */
+  virtual double evaluate_compute(const AbsDistMat& prediction,
+                                  const AbsDistMat& ground_truth) = 0;
 
   /** Get LBANN communicator. */
   lbann_comm& get_comm() { return *m_comm; }

--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -30,6 +30,7 @@
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/io/persist.hpp"
 
 namespace lbann {
 
@@ -37,6 +38,50 @@ namespace lbann {
 class model;
 class Layer;
 class target_layer;
+
+/** Metric statistics. */
+struct metric_statistics {
+  /** Sum of metric values. */
+  DataType m_sum;
+  /** Number of samples. */
+  int m_num_samples;
+  /** Default constructor. */
+  metric_statistics() { reset(); }
+  /** Move constructor. */
+  metric_statistics(metric_statistics& other) = default;
+  /** Copy constructor. */
+  metric_statistics(const metric_statistics& other) = default;
+  /** Move assignment operator. */
+  metric_statistics& operator=(metric_statistics& other) = default;
+  /** Copy assignment operator. */
+  metric_statistics& operator=(const metric_statistics& other) = default;
+  /** Destructor. */
+  ~metric_statistics() = default;
+  /** Add metric value to statistics. */
+  void add_value(DataType value, int num_samples = 1);
+  /** Get mean metric value.
+   *  If mini-batch sizes are not identical, the mean is over the
+   *  sample values rather than over the mini-batch mean values.
+   */
+  DataType get_mean() const;
+  /** Get number of samples. */
+  int get_num_samples() const { return m_num_samples; }
+  /** Reset statistics. */
+  void reset();
+
+  //************************************************************************
+  // Checkpointing
+  //************************************************************************
+  /** struct used to serialize mode fields in file and MPI transfer */
+  struct packing_header {
+    double sum;
+    uint64_t num_samples;
+  };
+  bool pack_scalars(persist& p);
+  bool unpack_scalars(persist& p, struct packing_header *header);
+  void unpack_header(struct packing_header& header);
+
+};
 
 /** Abstract base class for metric functions.
  *  A metric function can be used to evaluate the performance of a
@@ -70,28 +115,20 @@ class metric {
   virtual void setup(model& m);
   
   /** Evaluate the metric value. */
-  DataType evaluate();
+  DataType evaluate(execution_mode mode);
 
-  /** Get history of metric values. */
-  std::vector<DataType> get_history_values() const {
-    return m_history_values;
-  }
-  /** Get history of mini-batch sizes. */
-  std::vector<int> get_history_mini_batch_sizes() const {
-    return m_history_mini_batch_sizes;
-  }
-  /** Get total number of samples in history.
-   *  This is the sum of mini-batch sizes in history.
-   */
-  int get_history_num_samples() const;
-  /** Clear history of metric values. */
-  void clear_history();
+  /** Clear all statistics. */
+  void reset_statistics() { m_statistics.clear(); }
+  /** Clear statistics for an execution mode. */
+  void reset_statistics(execution_mode mode) { m_statistics.erase(mode); }
 
-  /** Get mean metric value in history.
+  /** Get mean metric value.
    *  If mini-batch sizes are not identical, the mean is over the
    *  sample values rather than over the mini-batch mean values.
    */
-  DataType get_history_mean_value() const;
+  DataType get_mean_value(execution_mode mode) const;
+  /** Get number of samples for statistics. */
+  int get_statistics_num_samples(execution_mode mode) const;
 
   /** Set pointer to target layer. */
   void set_target_layer(const target_layer *target) { m_target_layer = target; }
@@ -103,14 +140,19 @@ class metric {
   /** Set list of pointers to layers. */
   void set_layer_pointers(std::vector<Layer*> layers);
 
- protected:
+  /** Save metric state to checkpoint. */
+  virtual bool save_to_checkpoint_shared(persist& p);
+  /** Load metric state from checkpoint. */
+  virtual bool load_from_checkpoint_shared(persist& p);
 
-  /** Get LBANN communicator. */
-  lbann_comm& get_comm() { return *m_comm; }
+ protected:
 
   /** Computation to evaluate the metric function. */
   virtual DataType evaluate_compute(const AbsDistMat& prediction,
                                     const AbsDistMat& ground_truth) = 0;
+
+  /** Get LBANN communicator. */
+  lbann_comm& get_comm() { return *m_comm; }
 
  private:
 
@@ -120,10 +162,8 @@ class metric {
   /** Pointer to target layer. */
   const target_layer *m_target_layer;
 
-  /** History of metric values. */
-  std::vector<DataType> m_history_values;
-  /** History of mini-batch sizes. */
-  std::vector<int> m_history_mini_batch_sizes;
+  /** Metric statistics. */
+  std::map<execution_mode,metric_statistics> m_statistics;
 
 };
 

--- a/include/lbann/metrics/pearson_correlation.hpp
+++ b/include/lbann/metrics/pearson_correlation.hpp
@@ -37,14 +37,14 @@ class pearson_correlation_metric : public metric {
  public:
 
   /** Constructor. */
-  pearson_correlation_metric(lbann_comm *comm) : metric(comm) {}
+  pearson_correlation_metric(lbann_comm *comm);
 
   /** Copy constructor. */
-  pearson_correlation_metric(const pearson_correlation_metric& other) = default;
+  pearson_correlation_metric(const pearson_correlation_metric& other);
   /** Copy assignment operator. */
-  pearson_correlation_metric& operator=(const pearson_correlation_metric& other) = default;
+  pearson_correlation_metric& operator=(const pearson_correlation_metric& other);
   /** Destructor. */
-  virtual ~pearson_correlation_metric() = default;
+  virtual ~pearson_correlation_metric();
   /** Copy function. */
   pearson_correlation_metric* copy() const override {
     return new pearson_correlation_metric(*this);
@@ -52,6 +52,9 @@ class pearson_correlation_metric : public metric {
 
   /** Return a string name for this metric. */
   std::string name() const override { return "Pearson correlation"; }
+
+  /** Setup metric. */
+  virtual void setup(model& m) override;
 
  protected:
 
@@ -61,6 +64,19 @@ class pearson_correlation_metric : public metric {
    */
   double evaluate_compute(const AbsDistMat& prediction,
                           const AbsDistMat& ground_truth) override;
+
+ private:
+
+  /** Column-wise means of prediction matrix. */
+  AbsDistMat *m_prediction_means;
+  /** Column-wise standard deviations of prediction matrix. */
+  AbsDistMat *m_prediction_stdevs;
+  /** Column-wise means of ground truth matrix. */
+  AbsDistMat *m_ground_truth_means;
+  /** Column-wise standard deviations of ground truth matrix. */
+  AbsDistMat *m_ground_truth_stdevs;
+  /** Column-wise covariance between prediction and ground truth matrices. */
+  AbsDistMat *m_covariances;
 
 };
 

--- a/include/lbann/metrics/pearson_correlation.hpp
+++ b/include/lbann/metrics/pearson_correlation.hpp
@@ -55,9 +55,12 @@ class pearson_correlation_metric : public metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  DataType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  double evaluate_compute(const AbsDistMat& prediction,
+                          const AbsDistMat& ground_truth) override;
 
 };
 

--- a/include/lbann/metrics/top_k_categorical_accuracy.hpp
+++ b/include/lbann/metrics/top_k_categorical_accuracy.hpp
@@ -60,9 +60,12 @@ class top_k_categorical_accuracy_metric : public metric {
 
  protected:
 
-  /** Computation to evaluate the metric function. */
-  DataType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  double evaluate_compute(const AbsDistMat& prediction,
+                          const AbsDistMat& ground_truth) override;
 
  private:
 

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -309,6 +309,13 @@ class model {
   virtual std::string print_layer_description(const Layer* layer) const;
   /** Check if the layer execution order is topologically sorted. */
   virtual bool is_topologically_sorted() const;
+  /** Remap pointers.
+   *  Layer and weights pointers are remapped using the provided
+   *  maps. If a pointer is not a key in the corresponding map, the
+   *  pointer is not changed.
+   */
+  virtual void remap_pointers(const std::unordered_map<Layer *,Layer *>& layer_map,
+                              const std::unordered_map<weights *,weights *>& weights_map);
 
   /** Set up topology of layer graph.
    *  Called in setup function. All layers in connected component of

--- a/include/lbann/utils/statistics.hpp
+++ b/include/lbann/utils/statistics.hpp
@@ -94,5 +94,19 @@ void rowwise_mean_and_stdev(const AbsDistMat& data,
                             AbsDistMat& means,
                             AbsDistMat& stdevs);
 
+/// Compute column-wise covariances
+/** @param data1   Input matrix in U,V format.
+ *  @param data2   Input matrix in U,V format.
+ *  @param means1  Column-wise mean vector for data1 in STAR,V format.
+ *  @param means2  Column-wise mean vector for data2 in STAR,V format.
+ *  @param cov     Covariance vector in STAR,V format. Output as a row
+ *                 vector with same number of columns as 'data1'.
+ */
+void columnwise_covariance(const AbsDistMat& data1,
+                           const AbsDistMat& data2,
+                           const AbsDistMat& means1,
+                           const AbsDistMat& means2,
+                           AbsDistMat& cov);
+
 } // end namespace
 #endif // LBANN_UTILS_STATISTICS_HPP

--- a/src/callbacks/callback_ltfb.cpp
+++ b/src/callbacks/callback_ltfb.cpp
@@ -154,7 +154,7 @@ double lbann_callback_ltfb::evaluate(model *m) {
   m->evaluate(execution_mode::validation);
   for (const auto& met : m->get_metrics()) {
     if (dynamic_cast<categorical_accuracy_metric*>(met) != nullptr) {
-      return met->get_history_mean_value();
+      return met->get_mean_value(execution_mode::validation);
     }
   }
   return 0.0;

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -162,8 +162,8 @@ void lbann_callback_print::report_results(model *m) {
 
     // Report score for each metric
     for (const auto& met : m->get_metrics()) {
-      const double score = met->get_history_mean_value();
-      const int num_samples = met->get_history_num_samples();
+      const double score = met->get_mean_value(m->get_execution_mode());
+      const int num_samples = met->get_statistics_num_samples(m->get_execution_mode());
       if (comm->am_world_master()) {
         std::vector<double> score_list(comm->get_num_models());
         std::vector<int> num_samples_list(comm->get_num_models());

--- a/src/callbacks/callback_summary.cpp
+++ b/src/callbacks/callback_summary.cpp
@@ -69,7 +69,7 @@ void lbann_callback_summary::on_batch_end(model *m) {
 
 void lbann_callback_summary::on_epoch_end(model *m) {
   for (const auto& met : m->get_metrics()) {
-    double train_score = met->get_history_mean_value();
+    double train_score = met->get_mean_value(m->get_execution_mode());
     // Replace spaces with _ for consistency.
     std::string metric_name = met->name();
     std::transform(metric_name.begin(), metric_name.end(), metric_name.begin(),
@@ -84,7 +84,7 @@ void lbann_callback_summary::on_epoch_end(model *m) {
 void lbann_callback_summary::on_test_end(model *m) {
   lbann_comm *comm = m->get_comm();
   for (auto&& met : m->get_metrics()) {
-    double test_score = met->get_history_mean_value();
+    double test_score = met->get_mean_value(m->get_execution_mode());
     // Replace spaces with _ for consistency.
     std::string metric_name = met->name();
     std::transform(metric_name.begin(), metric_name.end(), metric_name.begin(),

--- a/src/metrics/categorical_accuracy.cpp
+++ b/src/metrics/categorical_accuracy.cpp
@@ -77,8 +77,8 @@ void categorical_accuracy_metric::setup(model& m) {
   m_prediction_indices.resize(m_prediction_values->LocalWidth());
 }
 
-DataType categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                       const AbsDistMat& ground_truth) {
+double categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                     const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
@@ -108,7 +108,7 @@ DataType categorical_accuracy_metric::evaluate_compute(const AbsDistMat& predict
       max_index = -1;
     }
     for (int row = 1; row < local_height; ++row) {
-      const DataType pred_val = prediction_local(row, col);
+      const double pred_val = prediction_local(row, col);
       if (pred_val > max_val) {
         max_val = pred_val;
         max_index = row;
@@ -151,7 +151,7 @@ DataType categorical_accuracy_metric::evaluate_compute(const AbsDistMat& predict
   correct_predictions = get_comm().model_allreduce(correct_predictions);
 
   // Return percentage of correct predictions
-  return correct_predictions * DataType(100) / width;
+  return correct_predictions * 100;
 
 }
 

--- a/src/metrics/mean_absolute_deviation.cpp
+++ b/src/metrics/mean_absolute_deviation.cpp
@@ -28,12 +28,11 @@
 
 namespace lbann {
 
-DataType mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                           const AbsDistMat& ground_truth) {
+double mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                        const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
-  const int width = prediction.Width();
   const int local_height = prediction.LocalHeight();
   const int local_width = prediction.LocalWidth();
   
@@ -42,21 +41,20 @@ DataType mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& pred
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of squared errors
-  DataType sum = 0;
+  double sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = prediction_local(row, col);
-      const DataType error = true_val - pred_val;
+      const double true_val = ground_truth_local(row, col);
+      const double pred_val = prediction_local(row, col);
+      const double error = true_val - pred_val;
       sum += error >= DataType(0) ? error : - error;
     }
   }
   
   // Compute mean value across mini-batch
-  return get_comm().allreduce(sum / (height * width),
-                              prediction.DistComm());
-
+  return get_comm().allreduce(sum / height, prediction.DistComm());
+  
 }
 
 }  // namespace lbann

--- a/src/metrics/mean_squared_error.cpp
+++ b/src/metrics/mean_squared_error.cpp
@@ -28,12 +28,11 @@
 
 namespace lbann {
 
-DataType mean_squared_error_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                     const AbsDistMat& ground_truth) {
+double mean_squared_error_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                   const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
-  const int width = prediction.Width();
   const int local_height = prediction.LocalHeight();
   const int local_width = prediction.LocalWidth();
   
@@ -42,20 +41,19 @@ DataType mean_squared_error_metric::evaluate_compute(const AbsDistMat& predictio
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of squared errors
-  DataType sum = 0;
+  double sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = prediction_local(row, col);
-      const DataType error = true_val - pred_val;
+      const double true_val = ground_truth_local(row, col);
+      const double pred_val = prediction_local(row, col);
+      const double error = true_val - pred_val;
       sum += error * error;
     }
   }
   
   // Compute mean value across mini-batch
-  return get_comm().allreduce(sum / (height * width),
-                              prediction.DistComm());
+  return get_comm().allreduce(sum / height, prediction.DistComm());
 
 }
 

--- a/src/metrics/metric.cpp
+++ b/src/metrics/metric.cpp
@@ -30,6 +30,51 @@
 
 namespace lbann {
 
+void metric_statistics::add_value(DataType value, int num_samples) {
+  m_sum += num_samples * value;
+  m_num_samples += num_samples;
+}
+
+DataType metric_statistics::get_mean() const {
+  if (m_num_samples == 0) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "attempted to get mean metric value with no statistics";
+    throw lbann_exception(err.str());
+  }
+  return m_sum / m_num_samples;
+}
+
+void metric_statistics::reset() {
+  m_sum = DataType(0);
+  m_num_samples = 0;
+}
+
+bool metric_statistics::pack_scalars(persist& p) {
+  p.write_double(persist_type::train, "sum", m_sum);
+  p.write_uint64(persist_type::train, "num_samples", m_num_samples);
+  return true;
+}
+
+bool metric_statistics::unpack_scalars(persist& p, struct packing_header *header) {
+  double sum;
+  uint64_t num_samples;
+  p.read_double(persist_type::train, "sum", &sum);
+  p.read_uint64(persist_type::train, "num_samples", (uint64_t *) &num_samples);
+  m_sum = sum;
+  m_num_samples = num_samples;
+  if (header != nullptr) {
+    header->sum = sum;
+    header->num_samples = num_samples;
+  }
+  return true;
+}
+
+void metric_statistics::unpack_header(struct packing_header& header) {
+  m_sum = header.sum;
+  m_num_samples = header.num_samples;
+}
+
 metric::metric(lbann_comm *comm) 
   : m_comm(comm),
     m_target_layer(nullptr) {}
@@ -56,7 +101,7 @@ void metric::setup(model& m) {
 
 }
 
-DataType metric::evaluate() {
+DataType metric::evaluate(execution_mode mode) {
 
   // Check if target layer pointer has been setup
   if (m_target_layer == nullptr) {
@@ -70,39 +115,32 @@ DataType metric::evaluate() {
   const DataType value = evaluate_compute(m_target_layer->get_prediction(),
                                           m_target_layer->get_ground_truth());
 
-  // Record result in history
-  m_history_values.push_back(value);
+  // Record result in statistics
   const int mini_batch_size = m_target_layer->get_prediction().Width();
-  m_history_mini_batch_sizes.push_back(mini_batch_size);
+  m_statistics[mode].add_value(value, mini_batch_size);
 
   // Return result
   return value;
 
 }
 
-int metric::get_history_num_samples() const {
-  return std::accumulate(m_history_mini_batch_sizes.begin(),
-                         m_history_mini_batch_sizes.end(),
-                         0);
-}
-
-void metric::clear_history() {
-  m_history_values.clear();
-  m_history_mini_batch_sizes.clear();
-}
-
-DataType metric::get_history_mean_value() const {
-  if (m_history_values.size() == 0) {
+DataType metric::get_mean_value(execution_mode mode) const {
+  if (m_statistics.count(mode) == 0
+      || m_statistics.at(mode).get_num_samples() == 0) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to get mean metric value with no history";
+        << "attempted to get mean metric value with no samples for statistics";
     throw lbann_exception(err.str());
   }
-  return (std::inner_product(m_history_values.begin(),
-                             m_history_values.end(),
-                             m_history_mini_batch_sizes.begin(),
-                             DataType(0))
-          / get_history_num_samples());
+  return m_statistics.at(mode).get_mean();
+}
+
+int metric::get_statistics_num_samples(execution_mode mode) const {
+  if (m_statistics.count(mode) == 0) {
+    return 0;
+  } else {
+    return m_statistics.at(mode).get_num_samples();
+  }
 }
 
 const target_layer& metric::get_target_layer() const {
@@ -129,5 +167,34 @@ void metric::set_layer_pointers(std::vector<Layer*> layers) {
   }
   m_target_layer = dynamic_cast<const target_layer *>(layers[0]);
 }
+
+bool metric::save_to_checkpoint_shared(persist& p) {
+  // write out fields we need to save for model
+  if (p.get_rank() == 0) {
+    m_statistics[execution_mode::training].pack_scalars(p);
+    m_statistics[execution_mode::validation].pack_scalars(p);
+    m_statistics[execution_mode::testing].pack_scalars(p);
+  }
+  return true;
+}
+
+bool metric::load_from_checkpoint_shared(persist& p) {
+  struct metric_statistics::packing_header training_header, validation_header, testing_header;
+  if (p.get_rank() == 0) {
+    m_statistics[execution_mode::training].unpack_scalars(p, &training_header);
+    m_statistics[execution_mode::validation].unpack_scalars(p, &validation_header);
+    m_statistics[execution_mode::testing].unpack_scalars(p, &testing_header);
+  }
+
+  MPI_Bcast(&training_header, sizeof(training_header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&validation_header, sizeof(validation_header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&testing_header, sizeof(testing_header), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+  m_statistics[execution_mode::training].unpack_header(training_header);
+  m_statistics[execution_mode::validation].unpack_header(validation_header);
+  m_statistics[execution_mode::testing].unpack_header(testing_header);
+  return true;
+}
+
 
 }  // namespace lbann

--- a/src/metrics/pearson_correlation.cpp
+++ b/src/metrics/pearson_correlation.cpp
@@ -29,8 +29,8 @@
 
 namespace lbann {
 
-DataType pearson_correlation_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                      const AbsDistMat& ground_truth) {
+double pearson_correlation_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                    const AbsDistMat& ground_truth) {
 
     double corr = 0.0;
 
@@ -69,7 +69,7 @@ DataType pearson_correlation_metric::evaluate_compute(const AbsDistMat& predicti
     //Compute correlation
     corr = corr_mean/(pred_std*true_std);
 
-    return corr / prediction.Width();
+    return corr;
 
 }
 

--- a/src/metrics/top_k_categorical_accuracy.cpp
+++ b/src/metrics/top_k_categorical_accuracy.cpp
@@ -32,8 +32,8 @@ top_k_categorical_accuracy_metric::top_k_categorical_accuracy_metric(int top_k,
                                                                      lbann_comm *comm) 
   : metric(comm), m_top_k(top_k) {}
 
-DataType top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                             const AbsDistMat& ground_truth) {
+double top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                           const AbsDistMat& ground_truth) {
     // This first computes the top k predictions within each column locally,
     // then each column master gathers these, computes the global top k, and
     // determines if an error was made.
@@ -74,7 +74,7 @@ DataType top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& p
       std::vector<top_k_ele> global_top_k(
         m_top_k * local_width * col_comm_size);
       get_comm().gather((DataType*) local_top_k.data(), 2*local_top_k.size(),
-                     (DataType*) global_top_k.data(), col_comm);
+                        (DataType*) global_top_k.data(), col_comm);
       // Compute the global top k elements in each column.
       std::vector<El::Int> global_indices(m_top_k * col_comm_size);
       std::iota(global_indices.begin(), global_indices.end(), 0);
@@ -111,7 +111,7 @@ DataType top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& p
     }
     num_errors = get_comm().model_allreduce(num_errors);
     const int mini_batch_size = prediction.Width();
-    return (mini_batch_size - num_errors) * DataType(100) / mini_batch_size;
+    return (mini_batch_size - num_errors) * 100;
 }
 
 }  // namespace lbann

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -519,7 +519,7 @@ void model::reset_epoch(execution_mode mode) {
   set_execution_mode(mode);
   m_objective_function->clear_history();
   for (const auto& m : m_metrics) {
-    m->clear_history();
+    m->reset_statistics(mode);
   }
   for (const auto& l : m_layers) {
     l->set_model(this);
@@ -531,7 +531,7 @@ bool model::evaluate_mini_batch(execution_mode mode) {
   forward_prop(mode);
   m_objective_function->evaluate();
   for (const auto& m : m_metrics) {
-    m->evaluate();
+    m->evaluate(mode);
   }
   const bool finished = update_layers();
   do_batch_end_cbs(mode);
@@ -545,7 +545,7 @@ bool model::train_mini_batch() {
   forward_prop(execution_mode::training);
   m_objective_function->evaluate();
   for (const auto& m : m_metrics) {
-    m->evaluate();
+    m->evaluate(execution_mode::training);
   }
 
   // Backward prop step


### PR DESCRIPTION
The Pearson correlation metric is computed independently for each sample so that it is independent of mini-batch size. I believe this should close #148.

When I run the convolutional autoencoder on an epoch of 1% ILSVRC, I get a validation Pearson correlation of 0.87. This seems consistent with the reconstruction quality.

| Input | Reconstruction |
|-----|-------|
| ![image](https://user-images.githubusercontent.com/4406448/34021404-8405545a-e0ee-11e7-949a-254bbfca220a.png) | ![image](https://user-images.githubusercontent.com/4406448/34021408-8c1b09b4-e0ee-11e7-9d31-d8bb79805481.png) |
