### PR TITLE
Optimizer refactor

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -538,7 +538,7 @@ class base_convolution_layer : public learning_layer {
                                                  m_bias_gradient_d.get_data(i)));
       }
       bias_optimizer->stage_gradient_for_accumulation_gpu(
-        m_bias_gradient_d.get_locked_data(),
+        m_bias_gradient_d,
         m_bias_scaling_factor / effective_mini_batch_size);
     }
 
@@ -606,7 +606,7 @@ class base_convolution_layer : public learning_layer {
 
       // Add gradient contribution
       kernel_optimizer->stage_gradient_for_accumulation_gpu(
-        m_kernel_gradient_d.get_locked_data(),
+        m_kernel_gradient_d,
         one / effective_mini_batch_size);
     }
 

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -537,9 +537,9 @@ class base_convolution_layer : public learning_layer {
                                                  m_bias_cudnn_desc,
                                                  m_bias_gradient_d.get_data(i)));
       }
-      bias_optimizer->stage_gradient_for_accumulation_gpu(
-        m_bias_gradient_d,
-        m_bias_scaling_factor / effective_mini_batch_size);
+      const DataType bias_scale = m_bias_scaling_factor / effective_mini_batch_size;
+      bias_optimizer->add_to_gradient_staging(m_bias_gradient_d,
+                                              bias_scale);
     }
 
     // Compute kernel gradient
@@ -605,9 +605,9 @@ class base_convolution_layer : public learning_layer {
       }
 
       // Add gradient contribution
-      kernel_optimizer->stage_gradient_for_accumulation_gpu(
-        m_kernel_gradient_d,
-        one / effective_mini_batch_size);
+      const DataType kernel_scale = one / effective_mini_batch_size;
+      kernel_optimizer->add_to_gradient_staging(m_kernel_gradient_d,
+                                                kernel_scale);
     }
 
   #endif // LBANN_HAS_CUDNN
@@ -804,9 +804,9 @@ class base_convolution_layer : public learning_layer {
         }
         local_bias_gradient(channel, 0) = m_bias_scaling_factor * sum;
       }
-      bias_optimizer->stage_gradient_for_accumulation(
-        m_bias_gradient,
-        DataType(1) / effective_mini_batch_size);
+      const DataType bias_scale = m_bias_scaling_factor / effective_mini_batch_size;
+      bias_optimizer->add_to_gradient_staging(m_bias_gradient,
+                                              bias_scale);
     }
 
     // Stop early if kernel is not being optimized
@@ -864,9 +864,9 @@ class base_convolution_layer : public learning_layer {
     }
 
     // Scale and accumulate gradients
-    kernel_optimizer->stage_gradient_for_accumulation(
-      m_kernel_gradient,
-      DataType(1) / effective_mini_batch_size);
+    const DataType kernel_scale = DataType(1) / effective_mini_batch_size;
+    kernel_optimizer->add_to_gradient_staging(m_kernel_gradient,
+                                              kernel_scale);
 
   }
 

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -407,7 +407,7 @@ class fully_connected_layer : public learning_layer {
                      DataType(0),
                      m_bias_gradient_d.get_data(i), 1);
       }
-      bias_optimizer->stage_gradient_for_accumulation_gpu(
+      bias_optimizer->add_to_gradient_staging(
         m_bias_gradient_d,
         m_bias_scaling_factor / this->m_model->get_effective_mini_batch_size());
     }
@@ -426,7 +426,7 @@ class fully_connected_layer : public learning_layer {
                      DataType(0),
                      m_linearity_gradient_d.get_data(i), output_size);
       }
-      linearity_optimizer->stage_gradient_for_accumulation_gpu(
+      linearity_optimizer->add_to_gradient_staging(
         m_linearity_gradient_d,
         DataType(1) / this->m_model->get_effective_mini_batch_size());
     }

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -408,7 +408,7 @@ class fully_connected_layer : public learning_layer {
                      m_bias_gradient_d.get_data(i), 1);
       }
       bias_optimizer->stage_gradient_for_accumulation_gpu(
-        m_bias_gradient_d.get_locked_data(),
+        m_bias_gradient_d,
         m_bias_scaling_factor / this->m_model->get_effective_mini_batch_size());
     }
       
@@ -427,7 +427,7 @@ class fully_connected_layer : public learning_layer {
                      m_linearity_gradient_d.get_data(i), output_size);
       }
       linearity_optimizer->stage_gradient_for_accumulation_gpu(
-        m_linearity_gradient_d.get_locked_data(),
+        m_linearity_gradient_d,
         DataType(1) / this->m_model->get_effective_mini_batch_size());
     }
 

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -503,13 +503,13 @@ class batch_normalization : public regularizer_layer {
     }
     optimizer* scale_optimizer = m_weights[0]->get_optimizer();
     if (scale_optimizer != nullptr) {
-      scale_optimizer->stage_gradient_for_accumulation_gpu(
+      scale_optimizer->add_to_gradient_staging(
         m_scale_gradient_d,
         DataType(1) / effective_mini_batch_size);
     }
     optimizer* bias_optimizer = m_weights[1]->get_optimizer();
     if (bias_optimizer != nullptr) {
-      bias_optimizer->stage_gradient_for_accumulation_gpu(
+      bias_optimizer->add_to_gradient_staging(
         m_bias_gradient_d,
         DataType(1) / effective_mini_batch_size);
     }
@@ -739,13 +739,13 @@ class batch_normalization : public regularizer_layer {
     }
     optimizer* scale_optimizer = m_weights[0]->get_optimizer();
     if (scale_optimizer != nullptr) {
-      scale_optimizer->stage_gradient_for_accumulation(
+      scale_optimizer->add_to_gradient_staging(
         *m_scale_gradient,
         DataType(1) / effective_mini_batch_size);
     }
     optimizer* bias_optimizer = m_weights[1]->get_optimizer();
     if (bias_optimizer != nullptr) {
-      bias_optimizer->stage_gradient_for_accumulation(
+      bias_optimizer->add_to_gradient_staging(
         *m_bias_gradient,
         DataType(1) / effective_mini_batch_size);
     }

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -504,13 +504,13 @@ class batch_normalization : public regularizer_layer {
     optimizer* scale_optimizer = m_weights[0]->get_optimizer();
     if (scale_optimizer != nullptr) {
       scale_optimizer->stage_gradient_for_accumulation_gpu(
-        m_scale_gradient_d.get_locked_data(),
+        m_scale_gradient_d,
         DataType(1) / effective_mini_batch_size);
     }
     optimizer* bias_optimizer = m_weights[1]->get_optimizer();
     if (bias_optimizer != nullptr) {
       bias_optimizer->stage_gradient_for_accumulation_gpu(
-        m_bias_gradient_d.get_locked_data(),
+        m_bias_gradient_d,
         DataType(1) / effective_mini_batch_size);
     }
 

--- a/include/lbann/optimizers/adagrad.hpp
+++ b/include/lbann/optimizers/adagrad.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// adagrad .hpp .cpp - SGD with AdaGrad optimizer
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_ADAGRAD_HPP

--- a/include/lbann/optimizers/adam.hpp
+++ b/include/lbann/optimizers/adam.hpp
@@ -22,10 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// adam .hpp .cpp .cu - SGD with Adam
-// Reference:
-// Kingma, D. and Ba, J. 2014. Adam: A Method for Stochastic Optimization.
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_ADAM_HPP
@@ -35,7 +31,10 @@
 
 namespace lbann {
 
-/** Adam optimizer. */
+/** Adam optimizer.
+ *  Reference:
+ *  Kingma, D. and Ba, J. 2014. Adam: A Method for Stochastic Optimization.
+ */
 class adam : public optimizer {
  public:
 
@@ -69,8 +68,8 @@ class adam : public optimizer {
   void step_compute(AbsDistMat& values, const AbsDistMat& gradient) override;
 #ifdef LBANN_HAS_CUDNN
   /** Perform the computation in an optimization step on GPU. */
-  void step_compute_gpu(std::vector<DataType*> values_d,
-                        std::vector<DataType*> gradient_d) override;
+  void step_compute_gpu(cudnn::matrix& values_d,
+                        const cudnn::matrix& gradient_d) override;
 #endif // LBANN_HAS_CUDNN
 
  private:

--- a/include/lbann/optimizers/hypergradient_adam.hpp
+++ b/include/lbann/optimizers/hypergradient_adam.hpp
@@ -22,10 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// hypergradient_adam .hpp .cpp - Hypergradient SGD with Adam
-// Reference:
-// Baydin et al. "Online Learning Rate Adaptation with Hypergradient Descent", 2017.
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_HYPERGRADIENT_ADAM_HPP
@@ -35,7 +31,10 @@
 
 namespace lbann {
 
-/** Hypergradient Adam optimizer. */
+/** Hypergradient Adam optimizer.
+ *  Reference:
+ *  Baydin et al. "Online Learning Rate Adaptation with Hypergradient Descent", 2017.
+ */
 class hypergradient_adam : public optimizer {
  public:
 

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_optimizer .hpp .cpp - Abstract optimizer class
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_HPP
@@ -82,7 +80,7 @@ class optimizer {
   /** Get gradient matrix on GPU.
    *  The gradient is accumulated on the GPU.
    */
-  std::vector<DataType*> get_gradient_gpu();
+  cudnn::matrix& get_gradient_gpu();
 #endif // LBANN_HAS_CUDNN
 
   /** Clear gradient matrix. */
@@ -99,14 +97,14 @@ class optimizer {
                                        DataType scale = DataType(1));
 #ifdef LBANN_HAS_CUDNN
   /** Add to the gradient matrix on GPU. */
-  void add_to_gradient_gpu(const std::vector<DataType*>& gradient,
+  void add_to_gradient_gpu(const cudnn::matrix& gradient,
                            DataType scale = DataType(1));
   /**
    *  The input is added to a staging matrix. When the gradient is
    *  needed, an allreduce is applied over the redundant communicator
    *  of the gradient matrix and the result is added to the gradient.
    */
-  void stage_gradient_for_accumulation_gpu(const std::vector<DataType*>& gradient,
+  void stage_gradient_for_accumulation_gpu(const cudnn::matrix& gradient,
                                            DataType scale = DataType(1));
 #endif // LBANN_HAS_CUDNN
 
@@ -125,8 +123,8 @@ class optimizer {
    *  The default implementation is to transfer data to CPU and call
    *  step_compute.
    */
-  virtual void step_compute_gpu(std::vector<DataType*> values_d,
-                                std::vector<DataType*> gradient_d);
+  virtual void step_compute_gpu(cudnn::matrix& values,
+                                const cudnn::matrix& gradient_d);
 #endif // LBANN_HAS_CUDNN
 
   /** Get the time spent in step(). */
@@ -153,7 +151,7 @@ class optimizer {
   AbsDistMat* m_gradient;
 #ifdef LBANN_HAS_CUDNN
   /** GPU memory for gradient matrix. */
-  std::vector<DataType*> m_gradient_d;
+  cudnn::matrix m_gradient_d;
 #endif // LBANN_HAS_CUDNN
 
  private:
@@ -178,7 +176,7 @@ class optimizer {
    *  GPUs and over the redundant communicator of the staging matrix
    *  and the result is added to the gradient matrix.
    */
-  std::vector<DataType*> m_staging_d;
+  cudnn::matrix m_staging_d;
 #endif // LBANN_HAS_CUDNN
 
   /** Running count of the time spent in step(). */

--- a/include/lbann/optimizers/rmsprop.hpp
+++ b/include/lbann/optimizers/rmsprop.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// rmsprop .hpp .cpp - SGD with RMSprop
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_RMSPROP_HPP

--- a/include/lbann/optimizers/sgd.hpp
+++ b/include/lbann/optimizers/sgd.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// sgd .hpp .cpp - Stochastic gradient descent optimizer
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_OPTIMIZER_SGD_HPP
@@ -67,8 +65,8 @@ class sgd : public optimizer {
   void step_compute(AbsDistMat& values, const AbsDistMat& gradient) override;
 #ifdef LBANN_HAS_CUDNN
   /** Perform the computation in an optimization step on GPU. */
-  void step_compute_gpu(std::vector<DataType*> values_d,
-                        std::vector<DataType*> gradient_d) override;
+  void step_compute_gpu(cudnn::matrix& values_d,
+                        const cudnn::matrix& gradient_d) override;
 #endif // LBANN_HAS_CUDNN
  
  private:

--- a/include/lbann/utils/cudnn_wrapper.hpp
+++ b/include/lbann/utils/cudnn_wrapper.hpp
@@ -127,7 +127,7 @@ public:
   /** Clear data. */
   void clear();
   /** Resize matrix. */
-  void resize(int height, int width_per_gpu);
+  void resize(int height, int width_per_gpu = 1);
   /** Copy matrix entries.
    *  The matrix is resized if needed.
    */
@@ -146,12 +146,12 @@ public:
   /** Attach matrix to GPU data. */
   void attach(std::vector<DataType*>& data,
               int height,
-              int width_per_gpu,
+              int width_per_gpu = 1,
               int leading_dim = 0);
   /** Attach matrix to GPU data. */
   void locked_attach(const std::vector<DataType*>& data,
                      int height,
-                     int width_per_gpu,
+                     int width_per_gpu = 1,
                      int leading_dim = 0);
 
   /** Get matrix height. */

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -102,7 +102,7 @@ void fully_connected_layer<data_layout::MODEL_PARALLEL>::bp_compute_cpu() {
       && bias_optimizer != nullptr) {
     El::RowSum(local_gradient_wrt_output,
                m_bias_gradient->Matrix());
-    bias_optimizer->stage_gradient_for_accumulation(
+    bias_optimizer->add_to_gradient_staging(
       *m_bias_gradient,
       m_bias_scaling_factor / mini_batch_size);
   }
@@ -115,7 +115,7 @@ void fully_connected_layer<data_layout::MODEL_PARALLEL>::bp_compute_cpu() {
       El::Gemm(El::NORMAL, El::TRANSPOSE,
                DataType(1), local_gradient_wrt_output, local_input,
                DataType(0), m_linearity_gradient->Matrix());
-      linearity_optimizer->stage_gradient_for_accumulation(
+      linearity_optimizer->add_to_gradient_staging(
         *m_linearity_gradient,
         DataType(1) / mini_batch_size);
     } else {
@@ -187,7 +187,7 @@ void fully_connected_layer<data_layout::DATA_PARALLEL>::bp_compute_cpu() {
       && bias_optimizer != nullptr) {
     El::RowSum(local_gradient_wrt_output,
                m_bias_gradient->Matrix());
-    bias_optimizer->stage_gradient_for_accumulation(
+    bias_optimizer->add_to_gradient_staging(
       *m_bias_gradient,
       m_bias_scaling_factor / mini_batch_size);
   }
@@ -198,7 +198,7 @@ void fully_connected_layer<data_layout::DATA_PARALLEL>::bp_compute_cpu() {
     El::Gemm(El::NORMAL, El::TRANSPOSE,
              DataType(1), local_gradient_wrt_output, local_input,
              DataType(0), m_linearity_gradient->Matrix());
-    linearity_optimizer->stage_gradient_for_accumulation(
+    linearity_optimizer->add_to_gradient_staging(
       *m_linearity_gradient,
       DataType(1) / mini_batch_size);
   }

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -123,7 +123,10 @@ void l2_weight_regularization::compute_weight_regularization() {
       err << __FILE__ << " " << __LINE__ << " :: cuDNN not detected";
       throw lbann_exception(err.str());
     #else
-      opt->add_to_gradient_gpu(w->get_values_gpu(), m_scale_factor);
+      cudnn::matrix values_d(w->get_cudnn_manager());
+      auto&& values_ptrs = w->get_values_gpu();
+      values_d.attach(values_ptrs, w->get_size());
+      opt->add_to_gradient_gpu(values_d, m_scale_factor);
     #endif // LBANN_HAS_CUDNN
     } else {
       opt->add_to_gradient(w->get_values(), m_scale_factor);

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -126,7 +126,7 @@ void l2_weight_regularization::compute_weight_regularization() {
       cudnn::matrix values_d(w->get_cudnn_manager());
       auto&& values_ptrs = w->get_values_gpu();
       values_d.attach(values_ptrs, w->get_size());
-      opt->add_to_gradient_gpu(values_d, m_scale_factor);
+      opt->add_to_gradient(values_d, m_scale_factor);
     #endif // LBANN_HAS_CUDNN
     } else {
       opt->add_to_gradient(w->get_values(), m_scale_factor);

--- a/src/optimizers/adagrad.cpp
+++ b/src/optimizers/adagrad.cpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// adagrad .hpp .cpp - SGD with AdaGrad
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/adagrad.hpp"

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -22,10 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// adam .hpp .cpp .cu - SGD with Adam
-// Reference:
-// Kingma, D. and Ba, J. 2014. Adam: A Method for Stochastic Optimization.
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/adam.hpp"

--- a/src/optimizers/adam.cu
+++ b/src/optimizers/adam.cu
@@ -22,10 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// adam .hpp .cpp .cu - SGD with Adam
-// Reference:
-// Kingma, D. and Ba, J. 2014. Adam: A Method for Stochastic Optimization.
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/adam.hpp"
@@ -55,8 +51,8 @@ __global__ void adam_kernel(DataType * __restrict__ values,
 
 }
 
-void adam::step_compute_gpu(std::vector<DataType*> values_d,
-                            std::vector<DataType*> gradient_d) {
+void adam::step_compute_gpu(cudnn::matrix& values_d,
+                            const cudnn::matrix& gradient_d) {
 
   // Precompute the bias correction and learning rate.
   m_current_beta1 *= m_beta1;
@@ -78,7 +74,8 @@ void adam::step_compute_gpu(std::vector<DataType*> values_d,
     CHECK_CUDA(cudaSetDevice(this->m_cudnn->get_gpu(i)));
     cudaStream_t stream = this->m_cudnn->get_stream(i);
     adam_kernel<<<grid_dims, block_dims, 0, stream>>>
-      (values_d[i], gradient_d[i], m_moment1_d[i], m_moment2_d[i],
+      (values_d.get_data(i), gradient_d.get_locked_data(i),
+       m_moment1_d[i], m_moment2_d[i],
        num_entries, correction, m_eps, m_beta1, m_beta2);
   }
 

--- a/src/optimizers/hypergradient_adam.cpp
+++ b/src/optimizers/hypergradient_adam.cpp
@@ -22,10 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// hypergradient_adam .hpp .cpp - Hypergradient SGD with Adam
-// Reference:
-// Baydin et al. "Online Learning Rate Adaptation with Hypergradient Descent", 2017.
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/hypergradient_adam.hpp"

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -36,15 +36,10 @@ optimizer::optimizer(lbann_comm *comm, DataType learning_rate)
     m_weights(nullptr),
     m_learning_rate(learning_rate),
     m_gradient(nullptr),
-    m_cpu_gradient_is_nonzero(false),
-    m_cpu_staging_is_nonzero(false),
-    m_staging(nullptr)
-#ifdef LBANN_HAS_CUDNN
-  ,
-    m_gpu_gradient_is_nonzero(false),
-    m_gpu_staging_is_nonzero(false)
-#endif // LBANN_HAS_CUDNN
-{}
+    m_gradient_staging(nullptr),
+    m_gradient_allreduce_needed(false),
+    m_gradient_allreduce_started(false),
+    m_gradient_allreduce_finished(false) {}
 
 optimizer::optimizer(const optimizer& other)
   : m_comm(other.m_comm),
@@ -55,21 +50,24 @@ optimizer::optimizer(const optimizer& other)
     #ifdef LBANN_HAS_CUDNN
     m_gradient_d(other.m_gradient_d),
     #endif // LBANN_HAS_CUDNN
-    m_cpu_gradient_is_nonzero(other.m_cpu_gradient_is_nonzero),
-    m_cpu_staging_is_nonzero(other.m_cpu_staging_is_nonzero),
-    m_staging(other.m_staging),
+    m_gradient_staging(other.m_gradient_staging),
     #ifdef LBANN_HAS_CUDNN
-    m_gpu_gradient_is_nonzero(other.m_gpu_gradient_is_nonzero),
-    m_gpu_staging_is_nonzero(other.m_gpu_staging_is_nonzero),
-    m_staging_d(other.m_staging_d),
+    m_gradient_staging_d(other.m_gradient_staging_d),
     #endif // LBANN_HAS_CUDNN
+    m_gradient_allreduce_needed(other.m_gradient_allreduce_needed),
+    m_gradient_allreduce_started(other.m_gradient_allreduce_started),
+    m_gradient_allreduce_finished(other.m_gradient_allreduce_finished),
     m_step_time(other.m_step_time)
     #ifdef LBANN_NBALLREDUCE_GRADIENT
-    , m_allreduce_started(other.m_allreduce_started)
+    , m_gradient_allreduce_started(other.m_gradient_allreduce_started)
     #endif  // LBANN_NBALLREDUCE_GRADIENT
 {
-  if (m_gradient != nullptr) { m_gradient = m_gradient->Copy(); }
-  if (m_staging != nullptr)  { m_staging = m_staging->Copy(); }
+  if (m_gradient != nullptr) {
+    m_gradient = m_gradient->Copy();
+  }
+  if (m_gradient_staging != nullptr) {
+    m_gradient_staging = m_gradient_staging->Copy();
+  }
 }
 
 optimizer& optimizer::operator=(const optimizer& other) {
@@ -78,32 +76,29 @@ optimizer& optimizer::operator=(const optimizer& other) {
   m_weights = other.m_weights;
   m_learning_rate = other.m_learning_rate;
   m_step_time = other.m_step_time;
+  m_gradient_allreduce_needed = other.m_gradient_allreduce_needed;
+  m_gradient_allreduce_started = other.m_gradient_allreduce_started;
+  m_gradient_allreduce_finished = other.m_gradient_allreduce_finished;
   #ifdef LBANN_NBALLREDUCE_GRADIENT
-  m_allreduce_started = other.m_allreduce_started;
+  m_gradient_allreduce_started = other.m_gradient_allreduce_started;
   #endif  // LBANN_NBALLREDUCE_GRADIENT
 
-  // Copy matrices
-  #define COPY_MATRIX(src, dst)                 \
-    do {                                        \
-      if(src != nullptr && dst != nullptr) {    \
-        El::Copy(*src, *dst);                   \
-      }                                         \
-      if(src != nullptr && dst == nullptr) {    \
-        dst = src->Copy();                      \
-      }                                         \
-      if(src == nullptr && dst != nullptr) {    \
-        delete dst;                             \
-        dst = nullptr;                          \
-      }                                         \
-    } while(false)
-  COPY_MATRIX(other.m_gradient, m_gradient);
-  COPY_MATRIX(other.m_staging, m_staging);
-  #undef COPY_MATRIX
+  // Deep copy matrices
+  if (m_gradient != nullptr) { delete m_gradient; }
+  if (m_gradient_staging != nullptr) { delete m_gradient_staging; }
+  m_gradient = other.m_gradient;
+  m_gradient_staging = other.m_gradient_staging;
+  if (m_gradient != nullptr) {
+    m_gradient = m_gradient->Copy();
+  }
+  if (m_gradient_staging != nullptr) {
+    m_gradient_staging = m_gradient_staging->Copy();
+  }
 
   // Copy GPU data
   #ifdef LBANN_HAS_CUDNN
   m_gradient_d = other.m_gradient_d;
-  m_staging_d = other.m_staging_d;
+  m_gradient_staging_d = other.m_gradient_staging_d;
   #endif // LBANN_HAS_CUDNN
 
   return *this;
@@ -111,7 +106,7 @@ optimizer& optimizer::operator=(const optimizer& other) {
 
 optimizer::~optimizer() {
   if (m_gradient != nullptr) { delete m_gradient; }
-  if (m_staging != nullptr)  { delete m_staging; }
+  if (m_gradient_staging != nullptr)  { delete m_gradient_staging; }
 }
 
 std::string optimizer::get_description() const {
@@ -134,7 +129,7 @@ weights& optimizer::get_weights() {
   return *m_weights;
 }
 
-AbsDistMat& optimizer::get_gradient() {
+const AbsDistMat& optimizer::get_gradient() {
 
   // Check if gradient is initialized
   if (!is_initialized()) {
@@ -144,58 +139,45 @@ AbsDistMat& optimizer::get_gradient() {
     throw lbann_exception(err.str());
   }
 
-  // Accumulate CPU allreduce staging matrix
-  if (m_cpu_staging_is_nonzero) {
-#ifdef LBANN_NBALLREDUCE_GRADIENT
-    if (m_allreduce_started) {
-      // Complete in-progress non-blocking allreduce.
-      m_comm->wait(m_allreduce_req);
-      m_allreduce_started = false;
+  // Perform allreduce on staging matrix if needed
+  if (m_gradient_allreduce_needed && !m_gradient_allreduce_started) {
+    start_gradient_staging_allreduce();
+  }
+  if (m_gradient_allreduce_started && !m_gradient_allreduce_finished) {
+    #ifdef LBANN_NBALLREDUCE_GRADIENT
+    m_comm->wait(m_gradient_allreduce_req);
+    #endif // LBANN_NBALLREDUCE_GRADIENT
+    m_gradient_allreduce_finished = true;
+  }
+  if (m_gradient_allreduce_needed) {
+    if (m_cudnn == nullptr) {
+      add_to_gradient(*m_gradient_staging);
     } else {
-      m_comm->allreduce(*m_staging, m_staging->RedundantComm());
+      #ifdef LBANN_HAS_CUDNN
+      add_to_gradient(m_gradient_staging_d);
+      #endif // LBANN_HAS_CUDNN
     }
-#else
-    m_comm->allreduce(*m_staging, m_staging->RedundantComm());
-#endif  // LBANN_NBALLREDUCE_GRADIENT
-    add_to_gradient(*m_staging);
-    El::Zero(*m_staging);
-    m_cpu_staging_is_nonzero = false;
   }
+  m_gradient_allreduce_needed = false;
+  m_gradient_allreduce_started = false;
+  m_gradient_allreduce_finished = false;
 
-#ifdef LBANN_HAS_CUDNN
-
-  // Accumulate GPU allreduce staging matrix
-  if (m_gpu_staging_is_nonzero) {
-    m_cudnn->global_allreduce_on_gpus(m_staging_d.get_data(),
-                                      m_staging_d.get_height(),
-                                      m_staging_d.get_width_per_gpu(),
-                                      m_gradient->RedundantComm());
-    add_to_gradient_gpu(m_staging_d);
-    m_staging_d.zero();
-    m_gpu_staging_is_nonzero = false;
-  }
-
-  // Accumulate gradient in CPU
-  if (m_gpu_gradient_is_nonzero) {
+  // Return CPU gradient matrix
+  if (m_cudnn != nullptr) {
+    #ifdef LBANN_HAS_CUDNN
     m_cudnn->copy_from_gpu(0,
-                           m_staging->Matrix(),
-                           m_gradient_d.get_data(0));
-    m_gradient_d.zero();
+                           m_gradient->Matrix(),
+                           m_gradient_d.get_locked_data(0),
+                           m_gradient_d.get_leading_dim());
     m_cudnn->synchronize();
-    add_to_gradient(*m_staging);
-    El::Zero(*m_staging);
-    m_gpu_gradient_is_nonzero = false;
+    #endif // LBANN_HAS_CUDNN
   }
-
-#endif // LBANN_HAS_CUDNN
-
-  // Return full gradient
   return *m_gradient;
 
 }
 
 #ifdef LBANN_HAS_CUDNN
-cudnn::matrix& optimizer::get_gradient_gpu() {
+const cudnn::matrix& optimizer::get_gradient_gpu() {
 
   // Check if gradient is initialized
   if (!is_initialized()) {
@@ -211,70 +193,75 @@ cudnn::matrix& optimizer::get_gradient_gpu() {
     throw lbann_exception(err.str());
   }
 
-  // Accumulate GPU allreduce staging matrix
-  if (m_gpu_staging_is_nonzero) {
-    m_cudnn->global_allreduce_on_gpus(m_staging_d.get_data(),
-                                      m_staging_d.get_height(),
-                                      m_staging_d.get_width_per_gpu(),
-                                      m_gradient->RedundantComm());
-    add_to_gradient_gpu(m_staging_d);
-    m_staging_d.zero();
-    m_gpu_staging_is_nonzero = false;
+  // Perform allreduce on staging matrix if needed
+  if (m_gradient_allreduce_needed && !m_gradient_allreduce_started) {
+    start_gradient_staging_allreduce();
   }
-
-  // Accumulate CPU allreduce staging matrix
-  if (m_cpu_staging_is_nonzero) {
-    m_comm->allreduce(*m_staging,
-                      m_staging->RedundantComm());
-    add_to_gradient(*m_staging);
-    El::Zero(*m_staging);
-    m_cpu_staging_is_nonzero = false;
+  if (m_gradient_allreduce_started && !m_gradient_allreduce_finished) {
+    #ifdef LBANN_NBALLREDUCE_GRADIENT
+    m_comm->wait(m_gradient_allreduce_req);
+    #endif // LBANN_NBALLREDUCE_GRADIENT
+    m_gradient_allreduce_finished = true;
   }
-
-  // Accumulate gradient in GPU
-  if (m_cpu_gradient_is_nonzero) {
-    m_cudnn->broadcast_to_gpus(m_staging_d.get_data(),
-                               m_gradient->LockedMatrix());
-    m_cudnn->synchronize();
-    add_to_gradient_gpu(m_staging_d);
-    El::Zero(*m_gradient);
-    m_staging_d.zero();
-    m_cpu_gradient_is_nonzero = false;
+  if (m_gradient_allreduce_needed) {
+    add_to_gradient(m_gradient_staging_d);
   }
+  m_gradient_allreduce_needed = false;
+  m_gradient_allreduce_started = false;
+  m_gradient_allreduce_finished = false;
 
-  // Return full gradient
+  // Return gradient
   return m_gradient_d;
 
 }
 #endif // LBANN_HAS_CUDNN
 
+void optimizer::start_gradient_staging_allreduce() {
+  if (!m_gradient_allreduce_needed || m_gradient_allreduce_started) {
+    return;
+  }
+
+  m_gradient_allreduce_started = true;
+  if (m_cudnn == nullptr) {
+    #ifdef LBANN_NBALLREDUCE_GRADIENT
+    m_comm->nb_allreduce(*m_gradient_staging,
+                         m_gradient_staging->RedundantComm(),
+                         m_gradient_allreduce_req);
+    m_gradient_allreduce_finished = false;
+    #else
+    m_comm->allreduce(*m_gradient_staging,
+                      m_gradient_staging->RedundantComm());
+    m_gradient_allreduce_finished = true;
+    #endif // LBANN_NBALLREDUCE_GRADIENT
+  } else {
+    #ifndef LBANN_HAS_CUDNN
+    throw lbann_exception("optimizer: cuDNN not detected");
+    #else
+    m_cudnn->global_allreduce_on_gpus(m_gradient_staging_d.get_data(),
+                                      m_gradient_staging_d.get_height(),
+                                      m_gradient_staging_d.get_width_per_gpu(),
+                                      m_gradient->RedundantComm());
+    m_gradient_allreduce_finished = true;
+    #endif // LBANN_HAS_CUDNN
+  }
+
+}
+
 void optimizer::clear_gradient() {
 
-  // Check if gradient is initialized
-  if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
-  }
-
-  // Zero out matrices
-  El::Zero(*m_gradient);
-  El::Zero(*m_staging);
-#ifdef LBANN_HAS_CUDNN
-  if (m_cudnn != nullptr) {
+  // Clear matrices
+  if (m_cudnn == nullptr) {
+    El::Zero(*m_gradient);
+  } else {
+    #ifdef LBANN_HAS_CUDNN
     m_gradient_d.zero();
-    m_staging_d.zero();
+    #endif // LBANN_HAS_CUDNN
   }
-#endif // LBANN_HAS_CUDNN
 
-  // Reset flags
-  m_cpu_gradient_is_nonzero = false;
-  m_cpu_staging_is_nonzero = false;
-#ifdef LBANN_HAS_CUDNN
-  m_gpu_gradient_is_nonzero = false;
-  m_gpu_staging_is_nonzero = false;
-#endif // LBANN_HAS_CUDNN
+  // Reset gradient allreduce flags
+  m_gradient_allreduce_needed = false;
+  m_gradient_allreduce_started = false;
+  m_gradient_allreduce_finished = false;
 
 }
 
@@ -287,42 +274,25 @@ void optimizer::add_to_gradient(const AbsDistMat& gradient,
     throw lbann_exception(err.str());
   }
   if (scale != DataType(0)) {
-    El::Axpy(scale, gradient, *m_gradient);
-    m_cpu_gradient_is_nonzero = true;
-  }
-}
-
-void optimizer::stage_gradient_for_accumulation(const AbsDistMat& gradient,
-                                                DataType scale) {
-  if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
-  }
-  if (scale != DataType(0)) {
-    El::Axpy(scale, gradient, *m_staging);
-    m_cpu_staging_is_nonzero = true;
-#ifdef LBANN_NBALLREDUCE_GRADIENT
-    // TODO: Does not handle case where weights are shared and this is called
-    // multiple times.
-    if (m_allreduce_started) {
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "attempted to start non-blocking allreduce twice";
-      throw lbann_exception(err.str());
+    if (m_cudnn == nullptr) {
+      El::Axpy(scale, gradient, *m_gradient);
+    } else {
+      #ifndef LBANN_HAS_CUDNN
+      throw lbann_exception("optimizer: cuDNN not detected");
+      #else
+      cudnn::matrix gradient_d(m_cudnn,
+                               gradient.LocalHeight(),
+                               gradient.LocalWidth());
+      m_cudnn->broadcast_to_gpus(gradient_d.get_data(),
+                                 gradient.LockedMatrix());
+      add_to_gradient(gradient_d, scale);
+      #endif // LBANN_HAS_CUDNN
     }
-    m_comm->nb_allreduce(*m_staging, m_staging->RedundantComm(),
-                         m_allreduce_req);
-    m_allreduce_started = true;
-#endif  // LBANN_NBALLREDUCE_GRADIENT
   }
 }
-
 #ifdef LBANN_HAS_CUDNN
-
-void optimizer::add_to_gradient_gpu(const cudnn::matrix& gradient_d,
-                                    DataType scale) {
+void optimizer::add_to_gradient(const cudnn::matrix& gradient_d,
+                                DataType scale) {
   if (!is_initialized()) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
@@ -336,24 +306,81 @@ void optimizer::add_to_gradient_gpu(const cudnn::matrix& gradient_d,
     throw lbann_exception(err.str());
   }
   if (scale != DataType(0)) {
-    const int num_gpus = m_cudnn->get_num_gpus();
-    for(int i=0; i<num_gpus; ++i) {
+    for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       CHECK_CUBLAS(cublas::axpy(m_cudnn->get_cublas_handle(i),
                                 m_weights->get_size(),
                                 scale, gradient_d.get_locked_data(i), 1,
                                 m_gradient_d.get_data(i), 1));
     }
-    m_gpu_gradient_is_nonzero = true;
   }
 }
+#endif // LBANN_HAS_CUDNN
 
-void optimizer::stage_gradient_for_accumulation_gpu(const cudnn::matrix& gradient_d,
-                                                    DataType scale) {
+void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
+                                        DataType scale) {
   if (!is_initialized()) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
         << "attempted to access gradients before they are set up";
+    throw lbann_exception(err.str());
+  }
+  if (m_gradient_allreduce_started) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "attempted to add to staging matrix after gradient accumulation has started";
+    throw lbann_exception(err.str());
+  }
+  if (scale != DataType(0)) {
+
+    // Clear staging matrix if needed
+    if (!m_gradient_allreduce_needed) {
+      if (m_cudnn == nullptr) {
+        El::Zero(*m_gradient_staging);
+      } else {
+        #ifndef LBANN_HAS_CUDNN
+        throw lbann_exception("optimizer: cuDNN not detected");
+        #else
+        m_gradient_staging_d.zero();
+        #endif // LBANN_HAS_CUDNN
+      }
+    }
+    m_gradient_allreduce_needed = true;
+
+    // Add to staging matrix
+    if (m_cudnn == nullptr) {
+      El::Axpy(scale, gradient, *m_gradient_staging);
+    } else {
+      #ifndef LBANN_HAS_CUDNN
+      throw lbann_exception("optimizer: cuDNN not detected");
+      #else
+      cudnn::matrix gradient_d(m_cudnn,
+                               gradient.LocalHeight(),
+                               gradient.LocalWidth());
+      gradient_d.zero();
+      m_cudnn->copy_to_gpu(0,
+                           gradient_d.get_data(0),
+                           gradient.LockedMatrix(),
+                           gradient_d.get_leading_dim());
+      add_to_gradient_staging(gradient_d, scale);
+      #endif // LBANN_HAS_CUDNN
+    }
+
+  }
+}
+#ifdef LBANN_HAS_CUDNN
+void optimizer::add_to_gradient_staging(const cudnn::matrix& gradient_d,
+                                        DataType scale) {
+  if (!is_initialized()) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "attempted to access gradients before they are set up";
+    throw lbann_exception(err.str());
+  }
+  if (m_gradient_allreduce_started) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "attempted to add to staging matrix after gradient accumulation has started";
     throw lbann_exception(err.str());
   }
   if (m_cudnn == nullptr) {
@@ -363,18 +390,24 @@ void optimizer::stage_gradient_for_accumulation_gpu(const cudnn::matrix& gradien
     throw lbann_exception(err.str());
   }
   if (scale != DataType(0)) {
-    const int num_gpus = m_cudnn->get_num_gpus();
-    for(int i=0; i<num_gpus; ++i) {
+
+    // Clear staging matrix if needed
+    if (!m_gradient_allreduce_needed) {
+      m_gradient_staging_d.zero();
+    }
+    m_gradient_allreduce_needed = true;
+
+    // Add to staging matrix
+    for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       CHECK_CUBLAS(cublas::axpy(m_cudnn->get_cublas_handle(i),
                                 m_weights->get_size(),
                                 scale, gradient_d.get_locked_data(i), 1,
-                                m_staging_d.get_data(i), 1));
+                                m_gradient_staging_d.get_data(i), 1));
     }
-    m_gpu_staging_is_nonzero = true;
+
   }
 }
-
 #endif // LBANN_HAS_CUDNN
 
 void optimizer::setup(weights& w) {
@@ -392,16 +425,16 @@ void optimizer::setup(weights& w) {
   const AbsDistMat& values = m_weights->get_values();
 
   m_gradient = values.Construct(values.Grid(), values.Root());
-  m_staging = values.Construct(values.Grid(), values.Root());
+  m_gradient_staging = values.Construct(values.Grid(), values.Root());
   m_gradient->Resize(height, width);
-  m_staging->Resize(height, width);
+  m_gradient_staging->Resize(height, width);
 
   // Initialize GPU
   m_cudnn = m_weights->m_cudnn;
   if (m_cudnn != nullptr) {
 #ifdef LBANN_HAS_CUDNN
     m_gradient_d = cudnn::matrix(m_cudnn, height, width);
-    m_staging_d = cudnn::matrix(m_cudnn, height, width);
+    m_gradient_staging_d = cudnn::matrix(m_cudnn, height, width);
 #endif // LBANN_HAS_CUDNN
   }
 
@@ -424,13 +457,13 @@ void optimizer::step() {
   #ifdef LBANN_HAS_CUDNN
     cudnn::matrix values_d(m_cudnn);
     values_d.attach(m_weights->m_values_d, m_weights->get_size());
-    cudnn::matrix& gradient_d = get_gradient_gpu();
+    const auto& gradient_d = get_gradient_gpu();
     step_compute_gpu(values_d, gradient_d);
   #endif // LBANN_HAS_CUDNN
   } else {
     m_weights->get_values(); // Move data to CPU
-    AbsDistMat& values = *m_weights->m_values;
-    const AbsDistMat& gradient = get_gradient();
+    auto& values = *m_weights->m_values;
+    const auto& gradient = get_gradient();
     step_compute(values, gradient);
   }
 

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -366,6 +366,13 @@ void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
       #endif // LBANN_HAS_CUDNN
     }
 
+    #ifdef LBANN_NBALLREDUCE_GRADIENT
+    /// @todo Handle shared weights
+    if (!m_gradient_allreduce_started) {
+      start_gradient_staging_allreduce();
+    }
+    #endif // LBANN_NBALLREDUCE_GRADIENT
+
   }
 }
 #ifdef LBANN_HAS_CUDNN
@@ -405,6 +412,13 @@ void optimizer::add_to_gradient_staging(const cudnn::matrix& gradient_d,
                                 scale, gradient_d.get_locked_data(i), 1,
                                 m_gradient_staging_d.get_data(i), 1));
     }
+
+    #ifdef LBANN_NBALLREDUCE_GRADIENT
+    /// @todo Handle shared weights
+    if (!m_gradient_allreduce_started) {
+      start_gradient_staging_allreduce();
+    }
+    #endif // LBANN_NBALLREDUCE_GRADIENT
 
   }
 }

--- a/src/optimizers/rmsprop.cpp
+++ b/src/optimizers/rmsprop.cpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// rmsprop .hpp .cpp - SGD with RMSprop
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/rmsprop.hpp"

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// sgd .hpp .cpp - Stochastic gradient descent optimizer
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/optimizers/sgd.hpp"

--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -64,8 +64,8 @@ matrix::matrix(const matrix& other)
     m_is_locked(false) {
   if (m_cudnn != nullptr) {
     m_data.assign(m_cudnn->get_num_gpus(), nullptr);
+    copy(other);
   }
-  copy(other);
 }
 
 matrix::matrix(matrix&& other)
@@ -82,7 +82,9 @@ matrix::matrix(matrix&& other)
 matrix& matrix::operator=(const matrix& other) {
   clear();
   m_cudnn = other.m_cudnn;
-  copy(other);
+  if (m_cudnn != nullptr) {
+    copy(other);
+  }
   return *this;
 }
 


### PR DESCRIPTION
This PR makes the following changes to the base optimizer class:
- GPU memory management is handled with GPU matrices.
- The GPU implementation is simpler since it keeps all gradient data on GPU.
- Added a function to launch an allreduce (possibly non-blocking) on the gradient staging matrix.
- Added flags to determine progress of an allreduce on the gradient staging matrix.
- Removed flags to determine if matrices are zero since they had no effect.

These changes provide a small performance boost to the GPU implementation since they remove some unnecessary calls to `El::Zero`. They will also make it easier to add a GPU allreduce that is non-blocking w.r.t. the GPU.