### PR TITLE
LSTMs

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -342,8 +342,10 @@ class Layer {
   /** Get local portion of error signal tensor. (const) */
   const Mat& get_local_error_signals(int parent_index = 0) const;
 
+  /** Get reference to LBANN communicator. */
+  lbann_comm* get_comm() const { return m_comm; }
   /** Get reference to cuDNN manager. */
-  cudnn::cudnn_manager* get_cudnn_manager() { return m_cudnn; }
+  cudnn::cudnn_manager* get_cudnn_manager() const { return m_cudnn; }
 
  protected:
 

--- a/include/lbann/layers/transform/concatenation.hpp
+++ b/include/lbann/layers/transform/concatenation.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/transform/transform.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/cublas_wrapper.hpp"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/reshape.hpp
+++ b/include/lbann/layers/transform/reshape.hpp
@@ -41,6 +41,8 @@ class reshape_layer : public transform_layer {
     transform_layer(comm) {
     this->m_num_neuron_dims = num_dims;
     this->m_neuron_dims.assign(dims, dims+num_dims);
+    this->m_num_neurons = std::accumulate(dims, dims+num_dims, 1,
+                                          std::multiplies<int>());
   }
   reshape_layer* copy() const override { return new reshape_layer(*this); }
   std::string get_type() const override { return "reshape"; }

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/transform/transform.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/cublas_wrapper.hpp"
 
 namespace lbann {
 
@@ -179,6 +180,11 @@ class slice_layer : public transform_layer {
     }
 
   }
+
+  /** Get slice points. */
+  std::vector<int>& get_slice_points() { return m_slice_points; }
+  /** Get slice points (const). */
+  const std::vector<int>& get_slice_points() const { return m_slice_points; }
 
   protected:
 

--- a/include/lbann/models/recurrent.hpp
+++ b/include/lbann/models/recurrent.hpp
@@ -29,7 +29,7 @@
 #ifndef LBANN_MODEL_RECURRENT_HPP
 #define LBANN_MODEL_RECURRENT_HPP
 
-#include "lbann/models/model.hpp"
+#include "lbann/models/directed_acyclic_graph.hpp"
 
 namespace lbann {
 
@@ -37,7 +37,7 @@ namespace lbann {
  *  Training is performed with back propagation through time, i.e. by
  *  unrolling the recurrent network into a DAG.
  */
-class recurrent_model : public model {
+class recurrent_model : public directed_acyclic_graph_model {
  public:
 
   /** Constructor. */
@@ -63,7 +63,6 @@ class recurrent_model : public model {
  protected:
 
   void setup_layer_topology() override;
-  void setup_layer_execution_order() override;
   void setup_layers() override;
 
  private:
@@ -71,16 +70,16 @@ class recurrent_model : public model {
   /** The number of times to unroll the recurrent network. */
   int m_unroll_depth;
 
-  /** Map to corresponding layer in previous roll.
-   *  Layers in the first roll map to null pointers. The input and
+  /** Map to corresponding layer in previous step.
+   *  Layers in the first step map to null pointers. The input and
    *  target layers map to themselves.
    */
-  std::unordered_map<Layer *, Layer *> m_previous_roll_layer;
-  /** Map to corresponding layer in next roll.
-   *  Layers in the last roll map to null pointers. The input and
+  std::unordered_map<const Layer*, Layer*> m_previous_step_layer;
+  /** Map to corresponding layer in next step.
+   *  Layers in the last step map to null pointers. The input and
    *  target layers map to themselves.
    */
-  std::unordered_map<Layer *, Layer *> m_next_roll_layer;
+  std::unordered_map<const Layer*, Layer*> m_next_step_layer;
 
 };
 

--- a/model_zoo/models/char_rnn/char_lstm.prototext
+++ b/model_zoo/models/char_rnn/char_lstm.prototext
@@ -1,0 +1,250 @@
+model {
+  name: "recurrent_model"
+  data_layout: "data_parallel"
+  mini_batch_size: 256
+  block_size: 256
+  num_epochs: 20
+  num_parallel_readers: 0
+  procs_per_model: 0
+  num_gpus: -1
+  recurrent {
+    unroll_depth : 5
+  }
+
+  ###################################################
+  # Objective function
+  ###################################################
+
+  objective_function {
+    mean_squared_error {}
+    l2_weight_regularization {
+      scale_factor: 0.0005
+    }
+  }
+
+  ###################################################
+  # Callbacks
+  ###################################################
+  callback { print {} }
+  callback { timer {} }
+
+  ###################################################
+  # Layers
+  ###################################################
+
+  # Data
+  layer {
+    name: "data"
+    input {
+      io_buffer: "partitioned"
+    }
+    data_layout: "data_parallel"
+  }
+
+  # lstm1 forget gate
+  layer {
+    parents: "data"
+    name: "lstm1_forgetgate_input"
+    fully_connected {
+      num_neurons: 128
+      has_bias: true
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_output"
+    name: "lstm1_forgetgate_output"
+    fully_connected {
+      num_neurons: 128
+      has_bias: false
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_forgetgate_input lstm1_forgetgate_output"
+    name: "lstm1_forgetgate_sum"
+    sum {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_forgetgate_sum"
+    name: "lstm1_forgetgate"
+    sigmoid {}
+    data_layout: "data_parallel"
+  }
+
+  # lstm1 input gate
+  layer {
+    parents: "data"
+    name: "lstm1_inputgate_input"
+    fully_connected {
+      num_neurons: 128
+      has_bias: true
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_output"
+    name: "lstm1_inputgate_output"
+    fully_connected {
+      num_neurons: 128
+      has_bias: false
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_inputgate_input lstm1_inputgate_output"
+    name: "lstm1_inputgate_sum"
+    sum {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_inputgate_sum"
+    name: "lstm1_inputgate"
+    sigmoid {}
+    data_layout: "data_parallel"
+  }
+
+  # lstm1 output gate
+  layer {
+    parents: "data"
+    name: "lstm1_outputgate_input"
+    fully_connected {
+      num_neurons: 128
+      has_bias: true
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_output"
+    name: "lstm1_outputgate_output"
+    fully_connected {
+      num_neurons: 128
+      has_bias: false
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_outputgate_input lstm1_outputgate_output"
+    name: "lstm1_outputgate_sum"
+    sum {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_outputgate_sum"
+    name: "lstm1_outputgate"
+    sigmoid {}
+    data_layout: "data_parallel"
+  }
+
+  # lstm1 cell update
+  layer {
+    parents: "data"
+    name: "lstm1_cellupdate_input"
+    fully_connected {
+      num_neurons: 128
+      has_bias: true
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_output"
+    name: "lstm1_cellupdate_history"
+    fully_connected {
+      num_neurons: 128
+      has_bias: false
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_cellupdate_input lstm1_cellupdate_history"
+    name: "lstm1_cellupdate_sum"
+    sum {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_cellupdate_sum"
+    name: "lstm1_cellupdate_tanh"
+    tanh {}
+    data_layout: "data_parallel"
+  }
+
+  # lstm1 cell state
+  layer {
+    parents: "lstm1_forgetgate lstm1_cell"
+    name: "lstm1_cell_history"
+    hadamard {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_inputgate lstm1_cellupdate_tanh"
+    name: "lstm1_cell_update"
+    hadamard {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_cell_history lstm1_cell_update"
+    name: "lstm1_cell_sum"
+    sum {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_cell_sum"
+    name: "lstm1_cell"
+    reshape {
+      num_dims: 1
+      dims: "128"
+    }
+    data_layout: "data_parallel"
+  }
+  
+  # lstm1 output
+  layer {
+    parents: "lstm1_cell"
+    name: "lstm1_output_tanh"
+    tanh {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_outputgate lstm1_output_tanh"
+    name: "lstm1_output_hadamard"
+    hadamard {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "lstm1_output_hadamard"
+    name: "lstm1_output"
+    reshape {
+      num_dims: 1
+      dims: "128"
+    }
+    data_layout: "data_parallel"
+  }
+
+  # prediction
+  layer {
+    parents: "lstm1_output"
+    name: "fc"
+    fully_connected {
+      num_neurons: 128
+      has_bias: false
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "fc"
+    name: "prob"
+    softmax {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "prob"
+    name: "eval"
+    target {
+      io_buffer: "partitioned"
+      shared_data_reader: true
+    }
+    data_layout: "data_parallel"
+  }
+
+}

--- a/model_zoo/models/char_rnn/char_rnn.prototext
+++ b/model_zoo/models/char_rnn/char_rnn.prototext
@@ -9,7 +9,7 @@ model {
   num_gpus: -1
   recurrent {
     unroll_depth : 5
-   }
+  }
 
   ###################################################
   # Objective function
@@ -41,19 +41,11 @@ model {
 
   # Data
   layer {
-    name: "data_concat"
+    name: "data"
     input {
       io_buffer: "partitioned"
     }
     data_layout: "data_parallel"
-  }
-  layer {
-    parents: "data_concat"
-    name: "data"
-    slice {
-      slice_points: "0 128 256 384 512 640"
-    }
-    data_layout: "model_parallel"
   }
 
   # rnn1
@@ -88,9 +80,13 @@ model {
     data_layout: "model_parallel"
   }
   layer {
+    # This reshape layer is a hack to get around ambiguous neuron dimensions
     parents: "rnn1_act"
     name: "rnn1"
-    split {}
+    reshape {
+      num_dims: 1
+      dims: "256"
+    }
     data_layout: "model_parallel"
   }
 
@@ -110,16 +106,8 @@ model {
     softmax {}
     data_layout: "model_parallel"
   }
-
-  # Evaluate
   layer {
     parents: "prob"
-    name: "prob_concat"
-    concatenation {}
-    data_layout: "model_parallel"
-  }
-  layer {
-    parents: "prob_concat"
     name: "eval"
     target {
       io_buffer: "partitioned"

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -507,6 +507,7 @@ void model::add_dummy_layers() {
       default:
         std::stringstream err;
         err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+        throw lbann_exception(err.str());
       }
       dummy->set_name(layer->get_name()
                       + "_dummy"
@@ -546,6 +547,7 @@ void model::add_split_layers() {
       default:
         std::stringstream err;
         err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+        throw lbann_exception(err.str());
       }
       split->set_name(layer->get_name() + "_split");
 

--- a/src/models/recurrent.cpp
+++ b/src/models/recurrent.cpp
@@ -26,319 +26,419 @@
 // recurrent .hpp .cpp - Recurrent neural network models
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include "lbann/models/recurrent.hpp"
 #include "lbann/layers/io/input/generic_input_layer.hpp"
 #include "lbann/layers/io/target/generic_target_layer.hpp"
+#include "lbann/layers/transform/slice.hpp"
+#include "lbann/layers/transform/split.hpp"
+#include "lbann/layers/transform/concatenation.hpp"
 #include "lbann/layers/transform/constant.hpp"
 #include "lbann/layers/transform/dummy.hpp"
 
 namespace lbann {
 
+namespace {
+
+/** Setup input layer to match unrolled network.
+ *  The first layer is assumed to be an input layer. A slice layer
+ *  and a split layer are inserted after the input layer.
+ */
+void unroll_input_layer(int unroll_depth,
+                        std::vector<Layer*>& layers,
+                        std::unordered_map<const Layer*,Layer*>& prev_step_layer,
+                        std::unordered_map<const Layer*,Layer*>& next_step_layer) {
+    std::stringstream err;
+
+  // We expect first layer to be an input layer
+  auto&& input = dynamic_cast<generic_input_layer*>(layers.front());
+  if (input == nullptr) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "expected the first layer to be an input layer";
+    throw lbann_exception(err.str());
+  }
+  
+  // Determine slice points
+  const auto& input_dims = input->get_neuron_dims();
+  const auto& slice_size = input_dims.front() / unroll_depth;
+  std::vector<int> slice_points;
+  for (int step = 0; step <= unroll_depth; ++step) {
+    slice_points.push_back(slice_size * step);
+  }
+
+  // Construct slice and split layer
+  Layer* slice = nullptr;
+  Layer* split = nullptr;
+  auto&& comm = input->get_comm();
+  cudnn::cudnn_manager* cudnn = nullptr;
+  switch (input->get_data_layout()) {
+  case data_layout::DATA_PARALLEL:
+    slice = new slice_layer<data_layout::DATA_PARALLEL>(comm, 0, slice_points, cudnn);
+    split = new split_layer<data_layout::DATA_PARALLEL>(comm, cudnn);
+    break;
+  case data_layout::MODEL_PARALLEL:
+    slice = new slice_layer<data_layout::MODEL_PARALLEL>(comm, 0, slice_points, cudnn);
+    split = new split_layer<data_layout::MODEL_PARALLEL>(comm, cudnn);
+    break;
+  default:
+    err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+    throw lbann_exception(err.str());
+  }
+  slice->set_name(input->get_name() + "_slice");
+  split->set_name(input->get_name() + "_split");
+  layers.insert(layers.begin() + 1, slice);
+  layers.insert(layers.begin() + 2, split);
+
+  // Setup relationships between split layer and child layers
+  for (auto&& child : input->get_child_layers()) {
+    split->add_child_layer(child);
+    auto& child_parents = const_cast<Layer*>(child)->get_parent_layers();
+    std::replace(child_parents.begin(), child_parents.end(),
+                 static_cast<Layer*>(input), split);
+  }
+  input->clear_child_layers();
+
+  // Setup relationship between input layer, slice layer, and split layer
+  input->add_child_layer(slice);
+  slice->add_parent_layer(input);
+  slice->add_child_layer(split);
+  split->add_parent_layer(slice);
+
+  // Input layer and slice layer are not unrolled any further
+  prev_step_layer[input] = input;
+  prev_step_layer[slice] = slice;
+  next_step_layer[input] = input;
+  next_step_layer[slice] = slice;
+
+}
+
+/** Setup target layer to match unrolled network.
+ *  The last layer is assumed to be a target layer. A concatenation
+ *  layer is inserted before the target layer.
+ */
+void unroll_target_layer(int unroll_depth,
+                         std::vector<Layer*>& layers,
+                         std::unordered_map<const Layer*,Layer*>& prev_step_layer,
+                         std::unordered_map<const Layer*,Layer*>& next_step_layer) {
+  std::stringstream err;
+
+  // We expect last layer to be a target layer
+  auto&& target = dynamic_cast<generic_target_layer*>(layers.back());
+  if (target == nullptr) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "expected the last layer to be a target layer";
+    throw lbann_exception(err.str());
+  }
+
+  // Construct concatenation layer
+  Layer* concat = nullptr;
+  auto&& comm = target->get_comm();
+  switch (target->get_data_layout()) {
+  case data_layout::DATA_PARALLEL:
+    concat = new concatenation_layer<data_layout::DATA_PARALLEL>(comm, 0, nullptr);
+    break;
+  case data_layout::MODEL_PARALLEL:
+    concat = new concatenation_layer<data_layout::MODEL_PARALLEL>(comm, 0, nullptr);
+    break;
+  default:
+    err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+    throw lbann_exception(err.str());
+  }
+  concat->set_name(target->get_name() + "_concat");
+  layers.insert(layers.end() - 1, concat);
+
+  // Setup relationships between concatenation layer and parent layers
+  for (auto&& parent : target->get_parent_layers()) {
+    concat->add_parent_layer(parent);
+    auto& parent_children = const_cast<Layer*>(parent)->get_child_layers();
+    std::replace(parent_children.begin(), parent_children.end(),
+                 static_cast<Layer*>(target), concat);
+  }
+  target->clear_parent_layers();
+
+  // Setup relationship between target layer and concatenation layer
+  concat->add_child_layer(target);
+  target->add_parent_layer(concat);
+
+  // Target layer and concatenation layer are not unrolled any further
+  prev_step_layer[target] = target;
+  prev_step_layer[concat] = concat;
+  next_step_layer[target] = target;
+  next_step_layer[concat] = concat;
+
+}
+
+/** Duplicate layer network to achieve desired recurrence depth.
+ *  The layers within each recurrence step have the same topology as
+ *  the original network.
+ */
+void add_unrolled_layers(int unroll_depth,
+                         std::vector<Layer*>& layers,
+                         std::unordered_map<const Layer*,Layer*>& prev_step_layer,
+                         std::unordered_map<const Layer*,Layer*>& next_step_layer) {
+
+  // Unroll network to desired depth
+  std::vector<Layer*> previous_step(layers.begin() + 2, layers.end() - 2);
+  const int num_step_layers = previous_step.size();
+  for (int step = 1; step < unroll_depth; ++step) {
+    
+    // Construct current step by copying layers from previous step
+    std::vector<Layer*> current_step;
+    for (const auto& previous_layer : previous_step) {
+      auto&& current_layer = previous_layer->copy();
+      current_step.push_back(current_layer);
+      prev_step_layer[current_layer] = previous_layer;
+      next_step_layer[previous_layer] = current_layer;
+    }
+
+    // Fix pointers within current step
+    for (const auto& current_layer : current_step) {
+      auto layer_pointers = current_layer->get_layer_pointers();
+      for (auto& layer_pointer : layer_pointers) {
+        layer_pointer = next_step_layer[layer_pointer];
+      }
+      current_layer->set_layer_pointers(layer_pointers);
+    }
+
+    // Add current step layers to model
+    layers.insert(layers.end() - 2, current_step.begin(), current_step.end());
+    previous_step = current_step;
+
+  }
+
+  // Rename layers
+  for (int step = 0; step < unroll_depth; ++step) {
+    const std::string name_suffix = "_step" + std::to_string(step);
+    const int step_start = 2 + step * num_step_layers;
+    const int step_end = 2 + (step + 1) * num_step_layers;
+    for (int i = step_start; i < step_end; ++i) {
+      layers[i]->set_name(layers[i]->get_name() + name_suffix);
+    }
+  }
+  
+}
+
+/** Add placeholder layers for first and last recurrence step.
+ *  If a layer in the first recurrence step expects input from an
+ *  earlier recurrence step, we insert a zero-valued constant
+ *  layer. If a layer in the last recurrence step expects to output to
+ *  a later recurrence step, we insert a dummy layer.
+ */
+void add_placeholder_layers(std::vector<Layer*>& layers,
+                            std::unordered_map<const Layer*,Layer*>& prev_step_layer,
+                            std::unordered_map<const Layer*,Layer*>& next_step_layer) {
+
+  std::unordered_map<const Layer*,bool> is_visited;
+  std::vector<Layer*> input_placeholders, output_placeholders;
+  for (const auto& l : layers) {
+
+    // Create constant layers as input placeholders
+    for (auto&& parent : l->get_parent_layers()) {
+      if (!is_visited[parent] && prev_step_layer[parent] == nullptr) {
+        if (parent->get_num_neurons() <= 0) {
+          std::stringstream err;
+          err << __FILE__ << " " << __LINE__ << " :: "
+              << l->get_name() << " has ambiguous neuron "
+              << "dimensions since it depends on "
+              << parent->get_name() << ", which does not have "
+              << "specified neuron dimensions. Consider inserting a "
+              << "reshape layer after " << parent->get_name() << " "
+              << "to explicitly specify neuron dimensions.";
+          throw lbann_exception(err.str());
+        }
+        Layer* placeholder = nullptr;
+        auto&& comm = parent->get_comm();
+        switch (parent->get_data_layout()) {
+        case data_layout::DATA_PARALLEL:
+          placeholder = new constant_layer<data_layout::DATA_PARALLEL>(
+                              comm,
+                              DataType(0),
+                              parent->get_neuron_dims()
+                            );
+          break;
+        case data_layout::MODEL_PARALLEL:
+          placeholder = new constant_layer<data_layout::MODEL_PARALLEL>(
+                              comm,
+                              DataType(0),
+                              parent->get_neuron_dims()
+                            );
+          break;
+        default:
+          std::stringstream err;
+          err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+          throw lbann_exception(err.str());
+        }
+        placeholder->set_name(parent->get_name() + "_input_placeholder");
+        placeholder->add_child_layer(l);
+        input_placeholders.push_back(placeholder);
+        prev_step_layer[parent] = placeholder;
+        next_step_layer[placeholder] = const_cast<Layer*>(parent);
+      }
+    }
+
+    // Visit layer
+    is_visited[l] = true;
+    
+    // Create dummy layers as output placeholders
+    for (auto&& child : l->get_child_layers()) {
+      if (is_visited[child] && next_step_layer[child] == nullptr) {
+        Layer* placeholder = nullptr;
+        auto&& comm = child->get_comm();
+        switch (child->get_data_layout()) {
+        case data_layout::DATA_PARALLEL:
+          placeholder = new dummy_layer<data_layout::DATA_PARALLEL>(comm);
+          break;
+        case data_layout::MODEL_PARALLEL:
+          placeholder = new dummy_layer<data_layout::MODEL_PARALLEL>(comm);
+          break;
+        default:
+          std::stringstream err;
+          err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
+          throw lbann_exception(err.str());
+        }
+        placeholder->set_name(child->get_name() + "_output_placeholder");
+        placeholder->add_parent_layer(l);
+        output_placeholders.push_back(placeholder);
+        next_step_layer[child] = placeholder;
+        prev_step_layer[placeholder] = const_cast<Layer*>(child);
+      }
+    }
+    
+  }
+
+  // Add placeholder layers to model
+  layers.insert(layers.begin() + 2,
+                input_placeholders.begin(),
+                input_placeholders.end());
+  layers.insert(layers.end() - 2,
+                output_placeholders.begin(),
+                output_placeholders.end());
+
+}
+
+/** Setup pointers between recurrence steps.
+ *  If a layer's parent appears after the layer itself, change the
+ *  parent to the corresponding layer in the previous recurrence
+ *  step. Similarly, if a layer's child appears before the layer
+ *  itself, change the child to the corresponding layer in the next
+ *  recurrence step.
+ */
+void setup_unrolled_layer_pointers(std::vector<Layer*>& layers,
+                                   const std::unordered_map<const Layer*,Layer*>& prev_step_layer,
+                                   const std::unordered_map<const Layer*,Layer*>& next_step_layer) {
+
+  std::unordered_map<const Layer*,bool> is_visited;
+  for (auto&& l : layers) {
+    for (auto& parent : l->get_parent_layers()) {
+      if (!is_visited[parent]) {
+        parent = prev_step_layer.at(parent);
+      }
+    }
+    is_visited[l] = true;
+    for (auto& child : l->get_child_layers()) {
+      if (is_visited[child]) {
+        child = next_step_layer.at(child);
+      }
+    }
+  }
+  
+}
+
+} // namespace
+  
 recurrent_model::recurrent_model(lbann_comm *comm,
                                  int mini_batch_size,
                                  objective_function *obj_fn,
                                  optimizer *default_optimizer,
                                  int unroll_depth)
-  : model(comm, mini_batch_size, obj_fn, default_optimizer) {
+  : directed_acyclic_graph_model(comm,
+                                 mini_batch_size,
+                                 obj_fn,
+                                 default_optimizer) {
   m_unroll_depth = std::max(unroll_depth, 1);
 }
 
 void recurrent_model::setup_layer_topology() {
-  model::setup_layer_topology();
+  
+  // Make sure parent/child relationships are reciprocated
+  for (const auto& l : m_layers) {
+    for (const auto& parent : l->get_parent_layers()) {
+      const_cast<Layer*>(parent)->add_child_layer(l);
+    }
+    for (const auto& child : l->get_child_layers()) {
+      const_cast<Layer*>(child)->add_parent_layer(l);
+    }
+  }
 
-  // Setup layer execution order
-  setup_layer_execution_order();
-
-  // We expect starting with input layer and ending with target layer
-  /// @todo Design a more general interface
-  if (m_layers.size() < 4) {
+  // Unroll layers
+  if (m_layers.size() < 2) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
-        << "expected the first layer to be an input layer, "
-        << "the second to be a slice layer, "
-        << "the second to last to be a concatenation layer "
+        << "expected the first layer to be an input layer "
         << "and the last to be a target layer";
     throw lbann_exception(err.str());
-  }
-  auto input         = *(m_layers.begin());
-  auto input_slice   = *(m_layers.begin() + 1);
-  auto target_concat = *(m_layers.end() - 2);
-  auto target        = *(m_layers.end() - 1);
-  if (dynamic_cast<generic_input_layer *>(m_layers.front()) == nullptr
-      || input_slice->get_type() != "slice"
-      || target_concat->get_type() != "concatenation"
-      || dynamic_cast<generic_target_layer *>(m_layers.back()) == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "expected the first layer to be an input layer, "
-        << "the second to be a slice layer, "
-        << "the second to last to be a concatenation layer "
-        << "and the last to be a target layer";
-    throw lbann_exception(err.str());
-  }
-
-  // Initialize pointers for input and target layer
-  m_previous_roll_layer.clear();
-  m_next_roll_layer.clear();
-  m_previous_roll_layer[input] = input;
-  m_previous_roll_layer[input_slice] = input_slice;
-  m_previous_roll_layer[target_concat] = target_concat;
-  m_previous_roll_layer[target] = target;
-  m_next_roll_layer[input] = input;
-  m_next_roll_layer[input_slice] = input_slice;
-  m_next_roll_layer[target_concat] = target_concat;
-  m_next_roll_layer[target] = target;
-  std::vector<Layer *> input_children, target_parents;
-  for (const auto& child : input_slice->get_child_layers()) {
-    input_children.push_back(const_cast<Layer *>(child));
-  }
-  for (const auto& parent : target_concat->get_parent_layers()) {
-    target_parents.push_back(const_cast<Layer *>(parent));
-  }
-
-  // Unroll network to desired depth
-  std::vector<Layer *> previous_roll_layers(m_layers.begin() + 2,
-                                            m_layers.end() - 2);
-  const int roll_size = previous_roll_layers.size();
-  for (int roll = 1; roll < m_unroll_depth; ++roll) {
-
-    // Construct current roll by copying layers from previous roll
-    std::vector<Layer *> current_roll_layers;
-    for (const auto& previous_layer : previous_roll_layers) {
-      Layer *current_layer = previous_layer->copy();
-      current_roll_layers.push_back(current_layer);
-      m_previous_roll_layer[current_layer] = previous_layer;
-      m_next_roll_layer[previous_layer] = current_layer;
-    }
-
-    // Fix pointers in current roll
-    for (const auto& current_layer : current_roll_layers) {
-      auto layer_pointers = current_layer->get_layer_pointers();
-      for (auto& layer_pointer : layer_pointers) {
-        layer_pointer = m_next_roll_layer[layer_pointer];
-      }
-      current_layer->set_layer_pointers(layer_pointers);
-    }
-
-    // Fix pointers in input and target layers
-    for (auto& child : input_children) {
-      child = m_next_roll_layer[child];
-      input_slice->add_child_layer(child);
-    }
-    for (auto& parent : target_parents) {
-      parent = m_next_roll_layer[parent];
-      target_concat->add_parent_layer(parent);
-    }
-
-    // Add current roll layers to model
-    m_layers.insert(m_layers.end() - 2,
-                    current_roll_layers.begin(),
-                    current_roll_layers.end());
-    previous_roll_layers = current_roll_layers;
 
   }
+  m_previous_step_layer.clear();
+  m_next_step_layer.clear();
+  unroll_input_layer(m_unroll_depth, m_layers, m_previous_step_layer, m_next_step_layer);
+  unroll_target_layer(m_unroll_depth, m_layers, m_previous_step_layer, m_next_step_layer);
+  add_unrolled_layers(m_unroll_depth, m_layers, m_previous_step_layer, m_next_step_layer);
+  add_placeholder_layers(m_layers, m_previous_step_layer, m_next_step_layer);
+  setup_unrolled_layer_pointers(m_layers, m_previous_step_layer, m_next_step_layer);
 
-  // Rename layers
-  for (int roll = 0; roll < m_unroll_depth; ++roll) {
-    const std::string name_suffix = "_" + std::to_string(roll);
-    const int roll_start = 2 + roll * roll_size;
-    const int roll_end = 2 + (roll + 1) * roll_size;
-    for (int i = roll_start; i < roll_end; ++i) {
-      m_layers[i]->set_name(m_layers[i]->get_name() + name_suffix);
-    }
-  }
-
-  // Fix pointers between adjacent rolls
-  std::unordered_map<Layer *,bool> is_visited;
-  std::vector<Layer *> placeholder_parents, placeholder_children;
-  for (const auto& layer : m_layers) {
-
-    // Fix pointers to parent layers
-    std::vector<Layer *> parents;
-    for (const auto& parent : layer->get_parent_layers()) {
-      parents.push_back(const_cast<Layer *>(parent));
-    }
-    for (auto& parent : parents) {
-      if (!is_visited[parent]) {
-        if (m_previous_roll_layer[parent] != nullptr) {
-          parent = m_previous_roll_layer[parent];
-        } else {
-          if (parent->get_num_neurons() <= 0) {
-            std::stringstream err;
-            err << __FILE__ << " " << __LINE__ << " :: "
-                << layer->get_name() << " has ambiguous neuron "
-                << "dimensions since it depends on "
-                << parent->get_name() << ", which does not have "
-                << "specified neuron dimensions. Consider inserting a "
-                << "reshape layer after " << parent->get_name()
-                << "to explicitly specify neuron dimensions.";
-            throw lbann_exception(err.str());
-          }
-          Layer *placeholder;
-          switch (parent->get_data_layout()) {
-          case data_layout::DATA_PARALLEL:
-            placeholder = new constant_layer<data_layout::DATA_PARALLEL>
-                            (get_comm(), DataType(0), parent->get_neuron_dims());
-            break;
-          case data_layout::MODEL_PARALLEL:
-            placeholder = new constant_layer<data_layout::MODEL_PARALLEL>
-                            (get_comm(), DataType(0), parent->get_neuron_dims());
-            break;
-          default:
-            std::stringstream err;
-            err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
-            throw lbann_exception(err.str());
-          }
-          placeholder->set_name(parent->get_name() + "_input_placeholder");
-          placeholder->add_child_layer(layer);
-          placeholder_parents.push_back(placeholder);
-          parent = placeholder;
-        }
-      }
-    }
-    layer->clear_parent_layers();
-    for (const auto& parent : parents) {
-      layer->add_parent_layer(parent);
-    }
-
-    // Visit layer
-    is_visited[layer] = true;
-
-    // Fix pointers to parent layers
-    std::vector<Layer *> children;
-    for (const auto& child : layer->get_child_layers()) {
-      children.push_back(const_cast<Layer *>(child));
-    }
-    for (auto& child : children) {
-      if (is_visited[child]) {
-        if (m_next_roll_layer[child] != nullptr) {
-          child = m_next_roll_layer[child];
-        } else {
-          Layer *placeholder;
-          switch (child->get_data_layout()) {
-          case data_layout::DATA_PARALLEL:
-            placeholder = new dummy_layer<data_layout::DATA_PARALLEL>(get_comm());
-            break;
-          case data_layout::MODEL_PARALLEL:
-            placeholder = new dummy_layer<data_layout::MODEL_PARALLEL>(get_comm());
-            break;
-          default:
-            std::stringstream err;
-            err << __FILE__ << " " << __LINE__ << " :: " << "invalid data layout";
-            throw lbann_exception(err.str());
-          }
-          placeholder->set_name(child->get_name() + "_output_placeholder");
-          placeholder->add_parent_layer(layer);
-          placeholder_children.push_back(placeholder);
-          child = placeholder;
-        }
-      }
-    }
-    layer->clear_child_layers();
-    for (const auto& child : children) {
-      layer->add_child_layer(child);
-    }
-
-  }
-
-  // Add placeholder layers to model
-  m_layers.insert(m_layers.begin() + 2,
-                  placeholder_parents.begin(),
-                  placeholder_parents.end());
-  m_layers.insert(m_layers.end() - 2,
-                  placeholder_children.begin(),
-                  placeholder_children.end());
-
-}
-
-void recurrent_model::setup_layer_execution_order() {
-  model::setup_layer_execution_order();
-
-  // Get layer graph
-  std::set<int> nodes;
-  std::map<int,std::set<int>> edges;
-  construct_layer_graph(nodes, edges);
-  const auto& edges_transpose = graph::transpose(nodes, edges);
-
-  // Return immediately if no recurrence is detected
-  if (!graph::is_cyclic(nodes, edges)) {
-    return;
-  }
-
-  // Get topologically sorted condensation graph
-  std::set<int> condensation_nodes;
-  std::map<int,std::set<int>> components, condensation_edges;
-  graph::condensation(nodes, edges,
-                      components,
-                      condensation_nodes, condensation_edges);
-
-  // Sort nodes in each strongly connected component (SCC)
-  std::vector<int> order;
-  for (const auto& component : condensation_nodes) {
-    const auto& component_nodes = components[component];
-
-    // Find a node that requires external input
-    // Note: Execution order is ambiguous if there are more than one
-    // such nodes.
-    int input_node = -1;
-    for (const auto& node : component_nodes) {
-      const auto& parents = graph::get_neighbors(node, edges_transpose);
-      for (const auto& parent : parents) {
-        if (!component_nodes.count(parent)) {
-          if (input_node != node && input_node >= 0) {
-            std::stringstream err;
-            err << __FILE__ << " " << __LINE__ << " :: "
-                << "recurrent network has ambiguous execution order "
-                << "(each strongly connected component in the layer "
-                << "graph can have at most one layer that requires "
-                << "external input)";
-            throw lbann_exception(err.str());
-          }
-          input_node = node;
-        }
-      }
-    }
-
-    // Induce subgraph on SCC and delete edges toward input node
-    // Note: Execution order is ambiguous if this subgraph is cyclic.
-    auto&& component_edges = graph::induce_subgraph(component_nodes,
-                                                    edges);
-    for (const auto& node : component_nodes) {
-      component_edges[node].erase(input_node);
-    }
-    if (graph::is_cyclic(component_nodes, component_edges)) {
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "recurrent network has ambiguous execution order "
-          << "(each strongly connected component in the layer graph "
-          << "must be a DAG after removing edges toward input nodes)";
-      throw lbann_exception(err.str());
-    }
-
-    // Sort SCC nodes topologically
-    const auto& component_order = graph::topological_sort(component_nodes,
-                                                          component_edges);
-    order.insert(order.end(), component_order.begin(), component_order.end());
-
-  }
-
-  // Reorder layers
-  permute_layers(order);
-
+  // Make sure unrolled topology is a DAG
+  directed_acyclic_graph_model::setup_layer_topology();
+  
 }
 
 void recurrent_model::setup_layers() {
-  for (const auto& layer : m_layers) {
-    if (m_previous_roll_layer[layer] != nullptr) {
-      layer->set_weights(m_previous_roll_layer[layer]->get_weights());
+  for (size_t i=0; i<m_layers.size(); ++i) {
+    auto&& l = m_layers[i];
+
+    // Set slice points for the inserted slice layer
+    if (i == 1) {
+      std::vector<int> slice_points;
+      const auto& input_dims = m_layers[0]->get_neuron_dims();
+      const auto& slice_size = input_dims[0] / m_unroll_depth;
+      for (int step = 0; step <= m_unroll_depth; ++step) {
+        slice_points.push_back(slice_size * step);
+      }
+      auto&& slice_dp = dynamic_cast<slice_layer<data_layout::DATA_PARALLEL>*>(l);
+      auto&& slice_mp = dynamic_cast<slice_layer<data_layout::MODEL_PARALLEL>*>(l);
+      if (slice_dp != nullptr) {
+        slice_dp->get_slice_points() = slice_points;
+      }
+      if (slice_mp != nullptr) {
+        slice_mp->get_slice_points() = slice_points;
+      }
+      if (slice_dp == nullptr && slice_mp == nullptr) {
+        std::stringstream err;
+        err << __FILE__ << " " << __LINE__ << " :: "
+            << "expected the second layer to be a slice layer, "
+            << "but " << l->get_name() << " is " << l->get_type();
+        throw lbann_exception(err.str());
+      }
     }
-    layer->set_model(this);
-    layer->setup();
-    layer->check_setup();
+  
+    // Corresponding weights in different steps share weights
+    auto&& prev_step_layer = m_previous_step_layer[l];
+    if (prev_step_layer != nullptr) {
+      auto&& w = prev_step_layer->get_weights();
+      if (!w.empty()) {
+        l->set_weights(w);
+      }
+    }
+
+    // Setup layer
+    l->set_model(this);
+    l->setup();
+    l->check_setup();
     if (m_comm->am_world_master()) {
-      std::cout << print_layer_description(layer) << std::endl;
+      std::cout << print_layer_description(l) << std::endl;
     }
+
   }
 }
-
+  
 }  // namespace lbann


### PR DESCRIPTION
This fixes an incorrect implementation of backprop through time for recurrent models. Recurrent models can now support traditional RNNs and LSTMs (and probably GRUs, although I haven't tested).

Sketch of the implementation:
1. Assume the first layer is an input layer and the last layer is a target layer. The data readers are assumed to provide concatenated data for all of the recurrence steps.
2. Add a slice layer after the input layer and add a concatenation layer before the target layer. This allows us to work with each recurrence step separately. We also add a split layer after the slice layer to make sure it has the right number of children.
3. Duplicate the layers to achieve the desired recurrence depth (excluding the input, slice, concatenation, and target layers discussed above). At this point, the layer topology for each recurrence step is the same as the original network, i.e. probably a cyclic graph.
4. Layers in step 0 might expect parents in step -1, so add some zero-valued constant layers to avoid problems. Similarly, layers in step `last` might expect children in step `last+1`, so add some dummy layers.
5. Setup layer pointers in between recurrence steps. In particular, if a layer has a parent that comes after it in the prototext, change the parent to the corresponding layer in the previous recurrence step. If a layer has a child that comes before it in the prototext, change the child to the corresponding layer in the next recurrence step.