### PR TITLE
Tensor representation of weights

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -325,8 +325,8 @@ class base_convolution_layer : public learning_layer {
     this->m_weights[1]->setup(this->m_neuron_dims[0], 1,
                               El::STAR, El::STAR);
     El::Zeros(*this->m_bias_weights_gradient,
-              this->m_weights[1]->get_height(),
-              this->m_weights[1]->get_width());
+              this->m_weights[1]->get_matrix_height(),
+              this->m_weights[1]->get_matrix_width());
 
   }
 

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -209,8 +209,8 @@ class convolution_layer : public base_convolution_layer {
                               this->m_neuron_dims[0],
                               El::STAR, El::STAR);
     El::Zeros(*this->m_kernel_weights_gradient,
-              this->m_weights[0]->get_height(),
-              this->m_weights[0]->get_width());
+              this->m_weights[0]->get_matrix_height(),
+              this->m_weights[0]->get_matrix_width());
   }
 
  protected:

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -184,8 +184,8 @@ class deconvolution_layer : public base_convolution_layer {
                               this->m_prev_neuron_dims[0],
                               El::STAR, El::STAR);
     El::Zeros(*this->m_kernel_weights_gradient,
-              this->m_weights[0]->get_height(),
-              this->m_weights[0]->get_width());
+              this->m_weights[0]->get_matrix_height(),
+              this->m_weights[0]->get_matrix_width());
   }
 
  protected:

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -317,11 +317,11 @@ class fully_connected_layer : public learning_layer {
 
     // Setup weight gradients
     El::Zeros(*this->m_matrix_weights_gradient,
-              this->m_weights[0]->get_height(),
-              this->m_weights[0]->get_width());
+              this->m_weights[0]->get_matrix_height(),
+              this->m_weights[0]->get_matrix_width());
     El::Zeros(*this->m_bias_weights_gradient,
-              this->m_weights[1]->get_height(),
-              this->m_weights[1]->get_width());
+              this->m_weights[1]->get_matrix_height(),
+              this->m_weights[1]->get_matrix_width());
 
   }
 
@@ -532,12 +532,12 @@ fully_connected_layer<data_layout::DATA_PARALLEL>::fp_compute_weights<device::CU
     CHECK_CUBLAS(cublas::gemm(this->m_cudnn->get_cublas_handle(i),
                               CUBLAS_OP_N,
                               CUBLAS_OP_N,
-                              m_weights[0]->get_height(),
+                              m_weights[0]->get_matrix_height(),
                               m_mini_batch_size_per_gpu,
-                              m_weights[0]->get_width(),
+                              m_weights[0]->get_matrix_width(),
                               DataType(1),
                               matrix_weights_d[i],
-                              m_weights[0]->get_height(),
+                              m_weights[0]->get_matrix_height(),
                               this->m_prev_activations_dv[i],
                               this->m_prev_activations_v->Height(),
                               DataType(0),
@@ -604,12 +604,12 @@ fully_connected_layer<data_layout::DATA_PARALLEL>::bp_compute_weights<device::CU
     CHECK_CUBLAS(cublas::gemm(this->m_cudnn->get_cublas_handle(i),
                               CUBLAS_OP_T,
                               CUBLAS_OP_N,
-                              m_weights[0]->get_width(),
+                              m_weights[0]->get_matrix_width(),
                               m_mini_batch_size_per_gpu,
-                              m_weights[0]->get_height(),
+                              m_weights[0]->get_matrix_height(),
                               DataType(1),
                               matrix_weights_d[i],
-                              m_weights[0]->get_height(),
+                              m_weights[0]->get_matrix_height(),
                               this->m_prev_error_signal_dv[i],
                               this->m_prev_error_signal_v->Height(),
                               DataType(0),
@@ -625,8 +625,8 @@ fully_connected_layer<data_layout::DATA_PARALLEL>::bp_compute_weights<device::CU
       CHECK_CUBLAS(cublas::gemm(this->m_cudnn->get_cublas_handle(i),
                                 CUBLAS_OP_N,
                                 CUBLAS_OP_T,
-                                m_weights[0]->get_height(),
-                                m_weights[0]->get_width(),
+                                m_weights[0]->get_matrix_height(),
+                                m_weights[0]->get_matrix_width(),
                                 m_mini_batch_size_per_gpu,
                                 DataType(1),
                                 this->m_prev_error_signal_dv[i],

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// weights .hpp .cpp - Layer weights class
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_WEIGHTS_HPP
@@ -43,57 +41,79 @@ namespace lbann {
 // Forward declaration
 class optimizer;
 
-/** Layer weights.
- *  Similar to Tensorflow "variables."
+/** Neural network weights.
+ *  Weights are tensors that act as trainable parameters for a neural
+ *  network. The values can be initialized with a weights initializer
+ *  and are optimized with first-order methods.
+ *
+ *  Internally, the weight values are stored in a distributed
+ *  matrix. The matrix height dimensions are tensor dimensions that
+ *  correspond to the matrix height. Similarly, the matrix width
+ *  dimensions correspond to the matrix width.
+ *
+ *  Note that LBANN weights are similar to Tensorflow variables and
+ *  Caffe parameters.
  */
 class weights {
-
   friend class optimizer;
 
  public:
-
-  /** Constructor. */
   weights(lbann_comm* comm,
           cudnn::cudnn_manager* cudnn = nullptr);
-
-  /** Copy constructor. */
   weights(const weights& other);
-  /** Copy assignment operator. */
   weights& operator=(const weights& other);
-  /** Destructor. */
   virtual ~weights();
 
   /** Set weights name.
    *  Each set of weights in a model should have a unique name.
    */
-  void set_name(std::string name) { m_name = name; }
-
+  inline void set_name(const std::string name) { m_name = name; }
   /** Get weights name. */
-  std::string get_name() const { return m_name; }
+  inline std::string get_name() const { return m_name; }
 
-  /** Create a copy of the weights. */
+  /** Create a copy of the weights.
+   *  This function dynamically allocates memory for a weights
+   *  instance and instantiates a copy. The caller is responsible for
+   *  deallocating the instance.
+   */
   virtual weights* copy() const { return new weights(*this); }
 
-  /** Setup weights. */
+  /** Setup weights as a vector. */
+  virtual void setup(int size);
+  /** Setup weights as a tensor. */
+  virtual void setup(std::vector<int> tensor_dims);
+  /** Setup weights as a matrix. */
   virtual void setup(int height,
                      int width,
                      El::Distribution col_dist,
                      El::Distribution row_dist);
-  /** Setup GPU objects for weights. */
-  virtual void setup_gpu();
+  /** Setup weights as a matrix with tensor height and width. */
+  virtual void setup(std::vector<int> matrix_height_dims,
+                     std::vector<int> matrix_width_dims,
+                     El::Distribution col_dist,
+                     El::Distribution row_dist);
 
-  /** Get height of weights matrix. */
-  int get_height() const { return m_height; }
-  /** Get width of weights matrix. */
-  int get_width() const { return m_width; }
+  /** Get weight tensor dimensions. */
+  std::vector<int> get_dims() const;
+  /** Get number of weights. */
+  inline int get_size() const { return get_matrix_height() * get_matrix_width(); }
 
-  /** Get cuDNN manager. */
-  cudnn::cudnn_manager* get_cudnn_manager() { return m_cudnn; }
+  /** Get tensor dimensions corresponding to weights matrix height. */
+  inline const std::vector<int>& get_matrix_height_dims() const { return m_matrix_height_dims; }
+  /** Get tensor dimensions corresponding to weights matrix width. */
+  inline const std::vector<int>& get_matrix_width_dims() const { return m_matrix_width_dims; }
+  /** Get weights matrix height. */
+  int get_matrix_height() const;
+  /** Get weights matrix width. */
+  int get_matrix_width() const;
+
+  /** Get reference to cuDNN manager. */
+  inline cudnn::cudnn_manager* get_cudnn_manager() { return m_cudnn; }
 
   /** Get weights initializer. */
-  weights_initializer& get_initializer() { return *m_initializer; }
+  inline weights_initializer& get_initializer() { return *m_initializer; }
   /** Get weights initializer (const). */
-  const weights_initializer& get_initializer() const { return *m_initializer; }
+  inline const weights_initializer& get_initializer() const { return *m_initializer; }
   /** Set weights initializer.
    *  This takes ownership of the initializer and deallocates it
    *  during destruction.
@@ -114,8 +134,12 @@ class weights {
   const AbsDistMat& get_values();
   /** Set the weights matrix. */
   void set_values(const AbsDistMat& values);
+  /** Set a weight value. */
+  void set_value(DataType value, int index);
+  /** Set an entry in the weights tensor. */
+  void set_value(DataType value, std::vector<int> pos);
   /** Set an entry in the weights matrix. */
-  void set_value(int row, int col, DataType value);
+  void set_value(DataType value, int row, int col);
 
   /** Get a view into the weights matrix.
    *  If values_v has a different matrix distribution than the
@@ -133,39 +157,46 @@ class weights {
   
   /** Write weights to proto file */
   virtual void write_proto(lbann_data::Weights* proto) const;
- protected:
+ private:
 
   /** Weights name.
    *  Each set of weights in a model should have a unique name.
    */
   std::string m_name;
 
-  /** LBANN communicator. */
+  /** Reference to LBANN communicator. */
   lbann_comm* m_comm;
-  /** cuDNN manager. */
+  /** Reference to cuDNN manager. */
   cudnn::cudnn_manager* m_cudnn;
 
-  /** Height of weights matrix. */
-  int m_height;
-  /** Width of weights matrix. */
-  int m_width;
+  /** Tensor dimensions corresponding to matrix height. */
+  std::vector<int> m_matrix_height_dims;
+  /** Tensor dimensions corresponding to matrix width. */
+  std::vector<int> m_matrix_width_dims;
 
   /** Weights matrix. */
-  AbsDistMat* m_values;
+  AbsDistMat* m_values = nullptr;
 
   /** Weights initializer.
    *  Default is zero initialization.
    */
-  weights_initializer* m_initializer;
+  weights_initializer* m_initializer = nullptr;
   /** Weights optimizer.
    *  Default is nullptr, which corresponds to no optimizer.
    */
-  optimizer* m_optimizer;
+  optimizer* m_optimizer = nullptr;
 
 #ifdef LBANN_HAS_CUDNN
   /** GPU memory for weights matrix. */
   std::vector<DataType*> m_values_d;
 #endif // LBANN_HAS_CUDNN
+
+  /** Setup GPU objects for weights. */
+  virtual void setup_gpu();
+
+  /** Get string describing weight tensor dimensions. */
+  std::string get_dims_string(const std::vector<int>& matrix_height_dims,
+                              const std::vector<int>& matrix_width_dims);
 
 };
 

--- a/src/callbacks/callback_gradient_check.cpp
+++ b/src/callbacks/callback_gradient_check.cpp
@@ -117,15 +117,15 @@ void lbann_callback_gradient_check::on_test_begin(model *m) {
         // Compute objective function values
         // Note: matrix entry is reset after computing objective
         // function values
-        w->set_value(row, col, initial_weight + 2 * step_size);
+        w->set_value(initial_weight + 2 * step_size, row, col);
         const DataType f_2h = compute_objective_function(m);
-        w->set_value(row, col, initial_weight + step_size);
+        w->set_value(initial_weight + step_size, row, col);
         const DataType f_h = compute_objective_function(m);
-        w->set_value(row, col, initial_weight - step_size);
+        w->set_value(initial_weight - step_size, row, col);
         const DataType f_nh = compute_objective_function(m);
-        w->set_value(row, col, initial_weight - 2 * step_size);
+        w->set_value(initial_weight - 2 * step_size, row, col);
         const DataType f_n2h = compute_objective_function(m);
-        w->set_value(row, col, initial_weight);
+        w->set_value(initial_weight, row, col);
 
         // Compute relative error in gradient.
         // Note: only weight owner participates

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -90,7 +90,7 @@ EvalType l2_weight_regularization::evaluate() {
 #ifdef LBANN_HAS_CUDNN
       CHECK_CUDA(cudaSetDevice(cudnn->get_gpu(0)));
       EvalType norm = cublas::nrm2(cudnn->get_cublas_handle(0),
-                                   w->get_height() * w->get_width(),
+                                   w->get_size(),
                                    w->get_values_gpu()[0], 1);
       value += norm * norm;
 #endif // LBANN_HAS_CUDNN

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -61,8 +61,8 @@ adam::adam(const adam& other)
   if (m_moment2 != nullptr) { m_moment2 = m_moment2->Copy(); }
   #ifdef LBANN_HAS_CUDNN
   if (m_cudnn != nullptr && other.m_weights != nullptr) {
-    const int height = other.m_weights->get_height();
-    const int width = other.m_weights->get_width();
+    const int height = other.m_weights->get_matrix_height();
+    const int width = other.m_weights->get_matrix_width();
     m_moment1_d = m_cudnn->copy(other.m_moment1_d, height, width);
     m_moment2_d = m_cudnn->copy(other.m_moment2_d, height, width);
   }
@@ -100,8 +100,8 @@ adam& adam::operator=(const adam& other) {
   // Copy GPU data
   #ifdef LBANN_HAS_CUDNN
   if (m_cudnn != nullptr && other.m_weights != nullptr) {
-    const int height = other.m_weights->get_height();
-    const int width = other.m_weights->get_width();
+    const int height = other.m_weights->get_matrix_height();
+    const int width = other.m_weights->get_matrix_width();
     m_cudnn->deallocate_on_gpus(m_moment1_d);
     m_cudnn->deallocate_on_gpus(m_moment2_d);
     m_moment1_d = m_cudnn->copy(other.m_moment1_d, height, width);

--- a/src/optimizers/adam.cu
+++ b/src/optimizers/adam.cu
@@ -66,7 +66,7 @@ void adam::step_compute_gpu(std::vector<DataType*> values_d,
                                / (DataType(1) - m_current_beta1));
 
   // Get matrix dimensions
-  const int num_entries = m_weights->get_height() * m_weights->get_width();
+  const int num_entries = m_weights->get_size();
   if (num_entries == 0) return;
 
   // Launch CUDA kernels

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -48,8 +48,8 @@ sgd::sgd(const sgd& other)
   if (m_velocity != nullptr) { m_velocity = m_velocity->Copy(); }
   #ifdef LBANN_HAS_CUDNN
   if (m_cudnn != nullptr && other.m_weights != nullptr) {
-    const int height = other.m_weights->get_height();
-    const int width = other.m_weights->get_width();
+    const int height = other.m_weights->get_matrix_height();
+    const int width = other.m_weights->get_matrix_width();
     m_velocity_d = m_cudnn->copy(other.m_velocity_d, height, width);
   }
   #endif // LBANN_HAS_CUDNN
@@ -74,8 +74,8 @@ sgd& sgd::operator=(const sgd& other) {
   // Copy GPU data
   #ifdef LBANN_HAS_CUDNN
   if (m_cudnn != nullptr && other.m_weights != nullptr) {
-    const int height = other.m_weights->get_height();
-    const int width = other.m_weights->get_width();
+    const int height = other.m_weights->get_matrix_height();
+    const int width = other.m_weights->get_matrix_width();
     m_cudnn->deallocate_on_gpus(m_velocity_d);
     m_velocity_d = m_cudnn->copy(other.m_velocity_d, height, width);
   }

--- a/src/optimizers/sgd.cu
+++ b/src/optimizers/sgd.cu
@@ -69,7 +69,7 @@ void sgd::step_compute_gpu(std::vector<DataType*> values_d,
                            std::vector<DataType*> gradient_d) {
 
   // Get matrix dimensions
-  const int num_entries = m_weights->get_height() * m_weights->get_width();
+  const int num_entries = m_weights->get_size();
   if (num_entries == 0) return;
 
   // SGD without momentum


### PR DESCRIPTION
Weights can now be represented as tensors. Since they are stored internally as distributed matrices, some tensor dimensions correspond to the matrix height and the rest to the matrix width. This should make it easier to export trained weights into a format readable by Tensorflow (#151). I am not sure if it will affect weight checkpointing.

Currently, none of the layers initialize weights using this new feature because I want to minimize merge conflicts with #171. It will just require simple modifications to the `setup_data` function in the base convolution, convolution, deconvolution, and batch normalization layers.