### PR TITLE
Multiple bug fixes for the distributed I/O buffer related to Issue #182

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -143,7 +143,7 @@ static void __attribute__((used)) _display_matrix(ElMat *m, const char *name) {
 #define log_msg(...) {\
   char str[256];\
   sprintf(str, __VA_ARGS__);\
-  std::cout << "[" << comm->get_model_rank() << "." << comm->get_rank_in_model() << "][" << __FUNCTION__ << "][Line " << __LINE__ << "]" << str << std::endl; \
+  std::cout << "[" << m_comm->get_model_rank() << "." << m_comm->get_rank_in_model() << "][" << __FUNCTION__ << "][Line " << __LINE__ << "]" << str << std::endl; \
   }
 #define log_simple_msg(...) {\
   char str[256];\

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -154,9 +154,6 @@ class generic_input_layer : public io_layer {
     }
 
     int max_mb_size = this->m_model->get_max_mini_batch_size();
-    #ifdef LBANN_DEBUG
-    std::cout << "Setting up data for the input layer " << io_layer::m_data_set_spans_models << std::endl;
-    #endif
     if(io_layer::m_data_set_spans_models) {
       calculate_num_iterations_per_epoch_training_spans_models(max_mb_size);
     } else {
@@ -209,11 +206,27 @@ class generic_input_layer : public io_layer {
         update_num_samples_processed(num_samples_in_batch);
       }
 
+      int expected_num_samples_in_batch = this->m_model->get_current_mini_batch_size();
+
       /// Let each rank know this size of the current mini-batch
       /// Note that this field has to be updated before distributing the data
-      this->m_model->set_current_mini_batch_size(Layer::m_comm->model_broadcast(((distributed_io_buffer*) io_buffer)->current_root_rank(mode), num_samples_in_batch));
+      num_samples_in_batch = Layer::m_comm->model_broadcast(((distributed_io_buffer*) io_buffer)->current_root_rank(mode), num_samples_in_batch);
+      this->m_model->set_current_mini_batch_size(num_samples_in_batch
+                                                 + get_current_world_master_mini_batch_adjustment(m_comm->get_model_rank()));
 
       io_buffer->distribute_from_local_matrix(*this->m_activations, get_data_reader(), mode);
+
+      if(num_samples_in_batch !=
+         (expected_num_samples_in_batch - get_current_world_master_mini_batch_adjustment(m_comm->get_model_rank()))) {
+        std::stringstream err;
+        err << __FILE__ << " " << __LINE__ << " :: "
+            << "I/O layers number of samples processed ("<< num_samples_in_batch
+            <<") does not match the mini-batch size ("
+            << (expected_num_samples_in_batch -
+                get_current_world_master_mini_batch_adjustment(m_comm->get_model_rank()))
+            << ")";
+        throw lbann_exception(err.str());
+      }
     }else {
       std::stringstream err;
       err << __FILE__ << " " << __LINE__ << " :: "
@@ -260,7 +273,7 @@ class generic_input_layer : public io_layer {
 
   virtual int get_num_parallel_readers(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_num_parallel_readers();
+    return (data_reader != nullptr) ? data_reader->get_num_parallel_readers() : 0;
   }
 
   virtual int get_num_parallel_readers() const {
@@ -269,7 +282,7 @@ class generic_input_layer : public io_layer {
 
   virtual int get_num_iterations_per_epoch(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_num_iterations_per_epoch();
+    return (data_reader != nullptr) ? data_reader->get_num_iterations_per_epoch() : 0;
   }
 
   virtual int get_num_iterations_per_epoch() const {
@@ -278,7 +291,7 @@ class generic_input_layer : public io_layer {
 
   virtual int get_current_step_in_epoch(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_current_step_in_epoch();
+    return (data_reader != nullptr) ? data_reader->get_current_step_in_epoch() : 0;
   }
 
   virtual int get_current_step_in_epoch() const {
@@ -287,12 +300,12 @@ class generic_input_layer : public io_layer {
 
   virtual int get_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_mini_batch_size() : 0;
   }
 
   virtual int get_last_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_last_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_last_mini_batch_size() : 0;
   }
 
   virtual int get_last_mini_batch_size() const {
@@ -301,7 +314,7 @@ class generic_input_layer : public io_layer {
 
   virtual int get_current_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_current_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_current_mini_batch_size() : 0;
   }
 
   virtual int get_current_mini_batch_size() const {
@@ -310,21 +323,39 @@ class generic_input_layer : public io_layer {
 
   virtual int get_global_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_global_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_global_mini_batch_size() : 0;
   }
 
   virtual int get_global_last_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_global_last_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_global_last_mini_batch_size() : 0;
   }
 
   virtual int get_current_global_mini_batch_size(execution_mode mode) const {
     const generic_data_reader *data_reader = get_data_reader(mode);
-    return data_reader->get_current_global_mini_batch_size();
+    return (data_reader != nullptr) ? data_reader->get_current_global_mini_batch_size() : 0;
   }
 
   virtual int get_current_global_mini_batch_size() const {
     return get_current_global_mini_batch_size(this->m_model->get_execution_mode());
+  }
+
+  virtual int get_world_master_mini_batch_adjustment(execution_mode mode) const {
+    const generic_data_reader *data_reader = get_data_reader(mode);
+    return (data_reader != nullptr) ? data_reader->get_world_master_mini_batch_adjustment() : 0;
+  }
+
+  virtual int get_world_master_mini_batch_adjustment() const {
+    return get_world_master_mini_batch_adjustment(this->m_model->get_execution_mode());
+  }
+
+  virtual int get_current_world_master_mini_batch_adjustment(execution_mode mode, int model_rank) const {
+    const generic_data_reader *data_reader = get_data_reader(mode);
+    return (data_reader != nullptr) ? data_reader->get_current_world_master_mini_batch_adjustment(model_rank) : 0;
+  }
+
+  virtual int get_current_world_master_mini_batch_adjustment(int model_rank) const {
+    return get_current_world_master_mini_batch_adjustment(this->m_model->get_execution_mode(), model_rank);
   }
 
   /** Calculate how many iterations are required for training, testing,

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -71,10 +71,13 @@ void lbann_callback_print::on_epoch_begin(model *m) {
               << " global last MB ="
               << " ["
               << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::training)
+              << std::setw(2) << " "
               << "/"
               << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::validation)
+              << std::setw(2) << " "
               << "/"
               << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::testing)
+              << std::setw(2) << " "
               << "]"
               << std::endl;
     std::cout << std::setfill(' ') << std::setw(23)
@@ -89,10 +92,13 @@ void lbann_callback_print::on_epoch_begin(model *m) {
               << "  local last MB ="
               << " ["
               << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::training)
+              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::training)
               << "/"
               << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::validation)
+              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::validation)
               << "/"
               << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::testing)
+              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::testing)
               << "]"
               << std::endl;
     std::cout << "--------------------------------------------------------------------------------"

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -52,6 +52,7 @@ void generic_data_reader::setup() {
   m_num_iterations_per_epoch = 0;
   m_global_mini_batch_size = 0;
   m_global_last_mini_batch_size = 0;
+  m_world_master_mini_batch_adjustment = 0;
 
   /// The amount of space needed will vary based on input layer type,
   /// but the batch size is the maximum space necessary
@@ -290,7 +291,7 @@ int generic_data_reader::get_loaded_mini_batch_size() const {
 
 int generic_data_reader::get_current_mini_batch_size() const {
   if (m_current_mini_batch_idx == (m_num_iterations_per_epoch-1)) {
-    return m_last_mini_batch_size;
+    return m_last_mini_batch_size + m_world_master_mini_batch_adjustment;
   } else {
     return m_mini_batch_size;
   }
@@ -301,6 +302,18 @@ int generic_data_reader::get_current_global_mini_batch_size() const {
     return m_global_last_mini_batch_size;
   } else {
     return m_global_mini_batch_size;
+  }
+}
+
+/// Returns the current adjustment to the mini-batch size based on if
+/// the world master (model 0) has any extra samples
+/// Note that any rank in model 0 does not need to add in this offset
+/// since the model will already be aware of the extra samples
+int generic_data_reader::get_current_world_master_mini_batch_adjustment(int model_rank) const {
+  if (model_rank != 0 && m_current_mini_batch_idx == (m_num_iterations_per_epoch-1)) {
+    return m_world_master_mini_batch_adjustment;
+  } else {
+    return 0;
   }
 }
 


### PR DESCRIPTION
*Fixed a bug there the mini-batch size would be different for multiple
models on the last round when model 0 had an extra sample.

*Fixed a bug where the distributed I/O buffer always assumed that rank
0 of model 0 had the extra sample on a partial round.

*Fixed a bug where the combination of the base and model offset were
incorrect for multiple model when there was so little data that a
ranks only mini-batch was a partial mini-batch (and thus the lower
rank models did not complete a full mini-batch for that round either).

*Fixed a bug where a null pointer was dereferenced in the callback for
printing if there was no valid testing data.

*Changed the reporting for the number of mini-batches and size of the
last mini-batch to include the world remainder data if is owned by a
rank other than the world master.