### PR TITLE
Layers setup weights with tensor dimensions

### DIFF
--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -186,10 +186,8 @@ class convolution_layer : public base_convolution_layer {
 
   void setup_data() override {
     base_convolution_layer::setup_data();
-    this->m_weights[0]->setup(m_kernel_size / this->m_neuron_dims[0],
-                              this->m_neuron_dims[0],
-                              El::STAR, El::STAR);
-    this->m_weights[0]->set_proto_dims(this->m_kernel_dims);
+    this->m_weights[0]->setup(m_kernel_dims);
+    this->m_weights[0]->set_proto_dims(m_kernel_dims);
     El::Zeros(this->m_kernel_gradient,
               this->m_weights[0]->get_matrix_height(),
               this->m_weights[0]->get_matrix_width());

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -187,7 +187,6 @@ class convolution_layer : public base_convolution_layer {
   void setup_data() override {
     base_convolution_layer::setup_data();
     this->m_weights[0]->setup(m_kernel_dims);
-    this->m_weights[0]->set_proto_dims(m_kernel_dims);
     El::Zeros(this->m_kernel_gradient,
               this->m_weights[0]->get_matrix_height(),
               this->m_weights[0]->get_matrix_width());

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -161,7 +161,6 @@ class deconvolution_layer : public base_convolution_layer {
   void setup_data() override {
     base_convolution_layer::setup_data();
     this->m_weights[0]->setup(m_kernel_dims);
-    this->m_weights[0]->set_proto_dims(m_kernel_dims);
     El::Zeros(this->m_kernel_gradient,
               this->m_weights[0]->get_matrix_height(),
               this->m_weights[0]->get_matrix_width());

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -160,9 +160,8 @@ class deconvolution_layer : public base_convolution_layer {
 
   void setup_data() override {
     base_convolution_layer::setup_data();
-    this->m_weights[0]->setup(m_kernel_size / this->m_prev_neuron_dims[0],
-                              this->m_prev_neuron_dims[0],
-                              El::STAR, El::STAR);
+    this->m_weights[0]->setup(m_kernel_dims);
+    this->m_weights[0]->set_proto_dims(m_kernel_dims);
     El::Zeros(this->m_kernel_gradient,
               this->m_weights[0]->get_matrix_height(),
               this->m_weights[0]->get_matrix_width());

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -264,10 +264,10 @@ class batch_normalization : public regularizer_layer {
     }
 
     // Setup weights
-    this->m_weights[0]->setup(this->m_neuron_dims[0], 1, El::STAR, El::STAR);
-    this->m_weights[1]->setup(this->m_neuron_dims[0], 1, El::STAR, El::STAR);
-    this->m_weights[2]->setup(this->m_neuron_dims[0], 1, El::STAR, El::STAR);
-    this->m_weights[3]->setup(this->m_neuron_dims[0], 1, El::STAR, El::STAR);
+    this->m_weights[0]->setup(this->m_neuron_dims[0]);
+    this->m_weights[1]->setup(this->m_neuron_dims[0]);
+    this->m_weights[2]->setup(this->m_neuron_dims[0]);
+    this->m_weights[3]->setup(this->m_neuron_dims[0]);
 
     // Initialize matrices
     El::Zeros(*m_mean, this->m_neuron_dims[0], 1);

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -143,9 +143,6 @@ class weights {
    */
   int get_matrix_width() const;
 
-  /** proto kernel dimensions*/
-  void set_proto_dims(std::vector<int> dims) { m_proto_dims = dims; }
-
   /** Get reference to cuDNN manager. */
   inline cudnn::cudnn_manager* get_cudnn_manager() { return m_cudnn; }
 
@@ -217,9 +214,6 @@ class weights {
    *  See get_matrix_width_dims function.
    */
   std::vector<int> m_matrix_width_dims;
-
-  /** proto  kernel dimensions*/
-  std::vector<int> m_proto_dims;
 
   /** Weights matrix. */
   AbsDistMat* m_values = nullptr;

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -466,23 +466,35 @@ bool weights::save_to_checkpoint_shared(lbann::persist& p)
 }
 
 void weights::write_proto(lbann_data::Weights* proto) const {
-  proto->Clear();
-  if(!m_proto_dims.empty()){
-    for(const auto& d : m_proto_dims) proto->mutable_shape()->add_dim(d);
-  }else {
-    for (const auto& d : get_dims())  proto->mutable_shape()->add_dim(d);
-  }
 
+  // Set proto properties
+  proto->Clear();
   proto->set_name(m_name);
+  for (const auto& d : get_dims()) {
+    proto->mutable_shape()->add_dim(d);
+  }
   proto->set_height(get_matrix_height());
   proto->set_width(get_matrix_width());
-  //Write weight values; mimic elemental Write/Print
-  //@todo openMP
-  for(auto i = 0; i < m_values->Height(); ++i) {
-    for(auto j = 0; j < m_values->Width(); ++j) {
-      //assume datatype is float
-      //@todo generalize
-      proto->add_data(m_values->Get(i,j));
+
+  // Write weight values to prototext on world master process
+  CircMat values = *m_values; /// @todo What if weights are on GPU?
+  values.SetRoot(0); /// @todo What if world master is not process 0?
+  if (m_comm->am_world_master()) {
+    const auto& local_values = values.LockedMatrix();
+    const El::Int height = local_values.Height();
+    const El::Int width = local_values.Width();
+    /// @todo OpenMP parallelization
+    /** @todo Our matrices are column-major while Numpy expects
+     *  row-major matrices. This row-wise iteration is fine for
+     *  matrices and column vectors, but it can mess up the order of
+     *  the weights if a high-dimensional tensor is represented as a
+     *  matrix. This is what we need for quantization on convolution
+     *  kernel weights.
+     */
+    for (El::Int i = 0; i < height; ++i) {
+      for (El::Int j = 0; j < width; ++j) {
+        proto->add_data(local_values(i,j));
+      }
     }
   }
 


### PR DESCRIPTION
Layers now use the functionality implemented in #173.

@samadejacobs: This implementation removes some shims used to export weights dimensions to prototext.

@ndryden: Convolution kernels are now stored as column vectors by default. Quantization is no longer filter-wise, but is rather across all filters. If we implement an interface to manually configure weights, expert users can reenable filter-wise quantization.