### PR TITLE
removing use_cudnn and replacing with disable_cuda, which defaults to…

### DIFF
--- a/bamboo/unit_tests/prototext/model_mnist_simple_1.prototext
+++ b/bamboo/unit_tests/prototext/model_mnist_simple_1.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 3
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/bamboo/unit_tests/prototext/model_mnist_simple_2.prototext
+++ b/bamboo/unit_tests/prototext/model_mnist_simple_2.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 3
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -43,8 +43,6 @@ int main(int argc, char *argv[]) {
   lbann_comm *comm = initialize(argc, argv, random_seed);
   bool master = comm->am_world_master();
 
-
-
   if (master) {
     std::cout << "\n\n==============================================================\n"
               << "STARTING lbann with this command line:\n";
@@ -67,6 +65,8 @@ int main(int argc, char *argv[]) {
       finalize(comm);
       return 0;
     }
+
+
 
     //this must be called after call to opts->init();
     //must also specify "--catch-signals" on cmd line
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
     // Check for cudnn, with user feedback
     cudnn::cudnn_manager *cudnn = nullptr;
 #ifdef LBANN_HAS_CUDNN
-    if (pb_model->use_cudnn()) {
+    if (! pb_model->disable_cuda()) {
       if (master) {
         std::cerr << "code was compiled with LBANN_HAS_CUDNN, and we are using cudnn\n";
       }
@@ -284,7 +284,6 @@ int main(int argc, char *argv[]) {
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }
-
 
   // free all resources by El and MPI
   finalize(comm);

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -186,7 +186,7 @@ model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &p
     // Check for cudnn, with user feedback
     cudnn::cudnn_manager *cudnn = nullptr;
 #ifdef LBANN_HAS_CUDNN
-    if (pb_model->use_cudnn()) {
+    if (! pb_model->disable_cuda()) {
       if (master) {
         std::cerr << "code was compiled with LBANN_HAS_CUDNN, and we are using cudnn\n";
       }

--- a/model_zoo/models/alexnet/data.prototext
+++ b/model_zoo/models/alexnet/data.prototext
@@ -62,7 +62,6 @@ model {
     }
   }
   data_layout: "data_parallel"
-  use_cudnn: true
   layer {
     input_partitioned_minibatch {
     }

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 72
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs:20 
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_dnn_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_dnn_chem_ecfp.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 100
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
@@ -7,8 +7,8 @@ model {
   num_parallel_readers: 1
   #procs_per_model: 12
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
+  disable_cuda: true
 
   ###################################################
   # Objective function

--- a/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
+++ b/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: 0
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 10
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
@@ -6,8 +6,8 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
+  disable_cuda: true
 
   ###################################################
   # Objective function

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 50
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/char_rnn/model_char_rnn.prototext
+++ b/model_zoo/models/char_rnn/model_char_rnn.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
   recurrent {
     unroll_depth : 5

--- a/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
+++ b/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 10
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/imagenet/model_imagenet.prototext
+++ b/model_zoo/models/imagenet/model_imagenet.prototext
@@ -2,7 +2,6 @@ model {
   name: "sequential_model"
   num_epochs: 20
   data_layout: "data_parallel"
-  use_cudnn: false
 
   ###################################################
   # Objective function

--- a/model_zoo/models/lenet_mnist/model_lenet_mnist.prototext
+++ b/model_zoo/models/lenet_mnist/model_lenet_mnist.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_autoencoder_pilot2.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 1
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/resnet50/model_resnet50.prototext
+++ b/model_zoo/models/resnet50/model_resnet50.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 10
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/resnet50/model_resnet50_motif.prototext
+++ b/model_zoo/models/resnet50/model_resnet50_motif.prototext
@@ -176,7 +176,6 @@ model {
   num_epochs: 10
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/resnet50/model_resnet50_sequential.prototext
+++ b/model_zoo/models/resnet50/model_resnet50_sequential.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 10
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/siamese/finetune-cub/model_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 50
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/siamese/siamese_alexnet/model_siamese_alexnet.prototext
+++ b/model_zoo/models/siamese/siamese_alexnet/model_siamese_alexnet.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
@@ -9,7 +9,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/simple_mnist/model_mnist_simple_1.prototext
+++ b/model_zoo/models/simple_mnist/model_mnist_simple_1.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 3
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/models/simple_mnist/model_mnist_simple_2.prototext
+++ b/model_zoo/models/simple_mnist/model_mnist_simple_2.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 3
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/tests/model_lenet_mnist_ckpt.prototext
+++ b/model_zoo/tests/model_lenet_mnist_ckpt.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/tests/model_mnist_distributed_io.prototext
+++ b/model_zoo/tests/model_mnist_distributed_io.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 1
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/tests/model_mnist_partitioned_io.prototext
+++ b/model_zoo/tests/model_mnist_partitioned_io.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 20
   num_parallel_readers: 0
   procs_per_model: 1
-  use_cudnn: false
   num_gpus: -1
 
   ###################################################

--- a/model_zoo/tests/model_mnist_resnet.prototext
+++ b/model_zoo/tests/model_mnist_resnet.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   use_nccl : false
   num_gpus: -1
 

--- a/model_zoo/tests/model_mnist_ridge_regression.prototext
+++ b/model_zoo/tests/model_mnist_ridge_regression.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   use_nccl : false
   num_gpus: -1
 

--- a/model_zoo/tests/model_mnist_softmax_regression.prototext
+++ b/model_zoo/tests/model_mnist_softmax_regression.prototext
@@ -6,7 +6,6 @@ model {
   num_epochs: 4
   num_parallel_readers: 0
   procs_per_model: 0
-  use_cudnn: true
   num_gpus: -1
 
   ###################################################

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -188,8 +188,7 @@ message Model {
   int64 evaluation_frequency = 54;
   int64 num_parallel_readers = 100;
 
-  //use cudnn_manager, if use_cudnn=true AND lbann was compiled with cudnn support
-  bool use_cudnn = 8;
+  bool disable_cuda = 8;
   bool use_nccl = 107;
 
   repeated Layer layer = 10;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -2288,8 +2288,8 @@ void get_cmdline_overrides(lbann::lbann_comm *comm, lbann_data::LbannPB& p)
   if (opts->has_int("num_parallel_readers")) {
     model->set_num_parallel_readers(opts->get_int("num_parallel_readers"));
   }
-  if (opts->has_bool("use_cudnn")) {
-    model->set_use_cudnn(opts->get_int("use_cudnn"));
+  if (opts->has_bool("disable_cuda")) {
+    model->set_disable_cuda(opts->get_bool("disable_cuda"));
   }
   if (opts->has_int("random_seed")) {
     model->set_random_seed(opts->get_int("random_seed"));
@@ -2374,7 +2374,7 @@ void print_parameters(lbann::lbann_comm *comm, lbann_data::LbannPB& p)
             << "  procs_per_model:      " << m.procs_per_model()  << std::endl
             << "  num_gpus:             " << m.num_gpus()  << std::endl
             << "  num_parallel_readers: " << m.num_parallel_readers()  << std::endl
-            << "  use_cudnn:            " << m.use_cudnn()  << std::endl
+            << "  disable_cuda:         " << m.disable_cuda()  << std::endl
             << "  random_seed:          " << m.random_seed() << std::endl
             << "  data_layout:          " << m.data_layout()  << std::endl
             << "     (only used for metrics)\n"
@@ -2438,7 +2438,7 @@ void print_help(lbann::lbann_comm *comm)
        "\n"
        "Some prototext values can be over-riden on the command line;\n"
        "(notes: use '1' or '0' for bool; if no value is given for a flag,\n"
-       "        e.g: --use_cudnn, then a value of '1' is assigned)\n"
+       "        e.g: --disable_cuda, then a value of '1' is assigned)\n"
        "\n"
        "General:\n"
        "  --dag_model\n"
@@ -2447,7 +2447,7 @@ void print_help(lbann::lbann_comm *comm)
        "  --block_size=<int>\n"
        "  --procs_per_model=<int>\n"
        "  --num_gpus=<int>\n"
-       "  --use_cudnn=<bool>\n"
+       "  --disable_cuda=<bool>\n"
        "     has no effect unless lbann was compiled with: LBANN_HAS_CUDNN\n"
        "  --random_seed=<int>\n"
        "  --objective_function<string>\n"


### PR DESCRIPTION
… false.

The models: autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
and autoencoder_mnist/model_conv_autoencoder_mnist.prototext contain:
  disable_cuda: true; remaining model files do not contain this field.
You can pass --disable_cuda or --disable_cuda=1 on the command line.
Logic was changed in model_zoo/lbann.cpp and model_zoo/lbann2.cpp for instantiating
cudnn::cudnn_manager