### PR TITLE
Checkpoint bug fix

### DIFF
--- a/include/lbann/callbacks/callback_checkpoint.hpp
+++ b/include/lbann/callbacks/callback_checkpoint.hpp
@@ -54,6 +54,7 @@ class lbann_callback_checkpoint : public lbann_callback {
   void setup(model *m) override;
   void on_epoch_end(model *m) override;
   void on_batch_end(model *m) override;
+  void on_validation_end(model *m) override;
 
   inline void set_checkpoint_dir(std::string dir){
     m_checkpoint_dir= dir;
@@ -87,6 +88,7 @@ class lbann_callback_checkpoint : public lbann_callback {
   bool m_checkpoint_per_rank;
   EvalType m_checkpoint_last;
   bool m_epoch_end;
+  bool m_val_end;
 };
 
 }  // namespace lbann

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -531,10 +531,10 @@ class generic_data_reader : public lbann_image_preprocessor {
   void use_unused_index_set();
 
   /** \brief Given directory to store checkpoint files, write state to file and add to number of bytes written */
-  bool saveToCheckpointShared(persist& p, const char *name);
+  bool save_to_checkpoint_shared(persist& p, const char *name);
 
   /** \brief Given directory to store checkpoint files, read state from file and add to number of bytes read */
-  bool loadFromCheckpointShared(persist& p, const char *name);
+  bool load_from_checkpoint_shared(persist& p, const char *name);
 
   struct packing_header {
     uint64_t mini_batch_size;
@@ -634,13 +634,6 @@ class generic_data_reader : public lbann_image_preprocessor {
 
     snprintf(fieldname, sizeof(fieldname), "%s_model_rank", name);
     p.write_uint64(persist_value, fieldname, (uint64_t) m_model_rank);
-    //std::ofstream rngSeq("RNGSeqtest");
-    //std::ofstream rng("RNGtest");
-    //rngSeq << get_data_seq_generator();
-    //rng << get_generator();
-    std::cout << m_shuffled_indices[0] << "\n";
-    std::cout <<  m_reset_mini_batch_index << "\n";
-    std::cout << m_current_pos << "\n";
     return true;
   }
 
@@ -680,7 +673,7 @@ class generic_data_reader : public lbann_image_preprocessor {
      //read list of indices
     snprintf(fieldname, sizeof(fieldname), "%s_data_indices", name);
     p.read_int32_contig(persist_value, fieldname, &m_shuffled_indices[0], (uint64_t) size);
-    // BEGIN TEST STUFF
+    // BEGIN TEST 
     snprintf(fieldname, sizeof(fieldname), "%s_stride_to_last_mini_batch", name);
     p.read_uint64(persist_value, fieldname, &val);
     m_stride_to_last_mini_batch = (int) val;
@@ -743,14 +736,7 @@ class generic_data_reader : public lbann_image_preprocessor {
     snprintf(fieldname, sizeof(fieldname), "%s_model_rank", name);
     p.read_uint64(persist_value, fieldname, &val);
     m_model_rank = (int) val;
-    //std::ofstream rngload("RNGtest");
-    //std::ofstream rngSeqload("RNGSeqtest");
-    //std::mt19937 rng;
-    //std::mt19937 rngSeq;
-    //rngSeqload << rngSeq;
-    //rngload << rng;
-    //get_data_seq_generator() = rngSeq; 
-    //get_generator() = rng;
+    
     if(header != nullptr){
       header->mini_batch_size = m_mini_batch_size;
       header->current_pos = m_current_pos;
@@ -800,9 +786,6 @@ class generic_data_reader : public lbann_image_preprocessor {
     m_global_last_mini_batch_size = (int) header.global_last_mini_batch_size;
     m_num_parallel_readers = (int) header.num_parallel_readers;
     m_model_rank = (int) header.model_rank;
-    std::cout << m_shuffled_indices[0] << "\n";
-    std::cout <<  m_reset_mini_batch_index << "\n";
-    std::cout << m_current_pos << "\n";
   }
   
   /// returns the data store, which may be a nullptr

--- a/include/lbann/io/persist.hpp
+++ b/include/lbann/io/persist.hpp
@@ -37,6 +37,7 @@ namespace lbann {
 enum class persist_type {
   train, // data should be saved in file with train data
   model, // data should be saved in file with model data
+  validate, 
 };
 
 class persist {
@@ -45,9 +46,10 @@ class persist {
   uint64_t m_bytes;
   int m_model_fd;
   int m_train_fd;
+  int m_validate_fd;
   char m_model_filename[1024];
   char m_train_filename[1024];
-
+  char m_validate_filename[1024];
  public:
   char m_checkpoint_dir[1024];
 
@@ -58,7 +60,7 @@ class persist {
   int get_rank() const {
     return m_rank;
   }
-  void open_checkpoint(const char *dir, bool per_rank);
+  void open_checkpoint(const char *dir, bool per_rank, bool val_end);
   void close_checkpoint();
 
   void open_restart(const char *dir, bool per_rank);

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -253,7 +253,7 @@ class softmax_layer : public activation_layer {
         local_gradient_wrt_input(row, col) += dx;
       }
     }
-
+  
   }
 
   void fp_compute_cudnn() {

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -622,11 +622,11 @@ class generic_input_layer : public io_layer {
     if(!val_end){
       it = this->m_data_readers.find(execution_mode::training);
       if ((it != this->m_data_readers.end()) && it->second) {
-        (it->second)->saveToCheckpointShared(p, "data_reader_training");
+        (it->second)->save_to_checkpoint_shared(p, "data_reader_training");
       }
       it = this->m_data_readers.find(execution_mode::testing);
       if ((it != this->m_data_readers.end()) && it->second) {
-        (it->second)->saveToCheckpointShared(p, "data_reader_testing");
+        (it->second)->save_to_checkpoint_shared(p, "data_reader_testing");
       }
       if (p.get_rank() == 0) {
         p.write_uint64(persist_type::train, "reader_train_processed",
@@ -649,28 +649,9 @@ class generic_input_layer : public io_layer {
       
       it = this->m_data_readers.find(execution_mode::validation);
       if ((it != this->m_data_readers.end()) && it->second) {
-        (it->second)->saveToCheckpointShared(p, "data_reader_validation");
+        (it->second)->save_to_checkpoint_shared(p, "data_reader_validation");
       }    
     }
-    // save our own state
-    // rank 0 writes the file
-    /*if (p.get_rank() == 0) {
-      p.write_uint64(persist_type::train, "reader_train_processed",
-                     (uint64_t) m_training_dataset.get_num_samples_processed());
-      p.write_uint64(persist_type::train, "reader_train_total",
-                     (uint64_t) m_training_dataset.get_total_samples());
-
-      p.write_uint64(persist_type::train, "reader_test_processed",
-                     (uint64_t) m_testing_dataset.get_num_samples_processed());
-      p.write_uint64(persist_type::train, "reader_test_total",
-                     (uint64_t) m_testing_dataset.get_total_samples());
-
-      p.write_uint64(persist_type::train, "reader_validate_processed",
-                     (uint64_t) m_validation_dataset.get_num_samples_processed());
-      p.write_uint64(persist_type::train, "reader_validate_total",
-                     (uint64_t) m_validation_dataset.get_total_samples());
-    }*/
-    //io_layer::save_to_checkpoint_shared(p);
     return true;  
   }
 
@@ -690,17 +671,11 @@ class generic_input_layer : public io_layer {
 
     it = this->m_data_readers.find(execution_mode::training);
     if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->loadFromCheckpointShared(p, "data_reader_training");
+      (it->second)->load_from_checkpoint_shared(p, "data_reader_training");
     }
-
-    //it = this->m_data_readers.find(execution_mode::validation);
-    //if ((it != this->m_data_readers.end()) && it->second) {
-    //  (it->second)->loadFromCheckpointShared(p, "data_reader_validation");
-    //}
-   
     it = this->m_data_readers.find(execution_mode::testing);
     if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->loadFromCheckpointShared(p, "data_reader_testing");
+      (it->second)->load_from_checkpoint_shared(p, "data_reader_testing");
     }
 
     // save our own state
@@ -717,13 +692,8 @@ class generic_input_layer : public io_layer {
 
     it = this->m_data_readers.find(execution_mode::validation);
     if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->loadFromCheckpointShared(p, "data_reader_validation");
+      (it->second)->load_from_checkpoint_shared(p, "data_reader_validation");
     }
-
-    //it = this->m_data_readers.find(execution_mode::testing);
-    //if ((it != this->m_data_readers.end()) && it->second) {
-    //  (it->second)->loadFromCheckpointShared(p, "data_reader_testing");
-    //}
 
     // TODO: assumes homogeneous hardware
     // broadcast data from rank 0

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -616,28 +616,45 @@ class generic_input_layer : public io_layer {
   //************************************************************************
 
   // save state of IO to a checkpoint
-  bool save_to_checkpoint_shared(persist& p) const override {
+  bool save_to_checkpoint_shared(persist& p, bool val_end) const override {
     // save state of data readers from input layer
     data_reader_map_t::const_iterator it;
+    if(!val_end){
+      it = this->m_data_readers.find(execution_mode::training);
+      if ((it != this->m_data_readers.end()) && it->second) {
+        (it->second)->saveToCheckpointShared(p, "data_reader_training");
+      }
+      it = this->m_data_readers.find(execution_mode::testing);
+      if ((it != this->m_data_readers.end()) && it->second) {
+        (it->second)->saveToCheckpointShared(p, "data_reader_testing");
+      }
+      if (p.get_rank() == 0) {
+        p.write_uint64(persist_type::train, "reader_train_processed",
+                       (uint64_t) m_training_dataset.get_num_samples_processed());
+        p.write_uint64(persist_type::train, "reader_train_total",
+                       (uint64_t) m_training_dataset.get_total_samples());
 
-    it = this->m_data_readers.find(execution_mode::training);
-    if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->saveToCheckpointShared(p, "data_reader_training");
+        p.write_uint64(persist_type::train, "reader_test_processed",
+                       (uint64_t) m_testing_dataset.get_num_samples_processed());
+        p.write_uint64(persist_type::train, "reader_test_total",
+                     (uint64_t) m_testing_dataset.get_total_samples());
+
+      }
     }
-
-    it = this->m_data_readers.find(execution_mode::validation);
-    if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->saveToCheckpointShared(p, "data_reader_validation");
+    else if(val_end){
+      p.write_uint64(persist_type::validate, "reader_validate_processed",
+                     (uint64_t) m_validation_dataset.get_num_samples_processed());
+      p.write_uint64(persist_type::validate, "reader_validate_total",
+                     (uint64_t) m_validation_dataset.get_total_samples());
+      
+      it = this->m_data_readers.find(execution_mode::validation);
+      if ((it != this->m_data_readers.end()) && it->second) {
+        (it->second)->saveToCheckpointShared(p, "data_reader_validation");
+      }    
     }
-
-    it = this->m_data_readers.find(execution_mode::testing);
-    if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->saveToCheckpointShared(p, "data_reader_testing");
-    }
-
     // save our own state
     // rank 0 writes the file
-    if (p.get_rank() == 0) {
+    /*if (p.get_rank() == 0) {
       p.write_uint64(persist_type::train, "reader_train_processed",
                      (uint64_t) m_training_dataset.get_num_samples_processed());
       p.write_uint64(persist_type::train, "reader_train_total",
@@ -652,10 +669,9 @@ class generic_input_layer : public io_layer {
                      (uint64_t) m_validation_dataset.get_num_samples_processed());
       p.write_uint64(persist_type::train, "reader_validate_total",
                      (uint64_t) m_validation_dataset.get_total_samples());
-    }
+    }*/
     //io_layer::save_to_checkpoint_shared(p);
-
-    return true;
+    return true;  
   }
 
   struct dataset_header {
@@ -677,11 +693,11 @@ class generic_input_layer : public io_layer {
       (it->second)->loadFromCheckpointShared(p, "data_reader_training");
     }
 
-    it = this->m_data_readers.find(execution_mode::validation);
-    if ((it != this->m_data_readers.end()) && it->second) {
-      (it->second)->loadFromCheckpointShared(p, "data_reader_validation");
-    }
-
+    //it = this->m_data_readers.find(execution_mode::validation);
+    //if ((it != this->m_data_readers.end()) && it->second) {
+    //  (it->second)->loadFromCheckpointShared(p, "data_reader_validation");
+    //}
+   
     it = this->m_data_readers.find(execution_mode::testing);
     if ((it != this->m_data_readers.end()) && it->second) {
       (it->second)->loadFromCheckpointShared(p, "data_reader_testing");
@@ -695,9 +711,19 @@ class generic_input_layer : public io_layer {
       p.read_uint64(persist_type::train, "reader_train_total",        &header.train_total);
       p.read_uint64(persist_type::train, "reader_test_processed",     &header.test_proc);
       p.read_uint64(persist_type::train, "reader_test_total",         &header.test_total);
-      p.read_uint64(persist_type::train, "reader_validate_processed", &header.validate_proc);
-      p.read_uint64(persist_type::train, "reader_validate_total",     &header.validate_total);
+      p.read_uint64(persist_type::validate, "reader_validate_processed", &header.validate_proc);
+      p.read_uint64(persist_type::validate, "reader_validate_total",     &header.validate_total);
     }
+
+    it = this->m_data_readers.find(execution_mode::validation);
+    if ((it != this->m_data_readers.end()) && it->second) {
+      (it->second)->loadFromCheckpointShared(p, "data_reader_validation");
+    }
+
+    //it = this->m_data_readers.find(execution_mode::testing);
+    //if ((it != this->m_data_readers.end()) && it->second) {
+    //  (it->second)->loadFromCheckpointShared(p, "data_reader_testing");
+    //}
 
     // TODO: assumes homogeneous hardware
     // broadcast data from rank 0
@@ -710,7 +736,6 @@ class generic_input_layer : public io_layer {
     m_testing_dataset.total_samples()            = (long) header.test_total;
     m_validation_dataset.num_samples_processed() = (long) header.validate_proc;
     m_validation_dataset.total_samples()         = (long) header.validate_total;
-
     return true;
   }
 

--- a/include/lbann/layers/io/target/generic_target_layer.hpp
+++ b/include/lbann/layers/io/target/generic_target_layer.hpp
@@ -332,14 +332,14 @@ class generic_target_layer : public io_layer {
     return Layer::loadFromCheckpoint(fd, filename, bytes);
   }
 
-  bool save_to_checkpoint_shared(persist& p) const override {
+  bool save_to_checkpoint_shared(persist& p, bool val_end) const override {
     // rank 0 writes softmax cost to file
-    if (p.get_rank() == 0) {
+    //if (p.get_rank() == 0) {
       // p.write_double(persist_type::train, "aggregate cost", (double) aggregate_cost);
       // p.write_uint64(persist_type::train, "num backprop steps", (uint64_t) num_backprop_steps);
-    }
+    //}
 
-    return Layer::save_to_checkpoint_shared(p);
+    return Layer::save_to_checkpoint_shared(p,val_end);
   }
 
   bool load_from_checkpoint_shared(persist& p) override {

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -210,7 +210,7 @@ class Layer {
   virtual bool saveToCheckpoint(int fd, const char *filename, size_t *bytes) const;
   virtual bool loadFromCheckpoint(int fd, const char *filename, size_t *bytes);
 
-  virtual bool save_to_checkpoint_shared(persist& p) const;
+  virtual bool save_to_checkpoint_shared(persist& p,bool val_end) const;
   virtual bool load_from_checkpoint_shared(persist& p);
   
   /** Write layer to proto file */

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -206,7 +206,7 @@ class model {
   void collect_indices(execution_mode mode);
 
   /** Checkpoint model to given file descriptor, return number of bytes written */
-  virtual bool save_to_checkpoint_shared(persist& p);
+  virtual bool save_to_checkpoint_shared(persist& p, bool val_end);
   /** Restore model by reading checkpoint from given file descriptor, return number of bytes read */
   virtual bool load_from_checkpoint_shared(persist& p);
 

--- a/include/lbann/models/sequential.hpp
+++ b/include/lbann/models/sequential.hpp
@@ -64,7 +64,7 @@ class sequential_model : public model {
   /** @todo This is old and likely broken */
   bool load_from_checkpoint(int fd, const char *filename, size_t *bytes);
 
-  bool save_to_checkpoint_shared(persist& p) override;
+  bool save_to_checkpoint_shared(persist& p,bool val_end) override;
   bool load_from_checkpoint_shared(persist& p) override;
 
   /** Write model to proto file */

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
+#include "lbann/io/persist.hpp"
 #include <random>
 
 namespace lbann {
@@ -55,7 +56,6 @@ fast_rng_gen& get_fast_generator();
  * @note If compiling with OpenMP, this is stored in a threadprivate variable.
  */
 rng_gen& get_data_seq_generator();
-
 /**
  * Return random integers uniformly distributed in [0, max).
  * @param g C++ uniform random bit generator.
@@ -155,6 +155,9 @@ void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p = 0.
  */
 void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n,
                           DataType center = 0.0f, DataType radius = 1.0f);
+
+bool save_rng_to_checkpoint_shared(persist& p);
+bool load_rng_from_checkpoint_shared(persist& p);
 
 template<typename DistType,typename DType=DataType>
 class rng {

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -141,12 +141,7 @@ static bool read_latest(const char *dir, const char *name, int *epochLast, int *
   }
   return true;
 }
-struct lbann_checkpoint {
-  int epoch; // current epoch number
-  int step;  // current offset into list of training example indices array
-  float learning_rate; // current learning rate
-};
-//bool model::checkpointShared(TrainingParams& trainParams)
+
 bool lbann_callback_checkpoint::checkpointShared(model *m) {
   // if the checkpoint directory is not defined, bail
   if (m_checkpoint_dir.length() == 0) {
@@ -177,12 +172,13 @@ bool lbann_callback_checkpoint::checkpointShared(model *m) {
   persist p;
   p.open_checkpoint(epochdir,m_checkpoint_per_rank, m_val_end);
   // call virtual function to checkpoint model state
-  if(m_epoch_end){
-    m->save_to_checkpoint_shared(p,m_val_end);
-  }
-  if(m_val_end){
-    m->save_to_checkpoint_shared(p,m_val_end);
-  }
+  //if(m_epoch_end){
+
+  m->save_to_checkpoint_shared(p,m_val_end);
+  //}
+  //if(m_val_end){
+  //  m->save_to_checkpoint_shared(p,m_val_end);
+  //}
   // close our checkpoint
   p.close_checkpoint();
   uint64_t bytes_count = p.get_bytes();

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -175,10 +175,6 @@ bool lbann_callback_checkpoint::checkpointShared(model *m) {
   //if(m_epoch_end){
 
   m->save_to_checkpoint_shared(p,m_val_end);
-  //}
-  //if(m_val_end){
-  //  m->save_to_checkpoint_shared(p,m_val_end);
-  //}
   // close our checkpoint
   p.close_checkpoint();
   uint64_t bytes_count = p.get_bytes();

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -32,7 +32,6 @@
 #include "lbann/data_readers/data_reader_imagenet.hpp"
 #include "lbann/data_readers/data_reader_merge_samples.hpp"
 #include <omp.h>
-//#include <iostream>
 namespace lbann {
 
 void generic_data_reader::shuffle_indices() {

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -384,10 +384,10 @@ void generic_data_reader::use_unused_index_set() {
 }
 
 /** \brief Given directory to store checkpoint files, write state to file and add to number of bytes written */
-bool generic_data_reader::saveToCheckpointShared(persist& p, const char *name) const {
+bool generic_data_reader::saveToCheckpointShared(persist& p, const char *name) {
   // rank 0 writes the training state file
   if (p.get_rank() == 0) {
-    char fieldname[1024];
+    /*char fieldname[1024];
     lbann::persist_type persist_value;
     //printf("%s\n",name);
     //  data_reader_validation
@@ -439,7 +439,8 @@ bool generic_data_reader::saveToCheckpointShared(persist& p, const char *name) c
     snprintf(fieldname, sizeof(fieldname), "%s_reset_mini_batch_index", name);
     p.write_uint64(persist_value, fieldname, (uint64_t) m_reset_mini_batch_index);
         
-    std::cout << "training indices: " << m_shuffled_indices[0] << "\n";
+    std::cout << "training indices: " << m_shuffled_indices[0] << "\n";*/
+    pack_scalars(p,name);
   }
   return true;
 }
@@ -447,8 +448,13 @@ bool generic_data_reader::saveToCheckpointShared(persist& p, const char *name) c
 /** \brief Given directory to store checkpoint files, read state from file and add to number of bytes read */
 bool lbann::generic_data_reader::loadFromCheckpointShared(persist& p, const char *name) {
   // rank 0 reads the training state file
+  struct packing_header header;
   if (p.get_rank() == 0) {
-    char fieldname[1024];
+    unpack_scalars(p,&header,name);
+  }
+  MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
+  unpack_header(header);  
+    /*char fieldname[1024];
     // Closest to non checkpoint run only loads m_current_pos
 
     lbann::persist_type persist_value;
@@ -477,10 +483,10 @@ bool lbann::generic_data_reader::loadFromCheckpointShared(persist& p, const char
 
      //read list of indices
     snprintf(fieldname, sizeof(fieldname), "%s_data_indices", name);
-    p.read_int32_contig(persist_value, fieldname, &m_shuffled_indices[0], (uint64_t) size);
+    p.read_int32_contig(persist_value, fieldname, &m_shuffled_indices[0], (uint64_t) size);*/
 
     /* Everything below is things i have tried loading to see if it was needed. No impact as far as I could tell*/
-    snprintf(fieldname, sizeof(fieldname), "%s_stride_to_last_mini_batch", name);
+    /*snprintf(fieldname, sizeof(fieldname), "%s_stride_to_last_mini_batch", name);
     p.read_uint64(persist_value, fieldname, &val);
     m_stride_to_last_mini_batch = (int) val;
 
@@ -547,7 +553,7 @@ bool lbann::generic_data_reader::loadFromCheckpointShared(persist& p, const char
 
   /// broadcast index array
   MPI_Bcast(&m_shuffled_indices[0], size, MPI_INT, 0, MPI_COMM_WORLD);
-  //set_initial_position();
+  //set_initial_position();*/
   return true;
 }
 

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -384,69 +384,16 @@ void generic_data_reader::use_unused_index_set() {
 }
 
 /** \brief Given directory to store checkpoint files, write state to file and add to number of bytes written */
-bool generic_data_reader::saveToCheckpointShared(persist& p, const char *name) {
+bool generic_data_reader::save_to_checkpoint_shared(persist& p, const char *name) {
   // rank 0 writes the training state file
   if (p.get_rank() == 0) {
-    /*char fieldname[1024];
-    lbann::persist_type persist_value;
-    //printf("%s\n",name);
-    //  data_reader_validation
-    std::string s_name(name);
-    if(s_name.compare("data_reader_validation") == 0){
-      persist_value = persist_type::validate;
-    } else {
-      persist_value= persist_type::train;
-    } 
-    // Closest to non checkpoint run only saves m_current_pos
-    snprintf(fieldname, sizeof(fieldname), "%s_current_mini_batch_idx", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_current_mini_batch_idx);
-    int size = m_shuffled_indices.size();
-
-    // record size of ShuffleIndices
-    snprintf(fieldname, sizeof(fieldname), "%s_data_size", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) size);
-
-    // TODO: each model may have a different position, need to gather and write these
-    // record current position within training data
-    snprintf(fieldname, sizeof(fieldname), "%s_data_position", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_current_pos);
-
-    // write list of indices
-    snprintf(fieldname, sizeof(fieldname), "%s_data_indices", name);
-    p.write_int32_contig(persist_value, fieldname, &m_shuffled_indices[0], (uint64_t) size);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_stride_to_last_mini_batch", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_stride_to_last_mini_batch);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_stride_to_next_mini_batch", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_stride_to_next_mini_batch);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_base_offset", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_base_offset);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_model_offset", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_model_offset);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_sample_stride", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_sample_stride);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_iteration_stride", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_iteration_stride);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_loaded_mini_batch_idx", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_loaded_mini_batch_idx);
-
-    snprintf(fieldname, sizeof(fieldname), "%s_reset_mini_batch_index", name);
-    p.write_uint64(persist_value, fieldname, (uint64_t) m_reset_mini_batch_index);
-        
-    std::cout << "training indices: " << m_shuffled_indices[0] << "\n";*/
     pack_scalars(p,name);
   }
   return true;
 }
 
 /** \brief Given directory to store checkpoint files, read state from file and add to number of bytes read */
-bool lbann::generic_data_reader::loadFromCheckpointShared(persist& p, const char *name) {
+bool lbann::generic_data_reader::load_from_checkpoint_shared(persist& p, const char *name) {
   // rank 0 reads the training state file
   struct packing_header header;
   if (p.get_rank() == 0) {
@@ -454,106 +401,6 @@ bool lbann::generic_data_reader::loadFromCheckpointShared(persist& p, const char
   }
   MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
   unpack_header(header);  
-    /*char fieldname[1024];
-    // Closest to non checkpoint run only loads m_current_pos
-
-    lbann::persist_type persist_value;
-    std::string s_name(name);
-    if(s_name.compare("data_reader_validation") == 0){
-      persist_value = persist_type::validate;
-    } else {
-       persist_value= persist_type::train;
-    }
-    // record minibatch index
-    uint64_t val;
-    snprintf(fieldname, sizeof(fieldname), "%s_current_mini_batch_idx", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_current_mini_batch_idx = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_data_size", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    auto size = (int) val;
-
-    // get current position within data
-    snprintf(fieldname, sizeof(fieldname), "%s_data_position", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_current_pos = (int) val;
-    //resize shuffled index array to hold values
-    m_shuffled_indices.resize(size);
-
-     //read list of indices
-    snprintf(fieldname, sizeof(fieldname), "%s_data_indices", name);
-    p.read_int32_contig(persist_value, fieldname, &m_shuffled_indices[0], (uint64_t) size);*/
-
-    /* Everything below is things i have tried loading to see if it was needed. No impact as far as I could tell*/
-    /*snprintf(fieldname, sizeof(fieldname), "%s_stride_to_last_mini_batch", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_stride_to_last_mini_batch = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_stride_to_next_mini_batch", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_stride_to_next_mini_batch = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_base_offset", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_base_offset = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_model_offset", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_model_offset = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_sample_stride", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_sample_stride= (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_iteration_stride", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_iteration_stride= (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_loaded_mini_batch_idx", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_loaded_mini_batch_idx = (int) val;
-
-    snprintf(fieldname, sizeof(fieldname), "%s_reset_mini_batch_index", name);
-    p.read_uint64(persist_value, fieldname, &val);
-    m_reset_mini_batch_index = (int) val;
-
-
-    std::cout << "training indices: " << m_shuffled_indices[0] << "\n";
-  }
-
-  // broadcast minibatch index
-  MPI_Bcast(&m_current_mini_batch_idx, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-  MPI_Bcast(&m_stride_to_last_mini_batch, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&m_stride_to_next_mini_batch, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&m_base_offset, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-  MPI_Bcast(&m_model_offset, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-  MPI_Bcast(&m_sample_stride, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&m_iteration_stride, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&m_loaded_mini_batch_idx, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&m_reset_mini_batch_index, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-
-  // TODO: with multiple readers, make this a scatter
-  // broadcast current position
-  MPI_Bcast(&m_current_pos, 1, MPI_INT, 0, MPI_COMM_WORLD);
-  //printf("%d\n", m_current_pos);
-  // broadcast values from rank 0
-  int size = m_shuffled_indices.size();
-  MPI_Bcast(&size, 1, MPI_INT, 0, MPI_COMM_WORLD);
-
-
-    // resize shuffled index array to hold values
-  if (p.get_rank() != 0) {
-    m_shuffled_indices.resize(size);
-  }
-
-  /// broadcast index array
-  MPI_Bcast(&m_shuffled_indices[0], size, MPI_INT, 0, MPI_COMM_WORLD);
-  //set_initial_position();*/
   return true;
 }
 

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -399,7 +399,13 @@ bool lbann::generic_data_reader::load_from_checkpoint_shared(persist& p, const c
     unpack_scalars(p,&header,name);
   }
   MPI_Bcast(&header, sizeof(header), MPI_BYTE, 0, MPI_COMM_WORLD);
-  unpack_header(header);  
+  unpack_header(header);
+  if(p.get_rank() ==0){
+    m_shuffled_indices.resize(header.data_size);
+    m_unused_indices.resize(header.unused_data_size);
+  }
+  MPI_Bcast(&m_shuffled_indices[0], header.data_size, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&m_unused_indices[0], header.unused_data_size, MPI_INT, 0, MPI_COMM_WORLD);
   return true;
 }
 

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -119,7 +119,6 @@ int lbann::closeread(int fd, const char *file) {
 int lbann::openwrite(const char *file) {
   // define mode (permissions) for new file
   mode_t mode_file = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP;
-
   // open the file for writing
   int fd = open(file, O_WRONLY | O_CREAT | O_TRUNC, mode_file);
   if (fd == -1) {

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -943,7 +943,7 @@ bool Layer::loadFromCheckpoint(int fd, const char *filename, size_t *bytes) {
   return true;
 }
 
-bool Layer::save_to_checkpoint_shared(persist& p) const {
+bool Layer::save_to_checkpoint_shared(persist& p, bool val_end) const {
   //for (weights *w : m_weights) {
   //  w->saveToCheckpointShared(p);  
   //}

--- a/src/metrics/metric.cpp
+++ b/src/metrics/metric.cpp
@@ -51,16 +51,16 @@ void metric_statistics::reset() {
 }
 
 bool metric_statistics::pack_scalars(persist& p) {
-  p.write_double(persist_type::train, "sum", m_sum);
-  p.write_uint64(persist_type::train, "num_samples", m_num_samples);
+  p.write_double(persist_type::validate, "sum", m_sum);
+  p.write_uint64(persist_type::validate, "num_samples", m_num_samples);
   return true;
 }
 
 bool metric_statistics::unpack_scalars(persist& p, struct packing_header *header) {
   double sum;
   uint64_t num_samples;
-  p.read_double(persist_type::train, "sum", &sum);
-  p.read_uint64(persist_type::train, "num_samples", (uint64_t *) &num_samples);
+  p.read_double(persist_type::validate, "sum", &sum);
+  p.read_uint64(persist_type::validate, "num_samples", (uint64_t *) &num_samples);
   m_sum = sum;
   m_num_samples = num_samples;
   if (header != nullptr) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -30,6 +30,7 @@
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/layers/io/input/generic_input_layer.hpp"
+#include "lbann/utils/random.hpp"
 #include <string>
 #include <unistd.h>
 #include <iomanip>
@@ -952,13 +953,11 @@ bool model::save_to_checkpoint_shared(persist& p, bool val_end) {
     p.write_uint32(persist_type::train, "max_mini_batch_size",      (uint32_t) m_max_mini_batch_size);
     p.write_uint32(persist_type::train, "current_mini_batch_size",      (uint32_t) m_current_mini_batch_size);
     p.write_uint32(persist_type::train, "current_phase",      (uint32_t) m_current_phase);
-    /*std::ofstream rngSeq("RNGSeqtest");
-    std::ofstream rng("RNGtest");
-    rngSeq << get_data_seq_generator();
-    rng << get_generator();*/
+    //save_rng_to_checkpoint_shared(p);
   }
   if(val_end){
     p.write_uint64(persist_type::validate, "current_validataion_step",       (uint64_t) m_current_validation_step);
+    save_rng_to_checkpoint_shared(p);
     //for (const auto& m : m_metrics) {
     //  m->save_to_checkpoint_shared(p);
     //}
@@ -980,14 +979,7 @@ bool model::load_from_checkpoint_shared(persist& p) {
     p.read_uint32(persist_type::train, "max_mini_batch_size",      &header.max_mini_batch_size);
     p.read_uint32(persist_type::train, "current_mini_batch_size",      &header.current_mini_batch_size);
     p.read_uint32(persist_type::train, "current_phase",      &header.current_phase);
-    /*std::ofstream rngload("RNGtest");
-    std::ofstream rngSeqload("RNGSeqtest");
-    std::mt19937 rng;
-    std::mt19937 rngSeq;
-    rngSeqload << rngSeq;
-    rngload << rng;
-    get_data_seq_generator() = rngSeq; 
-    get_generator() = rng;*/ 
+    load_rng_from_checkpoint_shared(p);
   }
   
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -952,6 +952,10 @@ bool model::save_to_checkpoint_shared(persist& p, bool val_end) {
     p.write_uint32(persist_type::train, "max_mini_batch_size",      (uint32_t) m_max_mini_batch_size);
     p.write_uint32(persist_type::train, "current_mini_batch_size",      (uint32_t) m_current_mini_batch_size);
     p.write_uint32(persist_type::train, "current_phase",      (uint32_t) m_current_phase);
+    /*std::ofstream rngSeq("RNGSeqtest");
+    std::ofstream rng("RNGtest");
+    rngSeq << get_data_seq_generator();
+    rng << get_generator();*/
   }
   if(val_end){
     p.write_uint64(persist_type::validate, "current_validataion_step",       (uint64_t) m_current_validation_step);
@@ -976,7 +980,16 @@ bool model::load_from_checkpoint_shared(persist& p) {
     p.read_uint32(persist_type::train, "max_mini_batch_size",      &header.max_mini_batch_size);
     p.read_uint32(persist_type::train, "current_mini_batch_size",      &header.current_mini_batch_size);
     p.read_uint32(persist_type::train, "current_phase",      &header.current_phase);
+    /*std::ofstream rngload("RNGtest");
+    std::ofstream rngSeqload("RNGSeqtest");
+    std::mt19937 rng;
+    std::mt19937 rngSeq;
+    rngSeqload << rngSeq;
+    rngload << rng;
+    get_data_seq_generator() = rngSeq; 
+    get_generator() = rng;*/ 
   }
+  
 
   // TODO: this assumes homogeneous processors
   // broadcast state from rank 0

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -948,14 +948,12 @@ bool model::save_to_checkpoint_shared(persist& p, bool val_end) {
     p.write_uint32(persist_type::train, "terminate_training", (uint32_t) m_terminate_training);
     p.write_uint64(persist_type::train, "current_epoch",      (uint64_t) m_current_epoch);
     p.write_uint64(persist_type::train, "current_step",       (uint64_t) m_current_step);
-    //p.write_uint64(persist_type::train, "current_validataion_step",       (uint64_t) m_current_validation_step);
     p.write_uint64(persist_type::train, "current_testing_step",       (uint64_t) m_current_testing_step);
     p.write_uint32(persist_type::train, "max_mini_batch_size",      (uint32_t) m_max_mini_batch_size);
     p.write_uint32(persist_type::train, "current_mini_batch_size",      (uint32_t) m_current_mini_batch_size);
     p.write_uint32(persist_type::train, "current_phase",      (uint32_t) m_current_phase);
-    //save_rng_to_checkpoint_shared(p);
   }
-  if(val_end){
+  if(p.get_rank() == 0 && val_end){
     p.write_uint64(persist_type::validate, "current_validataion_step",       (uint64_t) m_current_validation_step);
     save_rng_to_checkpoint_shared(p);
     //for (const auto& m : m_metrics) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -940,22 +940,24 @@ struct lbann_model_header {
   uint32_t current_phase;
 };
 
-bool model::save_to_checkpoint_shared(persist& p) {
+bool model::save_to_checkpoint_shared(persist& p, bool val_end) {
   // write out fields we need to save for model
-  if (p.get_rank() == 0) {
+  if (p.get_rank() == 0 && !val_end) {
     p.write_uint32(persist_type::train, "execution_mode",     (uint32_t) m_execution_mode);
     p.write_uint32(persist_type::train, "terminate_training", (uint32_t) m_terminate_training);
     p.write_uint64(persist_type::train, "current_epoch",      (uint64_t) m_current_epoch);
     p.write_uint64(persist_type::train, "current_step",       (uint64_t) m_current_step);
-    p.write_uint64(persist_type::train, "current_validataion_step",       (uint64_t) m_current_validation_step);
+    //p.write_uint64(persist_type::train, "current_validataion_step",       (uint64_t) m_current_validation_step);
     p.write_uint64(persist_type::train, "current_testing_step",       (uint64_t) m_current_testing_step);
     p.write_uint32(persist_type::train, "max_mini_batch_size",      (uint32_t) m_max_mini_batch_size);
     p.write_uint32(persist_type::train, "current_mini_batch_size",      (uint32_t) m_current_mini_batch_size);
     p.write_uint32(persist_type::train, "current_phase",      (uint32_t) m_current_phase);
   }
-
-  for (const auto& m : m_metrics) {
-    m->save_to_checkpoint_shared(p);
+  if(val_end){
+    p.write_uint64(persist_type::validate, "current_validataion_step",       (uint64_t) m_current_validation_step);
+    //for (const auto& m : m_metrics) {
+    //  m->save_to_checkpoint_shared(p);
+    //}
   }
   return true;
 }
@@ -969,7 +971,7 @@ bool model::load_from_checkpoint_shared(persist& p) {
     p.read_uint32(persist_type::train, "terminate_training", &header.terminate_training);
     p.read_uint64(persist_type::train, "current_epoch",      &header.current_epoch);
     p.read_uint64(persist_type::train, "current_step",       &header.current_step);
-    p.read_uint64(persist_type::train, "current_validation_step",       &header.current_validation_step);
+    p.read_uint64(persist_type::validate, "current_validation_step",       &header.current_validation_step);
     p.read_uint64(persist_type::train, "current_testing_step",       &header.current_testing_step);
     p.read_uint32(persist_type::train, "max_mini_batch_size",      &header.max_mini_batch_size);
     p.read_uint32(persist_type::train, "current_mini_batch_size",      &header.current_mini_batch_size);
@@ -990,10 +992,9 @@ bool model::load_from_checkpoint_shared(persist& p) {
   m_max_mini_batch_size = (int)           header.max_mini_batch_size;
   m_current_mini_batch_size = (int)       header.current_mini_batch_size;
   m_current_phase      =                  header.current_phase;
-
-  for (const auto& m : m_metrics) {
-    m->load_from_checkpoint_shared(p);
-  }
+  //for (const auto& m : m_metrics) {
+  //  m->load_from_checkpoint_shared(p);
+  //}
   return true;
 }
 

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -69,6 +69,40 @@ rng_gen& get_data_seq_generator() {
   return ::data_seq_generator;
 }
 
+bool save_rng_to_checkpoint_shared(persist& p){
+  std::string rng_name;
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_seq_generator";
+  std::ofstream rng_seq(rng_name);
+  rng_seq << ::data_seq_generator;
+  
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_generator";
+  std::ofstream rng(rng_name);
+  rng << ::generator;
+  
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_fast_generator";
+  std::ofstream rng_fast(rng_name);
+  rng_fast << ::fast_generator;
+
+  return true;
+}
+
+bool load_rng_from_checkpoint_shared(persist& p){
+  std::string rng_name;
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_seq_generator";
+  std::ifstream rng_seq(rng_name);
+  rng_seq >> ::data_seq_generator;
+
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_generator";
+  std::ifstream rng(rng_name);
+  rng >> ::generator;
+ 
+  rng_name = std::string(p.m_checkpoint_dir) + "/rng_fast_generator";
+  std::ifstream rng_fast(rng_name);
+  rng_fast >> ::fast_generator;
+
+  return true;
+}
+
 void init_random(int seed, lbann_comm *comm) {
   if (seed != -1) {
     // Seed every OpenMP thread, if present.


### PR DESCRIPTION
This PR addresses the bug which leads a restarted LBANN run to differ from a non-restarted run. 

Notable changes:
- Checkpoint callback now saves certain parameters to new 'validate' file during on_validation_end callbacks. This fixed the issue where parameters we were saving on_epoch_end were changing during validation phase but not being updated. 
- Added save/reload for RNG state. This fixed the issue where shuffled indices differed after a reload, which caused all other parameters to differ in each subsequent epoch. 
- Refactored data reader save/load to use the pack/unpack headers style seen in the rest of the checkpoint code. 
-  Checkpoint unit test now passes (for the first time ever)

To be fixed:
- I have not added the 'on_validation_end' functionality to metric save/load yet, so that call is currently commented out. 
- I am going to take this opportunity to clean up some of the checkpoint code as well (remove commented out portions etc).

