### PR TITLE
Preliminary Aluminum integration

### DIFF
--- a/cmake/modules/FindALUMINUM.cmake
+++ b/cmake/modules/FindALUMINUM.cmake
@@ -8,7 +8,7 @@
 # Find the header
 find_path(ALUMINUM_INCLUDE_DIRS allreduce.hpp
   HINTS ${ALUMINUM_DIR} $ENV{ALUMINUM_DIR}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES include src
   NO_DEFAULT_PATH
   DOC "Directory with ALUMINUM header.")
 find_path(ALUMINUM_INCLUDE_DIRS allreduce.hpp)

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -412,7 +412,7 @@ class lbann_comm {
 #ifdef LBANN_HAS_ALUMINUM
   /** Non-blocking matrix allreduce. */
   void nb_allreduce(AbsDistMat& m, const El::mpi::Comm c,
-                    allreduces::AllreduceRequest& req,
+                    allreduces::MPIBackend::req_type& req,
                     El::mpi::Op op = El::mpi::SUM);
 #endif
 
@@ -424,12 +424,12 @@ class lbann_comm {
 
 #ifdef LBANN_HAS_ALUMINUM
   /** Wait for a non-blocking request to complete. */
-  void wait(allreduces::AllreduceRequest& req) {
-    allreduces::Wait(req);
+  void wait(allreduces::MPIBackend::req_type& req) {
+    allreduces::Wait<allreduces::MPIBackend>(req);
   }
   /** Test whether a non-blocking request has completed; true if it has. */
-  bool test(allreduces::AllreduceRequest& req) {
-    return allreduces::Test(req);
+  bool test(allreduces::MPIBackend::req_type& req) {
+    return allreduces::Test<allreduces::MPIBackend>(req);
   }
 #endif
 

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -422,6 +422,17 @@ class lbann_comm {
     El::mpi::Wait(req);
   }
 
+#ifdef LBANN_HAS_ALUMINUM
+  /** Wait for a non-blocking request to complete. */
+  void wait(allreduces::AllreduceRequest& req) {
+    allreduces::Wait(req);
+  }
+  /** Test whether a non-blocking request has completed; true if it has. */
+  bool test(allreduces::AllreduceRequest& req) {
+    return allreduces::Test(req);
+  }
+#endif
+
   /** Barrier among the inter-model processes. */
   void intermodel_barrier();
   /** Barrier among processes in this model. */

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -32,6 +32,9 @@
 #include <vector>
 #include <unordered_map>
 #include "base.hpp"
+#ifdef LBANN_HAS_ALUMINUM
+#include <allreduce.hpp>
+#endif
 
 namespace lbann {
 
@@ -375,7 +378,7 @@ class lbann_comm {
   template <typename T>
   T allreduce(T snd, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
     bytes_sent += sizeof(T);
-    El::mpi::AllReduce(&snd, 1, op, c);
+    allreduce(&snd, 1, c, op);
     bytes_received += sizeof(T) * (El::mpi::Size(c) - 1);
     return snd;
   }
@@ -383,30 +386,35 @@ class lbann_comm {
   template <typename T>
   void allreduce(T *snd, int count, T *rcv, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
     bytes_sent += count * sizeof(T);
+#ifdef LBANN_HAS_ALUMINUM
+    allreduces::Allreduce<allreduces::MPIBackend>(
+      snd, rcv, count, mpi_op_to_al_op(op), *get_al_comm(c));
+#else
     El::mpi::AllReduce(snd, rcv, count, op, c);
+#endif
     bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
   }
   /** In-place scalar-array allreduce. */
   template <typename T>
   void allreduce(T *data, int count, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
     bytes_sent += count * sizeof(T);
+#ifdef LBANN_HAS_ALUMINUM
+    allreduces::Allreduce<allreduces::MPIBackend>(
+      data, count, mpi_op_to_al_op(op), *get_al_comm(c));
+#else
     El::mpi::AllReduce(data, count, op, c);
+#endif
     bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
   }
   /** Matrix allreduce. */
-  void allreduce(AbsDistMat& m, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
-    bytes_sent += sizeof(DataType) * m.LocalHeight() * m.LocalWidth();
-    El::AllReduce(m, c, op);
-    bytes_received += sizeof(DataType) * m.LocalHeight() * m.LocalWidth() * (El::mpi::Size(c) - 1);
-  }
+  void allreduce(AbsDistMat& m, const El::mpi::Comm c,
+    El::mpi::Op op = El::mpi::SUM);
+#ifdef LBANN_HAS_ALUMINUM
   /** Non-blocking matrix allreduce. */
   void nb_allreduce(AbsDistMat& m, const El::mpi::Comm c,
-                    El::mpi::Request<DataType>& req, El::mpi::Op op = El::mpi::SUM) {
-    bytes_sent += sizeof(DataType) * m.LocalHeight() * m.LocalWidth();
-    MPI_Iallreduce(MPI_IN_PLACE, m.Buffer(), m.LocalHeight()*m.LocalWidth(),
-                   El::mpi::TypeMap<DataType>(), op.op, c.comm, &req.backend);
-    bytes_received += sizeof(DataType) * m.LocalHeight() * m.LocalWidth() * (El::mpi::Size(c) - 1);
-  }
+                    allreduces::AllreduceRequest& req,
+                    El::mpi::Op op = El::mpi::SUM);
+#endif
 
   /** Wait for a non-blocking request to complete. */
   template <typename T>
@@ -849,6 +857,24 @@ class lbann_comm {
   /** Current default allreduce algorithm. */
   allreduce_algorithm default_allreduce_algo =
     allreduce_algorithm::DYNAMIC;
+
+#ifdef LBANN_HAS_ALUMINUM
+  /**
+   * Used to convert between Elemental Comm objects and an Aluminum
+   * communicator.
+   */
+  std::unordered_map<MPI_Comm, allreduces::MPICommunicator*> al_comms;
+
+  /**
+   * Get the Aluminum communicator associated with Elemental communicator c.
+   * This will create a new Al communicator if needed.
+   * @todo This currently only supports the Aluminum MPI backend.
+   */
+  allreduces::MPICommunicator* get_al_comm(El::mpi::Comm c);
+
+  /** Convert an MPI_Op to an Aluminum reduction operator. */
+  allreduces::ReductionOperator mpi_op_to_al_op(El::mpi::Op op);
+#endif
 
   // Various statistics counters.
   size_t num_model_barriers;

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -186,7 +186,7 @@ class optimizer {
 
 #ifdef LBANN_NBALLREDUCE_GRADIENT
   /** The request for non-blocking allreduces. */
-  El::mpi::Request<DataType> m_allreduce_req;
+  allreduces::AllreduceRequest m_allreduce_req;
   /** Whether a non-blocking allreduce was started. */
   bool m_allreduce_started = false;
 #endif  // LBANN_NBALLREDUCE_GRADIENT

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -186,7 +186,7 @@ class optimizer {
 
 #ifdef LBANN_NBALLREDUCE_GRADIENT
   /** The request for non-blocking allreduces. */
-  allreduces::AllreduceRequest m_allreduce_req;
+  allreduces::MPIBackend::req_type m_allreduce_req;
   /** Whether a non-blocking allreduce was started. */
   bool m_allreduce_started = false;
 #endif  // LBANN_NBALLREDUCE_GRADIENT

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -160,7 +160,7 @@ void lbann_comm::allreduce(AbsDistMat& m, const El::mpi::Comm c,
 
 #ifdef LBANN_HAS_ALUMINUM
 void lbann_comm::nb_allreduce(AbsDistMat& m, const El::mpi::Comm c,
-                              allreduces::AllreduceRequest& req,
+                              allreduces::MPIBackend::req_type& req,
                               El::mpi::Op op) {
   bytes_sent += sizeof(DataType) * m.LocalHeight() * m.LocalWidth();
   if (m.LocalHeight() != m.LDim()) {


### PR DESCRIPTION
This adds preliminary support for Aluminum's MPIBackend allreduces to `lbann_comm` when LBANN is built with Aluminum support. The other backends (NCCL and MPICUDA) are not currently supported. We need to think about the right way to handle communication for data that may reside in different memories.

Some other changes/issues:
* `nb_allreduce` now requires Aluminum.
* `LBANN_NBALLREDUCE_GRADIENT` (to enable non-blocking allreduces in the optimizers for CPU-based codepaths) needs Aluminum.
* ~~Finalization is a problem. Aluminum finalizes MPI, and then so does Elemental/Hydrogen, which is an error.~~ Aluminum deals with this now.