### PR TITLE
Boolean accuracy metrics

### DIFF
--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -178,6 +178,9 @@
 #include "lbann/metrics/mean_absolute_deviation.hpp"
 #include "lbann/metrics/pearson_correlation.hpp"
 #include "lbann/metrics/r2.hpp"
+#include "lbann/metrics/boolean_accuracy.hpp"
+#include "lbann/metrics/boolean_false_positives.hpp"
+#include "lbann/metrics/boolean_false_negatives.hpp"
 
 /// Utilities, exceptions, etc.
 #include "lbann/utils/exception.hpp"

--- a/include/lbann/metrics/CMakeLists.txt
+++ b/include/lbann/metrics/CMakeLists.txt
@@ -1,11 +1,15 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
   metric.hpp
-  metric_categorical_accuracy.hpp
-  metric_mean_absolute_deviation.hpp
-  metric_mean_squared_error.hpp
-  metric_pearson_correlation.hpp
-  metric_top_k_categorical_accuracy.hpp
+  categorical_accuracy.hpp
+  mean_absolute_deviation.hpp
+  mean_squared_error.hpp
+  pearson_correlation.hpp
+  top_k_categorical_accuracy.hpp
+  r2.hpp
+  boolean_accuracy.hpp
+  boolean_false_positives.hpp
+  boolean_false_negatives.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/metrics/boolean_accuracy.hpp
+++ b/include/lbann/metrics/boolean_accuracy.hpp
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_METRIC_BOOLEAN_ACCURACY_HPP
+#define LBANN_METRIC_BOOLEAN_ACCURACY_HPP
+
+#include "lbann/metrics/metric.hpp"
+
+namespace lbann {
+
+/** Boolean accuracy metric.
+ * This thresholds predictions and ground truth to boolean values using 0.5
+ * then checks that they are equal.
+ */
+class boolean_accuracy_metric : public metric {
+
+ public:
+  boolean_accuracy_metric(lbann_comm *comm) : metric(comm) {}
+  boolean_accuracy_metric(const boolean_accuracy_metric& other) = default;
+  boolean_accuracy_metric& operator=(const boolean_accuracy_metric& other) = default;
+  virtual ~boolean_accuracy_metric() = default;
+  boolean_accuracy_metric* copy() const override {
+    return new boolean_accuracy_metric(*this);
+  }
+
+  /** Return a string name for this metric. */
+  std::string name() const override { return "boolean accuracy"; }
+  std::string get_unit() const override { return "%"; }
+
+ protected:
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
+
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_METRIC_BOOLEAN_ACCURACY_HPP

--- a/include/lbann/metrics/boolean_false_negatives.hpp
+++ b/include/lbann/metrics/boolean_false_negatives.hpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_METRIC_BOOLEAN_FALSE_NEGATIVES_HPP
+#define LBANN_METRIC_BOOLEAN_FALSE_NEGATIVES_HPP
+
+#include "lbann/metrics/metric.hpp"
+
+namespace lbann {
+
+/** Boolean false negatives metric.
+ * This thresholds predictions and ground truth to boolean values using 0.5
+ * then checks for false negatives (i.e. prediction is false when ground truth
+ * is true). The reported false-negative percent is with respect to all values
+ * and not the errors.
+ */
+class boolean_false_negatives_metric : public metric {
+
+ public:
+  boolean_false_negatives_metric(lbann_comm *comm) : metric(comm) {}
+  boolean_false_negatives_metric(
+    const boolean_false_negatives_metric& other) = default;
+  boolean_false_negatives_metric& operator=(
+    const boolean_false_negatives_metric& other) = default;
+  virtual ~boolean_false_negatives_metric() = default;
+  boolean_false_negatives_metric* copy() const override {
+    return new boolean_false_negatives_metric(*this);
+  }
+
+  /** Return a string name for this metric. */
+  std::string name() const override { return "boolean false negatives"; }
+  std::string get_unit() const override { return "%"; }
+
+ protected:
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
+
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_METRIC_BOOLEAN_FALSE_NEGATIVES_HPP

--- a/include/lbann/metrics/boolean_false_positives.hpp
+++ b/include/lbann/metrics/boolean_false_positives.hpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_METRIC_BOOLEAN_FALSE_POSITIVES_HPP
+#define LBANN_METRIC_BOOLEAN_FALSE_POSITIVES_HPP
+
+#include "lbann/metrics/metric.hpp"
+
+namespace lbann {
+
+/** Boolean false positives metric.
+ * This thresholds predictions and ground truth to boolean values using 0.5
+ * then checks for false positives (i.e. prediction is true when ground truth
+ * is false). The reported false-positive percent is with respect to all values
+ * and not the errors.
+ */
+class boolean_false_positives_metric : public metric {
+
+ public:
+  boolean_false_positives_metric(lbann_comm *comm) : metric(comm) {}
+  boolean_false_positives_metric(
+    const boolean_false_positives_metric& other) = default;
+  boolean_false_positives_metric& operator=(
+    const boolean_false_positives_metric& other) = default;
+  virtual ~boolean_false_positives_metric() = default;
+  boolean_false_positives_metric* copy() const override {
+    return new boolean_false_positives_metric(*this);
+  }
+
+  /** Return a string name for this metric. */
+  std::string name() const override { return "boolean false positives"; }
+  std::string get_unit() const override { return "%"; }
+
+ protected:
+  /** Computation to evaluate the metric function.
+   *  This returns the sum of metric values across the mini-batch, not
+   *  the mean value.
+   */
+  EvalType evaluate_compute(const AbsDistMat& prediction,
+                            const AbsDistMat& ground_truth) override;
+
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_METRIC_BOOLEAN_FALSE_POSITIVES_HPP

--- a/src/metrics/CMakeLists.txt
+++ b/src/metrics/CMakeLists.txt
@@ -7,6 +7,9 @@ set_full_path(THIS_DIR_SOURCES
   pearson_correlation.cpp
   top_k_categorical_accuracy.cpp
   r2.cpp
+  boolean_accuracy.cpp
+  boolean_false_positives.cpp
+  boolean_false_negatives.cpp
   )
 
 # Propagate the files up the tree

--- a/src/metrics/boolean_accuracy.cpp
+++ b/src/metrics/boolean_accuracy.cpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/metrics/boolean_accuracy.hpp"
+
+namespace lbann {
+
+EvalType boolean_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
+                                                   const AbsDistMat& ground_truth) {
+  const El::Int height = prediction.Height();
+  const El::Int local_height = prediction.LocalHeight();
+  const El::Int local_width = prediction.LocalWidth();
+  const Mat& prediction_local = prediction.LockedMatrix();
+  const Mat& ground_truth_local = ground_truth.LockedMatrix();
+
+  // Compute sum of predictions.
+  EvalType sum = 0;
+  #pragma omp parallel for reduction(+:sum) collapse(2)
+  for(El::Int col = 0; col < local_width; ++col) {
+    for(El::Int row = 0; row < local_height; ++row) {
+      const bool true_val = ground_truth_local(row, col) > DataType(0.5);
+      const bool pred_val = prediction_local(row, col) > DataType(0.5);
+      sum += EvalType(true_val == pred_val);
+    }
+  }
+  
+  // Compute mean value across mini-batch.
+  return get_comm().allreduce(sum / height, prediction.DistComm()) *
+    EvalType(100);
+}
+
+}  // namespace lbann

--- a/src/metrics/boolean_false_negatives.cpp
+++ b/src/metrics/boolean_false_negatives.cpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/metrics/boolean_false_negatives.hpp"
+
+namespace lbann {
+
+EvalType boolean_false_negatives_metric::evaluate_compute(
+  const AbsDistMat& prediction, const AbsDistMat& ground_truth) {
+  const El::Int height = prediction.Height();
+  const El::Int local_height = prediction.LocalHeight();
+  const El::Int local_width = prediction.LocalWidth();
+  const Mat& prediction_local = prediction.LockedMatrix();
+  const Mat& ground_truth_local = ground_truth.LockedMatrix();
+
+  // Compute sum of predictions.
+  EvalType sum = 0;
+  #pragma omp parallel for reduction(+:sum) collapse(2)
+  for(El::Int col = 0; col < local_width; ++col) {
+    for(El::Int row = 0; row < local_height; ++row) {
+      const bool true_val = ground_truth_local(row, col) > DataType(0.5);
+      const bool pred_val = prediction_local(row, col) > DataType(0.5);
+      sum += EvalType((true_val != pred_val) && true_val);
+    }
+  }
+  
+  // Compute mean value across mini-batch.
+  return get_comm().allreduce(sum / height, prediction.DistComm()) *
+    EvalType(100);
+}
+
+}  // namespace lbann

--- a/src/metrics/boolean_false_positives.cpp
+++ b/src/metrics/boolean_false_positives.cpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/metrics/boolean_false_positives.hpp"
+
+namespace lbann {
+
+EvalType boolean_false_positives_metric::evaluate_compute(
+  const AbsDistMat& prediction, const AbsDistMat& ground_truth) {
+  const El::Int height = prediction.Height();
+  const El::Int local_height = prediction.LocalHeight();
+  const El::Int local_width = prediction.LocalWidth();
+  const Mat& prediction_local = prediction.LockedMatrix();
+  const Mat& ground_truth_local = ground_truth.LockedMatrix();
+
+  // Compute sum of predictions.
+  EvalType sum = 0;
+  #pragma omp parallel for reduction(+:sum) collapse(2)
+  for(El::Int col = 0; col < local_width; ++col) {
+    for(El::Int row = 0; row < local_height; ++row) {
+      const bool true_val = ground_truth_local(row, col) > DataType(0.5);
+      const bool pred_val = prediction_local(row, col) > DataType(0.5);
+      sum += EvalType((true_val != pred_val) && pred_val);
+    }
+  }
+  
+  // Compute mean value across mini-batch.
+  return get_comm().allreduce(sum / height, prediction.DistComm()) *
+    EvalType(100);
+}
+
+}  // namespace lbann

--- a/src/proto/factories/metric_factory.cpp
+++ b/src/proto/factories/metric_factory.cpp
@@ -52,6 +52,15 @@ metric* construct_metric(lbann_comm* comm,
   if (proto_metric.has_r2()) {
     return new r2_metric(comm);
   }
+  if (proto_metric.has_boolean_accuracy()) {
+    return new boolean_accuracy_metric(comm);
+  }
+  if (proto_metric.has_boolean_false_positives()) {
+    return new boolean_false_positives_metric(comm);
+  }
+  if (proto_metric.has_boolean_false_negatives()) {
+    return new boolean_false_negatives_metric(comm);
+  }
 
   // Return null pointer if no optimizer is specified
   return nullptr;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -303,6 +303,9 @@ message Metric {
   MeanAbsoluteError mean_absolute_error = 6;
   PearsonCorrelation pearson_correlation = 5;
   R2 r2 = 7;
+  BooleanAccuracy boolean_accuracy = 8;
+  BooleanFalsePositives boolean_false_positives = 9;
+  BooleanFalseNegatives boolean_false_negatives = 10;
 }
 
 message CategoricalAccuracy {
@@ -319,6 +322,15 @@ message PearsonCorrelation {
 }
 
 message R2 {
+}
+
+message BooleanAccuracy {
+}
+
+message BooleanFalsePositives {
+}
+
+message BooleanFalseNegatives {
 }
 
 //========================================================================


### PR DESCRIPTION
This adds (thresholded) boolean metrics, which are needed for the mesh data.

The idea is that predictions and ground truths are boolean/binary predictions (after thresholding with 0.5), and you compute the accuracy elementwise.