### PR TITLE
Fix scale_data to accept input out of range correctly.

### DIFF
--- a/include/lbann/data_readers/data_reader_pilot2_molecular.hpp
+++ b/include/lbann/data_readers/data_reader_pilot2_molecular.hpp
@@ -66,6 +66,7 @@ class pilot2_molecular_reader : public generic_data_reader {
   /// 'BL12'] (20)]
   template <class T>
   T scale_data(int idx, T datum) {
+    idx = idx % 20;
     T scaled_datum = datum;
     if(idx >= 0 && idx <= 2) { /// x,y,z
       scaled_datum /= position_scale_factor;
@@ -102,7 +103,7 @@ class pilot2_molecular_reader : public generic_data_reader {
   /// Neighbor information (adjacency matrix).
   cnpy::NpyArray m_neighbors;
 
-  DataType position_scale_factor = 350.0;
+  DataType position_scale_factor = 320.0;
   DataType bond_len_scale_factor = 10.0;
 };
 

--- a/src/data_readers/data_reader_pilot2_molecular.cpp
+++ b/src/data_readers/data_reader_pilot2_molecular.cpp
@@ -107,7 +107,7 @@ bool pilot2_molecular_reader::fetch_datum(
   // Fetch the actual molecule.
   fetch_molecule(X, data_id, 0, mb_idx);
   // Fetch the neighbors - note that the offset is 2x the max
-  // neighborhood size to accomodate the top and bottom of the
+  // neighborhood size to accommodate the top and bottom of the
   // bilayer
   const int neighbor_frame_offset =
     frame * m_num_samples_per_frame * (2 * m_max_neighborhood);


### PR DESCRIPTION
Scale molecules after the first one correctly too.
`scale_data` gets called with i in range(0, 240), but only works for i in range(0, 20). Alternatively, could change `pilot2_molecular_reader::fetch_molecule` to call `scale_data` correctly