### PR TITLE
Build script update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,16 @@
 ### LC Systems
    1. Clone this repo using `git clone https://github.com/LLNL/lbann.git`
    2. From anywhere in the lbann directory run the LC build script located in  
-   `~/lbann/scripts/build_lbann_lc.sh`
-   3. This will build LBANN in a newly created build directory.
+   `<LBANN_dir>/lbann/scripts/build_lbann_lc.sh`
+   3. This will build LBANN in a newly created build directory. This build script uses the CMake superbuild. Information on the super build can be found in the superbuild directory. 
+   4. After the first use of this script, subsequent uses will recompile LBANN using the Makefile found in `build/<compiler>.<cluster>.llnl.gov/lbann/build/`.
+   5. To reconfigure the build add the --reconfigure plan. For example, to change this build from a release build to a debug build, add --debug and --reconfigure. 
+   6. To completely rebuild LBANN and its dependencies add the --clean-build flag. Other useful configuration options can be viewed by running the script with the --help flag. 
 
 ### OS X
    1. Clone this repo using `git clone https://github.com/LLNL/lbann.git`
    2. From anywhere in the lbann directory run the LC build script located in  
-   `~/lbann/scripts/build_lbann_osx.sh`
+   `<LBANN_dir>/lbann/scripts/build_lbann_osx.sh`
    3. This will build LBANN in a newly created build directory.
 
 ## Building LBANN with Spack [for Users]
@@ -95,32 +98,35 @@ Note: User must include the -B singularity command, to bind any necessary files 
    1. Allocate compute resources using SLURM: `salloc -N1 -t 60`
    2. Run a test experiment for the MNIST data set; from the main lbann directory run the following command:
  ```
-  srun -n12 build/catalyst.llnl.gov/model_zoo/lbann \
+  srun -n12 build/gnu.catalyst.llnl.gov/install/bin/lbann \
 --model=model_zoo/tests/model_mnist_distributed_io.prototext \
 --reader=model_zoo/data_readers/data_reader_mnist.prototext \
 --optimizer=model_zoo/optimizers/opt_adagrad.prototext \
 --num_epochs=5
 ```
-Note: `srun -n12 build/catalyst.llnl.gov/model_zoo/lbann` assumes you are running on the LLNL catalyst platform;
+Note: `srun -n12 build/gnu.catalyst.llnl.gov/install/bin/lbann` assumes you are running on the LLNL catalyst platform;
   if running on some other platform, and/or have installed lbann in a different directory, you
   will need to adjust this command.
 
-  This should produce the following final results on Catalyst:
+  This should produce roughly the following final results on Catalyst:
 ```
 --------------------------------------------------------------------------------
-[5] Epoch : stats formated [tr/v/te] iter/epoch = [2700/600/1000]
-            global MB = [  20/  10/  10] global last MB = [  20/  10/  10]
-             local MB = [  10/  10/  10]  local last MB = [  10/  10/  10]
+[4] Epoch : stats formated [tr/v/te] iter/epoch = [844/94/157]
+            global MB = [  64/  64/  64] global last MB = [  48  /  48  /  16  ]
+             local MB = [  64/  64/  64]  local last MB = [  48+0/  48+0/  16+0]
 --------------------------------------------------------------------------------
-Model 0 @13500 steps Training categorical accuracy: 99.3519% @3000 validation steps Validation categorical accuracy: 97.9167%
-Model 1 @13500 steps Training categorical accuracy: 99.3222% @3000 validation steps Validation categorical accuracy: 97.6%
-Model 0 average cross entropy: 0.079888
-Model 1 average cross entropy: 0.0871397
-Model 0 Epoch time: 30.1591s; Mean minibatch time: 0.010775s; Min: 0.0104503s; Max: 0.0126789s; Stdev: 0.000117069s
-Model 1 Epoch time: 30.1591s; Mean minibatch time: 0.0107751s; Min: 0.010483s; Max: 0.0129022s; Stdev: 0.000118997s
-Model 0 @1000 testing steps external validation categorical accuracy: 98.01%
-Model 1 @1000 testing steps external validation categorical accuracy: 97.92%
-
+Model 0 training epoch 4 objective function : 0.0471567
+Model 0 training epoch 4 categorical accuracy : 99.6241%
+Model 0 training epoch 4 run time : 7.64182s
+Model 0 training epoch 4 mini-batch time statistics : 0.00901458s mean, 0.0212693s max, 0.0078979s min, 0.000458463s stdev
+Model 0 validation objective function : 0.0670221
+Model 0 validation categorical accuracy : 98.9%
+Model 0 validation run time : 0.25341s
+Model 0 validation mini-batch time statistics : 0.00269454s mean, 0.00285273s max, 0.0020936s min, 6.65695e-05s stdev
+Model 0 test objective function : 0.0600125
+Model 0 test categorical accuracy : 99.02%
+Model 0 test run time : 0.421912s
+Model 0 test mini-batch time statistics : 0.00268631s mean, 0.00278771s max, 0.00131827s min, 0.00011085s stdev
 ``` 
   Note: LBANN performance will vary on a machine to machine basis. Results will also vary, but should not do so significantly. 
 
@@ -128,4 +134,3 @@ Model 1 @1000 testing steps external validation categorical accuracy: 97.92%
 There are various prototext models under the lbann/model_zoo/models/ directory: alexnet, autoencoder_mnist, lenet_mnist, etc. Each of these directories should have a script called *runme.py*. Run this script with no command line parameters for complete usage. Basically, these scripts generate command lines similar to the one above (in the *Verifying LBANN on LC* section). The scripts take two required arguments: --nodes=`<int>` and --tasks=`<int>`. The "tasks" option is used to specify the number of tasks per node, hence, the total number of tasks (cores) is: nodes\*tasks. The generated command lines are designed to be executed using *srun* on LC systems, so you may need to modify, e.g, substitute mpirun, depending on your specific system.
 
 Note: some directories contain multiple models, e.g, as of this writing, the autoencoder_cifar10 directory contains both *model_autoencoder_cifar10.prototext* and *model_conv_autoencoder_cifar10.prototext*. In these cases there may be multiple python scripts, e.g, *runme_conv.py*.
-

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Note: User must include the -B singularity command, to bind any necessary files 
    2. Run a test experiment for the MNIST data set; from the main lbann directory run the following command:
  ```
   srun -n12 build/gnu.catalyst.llnl.gov/install/bin/lbann \
---model=model_zoo/tests/model_mnist_distributed_io.prototext \
+--model=model_zoo/models/lenet_mnist/model_lenet_mnist.prototext \
 --reader=model_zoo/data_readers/data_reader_mnist.prototext \
 --optimizer=model_zoo/optimizers/opt_adagrad.prototext \
 --num_epochs=5


### PR DESCRIPTION
Since the build system change the build_lbann_lc.sh script simply runs the superbuild. However, when using the script to rebuild lbann, superfluous work occurs for the dependencies. This update changes the script behavior to only build updated files. This PR also adds a little bit of information on the build script to the readme. 