### PR TITLE
GPU debugging

### DIFF
--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -320,22 +320,9 @@ class fully_connected_layer : public learning_layer {
       const auto& bias_d = m_weights[1]->get_values_gpu();
       
       // Initialize work space with ones
-      std::vector<DataType*> ones_d;
-      for (const auto& work_space : this->m_cudnn->get_work_spaces()) {
-        ones_d.push_back((DataType*) work_space);
-      }
-      const size_t min_size = mini_batch_size * sizeof(DataType);
-      for (const auto& size : this->m_cudnn->get_work_space_sizes()) {
-        if (size < min_size) {
-          std::stringstream err;
-          err << __FILE__ << " " << __LINE__ << " :: "
-              << "insufficient GPU work space "
-              << "(requires " << min_size << " bytes on each GPU, "
-              << "but only found " << size << " bytes)";
-          throw lbann_exception(err.str());
-        }
-      }
-      m_cudnn->set_on_gpus(ones_d, DataType(1), mini_batch_size);
+      cudnn::matrix ones_d(this->m_cudnn);
+      ones_d.attach_to_work_spaces(mini_batch_size);
+      m_cudnn->set_on_gpus(ones_d.get_data(), DataType(1), mini_batch_size);
 
       // Apply bias with outer product
       for (int i = 0; i < num_gpus; ++i) {
@@ -345,7 +332,7 @@ class fully_connected_layer : public learning_layer {
                      output_size, mini_batch_size, 1,
                      DataType(1),
                      bias_d[i], output_size,
-                     ones_d[i], mini_batch_size,
+                     ones_d.get_data(i), mini_batch_size,
                      DataType(1),
                      output_d.get_data(i), output_ldim);
       }
@@ -381,22 +368,9 @@ class fully_connected_layer : public learning_layer {
         && bias_optimizer != nullptr) {
 
       // Initialize work space with ones
-      std::vector<DataType*> ones_d;
-      for (const auto& work_space : this->m_cudnn->get_work_spaces()) {
-        ones_d.push_back((DataType*) work_space);
-      }
-      const size_t min_size = mini_batch_size * sizeof(DataType);
-      for (const auto& size : this->m_cudnn->get_work_space_sizes()) {
-        if (size < min_size) {
-          std::stringstream err;
-          err << __FILE__ << " " << __LINE__ << " :: "
-              << "insufficient GPU work space "
-              << "(requires " << min_size << " bytes on each GPU, "
-              << "but only have " << size << " bytes)";
-          throw lbann_exception(err.str());
-        }
-      }
-      m_cudnn->set_on_gpus(ones_d, DataType(1), mini_batch_size);
+      cudnn::matrix ones_d(this->m_cudnn);
+      ones_d.attach_to_work_spaces(mini_batch_size);
+      m_cudnn->set_on_gpus(ones_d.get_data(), DataType(1), mini_batch_size);
 
       // Obtain gradient with a sum over rows
       for (int i = 0; i < num_gpus; ++i) {
@@ -406,7 +380,7 @@ class fully_connected_layer : public learning_layer {
                      output_size, mini_batch_size,
                      DataType(1),
                      gradient_wrt_output_d.get_locked_data(i), gradient_wrt_output_ldim,
-                     ones_d[i], 1,
+                     ones_d.get_data(i), 1,
                      DataType(0),
                      m_bias_gradient_d.get_data(i), 1);
       }

--- a/include/lbann/utils/cudnn_wrapper.hpp
+++ b/include/lbann/utils/cudnn_wrapper.hpp
@@ -154,6 +154,11 @@ public:
                      int width_per_gpu = 1,
                      int leading_dim = 0);
 
+  /** Attach matrix to GPU workspace. */
+  void attach_to_work_spaces(int height,
+                             int width_per_gpu = 1,
+                             int leading_dim = 0);
+
   /** Get matrix height. */
   inline int get_height() const { return m_height; }
   /** Get matrix width per GPU. */

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -288,9 +288,9 @@ void optimizer::add_to_gradient(const AbsDistMat& gradient,
       #ifndef LBANN_HAS_CUDNN
       throw lbann_exception("optimizer: cuDNN not detected");
       #else
-      cudnn::matrix gradient_d(m_cudnn,
-                               gradient.LocalHeight(),
-                               gradient.LocalWidth());
+      cudnn::matrix gradient_d(m_cudnn);
+      gradient_d.attach_to_work_spaces(gradient.LocalHeight(),
+                                       gradient.LocalWidth());
       m_cudnn->broadcast_to_gpus(gradient_d.get_data(),
                                  gradient.LockedMatrix());
       add_to_gradient(gradient_d, scale);


### PR DESCRIPTION
This pull request avoids making invalid cuBLAS GEMM calls when the local mini-batch size is zero, which should fix a runtime warning. It also implements a convenience function to attach GPU matrices to the GPU workspace buffers.