### PR TITLE
Consistent objective function average

### DIFF
--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -114,8 +114,14 @@ class metric {
   /** Setup metric. */
   virtual void setup(model& m);
 
-  /** Evaluate the metric value. */
-  EvalType evaluate(execution_mode mode);
+  /** Evaluate the metric value.
+   *  This function takes the model's current mini-batch size. If
+   *  multiple models are being trained, the current mini-batch size
+   *  may be different from the effective mini-batch size. The result
+   *  is stored in history.
+   */
+  EvalType evaluate(execution_mode mode,
+                    int mini_batch_size);
 
   /** Clear all statistics. */
   void reset_statistics() { m_statistics.clear(); }

--- a/include/lbann/objective_functions/objective_function.hpp
+++ b/include/lbann/objective_functions/objective_function.hpp
@@ -60,9 +60,13 @@ class objective_function {
   void setup(model& m);
 
   /** Evaluate the objective function.
-   *  The result is stored in history.
+   *  This function takes the model's current mini-batch size. If
+   *  multiple models are being trained, the current mini-batch size
+   *  may be different from the effective mini-batch size. The result
+   *  is stored in history.
    */
-  EvalType evaluate(execution_mode mode);
+  EvalType evaluate(execution_mode mode,
+                    int mini_batch_size);
 
   /** Compute the objective function gradient.
    *  The gradient is with respect to the objective function inputs
@@ -80,8 +84,8 @@ class objective_function {
   void reset_statistics(execution_mode mode) { m_statistics.erase(mode); }
 
   /** Get mean objective function value.
-   *  The mean is over the mini-batches, even if the mini-batch sizes
-   *  are not identical.
+   *  This is a weighted average such that each mini-batch sample makes
+   *  an equal contribution.
    */
   EvalType get_mean_value(execution_mode mode) const;
   /** Get number of samples for statistics. */

--- a/src/callbacks/callback_gradient_check.cpp
+++ b/src/callbacks/callback_gradient_check.cpp
@@ -182,7 +182,8 @@ DataType lbann_callback_gradient_check::compute_objective_function(model *m) {
   for (size_t l = 1; l < layers.size(); l++) {
     layers[l]->forward_prop();
   }
-  return obj_fn->evaluate(m->get_execution_mode());
+  return obj_fn->evaluate(m->get_execution_mode(),
+                          m->get_current_mini_batch_size());
 }
 
 }  // namespace lbann

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -137,39 +137,46 @@ void lbann_callback_print::report_results(model *m) {
 
   if (comm->am_model_master()) {
     const int num_models = comm->get_num_models();
-
+    
     // Report objective function value
     const EvalType obj_fn = m->get_objective_function()->get_mean_value(mode);
+    const int obj_fn_samples = m->get_objective_function()->get_statistics_num_samples(mode);
     if (comm->am_world_master()) {
       std::vector<EvalType> obj_fn_list(comm->get_num_models());
+      std::vector<int> num_samples_list(comm->get_num_models());
       comm->intermodel_gather(obj_fn, obj_fn_list);
+      comm->intermodel_gather(obj_fn_samples, num_samples_list);
       for (int i = 0; i < num_models; ++i) {
         std::cout << "Model " << i << " " << mode_string << " "
                   << "objective function : " << obj_fn_list[i]
                   << std::endl;
       }
       if (num_models > 1) {
-        const EvalType avg_obj_fn = (std::accumulate(obj_fn_list.begin(),
-                                                     obj_fn_list.end(),
-                                                     EvalType(0))
-                                     / num_models);
+        const EvalType avg_obj_fn = (std::inner_product(num_samples_list.begin(),
+                                                        num_samples_list.end(),
+                                                        obj_fn_list.begin(),
+                                                        EvalType(0))
+                                     / std::accumulate(num_samples_list.begin(),
+                                                       num_samples_list.end(),
+                                                       0));
         std::cout << "World average " << mode_string << " "
                   << "objective function : " << avg_obj_fn
                   << std::endl;
       }
     } else {
       comm->intermodel_gather(obj_fn, comm->get_world_master());
+      comm->intermodel_gather(obj_fn_samples, comm->get_world_master());
     }
 
     // Report score for each metric
     for (const auto& met : m->get_metrics()) {
       const EvalType score = met->get_mean_value(mode);
-      const int num_samples = met->get_statistics_num_samples(mode);
+      const int score_samples = met->get_statistics_num_samples(mode);
       if (comm->am_world_master()) {
         std::vector<EvalType> score_list(comm->get_num_models());
         std::vector<int> num_samples_list(comm->get_num_models());
         comm->intermodel_gather(score, score_list);
-        comm->intermodel_gather(num_samples, num_samples_list);
+        comm->intermodel_gather(score_samples, num_samples_list);
         for (int i = 0; i < num_models; ++i) {
           std::cout << "Model " << i << " " << mode_string << " "
                     << met->name() << " : "
@@ -177,13 +184,13 @@ void lbann_callback_print::report_results(model *m) {
                     << std::endl;
         }
         if (num_models > 1) {
-          const EvalType avg_score = (std::inner_product(score_list.begin(),
-                                                         score_list.end(),
-                                                         num_samples_list.begin(),
+          const EvalType avg_score = (std::inner_product(num_samples_list.begin(),
+                                                         num_samples_list.end(),
+                                                         score_list.begin(),
                                                          EvalType(0))
                                       / std::accumulate(num_samples_list.begin(),
                                                         num_samples_list.end(),
-                                                        EvalType(0)));
+                                                        0));
           std::cout << "World " << mode_string << " "
                     << met->name() << " : "
                     << avg_score << met->get_unit()
@@ -191,7 +198,7 @@ void lbann_callback_print::report_results(model *m) {
         }
       } else {
         comm->intermodel_gather(score, comm->get_intermodel_master());
-        comm->intermodel_gather(num_samples, comm->get_intermodel_master());
+        comm->intermodel_gather(score_samples, comm->get_intermodel_master());
       }
     }
 

--- a/src/metrics/metric.cpp
+++ b/src/metrics/metric.cpp
@@ -101,7 +101,8 @@ void metric::setup(model& m) {
 
 }
 
-EvalType metric::evaluate(execution_mode mode) {
+EvalType metric::evaluate(execution_mode mode,
+                          int mini_batch_size) {
 
   // Check if target layer pointer has been setup
   if (m_target_layer == nullptr) {
@@ -112,7 +113,6 @@ EvalType metric::evaluate(execution_mode mode) {
   }
 
   // Evaluate objective function
-  const int mini_batch_size = m_target_layer->get_prediction().Width();
   const EvalType total_value = evaluate_compute(m_target_layer->get_prediction(),
                                                 m_target_layer->get_ground_truth());
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -551,9 +551,9 @@ void model::reset_epoch_statistics(execution_mode mode) {
 bool model::evaluate_mini_batch(execution_mode mode) {
   do_batch_begin_cbs(mode);
   forward_prop(mode);
-  m_objective_function->evaluate(mode);
+  m_objective_function->evaluate(mode, get_current_mini_batch_size());
   for (const auto& m : m_metrics) {
-    m->evaluate(mode);
+    m->evaluate(mode, get_current_mini_batch_size());
   }
   const bool finished = update_layers();
   switch(m_execution_mode) {
@@ -575,9 +575,11 @@ bool model::train_mini_batch() {
 
   // Forward prop step
   forward_prop(execution_mode::training);
-  m_objective_function->evaluate(execution_mode::training);
+  m_objective_function->evaluate(execution_mode::training,
+                                 get_current_mini_batch_size());
   for (const auto& m : m_metrics) {
-    m->evaluate(execution_mode::training);
+    m->evaluate(execution_mode::training,
+                get_current_mini_batch_size());
   }
 
   // Backward prop step

--- a/src/objective_functions/objective_function.cpp
+++ b/src/objective_functions/objective_function.cpp
@@ -72,13 +72,15 @@ void objective_function::setup(model& m) {
   }
 }
 
-EvalType objective_function::evaluate(execution_mode mode) {
+EvalType objective_function::evaluate(execution_mode mode,
+                                      int mini_batch_size) {
   const auto start_time = get_time();
   EvalType value = EvalType(0);
   for (const auto& term : m_terms) {
     value += term->evaluate();
   }
-  m_statistics[mode].add_value(value, 1);
+  m_statistics[mode].add_value(mini_batch_size * value,
+                               mini_batch_size);
   m_evaluation_time += get_time() - start_time;
   return value;
 }


### PR DESCRIPTION
When computing the average objective function across multiple models, this PR weights the average such that each mini-batch sample contributes equally. With a `double` datatype and sequential initialization, we now get identical objective function values in the single model and multi-model cases (as long as the effective mini-batch is the same).

I'm not sure how this affects our integration tests. I've heard that the current reporting format can be a bit annoying since it changes depending on the single model or multi-model case. This could be a good time to develop a nicer format.