### PR TITLE
Prototext interface for specifying weights

### DIFF
--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -53,6 +53,12 @@ Layer* construct_layer(lbann_comm* comm,
                        cudnn::cudnn_manager* cudnn,
                        const lbann_data::Layer& proto_layer);
 
+/** Construct weights specified with prototext. */
+weights* construct_weights(lbann_comm* comm,
+                           cudnn::cudnn_manager* cudnn,
+                           const lbann_data::Optimizer& proto_opt,
+                           const lbann_data::Weights& proto_weights);
+
 /** Construct a callback specified with prototext. */
 lbann_callback* construct_callback(lbann_comm* comm,
                                    const lbann_data::Callback& proto_cb,

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -193,7 +193,7 @@ class weights {
   bool load_from_checkpoint_shared(persist& p);
   
   /** Write weights to proto file */
-  virtual void write_proto(lbann_data::Weights* proto) const;
+  virtual void write_proto(lbann_data::WeightsData* proto) const;
  private:
 
   /** Weights name.

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -832,7 +832,7 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
   proto->set_top(get_name());
   //Add weights
   for (weights *w : m_weights) {
-    auto weight_proto = proto->add_weights();
+    auto weight_proto = proto->add_weights_data();
     w->write_proto(weight_proto);
   }
 }

--- a/src/proto/factories/CMakeLists.txt
+++ b/src/proto/factories/CMakeLists.txt
@@ -7,6 +7,7 @@ set_full_path(THIS_DIR_SOURCES
   model_factory.cpp
   objective_function_factory.cpp
   optimizer_factory.cpp
+  weights_factory.cpp
 )
 
 # Propagate the files up the tree

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -170,15 +170,18 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
     const auto& proto_layer = proto_model.layer(i);
 
     // Check that layer name is valid
-    std::string name = proto_layer.name();
-    if (parse_list<std::string>(name).size() > 1) {
-      err << "layer name \"" << name << "\" is invalid since it "
-          << "contains whitespace";
-      LBANN_ERROR(err.str());
-    }
-    if (!name.empty() && names_to_layers.count(name) != 0) {
-      err << "layer name " << name << " is not unique";
-      LBANN_ERROR(err.str());
+    auto name = proto_layer.name();
+    const auto& parsed_name = parse_list<std::string>(name);
+    if (!name.empty()) {
+      if (parsed_name.empty() || parsed_name.front() != name) {
+        err << "weights name \"" << name << "\" is invalid since it "
+            << "contains whitespace";
+        LBANN_ERROR(err.str());
+      }
+      if (names_to_layers.count(name) != 0) {
+        err << "layer name \"" << name << "\" is not unique";
+        LBANN_ERROR(err.str());
+      }
     }
     
     // Get parameters from prototext

--- a/src/proto/factories/weights_factory.cpp
+++ b/src/proto/factories/weights_factory.cpp
@@ -1,0 +1,117 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/proto/factories.hpp"
+
+namespace lbann {
+namespace proto {
+
+namespace {
+
+/** Construct a weights initialization specified with prototext. */  
+weights_initializer* construct_initializer(lbann_comm* comm,
+                                           const lbann_data::Weights& proto_weights) {
+
+  // Random initialization
+  if (proto_weights.has_uniform_initializer()) {
+    const auto& params = proto_weights.uniform_initializer();
+    const auto& min = params.min();
+    const auto& max = params.max();
+    if (min != 0.0 || max != 0.0) {
+      return new uniform_initializer(comm, min, max);
+    } else {
+      return new uniform_initializer(comm);
+    }
+  }
+  if (proto_weights.has_normal_initializer()) {
+    const auto& params = proto_weights.normal_initializer();
+    const auto& mean = params.mean();
+    const auto& standard_deviation = params.standard_deviation();
+    if (mean != 0.0 || standard_deviation != 0.0) {
+      return new normal_initializer(comm, mean, standard_deviation);
+    } else {
+      return new normal_initializer(comm);
+    }
+  }
+
+  // Glorot and He initialization
+  if (proto_weights.has_glorot_normal_initializer()) {
+    return new glorot_normal_initializer(comm);
+  }
+  if (proto_weights.has_glorot_uniform_initializer()) {
+    return new glorot_uniform_initializer(comm);
+  }
+  if (proto_weights.has_he_normal_initializer()) {
+    return new he_normal_initializer(comm);
+  }
+  if (proto_weights.has_he_uniform_initializer()) {
+    return new he_uniform_initializer(comm);
+  }
+
+  // Constant initialization
+  // Note: default is zero-initialization
+  const auto& params = proto_weights.constant_initializer();
+  return new constant_initializer(comm, params.value());
+
+}
+
+} // namespace
+
+weights* construct_weights(lbann_comm* comm,
+                           cudnn::cudnn_manager* cudnn,
+                           const lbann_data::Optimizer& proto_opt,
+                           const lbann_data::Weights& proto_weights) {
+  std::stringstream err;
+
+  // Instantiate weights
+  weights* w = new weights(comm, cudnn);
+  
+  // Set weights name if provided
+  const auto& name = proto_weights.name();
+  const auto& parsed_name = parse_list<std::string>(name);
+  if (!name.empty()) {
+    if (parsed_name.empty() || parsed_name.front() != name) {
+      err << "weights name \"" << name << "\" is invalid since it "
+          << "contains whitespace";
+      LBANN_ERROR(err.str());
+    }
+    w->set_name(name);
+  }
+
+  // Set weights initializer and optimizer
+  w->set_initializer(construct_initializer(comm, proto_weights));
+  if (proto_weights.has_optimizer()) {
+    w->set_optimizer(construct_optimizer(comm, proto_weights.optimizer()));
+  } else {
+    w->set_optimizer(construct_optimizer(comm, proto_opt));
+  }
+
+  return w;
+
+}
+
+} // namespace proto
+} // namespace lbann

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -567,11 +567,37 @@ message CallbackSaveModel {
 // Weights
 //========================================================================
 
-//
-// weight initialization should be one of:
-//    zero, uniform, normal, glorot_normal, he_normal, he_uniform
-// see: lbann/include/lbann/lbann_base.hpp
-//
+message Weights {
+
+  string name = 1;
+  Optimizer optimizer = 2;  
+
+  ConstantInitializer constant_initializer = 20;
+  UniformInitializer uniform_initializer = 21;
+  NormalInitializer normal_initializer = 22;
+  GlorotNormalInitializer glorot_normal_initializer = 23;
+  GlorotUniformInitializer glorot_uniform_initializer = 24;
+  HeNormalInitializer he_normal_initializer = 25;
+  HeUniformInitializer he_uniform_initializer = 26;
+
+}
+
+// Weight initializers
+message ConstantInitializer {
+  double value = 1;
+}
+message UniformInitializer {
+  double min = 1;
+  double max = 2; 
+}
+message NormalInitializer {
+  double mean = 1;
+  double standard_deviation = 2; 
+}
+message GlorotNormalInitializer {}
+message GlorotUniformInitializer {}
+message HeNormalInitializer {}
+message HeUniformInitializer {}
 
 //note: I'd like to put this enum inside of Layer, but if I do the enum values
 //      become, e.g, Layer_Imcomm_EXCLUDE, which is just ugly
@@ -584,12 +610,12 @@ enum Imcomm {
                 //in the CallbackImComm is set to true or false
 }
 
-message WeightShape {
+// Weight data for exporting
+message WeightsShape {
   repeated int64 dim = 1 [packed = true];
 }
-
-message Weights {
-  WeightShape shape = 5;
+message WeightsData {
+  WeightsShape shape = 5;
   string name = 1;
   int64 height = 2;
   int64 width = 3;
@@ -621,10 +647,10 @@ message Layer {
    string parents = 151;
    string children = 152;
    string data_layout = 52;
+   string weights = 54;
    bool num_neurons_from_data_reader = 53;
 
-
-   repeated Weights weights = 153;
+   repeated WeightsData weights_data = 153;
    string top = 154;
    string bottom = 155;
    string type = 156;

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -465,7 +465,7 @@ bool weights::save_to_checkpoint_shared(lbann::persist& p)
   return true;
 }
 
-void weights::write_proto(lbann_data::Weights* proto) const {
+void weights::write_proto(lbann_data::WeightsData* proto) const {
 
   // Set proto properties
   proto->Clear();


### PR DESCRIPTION
Users can now use the prototext interface to specify weights and assign them to layers. This provides full control over optimizers, weight initialization, and weight sharing. If a layer's weights are not explicitly set, then it constructs default weights.

Several changes were made to the prototext export functionality, so corresponding changes should be made to LBANNFlow. In particular, the `Weights` message was changed to `WeightsData` and `WeightShape` to `WeightsShape`. 