### PR TITLE
Skip autoencoder tests only

### DIFF
--- a/bamboo/integration_tests/model_tests/test_autoencoders.py
+++ b/bamboo/integration_tests/model_tests/test_autoencoders.py
@@ -2,10 +2,12 @@ import pytest
 from tools import *
 
 def test_model_conv_autoencoder_mnist(dirname, exe):
-    skeleton(dirname, exe, 'conv_autoencoder_mnist', should_log=True)
+    #skeleton(dirname, exe, 'conv_autoencoder_mnist', should_log=True)
+    pytest.skip('Test not finished yet')
 
 def test_model_conv_autoencoder_imagenet(dirname, exe, weekly):
-    if weekly:
-        skeleton(dirname, exe, 'conv_autoencoder_imagenet', should_log=True)
-    else:
-        pytest.skip('Not doing weekly testing')
+    #if weekly:
+    #    skeleton(dirname, exe, 'conv_autoencoder_imagenet', should_log=True)
+    #else:
+    #    pytest.skip('Not doing weekly testing')
+    pytest.skip('Test not finished yet')

--- a/bamboo/integration_tests/performance_tests/test_performance.py
+++ b/bamboo/integration_tests/performance_tests/test_performance.py
@@ -2,10 +2,10 @@ import pytest
 from test_tools import *
 
 def test_performance_lenet_mnist(dirname, exe):
-  pytest.skip('') #skeleton(dirname, exe, 'lenet_mnist', 'mnist', True)
+  skeleton(dirname, exe, 'lenet_mnist', 'mnist', True)
 
 def test_performance_alexnet(dirname, exe, weekly):
   if weekly:
-    pytest.skip('') #skeleton(dirname, exe, 'alexnet', 'imagenet', True)
+    skeleton(dirname, exe, 'alexnet', 'imagenet', True)
   else:
     pytest.skip('Not doing weekly testing')


### PR DESCRIPTION
#160 was merged before it was finished. This pull request removes skipping tests that should run and adds skipping to the autoencoder tests, which were unfinished.