### PR TITLE
Update Unit Test conftest.py

### DIFF
--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -1,9 +1,10 @@
-import pytest, re, subprocess
+import pytest, os, re, subprocess
 
 def pytest_addoption(parser):
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
-    default_exe = '%s/../LBANN-NIGHTD-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, cluster)
+    plan = os.environ['bamboo_planKey']
+    default_exe = '%s/../%s-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, plan, cluster)
     parser.addoption('--exe', action='store', default=default_exe,
                      help='--exe specifies the executable')
     parser.addoption('--dirname', action='store', default=default_dirname,


### PR DESCRIPTION
#144 updated `conftest.py` in `integration_tests` so that Bamboo would run tests using the appropriate executable. That is, tests of an individual's plan should use an executable built off their fork and not one built off the main repository's `develop` branch.

This pull request makes the same update to `conftest.py` for `unit_tests`.