### PR TITLE
Fix GPU workspace allocation

### DIFF
--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -611,6 +611,7 @@ void cudnn_manager::set_maximum_work_space_size(int i) {
   const size_t min_work_space_size = 1024;
   const double decay_factor = 0.8;
   size_t free_memory, total_memory;
+  CHECK_CUDA(cudaSetDevice(m_gpus[i]));  
   CHECK_CUDA(cudaMemGetInfo(&free_memory, &total_memory));
 
   // Clear work space


### PR DESCRIPTION
This should fix #150. 

The memory usage looks like this now:
```
+-----------------------------------------------------------------------------+
| Processes:                                                       GPU Memory |
|  GPU       PID  Type  Process name                               Usage      |
|=============================================================================|
|    0      4940    C   ...ild/ray/gcc/Release/lbann/model_zoo/lbann 13145MiB |
|    1      4940    C   ...ild/ray/gcc/Release/lbann/model_zoo/lbann 13145MiB |
|    2      4940    C   ...ild/ray/gcc/Release/lbann/model_zoo/lbann 13145MiB |
|    3      4940    C   ...ild/ray/gcc/Release/lbann/model_zoo/lbann 13145MiB |
+-----------------------------------------------------------------------------+
```

And here's output after one epoch:

```
--------------------------------------------------------------------------------
[1] Epoch : stats formated [tr/v/te] iter/epoch = [7749/861/297]
            global MB = [1024/1024/1024] global last MB = [ 448/ 960/ 896]
             local MB = [1024/1024/1024]  local last MB = [ 448/ 960/ 896]
--------------------------------------------------------------------------------
Model 0 training epoch 2 objective function : 2475.31
Model 0 training epoch 2 run time : 1016.49s
Model 0 training epoch 2 mini-batch time statistics : 0.131176s mean, 0.368846s max, 0.128588s min, 0.00978897s stdev
Model 0 validation objective function : 2441.99
Model 0 validation run time : 39.1889s
Model 0 validation mini-batch time statistics : 0.0455147s mean, 0.0567551s max, 0.0448319s min, 0.000746707s stdev
```