### PR TITLE
Miscellaneous bugfixes for VAEs

### DIFF
--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -47,8 +47,8 @@ class relu_layer : public entrywise_activation_layer {
 
  public:
   relu_layer(lbann_comm *comm,
-             cudnn::cudnn_manager *cudnn = nullptr) :
-    entrywise_activation_layer(comm) {
+             cudnn::cudnn_manager *cudnn = nullptr)
+    : entrywise_activation_layer(comm) {
   #ifdef LBANN_HAS_CUDNN
     m_activation_cudnn_desc = nullptr;
     this->m_cudnn = cudnn;
@@ -73,6 +73,7 @@ class relu_layer : public entrywise_activation_layer {
     cudnn::copy_activation_cudnn_desc(other.m_activation_cudnn_desc,
                                       m_activation_cudnn_desc);
   #endif // LBANN_HAS_CUDNN
+    return *this;
   }
 
   ~relu_layer() override {

--- a/include/lbann/layers/transform/noise.hpp
+++ b/include/lbann/layers/transform/noise.hpp
@@ -85,9 +85,13 @@ class noise_layer : public transform_layer {
 
   void fp_compute() override {
     auto& output = get_activations();
-    gaussian_fill(output,
-                  output.Height(), output.Width(),
-                  DataType(0), m_noise_factor);
+    if (this->m_model->get_execution_mode() == execution_mode::training) {
+      gaussian_fill(output,
+                    output.Height(), output.Width(),
+                    DataType(0), m_noise_factor);
+    } else {
+      El::Zero(output);
+    }
   }
 
   void bp_compute() override {

--- a/include/lbann/layers/transform/noise.hpp
+++ b/include/lbann/layers/transform/noise.hpp
@@ -32,7 +32,9 @@
 
 namespace lbann {
 
-/** Layer adds (Gaussian) noise to data. */
+/** Layer draws outputs from a Gaussian distribution.
+ *  During validation and testing, the layer outputs zeros.
+ */
 template <data_layout T_layout = data_layout::DATA_PARALLEL>
 class noise_layer : public transform_layer {
  private:

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -14,10 +14,10 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    binary_cross_entropy {}
     kl_divergence {
       layer1: "z_mean"
-      layer2: "exp_noise" 
+      layer2: "z_log_sigma" 
     }
     l2_weight_regularization {
       scale_factor: 1e-4
@@ -38,10 +38,7 @@ model {
       interval: 1
     }
   }
-#  callback {
-#    timer {
-#    }
-#  }
+  callback { timer {} }
   callback {
     dump_activations {
       basename: "dump_acts/"
@@ -75,7 +72,7 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "glorot_uniform"
+      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -93,7 +90,6 @@ model {
   layer {
     parents: "relu1"
     name: "split"
-    children: "z_mean z_log_sigma"
     data_layout: "model_parallel"
     split {
     }
@@ -106,9 +102,15 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2
-      weight_initialization: "glorot_uniform"
+      weight_initialization: "glorot_normal"
       has_bias: true
     }
+  }
+  layer {
+    parents: "z_mean"
+    name: "z_mean_id"
+    data_layout: "model_parallel"
+    identity {}
   }
 
   # FULLY_CONNECTED z_log_sigma
@@ -118,7 +120,7 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2
-      weight_initialization: "glorot_uniform"
+      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -156,7 +158,6 @@ model {
   layer {
     parents: "exp noise"
     name: "exp_noise"
-    children: "sum"
     data_layout: "model_parallel"
     hadamard {
     }
@@ -165,9 +166,8 @@ model {
 
   # Sum sum
   layer {
-    parents: "z_mean exp_noise"
+    parents: "z_mean_id exp_noise"
     name: "sum"
-    children: "decode1"
     data_layout: "model_parallel"
     sum {
     }
@@ -180,7 +180,7 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "glorot_uniform"
+      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -201,7 +201,7 @@ model {
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_uniform"
+      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -106,6 +106,13 @@ model {
       has_bias: true
     }
   }
+  # Note: This identity layer is a kludgy solution to a bug in the KL divergence.
+  #   The KL divergence adds to the "prev_error_signal" of z_mean, which is the
+  #   "error_signal" of z_mean's child layer. However, z_mean's child layer is a
+  #   sum layer, which has multiple parents and hence multiple error_signal's.
+  #   Putting this identity layer clears up that ambiguity, but it is not a good
+  #   solution to the problem. The objective function paradigm outlined in 
+  #   issue #193 will be a better long-term solution.
   layer {
     parents: "z_mean"
     name: "z_mean_id"

--- a/src/layers/activations/CMakeLists.txt
+++ b/src/layers/activations/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
+    sigmoid.cu
     softmax.cu
     )
 endif ()

--- a/src/layers/activations/sigmoid.cu
+++ b/src/layers/activations/sigmoid.cu
@@ -1,0 +1,162 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// softmax_cuda.cu - GPU helper routines for softmax layer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "math.h"
+#include "lbann/layers/activations/sigmoid.hpp"
+
+namespace {
+
+// Sigmoid function
+#if __CUDA_ARCH__ >= 530
+__device__ inline __half sigmoid(__half x) {
+  return __hdiv(__float2half(1.f),
+                __hadd(__float2half(1.f), hexp(__hneg(x))));
+}
+#endif // __CUDA_ARCH__ >= 530
+__device__ inline float sigmoid(float x) {
+  return 1 / (1.0f + expf(-x));
+}
+__device__ inline double sigmoid(double x) {
+  return 1 / (1.0 + exp(-x));
+}
+
+
+__global__ void fp_kernel(int height, int width,
+                          const lbann::DataType* __restrict__ input,
+                          int input_leading_dim,
+                          lbann::DataType* __restrict__ output,
+                          int output_leading_dim,
+                          lbann::DataType cutoff) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  while (tid < height * width) {
+
+    // Get input value
+    const int row = tid % height;
+    const int col = tid / height;
+    lbann::DataType x = input[row + col * input_leading_dim];
+    
+    // Compute output value
+  #ifdef LBANN_ENABLE_SIGMOID_CUTOFF
+    if (x < -cutoff) { x = -cutoff; }
+    if (x > cutoff) { x = cutoff; }
+  #endif // LBANN_ENABLE_SIGMOID_CUTOFF
+    output[row + col * output_leading_dim] = sigmoid(x);
+
+    // Move to next entry
+    tid += blockDim.x * gridDim.x;
+
+  }
+}
+
+__global__ void bp_kernel(int height, int width,
+                          const lbann::DataType* __restrict__ input,
+                          int input_leading_dim,
+                          const lbann::DataType* __restrict__ gradient_wrt_output,
+                          int gradient_wrt_output_leading_dim,
+                          lbann::DataType* __restrict__ gradient_wrt_input,
+                          int gradient_wrt_input_leading_dim,
+                          lbann::DataType cutoff) {
+  int tid = threadIdx.x + blockIdx.x * blockDim.x;
+  while (tid < height * width) {
+
+    // Get input value
+    const int row = tid % height;
+    const int col = tid / height;
+    const lbann::DataType x = input[row + col * input_leading_dim];
+    lbann::DataType dx = lbann::DataType(0);
+  #ifdef LBANN_ENABLE_SIGMOID_CUTOFF
+    if (-cutoff <= x && x <= cutoff)
+  #endif // LBANN_ENABLE_SIGMOID_CUTOFF
+    {
+      const lbann::DataType dy
+        = gradient_wrt_output[row + col * gradient_wrt_output_leading_dim];
+      const lbann::DataType sigx = sigmoid(x);
+      dx = dy * sigx * (lbann::DataType(1) - sigx);
+    }
+    gradient_wrt_input[row + col * gradient_wrt_input_leading_dim] = dx;
+
+    // Move to next entry
+    tid += blockDim.x * gridDim.x;
+
+  }
+}
+
+}
+
+namespace lbann {
+namespace sigmoid_cuda {
+
+void fp(cudnn::cudnn_manager& cudnn,
+        int height,
+        int width_per_gpu,
+        const std::vector<lbann::DataType*>& input,
+        int input_leading_dim,
+        std::vector<lbann::DataType*>& output,
+        int output_leading_dim,
+        lbann::DataType cutoff) {
+  const int size = height * width_per_gpu;
+  const int num_gpus = cudnn.get_num_gpus();
+  const int block_dim = 256;
+  const int grid_dim = size / block_dim + ((size % block_dim) ? 1 : 0);
+  for (int i = 0; i < num_gpus; ++i) {
+    CHECK_CUDA(cudaSetDevice(cudnn.get_gpu(i)));
+    fp_kernel<<<grid_dim, block_dim, 0, cudnn.get_stream(i)>>>(
+      height, width_per_gpu,
+      input[i], input_leading_dim,
+      output[i], output_leading_dim,
+      cutoff);
+  }
+}
+
+void bp(cudnn::cudnn_manager& cudnn,
+        int height,
+        int width_per_gpu,
+        const std::vector<lbann::DataType*>& input,
+        int input_leading_dim,
+        const std::vector<lbann::DataType*>& gradient_wrt_output,
+        int gradient_wrt_output_leading_dim,
+        std::vector<lbann::DataType*>& gradient_wrt_input,
+        int gradient_wrt_input_leading_dim,
+        lbann::DataType cutoff) {
+  const int size = height * width_per_gpu;
+  const int num_gpus = cudnn.get_num_gpus();
+  const int block_dim = 256;
+  const int grid_dim = size / block_dim + ((size % block_dim) ? 1 : 0);
+  for (int i = 0; i < num_gpus; ++i) {
+    CHECK_CUDA(cudaSetDevice(cudnn.get_gpu(i)));
+    bp_kernel<<<grid_dim, block_dim, 0, cudnn.get_stream(i)>>>(
+      height, width_per_gpu,
+      input[i], input_leading_dim,
+      gradient_wrt_output[i], gradient_wrt_output_leading_dim,
+      gradient_wrt_input[i], gradient_wrt_input_leading_dim,
+      cutoff);
+  }
+}
+
+} // namespace sigmoid_cuda
+} // namespace lbann

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -325,9 +325,9 @@ void add_layers(
     else if (layer.has_sigmoid()) {
       //const lbann_data::Sigmoid &ell = layer.sigmoid();
       if (layout == data_layout::MODEL_PARALLEL) {
-        d = new sigmoid_layer<data_layout::MODEL_PARALLEL>(comm);
+        d = new sigmoid_layer<data_layout::MODEL_PARALLEL>(comm, nullptr);
       } else {
-        d = new sigmoid_layer<data_layout::DATA_PARALLEL>(comm);
+        d = new sigmoid_layer<data_layout::DATA_PARALLEL>(comm, cudnn);
       }
     }
 


### PR DESCRIPTION
Major changes:
- Debugging KL divergence objective function.
- Noise layer is only random during training so that testing is deterministic.
- GPU implementation of sigmoid layer.
- Sigmoid layer output is strictly in (0,1) to avoid numerical issues with binary cross entropy.

Gradient checks come back clean on the MNIST VAE model (with ReLUs changed to sigmoids).