### PR TITLE
Improve comm/comp overlap in convolution

### DIFF
--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -206,11 +206,11 @@ class convolution_layer : public base_convolution_layer {
 
   void bp_compute() override {
     if(this->m_using_gpus) {
-      apply_transposed_convolution_cudnn(false);
       compute_gradients_cudnn(false);
+      apply_transposed_convolution_cudnn(false);
     } else {
-      apply_transposed_convolution_im2col(false);
       compute_gradients_im2col(false);
+      apply_transposed_convolution_im2col(false);
     }
   }
 

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -180,11 +180,11 @@ class deconvolution_layer : public base_convolution_layer {
 
   void bp_compute() override {
     if(this->m_using_gpus) {
-      apply_convolution_cudnn(false);
       compute_gradients_cudnn(true);
+      apply_convolution_cudnn(false);
     } else {
-      apply_convolution_im2col(false);
       compute_gradients_im2col(true);
+      apply_convolution_im2col(false);
     }
   }
 

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -58,9 +58,6 @@ optimizer::optimizer(const optimizer& other)
     m_gradient_allreduce_started(other.m_gradient_allreduce_started),
     m_gradient_allreduce_finished(other.m_gradient_allreduce_finished),
     m_step_time(other.m_step_time)
-    #ifdef LBANN_NBALLREDUCE_GRADIENT
-    , m_gradient_allreduce_started(other.m_gradient_allreduce_started)
-    #endif  // LBANN_NBALLREDUCE_GRADIENT
 {
   if (m_gradient != nullptr) {
     m_gradient = m_gradient->Copy();


### PR DESCRIPTION
This swaps the order of gradient and error signal computation in convolution and deconvolution layers. This enables non-blocking allreduces started in the gradient computation step to also overlap with the error signal computation of the same layer.