### PR TITLE
Parallelizing CPU-GPU memory transfers.

### DIFF
--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -43,12 +43,6 @@ model {
   callback { print {} }
   callback { timer {} }
   callback {
-    summary {
-      dir: "."
-      mat_interval: 25
-    }
-  }
-  callback {
     drop_fixed_learning_rate {
       drop_epoch: 20
       drop_epoch: 40
@@ -56,33 +50,6 @@ model {
       amt: 0.1
     }
   }
-  # callback {
-  #   save_images {
-  #     image_dir: "
-  #     extension: "jpg"
-  #   }
-  # }
-  # callback {
-  #   dump_mb_indices {
-  #     basename: "debug_alexnet/"
-  #   }
-  # }
-  # callback {
-  #   debug {
-  #     phase: "train"
-  #   }
-  # }
-  # callback {
-  #   debug_io {
-  #     phase: "train"
-  #     lvl: 1
-  #   }
-  # }
-  # callback {
-  #   gradient_check {
-  #     verbose: false
-  #   }
-  # }
 
   ###################################################
   # start of layers

--- a/model_zoo/models/resnet50/model_resnet50.prototext
+++ b/model_zoo/models/resnet50/model_resnet50.prototext
@@ -34,29 +34,14 @@ model {
   ###################################################
   # Callbacks
   ###################################################
-  callback {
-    print {
-      interval: 1
-    }
-  }
-  callback {
-    timer {
-    }
-  }
-  callback {
-    summary {
-      dir: "."
-      batch_interval: 1
-      mat_interval: 25
-    }
-  }
+  callback { print {} }
+  callback { timer {} }
   callback {
     imcomm {
       intermodel_comm_method: "normal"
       all_optimizers: true
     }
   }
-  # callback { gradient_check {} }
 
   ###################################################
   # Layers

--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -626,6 +626,7 @@ void cudnn_manager::cudnn_manager::scatter_to_gpus(std::vector<DataType *>& gpu_
     const int width = cpu_data.Width();
 
     // Perform memory transfer on each GPU
+    #pragma omp parallel for
     for(int i=0; i<m_num_gpus; ++i) {
         const int first_pos = std::min(i * width_per_gpu, width);
         const int last_pos = std::min((i+1) * width_per_gpu, width);
@@ -654,6 +655,7 @@ void cudnn_manager::cudnn_manager::gather_from_gpus(Mat& cpu_data,
     }
 
     const int width = cpu_data.Width();
+    #pragma omp parallel for
     for(int i=0; i<m_num_gpus; ++i) {
         const int first_pos = std::min(i * width_per_gpu, width);
         const int last_pos = std::min((i+1) * width_per_gpu, width);
@@ -670,6 +672,7 @@ void cudnn_manager::cudnn_manager::broadcast_to_gpus(std::vector<DataType *>& gp
     if (gpu_data.empty()) {
         throw lbann_exception("cudnn_wrapper: attempted to broadcast to GPUs before allocating GPU memory");
     }
+    #pragma omp parallel for
     for(int i=0; i<m_num_gpus; ++i) {
         copy_to_gpu(i, gpu_data[i], cpu_data, gpu_data_leading_dim);
     }


### PR DESCRIPTION
This yields a ~20% performance boost with AlexNet.

@ndryden This PR also removes the summarizer callback from the AlexNet and Resnet-50 prototexts. The summarizer requires accessing matrix entries serially, so it shouldn't be enabled by default.