### PR TITLE
Bamboo prototext updates to comply with refactored IO layers.

### DIFF
--- a/bamboo/unit_tests/prototext/model_mnist_simple_1.prototext
+++ b/bamboo/unit_tests/prototext/model_mnist_simple_1.prototext
@@ -54,7 +54,9 @@ model {
   layer {
     name: "data"
     data_layout: "data_parallel"
-    input_partitioned_minibatch {}
+    input {
+      io_buffer: "partitioned"
+    }
   }
 
   layer {
@@ -90,10 +92,10 @@ model {
   layer {
     name: "target"
     data_layout: "data_parallel"
-    target_partitioned_minibatch {
+    target {
+      io_buffer: "partitioned"
       shared_data_reader: true
     }
   }
 
 }
-

--- a/bamboo/unit_tests/prototext/model_mnist_simple_2.prototext
+++ b/bamboo/unit_tests/prototext/model_mnist_simple_2.prototext
@@ -54,7 +54,9 @@ model {
   layer {
     name: "data"
     data_layout: "data_parallel"
-    input_partitioned_minibatch {}
+    input {
+      io_buffer: "partitioned"
+    }
   }
 
   layer {
@@ -86,7 +88,6 @@ model {
     data_layout: "model_parallel"
     relu {}
   }
-
   layer {
     name: "ip2"
     data_layout: "model_parallel"
@@ -105,10 +106,10 @@ model {
   layer {
     name: "target"
     data_layout: "data_parallel"
-    target_partitioned_minibatch {
+    target {
+      io_buffer: "partitioned"
       shared_data_reader: true
     }
   }
 
 }
-


### PR DESCRIPTION
Fixes incorrectly failing unit tests. Prototext model files were not updated with IO refactor. Since the expected behavior of test_lbann_invocation.py is failure for all but one of the tests this slipped through the cracks. 