### PR TITLE
Mesh reader

### DIFF
--- a/include/lbann/data_readers/data_reader_mesh.hpp
+++ b/include/lbann/data_readers/data_reader_mesh.hpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// data_reader_mesh .hpp .cpp - data reader for mesh data
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_DATA_READER_MESH_HPP
+#define LBANN_DATA_READER_MESH_HPP
+
+#include "data_reader.hpp"
+
+namespace lbann {
+
+/**
+ * Data reader for reading dumped mesh images.
+ * Provide the directory containing all the channel subdirectories.
+ * This assumes the data is stored as floats in row-major order.
+ * The channels to load are currently hardcoded. This only supports regression.
+ */
+class mesh_reader : public generic_data_reader {
+ public:
+  mesh_reader(bool shuffle = true);
+  ~mesh_reader() override {}
+
+  mesh_reader* copy() const override { return new mesh_reader(*this); }
+  std::string get_type() const override { return "mesh_reader"; }
+
+  /// Set a suffix to append to the channel directories.
+  void set_suffix(const std::string suffix) { m_suffix = suffix; }
+  /// Set the shape (height and width) of the data.
+  void set_data_shape(int height, int width) {
+    m_data_height = height;
+    m_data_width = width;
+  }
+  /// Set the index length for filenames.
+  void set_index_length(int l) {
+    m_index_length = l;
+  }
+
+  void load() override;
+  int get_linearized_data_size() const override {
+    return m_channels.size() * m_data_height * m_data_width;
+  }
+  int get_linearized_response_size() const override {
+    return m_data_height * m_data_width;
+  }
+  const std::vector<int> get_data_dims() const override {
+    return {static_cast<int>(m_channels.size()),
+        m_data_height,
+        m_data_width};
+  }
+ protected:
+  bool fetch_datum(Mat& X, int data_id, int mb_idx, int tid) override;
+  bool fetch_response(Mat& Y, int data_id, int mb_idx, int tid) override;
+
+  /**
+   * Load filename into mat.
+   * This may do datatype conversion if DataType is not float.
+   * mat should be of size (m_data_height, m_data_width).
+   */
+  void load_file(const std::string filename, Mat& mat);
+  /// Return the full path to the data file for datum data_id's channel.
+  std::string construct_filename(std::string channel, int data_id);
+
+  /// A suffix to append to each channel directory (e.g. "128").
+  std::string m_suffix = "128";
+  /// Target channel; contains the relaxation information.
+  std::string m_target_name = "mask";
+  /// Names of each channel to load as data.
+  std::vector<std::string> m_channels = {
+    "Density",
+    "Pressure",
+    "VectorComp_AvgVelocity_R",
+    "VolumeFractions_bubble",
+    "aspectRatio",
+    "conditionNumber",
+    "distortion",
+    "jacobian",
+    "largestAngle",
+    "oddy",
+    "scaledJacobian",
+    "shape",
+    //"shapeAndSize",
+    "shear",
+    //"shearAndSize",
+    "skew",
+    "smallestAngle",
+    "stretch",
+    "taper",
+    "volume"
+  };
+  /**
+   * Character length of the index in filenames.
+   * Indices will be left-padded with zeros to this length.
+   */
+  int m_index_length = 4;
+  /// Format string for the index.
+  std::string m_index_format_str;
+  /// X dimension of the mesh data.
+  int m_data_height = 128;
+  /// Y dimension of the mesh data.
+  int m_data_width = 128;
+  /// Number of samples.
+  int m_num_samples = 0;
+  /// Buffers for loading data into.
+  std::vector<std::vector<float>> m_load_bufs;
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_DATA_READER_MESH_HPP

--- a/include/lbann/data_readers/data_reader_mesh.hpp
+++ b/include/lbann/data_readers/data_reader_mesh.hpp
@@ -58,6 +58,8 @@ class mesh_reader : public generic_data_reader {
   void set_index_length(int l) {
     m_index_length = l;
   }
+  /// Set whether to do random horizontal and vertical flips.
+  void set_random_flips(bool b) { m_random_flips = b; }
 
   void load() override;
   int get_linearized_data_size() const override {
@@ -80,9 +82,14 @@ class mesh_reader : public generic_data_reader {
    * This may do datatype conversion if DataType is not float.
    * mat should be of size (m_data_height, m_data_width).
    */
-  void load_file(const std::string filename, Mat& mat);
+  void load_file(int data_id, const std::string channel, Mat& mat);
   /// Return the full path to the data file for datum data_id's channel.
   std::string construct_filename(std::string channel, int data_id);
+
+  /// Flip mat horizontally (i.e. about its vertical axis).
+  void horizontal_flip(Mat& mat);
+  /// Flip mat vertically (i.e. about its horizontal axis).
+  void vertical_flip(Mat& mat);
 
   /// A suffix to append to each channel directory (e.g. "128").
   std::string m_suffix = "128";
@@ -126,6 +133,14 @@ class mesh_reader : public generic_data_reader {
   int m_num_samples = 0;
   /// Buffers for loading data into.
   std::vector<std::vector<float>> m_load_bufs;
+  /// Whether to do random horizontal/vertical flips.
+  bool m_random_flips = false;
+  /**
+   * This records the flip choices made for each sample.
+   * This is needed because both the data and target need the same
+   * transformation applied.
+   */
+  std::vector<std::pair<bool, bool>> m_flip_choices;
 };
 
 }  // namespace lbann

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -107,6 +107,7 @@
 #include "lbann/data_readers/data_reader_merge_features.hpp"
 #include "lbann/data_readers/data_reader_ascii.hpp"
 #include "lbann/data_readers/data_reader_pilot2_molecular.hpp"
+#include "lbann/data_readers/data_reader_mesh.hpp"
 
 /// Data Store
 #include "lbann/data_store/generic_data_store.hpp"

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -23,6 +23,7 @@ set_full_path(THIS_DIR_SOURCES
   data_reader_jag.cpp
   data_reader_merge_features.cpp
   data_reader_merge_samples.cpp
+  data_reader_mesh.cpp
   data_reader_mnist.cpp
   data_reader_nci.cpp
   data_reader_numpy.cpp

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -90,7 +90,8 @@ void mesh_reader::load_file(const std::string filename, Mat& mat) {
   if (std::is_same<float, DataType>::value) {
     // Need to transpose from row-major to column-major order.
     Mat tmp_mat(m_data_width, m_data_height, buf, m_data_width);
-    El::Transpose(tmp_mat, mat);
+    Mat mat_reshape(m_data_height, m_data_width, mat.Buffer(), m_data_height);
+    El::Transpose(tmp_mat, mat_reshape);
   } else {
     // Need to transpose and convert from float. Not yet supported.
     throw lbann_exception("mesh_reader: does not support DataType != float");

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -1,0 +1,107 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// data_reader_mesh .hpp .cpp - data reader for mesh data
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/data_readers/data_reader_mesh.hpp"
+#include "lbann/utils/glob.hpp"
+
+namespace lbann {
+
+mesh_reader::mesh_reader(bool shuffle)
+  : generic_data_reader(shuffle) {}
+
+void mesh_reader::load() {
+  if (m_data_height == 0 || m_data_width == 0) {
+    throw lbann_exception("mesh_reader: data shape must be non-zero");
+  }
+  // Compute total number of samples based on number of targets.
+  std::vector<std::string> matches = glob(
+    get_file_dir() + m_target_name + m_suffix + "/*.bin");
+  if (matches.size() == 0) {
+    throw lbann_exception("mesh_reader: could not find any targets");
+  }
+  m_num_samples = matches.size();
+  // Set up buffers to load data into.
+  m_load_bufs.resize(omp_get_max_threads());
+  for (auto&& buf : m_load_bufs) {
+    buf.resize(m_data_height * m_data_width);
+  }
+  // Set up the format string.
+  if (std::pow(10, m_index_length) <= m_num_samples) {
+    throw lbann_exception("mesh_reader: index length too small");
+  }
+  m_index_format_str = "%0" + std::to_string(m_index_length) + "d";
+  // Reset indices.
+  m_shuffled_indices.resize(m_num_samples);
+  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  select_subset_of_data();
+}
+
+bool mesh_reader::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
+  for (size_t i = 0; i < m_channels.size(); ++i) {
+    Mat X_view = El::View(
+      X, El::IR(i*m_data_height*m_data_width, (i+1)*m_data_height*m_data_width),
+      El::IR(mb_idx, mb_idx + 1));
+    std::string filename = construct_filename(m_channels[i], data_id);
+    load_file(filename, X_view);
+  }
+  return true;
+}
+
+bool mesh_reader::fetch_response(Mat& Y, int data_id, int mb_idx, int tid) {
+  std::string filename = construct_filename(m_target_name, data_id);
+  Mat Y_view = El::View(Y, El::IR(0, Y.Height()), El::IR(mb_idx, mb_idx + 1));
+  load_file(filename, Y_view);
+  return true;
+}
+
+void mesh_reader::load_file(const std::string filename, Mat& mat) {
+  std::ifstream f(filename, std::ios::binary);
+  if (f.fail()) {
+    throw lbann_exception("mesh_reader: failed to open " + filename);
+  }
+  // Load into a local buffer.
+  float* buf = m_load_bufs[omp_get_thread_num()].data();
+  f.read((char*) buf, m_data_height * m_data_width * sizeof(float));
+  if (std::is_same<float, DataType>::value) {
+    // Need to transpose from row-major to column-major order.
+    Mat tmp_mat(m_data_width, m_data_height, buf, m_data_width);
+    El::Transpose(tmp_mat, mat);
+  } else {
+    // Need to transpose and convert from float. Not yet supported.
+    throw lbann_exception("mesh_reader: does not support DataType != float");
+  }
+}
+
+std::string mesh_reader::construct_filename(std::string channel, int data_id) {
+  std::string filename = get_file_dir() + channel + m_suffix + "/" + channel;
+  char idx[m_index_length + 1];
+  std::snprintf(idx, m_index_length + 1, m_index_format_str.c_str(), data_id);
+  return filename + std::string(idx) + ".bin";
+}
+
+}  // namespace lbann

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -86,7 +86,9 @@ void mesh_reader::load_file(const std::string filename, Mat& mat) {
   }
   // Load into a local buffer.
   float* buf = m_load_bufs[omp_get_thread_num()].data();
-  f.read((char*) buf, m_data_height * m_data_width * sizeof(float));
+  if (!f.read((char*) buf, m_data_height * m_data_width * sizeof(float))) {
+    throw lbann_exception("mesh_reader: failed to read " + filename);
+  }
   if (std::is_same<float, DataType>::value) {
     // Need to transpose from row-major to column-major order.
     Mat tmp_mat(m_data_width, m_data_height, buf, m_data_width);

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -65,7 +65,7 @@ bool mesh_reader::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
   for (size_t i = 0; i < m_channels.size(); ++i) {
     Mat X_view = El::View(
       X, El::IR(i*m_data_height*m_data_width, (i+1)*m_data_height*m_data_width),
-      El::IR(mb_idx, mb_idx + 1));
+      El::IR(mb_idx));
     std::string filename = construct_filename(m_channels[i], data_id);
     load_file(filename, X_view);
   }
@@ -74,7 +74,7 @@ bool mesh_reader::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
 
 bool mesh_reader::fetch_response(Mat& Y, int data_id, int mb_idx, int tid) {
   std::string filename = construct_filename(m_target_name, data_id);
-  Mat Y_view = El::View(Y, El::IR(0, Y.Height()), El::IR(mb_idx, mb_idx + 1));
+  Mat Y_view = El::View(Y, El::ALL, El::IR(mb_idx));
   load_file(filename, Y_view);
   return true;
 }

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -1976,6 +1976,8 @@ void init_data_readers(bool master, const lbann_data::LbannPB& p, std::map<execu
       reader = new data_reader_synthetic(readme.num_samples(), readme.num_features(), shuffle);
     } else if (name == "ascii") {
       reader = new ascii_reader(p.model().recurrent().unroll_depth(), shuffle);
+    } else if (name == "mesh") {
+      reader = new mesh_reader(shuffle);
     } else {
       if (master) {
         err << __FILE__ << " " << __LINE__ << " :: unknown name for data reader: "
@@ -2068,6 +2070,9 @@ void init_data_readers(bool master, const lbann_data::LbannPB& p, std::map<execu
       } else if (name == "ascii") {
         reader_validation = new ascii_reader(p.model().recurrent().unroll_depth(), shuffle);
         (*(ascii_reader *)reader_validation) = (*(ascii_reader *)reader);
+      } else if (name == "mesh") {
+        reader_validation = new mesh_reader(shuffle);
+        (*(mesh_reader *)reader_validation) = (*(mesh_reader *)reader);
       }
 
       reader_validation->swap_role("validate");


### PR DESCRIPTION
This adds an initial implementation of a data reader for loading mesh data.

Loading the data seems to work, but LBANN isn't able to learn it, so I don't want to merge yet in case the issue turns out to be in this code.

@timmoon10 I do some "interesting" things in the `mesh_reader::fetch_datum`/`fetch_response`/`load_file` methods involving `El::Transpose` and views. It appears to work but I'd appreciate a second glance since you implemented `El::Transpose`.