### PR TITLE
Objective function refactor

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -32,16 +32,22 @@
 #include "El.hpp"
 #include "lbann/Elemental_extensions.hpp"
 
+// Datatype for numerical computation
+// Default: float
 #if LBANN_DATATYPE == 8
 typedef double DataType;
 #elif LBANN_DATATYPE == 4
 typedef float DataType;
 #else
-// Default to floats
 #define LBANN_DATATYPE 4
 typedef float DataType; 
 #endif
 
+// Datatype for model evaluation
+// Examples: timing, metrics, objective functions
+typedef double EvalType;
+
+// Elemental matrices
 typedef El::Grid EGrid;
 typedef El::Grid Grid;
 typedef El::Matrix<DataType> Mat;

--- a/include/lbann/callbacks/callback_check_reconstruction_error.hpp
+++ b/include/lbann/callbacks/callback_check_reconstruction_error.hpp
@@ -41,7 +41,7 @@ namespace lbann {
  */
 class lbann_callback_check_reconstruction_error : public lbann_callback {
  public:
-  lbann_callback_check_reconstruction_error(double max_error = 1.0);
+  lbann_callback_check_reconstruction_error(EvalType max_error = EvalType(1));
   lbann_callback_check_reconstruction_error(const lbann_callback_check_reconstruction_error&) = default;
   lbann_callback_check_reconstruction_error& operator=(
     const lbann_callback_check_reconstruction_error&) = default;
@@ -53,7 +53,7 @@ class lbann_callback_check_reconstruction_error : public lbann_callback {
   std::string name() const override{ return "check reconstruction error"; }
  private:
   /** maximum error value, default is 1.0 */
-  double m_max_error;
+  EvalType m_max_error;
 };
 
 }  // namespace lbann

--- a/include/lbann/callbacks/callback_checkpoint.hpp
+++ b/include/lbann/callbacks/callback_checkpoint.hpp
@@ -1,30 +1,30 @@
+//////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_callback_checkpoint .hpp .cpp - Callback hooks to checkpoint model
 ////////////////////////////////////////////////////////////////////////////////
-//// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
-//// Produced at the Lawrence Livermore National Laboratory.
-//// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
-//// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
-////
-//// LLNL-CODE-697807.
-//// All rights reserved.
-////
-//// This file is part of LBANN: Livermore Big Artificial Neural Network
-//// Toolkit. For details, see http://software.llnl.gov/LBANN or
-//// https://github.com/LLNL/LBANN.
-////
-//// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
-//// may not use this file except in compliance with the License.  You may
-//// obtain a copy of the License at:
-////
-//// http://www.apache.org/licenses/LICENSE-2.0
-////
-//// Unless required by applicable law or agreed to in writing, software
-//// distributed under the License is distributed on an "AS IS" BASIS,
-//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-//// implied. See the License for the specific language governing
-//// permissions and limitations under the license.
-////
-//// lbann_callback_checkpoint .hpp .cpp - Callback hooks to checkpoint model
-//////////////////////////////////////////////////////////////////////////////////
 #ifndef LBANN_CALLBACKS_CALLBACK_CHECKPOINT_HPP_INCLUDED
 #define LBANN_CALLBACKS_CALLBACK_CHECKPOINT_HPP_INCLUDED
 
@@ -67,7 +67,7 @@ class lbann_callback_checkpoint : public lbann_callback {
     m_checkpoint_steps= steps;
   }
 
-  inline void set_checkpoint_secs(double secs){
+  inline void set_checkpoint_secs(EvalType secs){
     m_checkpoint_secs= secs;
   }
   
@@ -83,9 +83,9 @@ class lbann_callback_checkpoint : public lbann_callback {
   std::string m_checkpoint_dir;
   int m_checkpoint_epochs;
   int m_checkpoint_steps;
-  double m_checkpoint_secs;
+  EvalType m_checkpoint_secs;
   bool m_checkpoint_per_rank;
-  double m_checkpoint_last;
+  EvalType m_checkpoint_last;
   bool m_epoch_end;
 };
 

--- a/include/lbann/callbacks/callback_early_stopping.hpp
+++ b/include/lbann/callbacks/callback_early_stopping.hpp
@@ -57,7 +57,7 @@ class lbann_callback_early_stopping : public lbann_callback {
   /** Number of epochs to wait for improvements. */
   int64_t m_patience;
   /** Last recorded score. */
-  double m_last_score = std::numeric_limits<double>::max();
+  EvalType m_last_score = std::numeric_limits<EvalType>::max();
   /** Current number of epochs without improvement. */
   int64_t m_wait = 0;
 };

--- a/include/lbann/callbacks/callback_imcomm.hpp
+++ b/include/lbann/callbacks/callback_imcomm.hpp
@@ -136,7 +136,7 @@ class lbann_callback_imcomm : public lbann_callback {
   }
 
   /** Summarize relevant statistics. */
-  void do_summary(model *m, weights *w, double im_time);
+  void do_summary(model *m, weights *w, EvalType im_time);
 };
 
 

--- a/include/lbann/callbacks/callback_learning_rate.hpp
+++ b/include/lbann/callbacks/callback_learning_rate.hpp
@@ -144,7 +144,7 @@ class lbann_callback_adaptive_learning_rate : public lbann_callback_learning_rat
   /** Current epoch. */
   int m_cur_epoch = -1;
   /** Last recorded score. */
-  double m_last_score = std::numeric_limits<double>::max();
+  EvalType m_last_score = std::numeric_limits<EvalType>::max();
   /** Current number of epochs without improvement. */
   int64_t m_wait = 0;
   /** Whether to adjust learning rate for current epoch. */

--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -89,7 +89,7 @@ class lbann_callback_ltfb : public lbann_callback {
   /**
    * Evaluate a model on tournament data and return its accuracy.
    */
-  double evaluate(model *m);
+  EvalType evaluate(model *m);
   /**
    * Replace the local model m with the remote model data.
    */

--- a/include/lbann/callbacks/callback_timeline.hpp
+++ b/include/lbann/callbacks/callback_timeline.hpp
@@ -69,22 +69,22 @@ class lbann_callback_timeline : public lbann_callback {
   void on_optimize_end(model *m, weights *w) override;
  private:
   /// Get time relative to the start time.
-  double get_rel_time() const { return get_time() - m_start_time; }
+  EvalType get_rel_time() const { return get_time() - m_start_time; }
 
   /// Directory to write output to.
   std::string m_outdir;
   /// Time training started; all times are relative to this.
-  double m_start_time = 0.0;
+  EvalType m_start_time = EvalType(0);
   /// Time the current layer's forward pass started.
-  double m_fp_start_time = 0.0;
+  EvalType m_fp_start_time = EvalType(0);
   /// Time the current layer's backward pass started.
-  double m_bp_start_time = 0.0;
+  EvalType m_bp_start_time = EvalType(0);
   /// Time the current weights' optimization pass started.
-  double m_opt_start_time = 0.0;
+  EvalType m_opt_start_time = EvalType(0);
   /// Store (relative) timing information.
-  std::unordered_map<std::string, std::vector<std::pair<double, double>>> m_fp_times;
-  std::unordered_map<std::string, std::vector<std::pair<double, double>>> m_bp_times;
-  std::unordered_map<std::string, std::vector<std::pair<double, double>>> m_opt_times;
+  std::unordered_map<std::string, std::vector<std::pair<EvalType, EvalType>>> m_fp_times;
+  std::unordered_map<std::string, std::vector<std::pair<EvalType, EvalType>>> m_bp_times;
+  std::unordered_map<std::string, std::vector<std::pair<EvalType, EvalType>>> m_opt_times;
 };
 
 }  // namespace lbann

--- a/include/lbann/callbacks/callback_timer.hpp
+++ b/include/lbann/callbacks/callback_timer.hpp
@@ -82,11 +82,11 @@ class lbann_callback_timer : public lbann_callback {
  private:
 
   /** Start time for the current timing. */
-  double m_start_time;
+  EvalType m_start_time;
   /** Start time for the current mini-batch. */
-  double m_batch_start_time;
+  EvalType m_batch_start_time;
   /** History of mini-batch times for the current timing. */
-  std::vector<double> m_batch_times;
+  std::vector<EvalType> m_batch_times;
 
   /** Start timing. */
   void timing_begin(model *m);

--- a/include/lbann/layers/io/target/reconstruction.hpp
+++ b/include/lbann/layers/io/target/reconstruction.hpp
@@ -131,7 +131,8 @@ class reconstruction_layer : public target_layer {
 
   void summarize_stats(lbann_summary& summarizer, int step) override {
     std::string tag = this->m_name + "/ReconstructionCost";
-    summarizer.reduce_scalar(tag, this->m_model->get_objective_function()->get_history_mean_value(), step);
+    execution_mode mode = this->m_model->get_execution_mode();
+    summarizer.reduce_scalar(tag, this->m_model->get_objective_function()->get_mean_value(mode), step);
     // Skip target layer (for now).
     io_layer::summarize_stats(summarizer, step);
   }

--- a/include/lbann/metrics/categorical_accuracy.hpp
+++ b/include/lbann/metrics/categorical_accuracy.hpp
@@ -66,8 +66,8 @@ class categorical_accuracy_metric : public metric {
    *  This returns the sum of metric values across the mini-batch, not
    *  the mean value.
    */
-  double evaluate_compute(const AbsDistMat& prediction,
-                          const AbsDistMat& ground_truth) override;
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
 
  private:
 

--- a/include/lbann/metrics/mean_absolute_deviation.hpp
+++ b/include/lbann/metrics/mean_absolute_deviation.hpp
@@ -61,8 +61,8 @@ class mean_absolute_deviation_metric : public metric {
    *  This returns the sum of metric values across the mini-batch, not
    *  the mean value.
    */
-  double evaluate_compute(const AbsDistMat& prediction,
-                          const AbsDistMat& ground_truth) override;
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
 
 };
 

--- a/include/lbann/metrics/mean_squared_error.hpp
+++ b/include/lbann/metrics/mean_squared_error.hpp
@@ -61,8 +61,8 @@ class mean_squared_error_metric : public metric {
    *  This returns the sum of metric values across the mini-batch, not
    *  the mean value.
    */
-  double evaluate_compute(const AbsDistMat& prediction,
-                          const AbsDistMat& ground_truth) override;
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
 
 };
 

--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -42,7 +42,7 @@ class target_layer;
 /** Metric statistics. */
 struct metric_statistics {
   /** Sum of metric values. */
-  double m_sum;
+  EvalType m_sum;
   /** Number of samples. */
   int m_num_samples;
   /** Default constructor. */
@@ -58,12 +58,12 @@ struct metric_statistics {
   /** Destructor. */
   ~metric_statistics() = default;
   /** Add metric value to statistics. */
-  void add_value(double value, int num_samples = 1);
+  void add_value(EvalType value, int num_samples = 1);
   /** Get mean metric value.
    *  If mini-batch sizes are not identical, the mean is over the
    *  sample values rather than over the mini-batch mean values.
    */
-  double get_mean() const;
+  EvalType get_mean() const;
   /** Get number of samples. */
   int get_num_samples() const { return m_num_samples; }
   /** Reset statistics. */
@@ -115,7 +115,7 @@ class metric {
   virtual void setup(model& m);
   
   /** Evaluate the metric value. */
-  double evaluate(execution_mode mode);
+  EvalType evaluate(execution_mode mode);
 
   /** Clear all statistics. */
   void reset_statistics() { m_statistics.clear(); }
@@ -126,7 +126,7 @@ class metric {
    *  If mini-batch sizes are not identical, the mean is over the
    *  sample values rather than over the mini-batch mean values.
    */
-  double get_mean_value(execution_mode mode) const;
+  EvalType get_mean_value(execution_mode mode) const;
   /** Get number of samples for statistics. */
   int get_statistics_num_samples(execution_mode mode) const;
 
@@ -151,8 +151,8 @@ class metric {
    *  This should return the sum of metric values across the
    *  mini-batch, not the mean value.
    */
-  virtual double evaluate_compute(const AbsDistMat& prediction,
-                                  const AbsDistMat& ground_truth) = 0;
+  virtual EvalType evaluate_compute(const AbsDistMat& prediction,
+                                    const AbsDistMat& ground_truth) = 0;
 
   /** Get LBANN communicator. */
   lbann_comm& get_comm() { return *m_comm; }

--- a/include/lbann/metrics/pearson_correlation.hpp
+++ b/include/lbann/metrics/pearson_correlation.hpp
@@ -62,8 +62,8 @@ class pearson_correlation_metric : public metric {
    *  This returns the sum of metric values across the mini-batch, not
    *  the mean value.
    */
-  double evaluate_compute(const AbsDistMat& prediction,
-                          const AbsDistMat& ground_truth) override;
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
 
  private:
 

--- a/include/lbann/metrics/top_k_categorical_accuracy.hpp
+++ b/include/lbann/metrics/top_k_categorical_accuracy.hpp
@@ -64,8 +64,8 @@ class top_k_categorical_accuracy_metric : public metric {
    *  This returns the sum of metric values across the mini-batch, not
    *  the mean value.
    */
-  double evaluate_compute(const AbsDistMat& prediction,
-                          const AbsDistMat& ground_truth) override;
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
 
  private:
 

--- a/include/lbann/objective_functions/loss_functions/binary_cross_entropy.hpp
+++ b/include/lbann/objective_functions/loss_functions/binary_cross_entropy.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class binary_cross_entropy : public loss_function {
  public:
   /** Default constructor. */
-  binary_cross_entropy(DataType scale_factor = DataType(1))
+  binary_cross_entropy(EvalType scale_factor = EvalType(1))
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -59,7 +59,7 @@ class binary_cross_entropy : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the binary cross entropy across the mini-batch.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the binary cross entropy objective function.

--- a/include/lbann/objective_functions/loss_functions/cross_entropy.hpp
+++ b/include/lbann/objective_functions/loss_functions/cross_entropy.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class cross_entropy : public loss_function {
  public:
   /** Default constructor. */
-  cross_entropy(DataType scale_factor = DataType(1)) 
+  cross_entropy(EvalType scale_factor = EvalType(1))
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -61,7 +61,7 @@ class cross_entropy : public loss_function {
    *  the predictions and ground truth matrices should have
    *  non-negative entries that add up to one.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the cross entropy objective function.

--- a/include/lbann/objective_functions/loss_functions/cross_entropy_with_uncertainty.hpp
+++ b/include/lbann/objective_functions/loss_functions/cross_entropy_with_uncertainty.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class cross_entropy_with_uncertainty : public loss_function {
  public:
   /** Default constructor. */
-  cross_entropy_with_uncertainty(DataType scale_factor = DataType(1));
+  cross_entropy_with_uncertainty(EvalType scale_factor = EvalType(1));
 
   /** Copy constructor. */
   cross_entropy_with_uncertainty(const cross_entropy_with_uncertainty& other);
@@ -65,7 +65,7 @@ class cross_entropy_with_uncertainty : public loss_function {
    *  the predictions matrix should have non-negative entries that add up 
    *  to one.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the cross entropy objective function.

--- a/include/lbann/objective_functions/loss_functions/geom_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/geom_negloglike.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class geom_negloglike : public loss_function {
  public:
   /** Default constructor. */
-  geom_negloglike(DataType scale_factor = DataType(1)) 
+  geom_negloglike(EvalType scale_factor = EvalType(1)) 
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -59,7 +59,7 @@ class geom_negloglike : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean squared error across the mini-batch.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Geometric negative log-likelihood objective function.

--- a/include/lbann/objective_functions/loss_functions/loss_function.hpp
+++ b/include/lbann/objective_functions/loss_functions/loss_function.hpp
@@ -36,7 +36,7 @@ namespace lbann {
 class loss_function : public objective_function_term {
  public:
   /** Default constructor. */
-  loss_function(DataType scale_factor = DataType(1));
+  loss_function(EvalType scale_factor = EvalType(1));
 
   /** Copy constructor. */
   loss_function(const loss_function& other);
@@ -51,7 +51,7 @@ class loss_function : public objective_function_term {
   virtual void setup(model& m) override;
   
   /** Evaluate the objective function term. */
-  DataType evaluate() override;
+  EvalType evaluate() override;
 
   /** Compute the gradient of the objective function term.
    *  The gradient is computed w.r.t. the objective function term
@@ -62,8 +62,8 @@ class loss_function : public objective_function_term {
   /** Evaluate the loss function.
    *  This should not include the scale factor.
    */
-  virtual DataType evaluate_compute(const AbsDistMat& prediction,
-                                    const AbsDistMat& ground_truth) = 0;
+  virtual double evaluate_compute(const AbsDistMat& prediction,
+                                  const AbsDistMat& ground_truth) = 0;
 
   /** Compute the loss function gradient.
    *  The gradient should be w.r.t. the prediction vector. This should

--- a/include/lbann/objective_functions/loss_functions/mean_absolute_deviation.hpp
+++ b/include/lbann/objective_functions/loss_functions/mean_absolute_deviation.hpp
@@ -37,7 +37,7 @@ namespace lbann {
 class mean_absolute_deviation_loss : public loss_function {
  public:
   /** Default constructor. */
-  mean_absolute_deviation_loss(DataType scale_factor = DataType(1)) 
+  mean_absolute_deviation_loss(EvalType scale_factor = EvalType(1)) 
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -63,7 +63,7 @@ class mean_absolute_deviation_loss : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean absolute deviation across the mini-batch.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the mean absolution deviation gradient.

--- a/include/lbann/objective_functions/loss_functions/mean_squared_error.hpp
+++ b/include/lbann/objective_functions/loss_functions/mean_squared_error.hpp
@@ -37,7 +37,7 @@ namespace lbann {
 class mean_squared_error_loss : public loss_function {
  public:
   /** Default constructor. */
-  mean_squared_error_loss(DataType scale_factor = DataType(1)) 
+  mean_squared_error_loss(EvalType scale_factor = EvalType(1)) 
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -63,7 +63,7 @@ class mean_squared_error_loss : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean absolute deviation across the mini-batch.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the mean squared error objective function.

--- a/include/lbann/objective_functions/loss_functions/poisson_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/poisson_negloglike.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class poisson_negloglike : public loss_function {
  public:
   /** Default constructor. */
-  poisson_negloglike(DataType scale_factor = DataType(1)) 
+  poisson_negloglike(EvalType scale_factor = EvalType(1)) 
     : loss_function(scale_factor) {}
 
   /** Copy constructor. */
@@ -59,7 +59,7 @@ class poisson_negloglike : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the Poisson negative log-likelihood across the mini-batch.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Poisson negative log-likelihood objective function.

--- a/include/lbann/objective_functions/loss_functions/polya_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/polya_negloglike.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class polya_negloglike : public loss_function {
  public:
   /** Default constructor. */
-  polya_negloglike(DataType scale_factor = DataType(1));
+  polya_negloglike(EvalType scale_factor = EvalType(1));
 
   /** Copy constructor. */
   polya_negloglike(const polya_negloglike& other);
@@ -65,7 +65,7 @@ class polya_negloglike : public loss_function {
    *  the predictions and ground truth matrices should have
    *  non-negative entries.
    */
-  DataType evaluate_compute(const AbsDistMat& prediction,
+  EvalType evaluate_compute(const AbsDistMat& prediction,
                             const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Polya negative log-likelihood objective function.

--- a/include/lbann/objective_functions/objective_function_term.hpp
+++ b/include/lbann/objective_functions/objective_function_term.hpp
@@ -38,7 +38,7 @@ class objective_function_term {
  public:
 
   /** Default constructor. */
-  objective_function_term(DataType scale_factor = DataType(1));
+  objective_function_term(EvalType scale_factor = EvalType(1));
 
   /** Copy constructor. */
   objective_function_term(const objective_function_term& other) = default;
@@ -58,7 +58,7 @@ class objective_function_term {
   /** Evaluate the objective function term.
    *  This should include the scaling factor.
    */
-  virtual DataType evaluate() = 0;
+  virtual EvalType evaluate() = 0;
   
   /** Compute the gradient of the objective function term.
    *  The gradient is computed w.r.t. the objective function term
@@ -82,7 +82,7 @@ class objective_function_term {
  protected:
 
   /** Scaling factor for objective function term. */
-  DataType m_scale_factor;
+  EvalType m_scale_factor;
 
   /** Layers used to compute objective function term. */
   std::vector<Layer*> m_layers;

--- a/include/lbann/objective_functions/weight_regularization/group_lasso.hpp
+++ b/include/lbann/objective_functions/weight_regularization/group_lasso.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class group_lasso_weight_regularization : public objective_function_term {
  public:
   /** Default constructor. */
-  group_lasso_weight_regularization(DataType scale_factor = DataType(1))
+  group_lasso_weight_regularization(EvalType scale_factor = EvalType(1))
     : objective_function_term(scale_factor) {}
 
   /** Copy constructor. */
@@ -54,7 +54,7 @@ class group_lasso_weight_regularization : public objective_function_term {
   void setup(model& m) override;
   
   /** Get the value of the group lasso regularization term. */
-  DataType evaluate() override;
+  EvalType evaluate() override;
 
   /** Compute the gradient of the group lasso regularization term.
    *  The gradient is computed w.r.t. the weights.

--- a/include/lbann/objective_functions/weight_regularization/l1.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l1.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class l1_weight_regularization : public objective_function_term {
  public:
   /** Default constructor. */
-  l1_weight_regularization(DataType scale_factor = DataType(1))
+  l1_weight_regularization(EvalType scale_factor = EvalType(1))
     : objective_function_term(scale_factor) {}
 
   /** Copy constructor. */
@@ -54,7 +54,7 @@ class l1_weight_regularization : public objective_function_term {
   void setup(model& m) override;
   
   /** Get the value of the L1 regularization term. */
-  DataType evaluate() override;
+  EvalType evaluate() override;
 
   /** Compute the gradient of the L1 regularization term.
    *  The gradient is computed w.r.t. the weights.

--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -35,7 +35,7 @@ namespace lbann {
 class l2_weight_regularization : public objective_function_term {
  public:
   /** Default constructor. */
-  l2_weight_regularization(DataType scale_factor = DataType(1))
+  l2_weight_regularization(EvalType scale_factor = EvalType(1))
     : objective_function_term(scale_factor) {}
 
   /** Copy constructor. */
@@ -54,7 +54,7 @@ class l2_weight_regularization : public objective_function_term {
   void setup(model& m) override;
   
   /** Get the value of the L2 regularization term. */
-  DataType evaluate() override;
+  EvalType evaluate() override;
 
   /** Compute the gradient of the L2 regularization term.
    *  The gradient is computed w.r.t. the weights.
@@ -64,7 +64,7 @@ class l2_weight_regularization : public objective_function_term {
  private:
 
   /** Compute the squared L2 norm of mat. */
-  DataType local_squared_l2_norm(const Mat& mat) const;
+  EvalType local_squared_l2_norm(const Mat& mat) const;
 
 };
 

--- a/src/callbacks/callback_check_reconstruction_error.cpp
+++ b/src/callbacks/callback_check_reconstruction_error.cpp
@@ -36,7 +36,7 @@ lbann_callback_check_reconstruction_error::lbann_callback_check_reconstruction_e
 
 
 void lbann_callback_check_reconstruction_error::on_epoch_end(model *m) {
-  double reconstr_error  = m->get_objective_function()->get_history_mean_value();
+  double reconstr_error  = m->get_objective_function()->get_mean_value(m->get_execution_mode());
   if( reconstr_error < m_max_error) {
     if (m->get_comm()->am_model_master()) {
       std::cout << "Reconstruction error " << reconstr_error << "is less than " <<  m_max_error << 

--- a/src/callbacks/callback_check_reconstruction_error.cpp
+++ b/src/callbacks/callback_check_reconstruction_error.cpp
@@ -31,12 +31,12 @@
 
 namespace lbann {
 
-lbann_callback_check_reconstruction_error::lbann_callback_check_reconstruction_error(double max_error) :
+lbann_callback_check_reconstruction_error::lbann_callback_check_reconstruction_error(EvalType max_error) :
   lbann_callback(), m_max_error(max_error) {}
 
 
 void lbann_callback_check_reconstruction_error::on_epoch_end(model *m) {
-  double reconstr_error  = m->get_objective_function()->get_mean_value(m->get_execution_mode());
+  EvalType reconstr_error  = m->get_objective_function()->get_mean_value(m->get_execution_mode());
   if( reconstr_error < m_max_error) {
     if (m->get_comm()->am_model_master()) {
       std::cout << "Reconstruction error " << reconstr_error << "is less than " <<  m_max_error << 

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -1,30 +1,30 @@
+////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_callback_checkpoint .hpp .cpp - Callback hooks to checkpoint model
 ////////////////////////////////////////////////////////////////////////////////
-////// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
-////// Produced at the Lawrence Livermore National Laboratory.
-////// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
-////// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
-//////
-////// LLNL-CODE-697807.
-////// All rights reserved.
-//////
-////// This file is part of LBANN: Livermore Big Artificial Neural Network
-////// Toolkit. For details, see http://software.llnl.gov/LBANN or
-////// https://github.com/LLNL/LBANN.
-//////
-////// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
-////// may not use this file except in compliance with the License.  You may
-////// obtain a copy of the License at:
-//////
-////// http://www.apache.org/licenses/LICENSE-2.0
-//////
-////// Unless required by applicable law or agreed to in writing, software
-////// distributed under the License is distributed on an "AS IS" BASIS,
-////// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-////// implied. See the License for the specific language governing
-////// permissions and limitations under the license.
-//////
-////// lbann_callback_checkpoint .hpp .cpp - Callback hooks to checkpoint model
-////////////////////////////////////////////////////////////////////////////////////
 
 
 #include "lbann/callbacks/callback_checkpoint.hpp"
@@ -76,9 +76,9 @@ bool lbann_callback_checkpoint::need_checkpoint(model *m) {
     // to avoid issues with clock skew, we rely on rank 0 to make decision
     if (comm->am_world_master()) {
       // get the current time
-      double current = MPI_Wtime();
+      EvalType current = MPI_Wtime();
       // compute time next checkpoint is due
-      double next = m_checkpoint_last + m_checkpoint_secs;
+      EvalType next = m_checkpoint_last + m_checkpoint_secs;
       // determine whether it's time for a checkpoint
       checkpoint_now = (current >= next);
     }
@@ -175,10 +175,10 @@ bool lbann_callback_checkpoint::checkpointShared(model *m) {
   // stop timer and report cost
   MPI_Barrier(MPI_COMM_WORLD);
   if (comm->am_world_master()) {
-    double secs = timer.Stop();
-    double bw = 0.0;
+    EvalType secs = timer.Stop();
+    EvalType bw = 0;
     if (secs > 0.0) {
-      bw = ((double) bytes_count) / (secs * 1024.0 * 1024.0);
+      bw = EvalType(bytes_count) / (secs * 1024.0 * 1024.0);
     }
     printf("Checkpoint complete: Epoch=%d Step=%d (%f secs, %llu bytes, %f MB/sec)\n",
            epoch, step, secs, (unsigned long long) bytes_count, bw
@@ -231,10 +231,10 @@ bool lbann_callback_checkpoint::restartShared(model *m) {
   // let user know we've completed reading our restart
   MPI_Barrier(MPI_COMM_WORLD);
   if (comm->am_world_master()) {
-    double secs = timer.Stop();
-    double bw = 0.0;
+    EvalType secs = timer.Stop();
+    EvalType bw = 0.0;
     if (secs > 0.0) {
-      bw = ((double) bytes_count) / (secs * 1024.0 * 1024.0);
+      bw = EvalType(bytes_count) / (secs * 1024.0 * 1024.0);
     }
     printf("Restart complete: Epoch=%d Step=%d (%f secs, %llu bytes, %f MB/sec)\n",
            epoch, step, secs, (unsigned long long) bytes_count, bw

--- a/src/callbacks/callback_early_stopping.cpp
+++ b/src/callbacks/callback_early_stopping.cpp
@@ -36,7 +36,8 @@ lbann_callback_early_stopping::lbann_callback_early_stopping(int64_t patience) :
 /// Monitor the objective function to see if the validation score
 /// continues to improve
 void lbann_callback_early_stopping::on_validation_end(model *m) {
-  double score = m->get_objective_function()->get_history_mean_value();
+  execution_mode mode = m->get_execution_mode();
+  double score = m->get_objective_function()->get_mean_value(mode);
   if (score < m_last_score) {
     if (m->get_comm()->am_model_master()) {
       std::cout << "Model " << m->get_comm()->get_model_rank() <<

--- a/src/callbacks/callback_early_stopping.cpp
+++ b/src/callbacks/callback_early_stopping.cpp
@@ -37,7 +37,7 @@ lbann_callback_early_stopping::lbann_callback_early_stopping(int64_t patience) :
 /// continues to improve
 void lbann_callback_early_stopping::on_validation_end(model *m) {
   execution_mode mode = m->get_execution_mode();
-  double score = m->get_objective_function()->get_mean_value(mode);
+  EvalType score = m->get_objective_function()->get_mean_value(mode);
   if (score < m_last_score) {
     if (m->get_comm()->am_model_master()) {
       std::cout << "Model " << m->get_comm()->get_model_rank() <<

--- a/src/callbacks/callback_gradient_check.cpp
+++ b/src/callbacks/callback_gradient_check.cpp
@@ -181,7 +181,7 @@ DataType lbann_callback_gradient_check::compute_objective_function(model *m) {
   for (size_t l = 1; l < layers.size(); l++) {
     layers[l]->forward_prop();
   }
-  return obj_fn->evaluate();
+  return obj_fn->evaluate(m->get_execution_mode());
 }
 
 }  // namespace lbann

--- a/src/callbacks/callback_imcomm.cpp
+++ b/src/callbacks/callback_imcomm.cpp
@@ -157,7 +157,7 @@ void lbann_callback_imcomm::on_backward_prop_end(model *m) {
     return;  // No point with only one model.
   }
   for (weights *w : m->get_weights()) {
-    double start_time = get_time();
+    EvalType start_time = get_time();
     imcomm_params& params = m_weights_params[w];
     if (params.ct == NONE) {
       continue;
@@ -193,13 +193,13 @@ void lbann_callback_imcomm::on_backward_prop_end(model *m) {
          + "imcomm: unknown comm type");
     }
     *local_gradients *= DataType(1) / comm->get_num_models();
-    double im_time = get_time() - start_time;
+    EvalType im_time = get_time() - start_time;
     do_summary(m, w, im_time);
   }
 }
 
 void lbann_callback_imcomm::do_summary(model *m, weights *w,
-                                       double im_time) {
+                                       EvalType im_time) {
   if (m_summarizer == nullptr) {
     return;
   }

--- a/src/callbacks/callback_learning_rate.cpp
+++ b/src/callbacks/callback_learning_rate.cpp
@@ -121,7 +121,8 @@ float lbann_callback_adaptive_learning_rate::global_schedule(model *m) {
   // Determine behavior the first time this is called in an epoch
   if (m_cur_epoch != m->get_cur_epoch()) {
     m_cur_epoch = m->get_cur_epoch();
-    const double score = m->get_objective_function()->get_history_mean_value();
+    const execution_mode mode = m->get_execution_mode();
+    const double score = m->get_objective_function()->get_mean_value(mode);
     if (score < m_last_score) {
       // Reset wait counter if score has decreased
       m_last_score = score;

--- a/src/callbacks/callback_learning_rate.cpp
+++ b/src/callbacks/callback_learning_rate.cpp
@@ -122,7 +122,7 @@ float lbann_callback_adaptive_learning_rate::global_schedule(model *m) {
   if (m_cur_epoch != m->get_cur_epoch()) {
     m_cur_epoch = m->get_cur_epoch();
     const execution_mode mode = m->get_execution_mode();
-    const double score = m->get_objective_function()->get_mean_value(mode);
+    const EvalType score = m->get_objective_function()->get_mean_value(mode);
     if (score < m_last_score) {
       // Reset wait counter if score has decreased
       m_last_score = score;

--- a/src/callbacks/callback_ltfb.cpp
+++ b/src/callbacks/callback_ltfb.cpp
@@ -86,8 +86,8 @@ void lbann_callback_ltfb::on_batch_begin(model *m) {
   exchange(m, partner);
   // Evaluate on tournament data.
   // Have to cast, assumes deep_neural_network.
-  double local_acc = evaluate(m);
-  double remote_acc = evaluate(m_remote_model);
+  EvalType local_acc = evaluate(m);
+  EvalType remote_acc = evaluate(m_remote_model);
   // If the remote is better, keep it.
   if (remote_acc > local_acc) {
     if (m_comm->am_model_master()) {
@@ -150,14 +150,14 @@ void lbann_callback_ltfb::exchange(model *m, int partner) {
   }
 }
 
-double lbann_callback_ltfb::evaluate(model *m) {
+EvalType lbann_callback_ltfb::evaluate(model *m) {
   m->evaluate(execution_mode::validation);
   for (const auto& met : m->get_metrics()) {
     if (dynamic_cast<categorical_accuracy_metric*>(met) != nullptr) {
       return met->get_mean_value(execution_mode::validation);
     }
   }
-  return 0.0;
+  return EvalType(0);
 }
 
 void lbann_callback_ltfb::replace_with_remote(model *m) {

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -116,8 +116,9 @@ void lbann_callback_print::report_results(model *m) {
   lbann_comm *comm = m->get_comm();
 
   // Get string for execution mode
+  const execution_mode mode = m->get_execution_mode();
   std::string mode_string;
-  switch(m->get_execution_mode()) {
+  switch (mode) {
   case execution_mode::training:
     mode_string = "training epoch " + std::to_string(m->get_cur_epoch());
     break;
@@ -138,7 +139,7 @@ void lbann_callback_print::report_results(model *m) {
     const int num_models = comm->get_num_models();
 
     // Report objective function value
-    const double obj_fn = m->get_objective_function()->get_history_mean_value();
+    const double obj_fn = m->get_objective_function()->get_mean_value(mode);
     if (comm->am_world_master()) {
       std::vector<double> obj_fn_list(comm->get_num_models());
       comm->intermodel_gather(obj_fn, obj_fn_list);
@@ -162,8 +163,8 @@ void lbann_callback_print::report_results(model *m) {
 
     // Report score for each metric
     for (const auto& met : m->get_metrics()) {
-      const double score = met->get_mean_value(m->get_execution_mode());
-      const int num_samples = met->get_statistics_num_samples(m->get_execution_mode());
+      const double score = met->get_mean_value(mode);
+      const int num_samples = met->get_statistics_num_samples(mode);
       if (comm->am_world_master()) {
         std::vector<double> score_list(comm->get_num_models());
         std::vector<int> num_samples_list(comm->get_num_models());

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -139,9 +139,9 @@ void lbann_callback_print::report_results(model *m) {
     const int num_models = comm->get_num_models();
 
     // Report objective function value
-    const double obj_fn = m->get_objective_function()->get_mean_value(mode);
+    const EvalType obj_fn = m->get_objective_function()->get_mean_value(mode);
     if (comm->am_world_master()) {
-      std::vector<double> obj_fn_list(comm->get_num_models());
+      std::vector<EvalType> obj_fn_list(comm->get_num_models());
       comm->intermodel_gather(obj_fn, obj_fn_list);
       for (int i = 0; i < num_models; ++i) {
         std::cout << "Model " << i << " " << mode_string << " "
@@ -149,10 +149,10 @@ void lbann_callback_print::report_results(model *m) {
                   << std::endl;
       }
       if (num_models > 1) {
-        const double avg_obj_fn = (std::accumulate(obj_fn_list.begin(),
-                                                   obj_fn_list.end(),
-                                                   0.0)
-                                   / num_models);
+        const EvalType avg_obj_fn = (std::accumulate(obj_fn_list.begin(),
+                                                     obj_fn_list.end(),
+                                                     EvalType(0))
+                                     / num_models);
         std::cout << "World average " << mode_string << " "
                   << "objective function : " << avg_obj_fn
                   << std::endl;
@@ -163,10 +163,10 @@ void lbann_callback_print::report_results(model *m) {
 
     // Report score for each metric
     for (const auto& met : m->get_metrics()) {
-      const double score = met->get_mean_value(mode);
+      const EvalType score = met->get_mean_value(mode);
       const int num_samples = met->get_statistics_num_samples(mode);
       if (comm->am_world_master()) {
-        std::vector<double> score_list(comm->get_num_models());
+        std::vector<EvalType> score_list(comm->get_num_models());
         std::vector<int> num_samples_list(comm->get_num_models());
         comm->intermodel_gather(score, score_list);
         comm->intermodel_gather(num_samples, num_samples_list);
@@ -177,13 +177,13 @@ void lbann_callback_print::report_results(model *m) {
                     << std::endl;
         }
         if (num_models > 1) {
-          const double avg_score = (std::inner_product(score_list.begin(),
-                                                       score_list.end(),
-                                                       num_samples_list.begin(),
-                                                       0.0)
-                                    / std::accumulate(num_samples_list.begin(),
-                                                      num_samples_list.end(),
-                                                      0));
+          const EvalType avg_score = (std::inner_product(score_list.begin(),
+                                                         score_list.end(),
+                                                         num_samples_list.begin(),
+                                                         EvalType(0))
+                                      / std::accumulate(num_samples_list.begin(),
+                                                        num_samples_list.end(),
+                                                        EvalType(0)));
           std::cout << "World " << mode_string << " "
                     << met->name() << " : "
                     << avg_score << met->get_unit()

--- a/src/callbacks/callback_summary.cpp
+++ b/src/callbacks/callback_summary.cpp
@@ -69,7 +69,7 @@ void lbann_callback_summary::on_batch_end(model *m) {
 
 void lbann_callback_summary::on_epoch_end(model *m) {
   for (const auto& met : m->get_metrics()) {
-    double train_score = met->get_mean_value(m->get_execution_mode());
+    EvalType train_score = met->get_mean_value(m->get_execution_mode());
     // Replace spaces with _ for consistency.
     std::string metric_name = met->name();
     std::transform(metric_name.begin(), metric_name.end(), metric_name.begin(),
@@ -84,7 +84,7 @@ void lbann_callback_summary::on_epoch_end(model *m) {
 void lbann_callback_summary::on_test_end(model *m) {
   lbann_comm *comm = m->get_comm();
   for (auto&& met : m->get_metrics()) {
-    double test_score = met->get_mean_value(m->get_execution_mode());
+    EvalType test_score = met->get_mean_value(m->get_execution_mode());
     // Replace spaces with _ for consistency.
     std::string metric_name = met->name();
     std::transform(metric_name.begin(), metric_name.end(), metric_name.begin(),

--- a/src/callbacks/callback_timeline.cpp
+++ b/src/callbacks/callback_timeline.cpp
@@ -35,11 +35,11 @@ namespace lbann {
 void lbann_callback_timeline::on_train_begin(model *m) {
   // Set up layers and weights.
   for (const auto& l : m->get_layers()) {
-    m_fp_times.emplace(l->get_name(), std::vector<std::pair<double,double>>());
-    m_bp_times.emplace(l->get_name(), std::vector<std::pair<double,double>>());
+    m_fp_times.emplace(l->get_name(), std::vector<std::pair<EvalType,EvalType>>());
+    m_bp_times.emplace(l->get_name(), std::vector<std::pair<EvalType,EvalType>>());
   }
   for (const auto& w : m->get_weights()) {
-    m_opt_times.emplace(w->get_name(), std::vector<std::pair<double,double>>());
+    m_opt_times.emplace(w->get_name(), std::vector<std::pair<EvalType,EvalType>>());
   }
   // Ensure the model is synchronized at the start.
   m->get_comm()->model_barrier();
@@ -76,7 +76,7 @@ void lbann_callback_timeline::on_forward_prop_begin(model *m, Layer *l) {
 }
 
 void lbann_callback_timeline::on_forward_prop_end(model *m, Layer *l) {
-  double end = get_rel_time();
+  EvalType end = get_rel_time();
   m_fp_times[l->get_name()].emplace_back(m_fp_start_time, end);
 }
 
@@ -85,7 +85,7 @@ void lbann_callback_timeline::on_backward_prop_begin(model *m, Layer *l) {
 }
 
 void lbann_callback_timeline::on_backward_prop_end(model *m, Layer *l) {
-  double end = get_rel_time();
+  EvalType end = get_rel_time();
   m_bp_times[l->get_name()].emplace_back(m_bp_start_time, end);
 }
 
@@ -94,7 +94,7 @@ void lbann_callback_timeline::on_optimize_begin(model *m, weights *w) {
 }
 
 void lbann_callback_timeline::on_optimize_end(model *m, weights *w) {
-  double end = get_rel_time();
+  EvalType end = get_rel_time();
   m_opt_times[w->get_name()].emplace_back(m_opt_start_time, end);
 }
 

--- a/src/callbacks/callback_timer.cpp
+++ b/src/callbacks/callback_timer.cpp
@@ -37,7 +37,7 @@ void lbann_callback_timer::batch_timing_begin(model *m) {
 }
 
 void lbann_callback_timer::batch_timing_end(model *m) {
-  const double mb_time = get_time() - m_batch_start_time;
+  const EvalType mb_time = get_time() - m_batch_start_time;
   m_batch_times.push_back(mb_time);
   if (m_summarizer != nullptr) {
     m_summarizer->reduce_scalar("minibatch_time", mb_time, m->get_cur_step());
@@ -53,14 +53,14 @@ void lbann_callback_timer::timing_end(model *m) {
   lbann_comm *comm = m->get_comm();
 
   // Get run time
-  const double run_time = get_time() - m_start_time;
+  const EvalType run_time = get_time() - m_start_time;
 
   // Compute minibatch statistics
   const int num_batches = m_batch_times.size();
-  double batch_time_mean = std::nan("");
-  double batch_time_min = std::nan("");
-  double batch_time_max = std::nan("");
-  double batch_time_stdev = std::nan("");
+  EvalType batch_time_mean = std::nan("");
+  EvalType batch_time_min = std::nan("");
+  EvalType batch_time_max = std::nan("");
+  EvalType batch_time_stdev = std::nan("");
   if (num_batches > 0) {
     batch_time_mean = std::accumulate(m_batch_times.begin(),
                                       m_batch_times.end(),
@@ -72,11 +72,11 @@ void lbann_callback_timer::timing_end(model *m) {
                                        m_batch_times.end());
   }
   if (num_batches > 1) {
-    const double sqsum = std::inner_product(m_batch_times.begin(),
+    const EvalType sqsum = std::inner_product(m_batch_times.begin(),
                                             m_batch_times.end(),
                                             m_batch_times.begin(),
                                             0.0);
-    double var = sqsum / num_batches - batch_time_mean * batch_time_mean;
+    EvalType var = sqsum / num_batches - batch_time_mean * batch_time_mean;
     var = num_batches * var / (num_batches - 1);
     batch_time_stdev = std::sqrt(std::max(var, 0.0));
   }
@@ -105,11 +105,11 @@ void lbann_callback_timer::timing_end(model *m) {
   if (comm->am_model_master()) {
 
     // Gather timing results in world master
-    std::vector<double> run_time_list(num_models);
-    std::vector<double> mean_list(num_models);
-    std::vector<double> min_list(num_models);
-    std::vector<double> max_list(num_models);
-    std::vector<double> stdev_list(num_models);
+    std::vector<EvalType> run_time_list(num_models);
+    std::vector<EvalType> mean_list(num_models);
+    std::vector<EvalType> min_list(num_models);
+    std::vector<EvalType> max_list(num_models);
+    std::vector<EvalType> stdev_list(num_models);
     if (comm->am_world_master()) {
       comm->intermodel_gather(run_time, run_time_list);
       comm->intermodel_gather(batch_time_mean, mean_list);

--- a/src/metrics/categorical_accuracy.cpp
+++ b/src/metrics/categorical_accuracy.cpp
@@ -77,8 +77,8 @@ void categorical_accuracy_metric::setup(model& m) {
   m_prediction_indices.resize(m_prediction_values->LocalWidth());
 }
 
-double categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                     const AbsDistMat& ground_truth) {
+EvalType categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                       const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
@@ -108,7 +108,7 @@ double categorical_accuracy_metric::evaluate_compute(const AbsDistMat& predictio
       max_index = -1;
     }
     for (int row = 1; row < local_height; ++row) {
-      const double pred_val = prediction_local(row, col);
+      const DataType pred_val = prediction_local(row, col);
       if (pred_val > max_val) {
         max_val = pred_val;
         max_index = row;
@@ -151,7 +151,7 @@ double categorical_accuracy_metric::evaluate_compute(const AbsDistMat& predictio
   correct_predictions = get_comm().model_allreduce(correct_predictions);
 
   // Return percentage of correct predictions
-  return correct_predictions * 100;
+  return EvalType(100) * correct_predictions;
 
 }
 

--- a/src/metrics/mean_absolute_deviation.cpp
+++ b/src/metrics/mean_absolute_deviation.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-double mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                        const AbsDistMat& ground_truth) {
+EvalType mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                          const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
@@ -41,13 +41,13 @@ double mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& predic
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of squared errors
-  double sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const double true_val = ground_truth_local(row, col);
-      const double pred_val = prediction_local(row, col);
-      const double error = true_val - pred_val;
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = prediction_local(row, col);
+      const EvalType error = true_val - pred_val;
       sum += error >= DataType(0) ? error : - error;
     }
   }

--- a/src/metrics/mean_squared_error.cpp
+++ b/src/metrics/mean_squared_error.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-double mean_squared_error_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                   const AbsDistMat& ground_truth) {
+EvalType mean_squared_error_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                     const AbsDistMat& ground_truth) {
 
   // Get matrix dimensions
   const int height = prediction.Height();
@@ -41,13 +41,13 @@ double mean_squared_error_metric::evaluate_compute(const AbsDistMat& prediction,
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of squared errors
-  double sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const double true_val = ground_truth_local(row, col);
-      const double pred_val = prediction_local(row, col);
-      const double error = true_val - pred_val;
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = prediction_local(row, col);
+      const EvalType error = true_val - pred_val;
       sum += error * error;
     }
   }

--- a/src/metrics/pearson_correlation.cpp
+++ b/src/metrics/pearson_correlation.cpp
@@ -132,8 +132,8 @@ void pearson_correlation_metric::setup(model& m) {
   m_covariances->Resize(1, m.get_max_mini_batch_size());
 }
 
-double pearson_correlation_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                    const AbsDistMat& ground_truth) {
+EvalType pearson_correlation_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                      const AbsDistMat& ground_truth) {
 
   // Compute means, standard deviations, and covariances
   columnwise_mean_and_stdev(prediction, *m_prediction_means, *m_prediction_stdevs);
@@ -144,11 +144,11 @@ double pearson_correlation_metric::evaluate_compute(const AbsDistMat& prediction
 
   // Compute Pearson correlation of each column
   // Note: Pearson(x,y) = cov(x,y) / ( stdev(x) * stdev(y) )
-  double local_sum = 0.0;
+  EvalType local_sum = 0.0;
   for (int col = 0; col < m_covariances->LocalWidth(); ++col) {
-    const double pred_stdev = m_prediction_stdevs->GetLocal(0, col);
-    const double true_stdev = m_ground_truth_stdevs->GetLocal(0, col);
-    const double cov        = m_covariances->GetLocal(0, col);
+    const EvalType pred_stdev = m_prediction_stdevs->GetLocal(0, col);
+    const EvalType true_stdev = m_ground_truth_stdevs->GetLocal(0, col);
+    const EvalType cov        = m_covariances->GetLocal(0, col);
     local_sum += cov / (pred_stdev * true_stdev);
   }
   return get_comm().allreduce(local_sum, m_covariances->DistComm());

--- a/src/metrics/top_k_categorical_accuracy.cpp
+++ b/src/metrics/top_k_categorical_accuracy.cpp
@@ -32,8 +32,8 @@ top_k_categorical_accuracy_metric::top_k_categorical_accuracy_metric(int top_k,
                                                                      lbann_comm *comm) 
   : metric(comm), m_top_k(top_k) {}
 
-double top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
-                                                           const AbsDistMat& ground_truth) {
+EvalType top_k_categorical_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                             const AbsDistMat& ground_truth) {
     // This first computes the top k predictions within each column locally,
     // then each column master gathers these, computes the global top k, and
     // determines if an error was made.

--- a/src/objective_functions/loss_functions/binary_cross_entropy.cpp
+++ b/src/objective_functions/loss_functions/binary_cross_entropy.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType binary_cross_entropy::evaluate_compute(const AbsDistMat& predictions,
+EvalType binary_cross_entropy::evaluate_compute(const AbsDistMat& predictions,
                                                 const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -41,16 +41,16 @@ DataType binary_cross_entropy::evaluate_compute(const AbsDistMat& predictions,
   const int local_width = predictions_local.Width();
 
   // Compute sum of cross entropy terms
-  DataType sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for (int col = 0; col < local_width; ++col) {
     for (int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = predictions_local(row, col);
-      if (true_val == DataType(1)) {
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = predictions_local(row, col);
+      if (true_val == EvalType(1)) {
         sum += - std::log(pred_val);
-      } else if (true_val == DataType(0)) {
-        sum += - std::log(DataType(1) - pred_val);
+      } else if (true_val == EvalType(0)) {
+        sum += - std::log(EvalType(1) - pred_val);
       } else {
         std::stringstream err;
         err << __FILE__ << " " << __LINE__ << " :: "

--- a/src/objective_functions/loss_functions/cross_entropy.cpp
+++ b/src/objective_functions/loss_functions/cross_entropy.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType cross_entropy::evaluate_compute(const AbsDistMat& predictions,
+EvalType cross_entropy::evaluate_compute(const AbsDistMat& predictions,
                                          const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -41,14 +41,14 @@ DataType cross_entropy::evaluate_compute(const AbsDistMat& predictions,
   const int local_width = predictions_local.Width();
 
   // Compute sum of cross entropy terms
-  DataType sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for (int col = 0; col < local_width; ++col) {
     for (int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      sum += (true_val != DataType(0) ?
+      const EvalType true_val = ground_truth_local(row, col);
+      sum += (true_val != EvalType(0) ?
               - true_val * std::log(predictions_local(row, col)) :
-              DataType(0));
+              EvalType(0));
     }
   }
 

--- a/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
+++ b/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-cross_entropy_with_uncertainty::cross_entropy_with_uncertainty(DataType scale_factor)
+cross_entropy_with_uncertainty::cross_entropy_with_uncertainty(EvalType scale_factor)
   : loss_function(scale_factor),
     m_prediction_sums(nullptr) {}
 
@@ -71,7 +71,7 @@ void cross_entropy_with_uncertainty::setup(model& m) {
 
 }
 
-DataType cross_entropy_with_uncertainty::evaluate_compute(const AbsDistMat& predictions,
+EvalType cross_entropy_with_uncertainty::evaluate_compute(const AbsDistMat& predictions,
                                                           const AbsDistMat& ground_truth) {
 
   // Initialize workspace
@@ -90,9 +90,9 @@ DataType cross_entropy_with_uncertainty::evaluate_compute(const AbsDistMat& pred
   // Compute sum of predictions
   #pragma omp parallel for
   for (int col = 0; col < local_width; ++col) {
-    DataType pred_sum = DataType(0);
+    EvalType pred_sum = EvalType(0);
     for (int row = 0; row < local_height; ++row) {
-      if (ground_truth_local(row, col) != DataType(0)) {
+      if (ground_truth_local(row, col) != EvalType(0)) {
         pred_sum += predictions_local(row, col);
       }
     }
@@ -102,7 +102,7 @@ DataType cross_entropy_with_uncertainty::evaluate_compute(const AbsDistMat& pred
                         m_prediction_sums->RedundantComm());
 
   // Compute mean objective function value
-  DataType local_sum = DataType(0);
+  EvalType local_sum = EvalType(0);
   for (int col = 0; col < local_width; ++col) {
     local_sum += -std::log(prediction_sums_local(0, col));
   }

--- a/src/objective_functions/loss_functions/geom_negloglike.cpp
+++ b/src/objective_functions/loss_functions/geom_negloglike.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType geom_negloglike::evaluate_compute(const AbsDistMat& predictions,
+EvalType geom_negloglike::evaluate_compute(const AbsDistMat& predictions,
                                            const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -41,13 +41,13 @@ DataType geom_negloglike::evaluate_compute(const AbsDistMat& predictions,
   const int local_width = predictions_local.Width();
 
   // Compute sum of terms
-  DataType sum = 0;
+  EvalType sum = EvalType(0);
 #pragma omp parallel for reduction(+:sum) collapse(2)
   for (int col = 0; col < local_width; ++col) {
     for (int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = predictions_local(row, col);
-      sum += (- true_val * std::log(DataType(1) - pred_val)
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = predictions_local(row, col);
+      sum += (- true_val * std::log(EvalType(1) - pred_val)
               - std::log(pred_val));
     }
   }

--- a/src/objective_functions/loss_functions/loss_function.cpp
+++ b/src/objective_functions/loss_functions/loss_function.cpp
@@ -29,7 +29,7 @@
 
 namespace lbann {
 
-loss_function::loss_function(DataType scale_factor)
+loss_function::loss_function(EvalType scale_factor)
   : objective_function_term(scale_factor),
     m_gradient(nullptr) {}
 
@@ -111,8 +111,8 @@ void loss_function::setup(model& m) {
 
 }
 
-DataType loss_function::evaluate() {
-  if (m_scale_factor == DataType(0)) { return DataType(0); }
+EvalType loss_function::evaluate() {
+  if (m_scale_factor == EvalType(0)) { return EvalType(0); }
   auto *target = (target_layer*) m_layers[0];
   const AbsDistMat& prediction = target->get_prediction();
   const AbsDistMat& ground_truth = target->get_ground_truth();
@@ -120,13 +120,13 @@ DataType loss_function::evaluate() {
 }
 
 void loss_function::differentiate() {
-  if (m_scale_factor == DataType(0)) { return; }
+  if (m_scale_factor == EvalType(0)) { return; }
   auto *target = (target_layer*) m_layers[0];
   const AbsDistMat& prediction = target->get_prediction();
   const AbsDistMat& ground_truth = target->get_ground_truth();
   El::Zeros(*m_gradient, prediction.Height(), prediction.Width());
   differentiate_compute(prediction, ground_truth, *m_gradient);
-  target->add_to_error_signal(*m_gradient, m_scale_factor);
+  target->add_to_error_signal(*m_gradient, DataType(m_scale_factor));
 }
 
   bool loss_function::save_to_checkpoint_shared(persist& p)  {

--- a/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
+++ b/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType mean_absolute_deviation_loss::evaluate_compute(const AbsDistMat& predictions,
+EvalType mean_absolute_deviation_loss::evaluate_compute(const AbsDistMat& predictions,
                                                         const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -42,14 +42,14 @@ DataType mean_absolute_deviation_loss::evaluate_compute(const AbsDistMat& predic
   const El::Int local_width = predictions_local.Width();
 
   // Compute sum of errors
-  DataType sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = predictions_local(row, col);
-      const DataType error = true_val - pred_val;
-      sum += error >= DataType(0) ? error : - error;
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = predictions_local(row, col);
+      const EvalType error = true_val - pred_val;
+      sum += error >= EvalType(0) ? error : - error;
     }
   }
   

--- a/src/objective_functions/loss_functions/mean_squared_error.cpp
+++ b/src/objective_functions/loss_functions/mean_squared_error.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType mean_squared_error_loss::evaluate_compute(const AbsDistMat& predictions,
+EvalType mean_squared_error_loss::evaluate_compute(const AbsDistMat& predictions,
                                                    const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -42,13 +42,13 @@ DataType mean_squared_error_loss::evaluate_compute(const AbsDistMat& predictions
   const El::Int local_width = predictions_local.Width();
 
   // Compute sum of squared errors
-  DataType sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for(El::Int col = 0; col < local_width; ++col) {
     for(El::Int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = predictions_local(row, col);
-      const DataType error = true_val - pred_val;
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = predictions_local(row, col);
+      const EvalType error = true_val - pred_val;
       sum += error * error;
     }
   }

--- a/src/objective_functions/loss_functions/poisson_negloglike.cpp
+++ b/src/objective_functions/loss_functions/poisson_negloglike.cpp
@@ -28,7 +28,7 @@
 
 namespace lbann {
 
-DataType poisson_negloglike::evaluate_compute(const AbsDistMat& predictions,
+EvalType poisson_negloglike::evaluate_compute(const AbsDistMat& predictions,
                                               const AbsDistMat& ground_truth) {
 
   // Local matrices
@@ -41,12 +41,12 @@ DataType poisson_negloglike::evaluate_compute(const AbsDistMat& predictions,
   const int local_width = predictions_local.Width();
 
   // Compute sum of cross entropy terms
-  DataType sum = 0;
+  EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
   for (int col = 0; col < local_width; ++col) {
     for (int row = 0; row < local_height; ++row) {
-      const DataType true_val = ground_truth_local(row, col);
-      const DataType pred_val = predictions_local(row, col);
+      const EvalType true_val = ground_truth_local(row, col);
+      const EvalType pred_val = predictions_local(row, col);
       sum += (pred_val
               - true_val * std::log(pred_val)
               + std::lgamma(true_val + 1)); // \f[\lambda - k\log(\lambda) + \log(k!)\f]

--- a/src/objective_functions/loss_functions/polya_negloglike.cpp
+++ b/src/objective_functions/loss_functions/polya_negloglike.cpp
@@ -44,7 +44,7 @@ double digamma(double x) {
 
 namespace lbann {
 
-polya_negloglike::polya_negloglike(DataType scale_factor)
+polya_negloglike::polya_negloglike(EvalType scale_factor)
   : loss_function(scale_factor),
     m_counts(nullptr),
     m_alpha_sums(nullptr),
@@ -126,7 +126,7 @@ void polya_negloglike::setup(model& m) {
 
 }
 
-DataType polya_negloglike::evaluate_compute(const AbsDistMat& predictions,
+EvalType polya_negloglike::evaluate_compute(const AbsDistMat& predictions,
                                             const AbsDistMat& ground_truth) {
 
   // Initialize workspace
@@ -174,7 +174,7 @@ DataType polya_negloglike::evaluate_compute(const AbsDistMat& predictions,
                         m_lgamma_alpha_level_count_sums->RedundantComm());
 
   // Compute mean objective function value across mini-batch
-  DataType local_sum = DataType(0);
+  EvalType local_sum = EvalType(0);
   for (int col = 0; col < local_width; ++col) {
     local_sum += (- std::lgamma(alpha_sums_local(0, col))
                   + std::lgamma(counts_local(0, col) + alpha_sums_local(0, col))

--- a/src/objective_functions/objective_function_term.cpp
+++ b/src/objective_functions/objective_function_term.cpp
@@ -29,10 +29,10 @@
 
 namespace lbann {
 
-objective_function_term::objective_function_term(DataType scale_factor)
+objective_function_term::objective_function_term(EvalType scale_factor)
   : m_scale_factor(scale_factor) {
-  if (m_scale_factor == DataType(0)) {
-    m_scale_factor = DataType(1);
+  if (m_scale_factor == EvalType(0)) {
+    m_scale_factor = EvalType(1);
   }
 }
 

--- a/src/objective_functions/weight_regularization/group_lasso.cpp
+++ b/src/objective_functions/weight_regularization/group_lasso.cpp
@@ -51,9 +51,9 @@ void group_lasso_weight_regularization::setup(model& m) {
 
 }
 
-DataType group_lasso_weight_regularization::evaluate() {
-  if (m_scale_factor == DataType(0)) { return DataType(0); }
-  DataType value = DataType(0);
+EvalType group_lasso_weight_regularization::evaluate() {
+  if (m_scale_factor == EvalType(0)) { return EvalType(0); }
+  EvalType value = EvalType(0);
   Mat sqsums;
   for (weights* w : m_weights) {
 
@@ -67,7 +67,7 @@ DataType group_lasso_weight_regularization::evaluate() {
     sqsums.Resize(1, local_width);
     #pragma omp parallel for
     for (int col = 0; col < local_width; ++col) {
-      DataType sqsum = DataType(0);
+      DataType sqsum = EvalType(0);
       for (int row = 0; row < local_height; ++row) {
         const DataType val = values_local(row, col);
         sqsum += val * val;
@@ -78,7 +78,7 @@ DataType group_lasso_weight_regularization::evaluate() {
                           values.ColComm());
 
     // Compute group lasso term
-    DataType w_sum = DataType(0);
+    EvalType w_sum = EvalType(0);
     for (int col = 0; col < local_width; ++col) {
       w_sum += std::sqrt(sqsums(0, col));
     }
@@ -89,7 +89,7 @@ DataType group_lasso_weight_regularization::evaluate() {
 }
 
 void group_lasso_weight_regularization::differentiate() {
-  if (m_scale_factor == DataType(0)) { return; }
+  if (m_scale_factor == EvalType(0)) { return; }
   Mat sqsums;
   AbsDistMat* gradient;
   for (weights* w : m_weights) {

--- a/src/objective_functions/weight_regularization/l1.cpp
+++ b/src/objective_functions/weight_regularization/l1.cpp
@@ -51,9 +51,9 @@ void l1_weight_regularization::setup(model& m) {
 
 }
 
-DataType l1_weight_regularization::evaluate() {
-  if (m_scale_factor == DataType(0)) { return DataType(0); }
-  DataType value = DataType(0);
+EvalType l1_weight_regularization::evaluate() {
+  if (m_scale_factor == EvalType(0)) { return EvalType(0); }
+  EvalType value = EvalType(0);
   for (weights* w : m_weights) {
 
     // Get matrices
@@ -63,12 +63,12 @@ DataType l1_weight_regularization::evaluate() {
     const int local_width = values_local.Width();
 
     // Compute L1 regularization term
-    DataType sum = 0;
+    EvalType sum = 0;
     #pragma omp parallel for reduction(+:sum) collapse(2)
     for (int col = 0; col < local_width; ++col) {
       for (int row = 0; row < local_height; ++row) {
-        const DataType val = values_local(row, col);
-        sum += val >= DataType(0) ? val : - val;
+        const EvalType val = values_local(row, col);
+        sum += val >= EvalType(0) ? val : - val;
       }
     }
     value += get_comm().allreduce(sum, values.DistComm());
@@ -78,7 +78,7 @@ DataType l1_weight_regularization::evaluate() {
 }
 
 void l1_weight_regularization::differentiate() {
-  if (m_scale_factor == DataType(0)) { return; }
+  if (m_scale_factor == EvalType(0)) { return; }
   AbsDistMat* gradient;
   for (weights* w : m_weights) {
     


### PR DESCRIPTION
This pull request adds functionality to compute separate statistics for each execution mode. This will be especially useful for LTFB.

It also adds the EvalType typedef, currently defined as a double. This is intended to provide a consistent datatype for objective function values, metrics, and timings that is independent of DataType.