### PR TITLE
fix regression mode setup

### DIFF
--- a/include/lbann/layers/io/input/input_layer.hpp
+++ b/include/lbann/layers/io/input/input_layer.hpp
@@ -42,8 +42,9 @@ class input_layer : public generic_input_layer {
  public:
 
   /// @todo make the map and vector references
-  input_layer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers, bool data_set_spans_models = true)
-    : generic_input_layer(comm, num_parallel_readers, data_readers, data_set_spans_models) {
+  input_layer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode,
+    generic_data_reader *> data_readers, bool data_set_spans_models = true, bool for_regression = false)
+    : generic_input_layer(comm, num_parallel_readers, data_readers, data_set_spans_models, for_regression) {
     validate_data_layout();
     initialize_io_buffer(comm, std::min(num_parallel_readers, Layer::m_comm->get_procs_per_model()), data_readers);
     io_buffer->fetch_data_fn = new fetch_data_functor(true, false);

--- a/include/lbann/layers/io/target/generic_target_layer.hpp
+++ b/include/lbann/layers/io/target/generic_target_layer.hpp
@@ -114,12 +114,9 @@ class generic_target_layer : public io_layer {
   void setup_dims() override {
     io_layer::setup_dims();
     if (this->is_for_regression()) {
-      this->m_neuron_dims = get_data_dims();
-      this->m_num_neuron_dims = this->m_neuron_dims.size();
-      this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                            this->m_neuron_dims.end(),
-                                            1,
-                                            std::multiplies<int>());
+      this->m_num_neurons = get_linearized_response_size();
+      this->m_num_neuron_dims = 1;
+      this->m_neuron_dims.assign(1, this->m_num_neurons);
     } else {
       this->m_num_neurons = get_linearized_label_size();
       this->m_num_neuron_dims = 1;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -770,6 +770,7 @@ message Dropout {
 message Input {
   bool data_set_per_model = 1;  //default: false
   string io_buffer = 2;
+  bool for_regression = 3; //default: false
 }
 
 //////////////////////

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -136,6 +136,11 @@ void setup_pointers(
 
       // Set input layer
       auto *input = dynamic_cast<generic_input_layer*>(model_layers[name]);
+      if(master and (target->is_for_regression() != input->is_for_regression())) {
+        err << __FILE__ << " " << __LINE__ << " :: "
+            << "target layer and its paired input layer are not consistent regarding regression/classification";
+        throw lbann_exception(err.str());
+      }
       target->set_paired_input_layer(input);
 
     }
@@ -366,13 +371,15 @@ void add_layers(
             comm,
             m.num_parallel_readers(),
             data_readers,
-            !ell.data_set_per_model());
+            !ell.data_set_per_model(),
+            ell.for_regression());
         } else {
           d = new input_layer<distributed_io_buffer, data_layout::DATA_PARALLEL>(
             comm,
             m.num_parallel_readers(),
             data_readers,
-            !ell.data_set_per_model());
+            !ell.data_set_per_model(),
+            ell.for_regression());
         }
       }else if(io_buffer == "partitioned") {
         if (layout == data_layout::MODEL_PARALLEL and master) {
@@ -384,7 +391,8 @@ void add_layers(
             comm,
             m.num_parallel_readers(),
             data_readers,
-            !ell.data_set_per_model());
+            !ell.data_set_per_model(),
+            ell.for_regression());
         }
       }
     }


### PR DESCRIPTION
To address the bug #198 

- Have target layer uses the linearized response size for setting up  the dependent variable matrix in the regression mode.
- Have the input layer report the correct linearized response size and allow it to enable regression by taking the flag in the constructors.
- added the prototext support to specify regression for input layer and  check the consistency between a target layer and its paired input layer
