### PR TITLE
Update README and default exe

### DIFF
--- a/bamboo/README.md
+++ b/bamboo/README.md
@@ -47,3 +47,7 @@ To run tests locally (outside of the Bamboo infrastructure) you will likely need
 You can also run an individual test by specifying the test filename on the command line, e.g:
 
  `python -m pytest -s --exe ../../build/catalyst.llnl.gov/model_zoo/lbann test_ridge_regression.py`
+
+The above commands must be run from the appropriate subdirectory. For example, to run unit tests, first `cd` into `lbann/bamboo/unit_tests`. 
+
+To run all tests in a subdirectory, add the `--weekly` option.

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -3,8 +3,12 @@ import pytest, os, re, subprocess
 def pytest_addoption(parser):
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
-    plan = os.environ['bamboo_planKey']
-    default_exe = '%s/../%s-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, plan, cluster)
+    key = 'bamboo_planKey'
+    if key in os.environ:
+        plan = os.environ['bamboo_planKey']
+        default_exe = '%s/../%s-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, plan, cluster)
+    else:
+        default_exe = '%s/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname,cluster)
     parser.addoption('--log', action='store', default=0,
                      help='--log=1 to keep trimmed accuracy files. Default (--log=0) removes files')
     parser.addoption('--exe', action='store', default=default_exe,

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -3,8 +3,12 @@ import pytest, os, re, subprocess
 def pytest_addoption(parser):
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
-    plan = os.environ['bamboo_planKey']
-    default_exe = '%s/../%s-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, plan, cluster)
+    key = 'bamboo_planKey'
+    if key in os.environ:
+        plan = os.environ['bamboo_planKey']
+        default_exe = '%s/../%s-BDE/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, plan, cluster)
+    else:
+        default_exe = '%s/build/%s.llnl.gov/model_zoo/lbann' % (default_dirname, cluster)
     parser.addoption('--exe', action='store', default=default_exe,
                      help='--exe specifies the executable')
     parser.addoption('--dirname', action='store', default=default_dirname,


### PR DESCRIPTION
- Update Bamboo README to further specify how to manually run tests.
- Update default executable in `conftest.py` in `integration_tests` and `unit_tests` to only use Bamboo's plan key if the test is being run from Bamboo.