### PR TITLE
To remove swap_role()

### DIFF
--- a/include/lbann/data_readers/compound_data_reader.hpp
+++ b/include/lbann/data_readers/compound_data_reader.hpp
@@ -92,12 +92,14 @@ class generic_compound_data_reader : public generic_data_reader {
     }
   }
 
+/*
   void swap_role(std::string role) override {
     generic_data_reader::swap_role(role);
     for (auto&& reader : m_data_readers) {
       reader->swap_role(role);
     }
   }
+*/
 
   void set_master(bool m) override {
     generic_data_reader::set_master(m);

--- a/include/lbann/data_readers/compound_data_reader.hpp
+++ b/include/lbann/data_readers/compound_data_reader.hpp
@@ -92,15 +92,6 @@ class generic_compound_data_reader : public generic_data_reader {
     }
   }
 
-/*
-  void swap_role(std::string role) override {
-    generic_data_reader::swap_role(role);
-    for (auto&& reader : m_data_readers) {
-      reader->swap_role(role);
-    }
-  }
-*/
-
   void set_master(bool m) override {
     generic_data_reader::set_master(m);
     for (auto&& reader : m_data_readers) {

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -189,24 +189,11 @@ class generic_data_reader : public lbann_image_preprocessor {
   void set_absolute_sample_count(size_t s);
 
   /**
-   * Return the absolute number of data samples that will be used for training
-   * or testing.
-   */
-  size_t get_absolute_sample_count() const;
-
-  /**
    * Set the percentage of the data set to use for training and validation or
    * testing.
    * @param s The percentage used, in the range [0, 1].
    */
   void set_use_percent(double s);
-
-  /**
-   * Returns the percent of the dataset to be used for training or testing.
-   * If training, this is the total for training and validation. Throws if
-   * set_use_percent was not called.
-   */
-  double get_use_percent() const;
 
   /**
    * Sets the percentage of the dataset to be used for validation.
@@ -215,33 +202,11 @@ class generic_data_reader : public lbann_image_preprocessor {
   virtual void set_validation_percent(double s);
 
   /**
-   * Return the percent of the dataset to be used for validation.
-   */
-  double get_validation_percent() const;
-
-  /**
    * Set an idenifier for the dataset.
    * The role should be one of "train", "test", or "validate".
    */
   virtual void set_role(std::string role) {
     m_role = role;
-  }
-
-  /**
-   * Switch the role of the data set, and swap the used percentage
-   * with the heldout percentage.
-   * Typically this changes from "train" to "validate".
-   */
-  virtual void swap_role(std::string role) {
-    m_role = role;
-    if(m_validation_percent == -1) {
-      throw lbann_exception(
-        std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-        " :: generic_data_reader: data reader is swapping roles but has an invalid (-1) holdout percentage");
-    }
-    double old_use_percent = m_use_percent;
-    m_use_percent = m_validation_percent;
-    m_validation_percent = old_use_percent;
   }
 
   /**
@@ -556,6 +521,26 @@ class generic_data_reader : public lbann_image_preprocessor {
   const std::vector<std::vector<int> > & get_minibatch_indices() const {
     return m_my_minibatch_indices;
   }
+
+ protected:
+
+  /**
+   * Return the absolute number of data samples that will be used for training
+   * or testing.
+   */
+  size_t get_absolute_sample_count() const;
+
+  /**
+   * Returns the percent of the dataset to be used for training or testing.
+   * If training, this is the total for training and validation. Throws if
+   * set_use_percent was not called.
+   */
+  double get_use_percent() const;
+
+  /**
+   * Return the percent of the dataset to be used for validation.
+   */
+  double get_validation_percent() const;
 
  protected:
 

--- a/src/io/data_buffers/distributed_io_buffer.cpp
+++ b/src/io/data_buffers/distributed_io_buffer.cpp
@@ -159,7 +159,7 @@ int lbann::distributed_io_buffer::compute_max_num_parallel_readers(long data_set
 void lbann::distributed_io_buffer::calculate_num_iterations_per_epoch(int num_models, int model_rank, int max_mini_batch_size, generic_data_reader *data_reader) {
   if(data_reader == nullptr) { return; }
   // If the data reader does not have any data bail out (e.g. unused validation reader)
-  if(data_reader->get_use_percent() == double(0.0)) { return; }
+  if(data_reader->get_num_data() == 0) { return; }
 
   if(max_mini_batch_size > data_reader->get_num_data()) {
     max_mini_batch_size = data_reader->get_num_data();

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -104,7 +104,7 @@ int lbann::partitioned_io_buffer::compute_max_num_parallel_readers(long data_set
 void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_spanning_models(int max_mini_batch_size, generic_data_reader *data_reader) {
   if(data_reader == nullptr) { return; }
   // If the data reader does not have any data bail out (e.g. unused validation reader)
-  if(data_reader->get_use_percent() == double(0.0)) { return; }
+  if(data_reader->get_num_data() == 0) { return; }
 
   /// Make sure that the mini-batch size is not larger than the data set
   if(max_mini_batch_size > data_reader->get_num_data()) {
@@ -198,7 +198,7 @@ void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_spanning_m
 void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_single_model(int max_mini_batch_size, generic_data_reader *data_reader) {
   if(data_reader == nullptr) { return; }
   // If the data reader does not have any data bail out (e.g. unused validation reader)
-  if(data_reader->get_use_percent() == double(0.0)) { return; }
+  if(data_reader->get_num_data() == 0) { return; }
 
   if(max_mini_batch_size > data_reader->get_num_data()) {
     max_mini_batch_size = data_reader->get_num_data();

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -2038,7 +2038,7 @@ void init_data_readers(bool master, const lbann_data::LbannPB& p, std::map<execu
         (*(ascii_reader *)reader_validation) = (*(ascii_reader *)reader);
       }
 
-      reader_validation->swap_role("validate");
+      reader_validation->set_role("validate");
       reader_validation->use_unused_index_set();
 
       if (master) {


### PR DESCRIPTION
To address the issue #207 
- change the only use of `swap_role()` to `set_role()`
- remove the `swap_role()` method
- change the `public` member methods for determining the number of samples to use to `protected` ones:
  `get_use_percent()`, `get_validation_percent()`, and `get_absolute_sample_count()`
However this depends on PR #208, which removes the external use of `get_use_percent()` under src/io/data_buffers. Those changes also show up here as I started new topic branch off from it.