### PR TITLE
Minor performance optimization and bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ option(${UPPER_PROJECT_NAME}_WITH_NVPROF
 option(${UPPER_PROJECT_NAME}_WITH_TOPO_AWARE
   "Enable topology-aware profiling (HWLOC)" ON)
 
-option(${UPPER_PROJECT_NAME}_WITH_ALUNINUM 
+option(${UPPER_PROJECT_NAME}_WITH_ALUMINUM 
   "Enable Aluminum all-reduce library" OFF)
 
 option(${UPPER_PROJECT_NAME}_VERBOSE "Enable verbose output" OFF)

--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -320,6 +320,7 @@ cudnn_manager::cudnn_manager(lbann::lbann_comm *_comm, int max_num_gpus, bool nc
         FORCE_CHECK_CUDNN(cudnnCreate(&m_handles.back()));
         FORCE_CHECK_CUDNN(cudnnSetStream(m_handles.back(), m_streams.back()));
         FORCE_CHECK_CUBLAS(cublasCreate(&m_cublas_handles.back()));
+        FORCE_CHECK_CUBLAS(cublasSetStream(m_cublas_handles.back(), m_streams.back()));
     }
 
 

--- a/src/utils/cudnn_wrapper.cu
+++ b/src/utils/cudnn_wrapper.cu
@@ -147,7 +147,7 @@ void cudnn_manager::global_allreduce_on_gpus(std::vector<DataType*>& gpu_data,
                                              El::mpi::Comm comm) {
   if(!is_nccl_used()){
     static Mat cpu_workspace;
-    cpu_workspace.Resize(height, width);
+    cpu_workspace.Resize(height, width, height);
     allreduce_on_gpus(gpu_data, height, width);
     copy_from_gpu(0, cpu_workspace, gpu_data[0]);
     synchronize();

--- a/superbuild/openblas/CMakeLists.txt
+++ b/superbuild/openblas/CMakeLists.txt
@@ -16,7 +16,7 @@ set(OPENBLAS_CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}"
 set(OPENBLAS_URL "https://github.com/xianyi/OpenBLAS.git"
   CACHE STRING "The URL from which to clone OpenBLAS")
 
-set(OPENBLAS_TAG "v0.2.15"
+set(OPENBLAS_TAG "db72ad8"
   CACHE STRING "The git tag or hash to checkout for OpenBLAS")
 
 # Handle the options


### PR DESCRIPTION
- Updating OpenBLAS version to use better multi-threaded GEMMs (https://github.com/xianyi/OpenBLAS/pull/1320).
- Use contiguous CPU workspace for naive GPU allreduces.
- Use same CUDA stream for cuBLAS and cuDNN to avoid potential race conditions.