### PR TITLE
Ds4triplet

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -761,13 +761,13 @@ class generic_data_reader : public lbann_image_preprocessor {
   }
   
   /// returns the data store, which may be a nullptr
-  generic_data_store * get_data_store() {
+  generic_data_store * get_data_store() const {
     return m_data_store;
   }
 
   /// sets up a data_store. @todo: must modify this method
   /// anytime you derive a class from generic_data_store
-  void setup_data_store(model *m, lbann_comm *comm);
+  virtual void setup_data_store(model *m, lbann_comm *comm);
 
   /** This call changes the functionality of fetch_data(); when set,
     * indices are added to m_my_minibatch_indices, but fetch_datum()

--- a/include/lbann/data_readers/data_reader_imagenet.hpp
+++ b/include/lbann/data_readers/data_reader_imagenet.hpp
@@ -47,6 +47,11 @@ class imagenet_reader : public image_data_reader {
     return "imagenet_reader";
   }
 
+  /** sets up a data_store. @todo: must modify this method
+   *  anytime you derive a class from generic_data_store
+   */
+  void setup_data_store(model *m, lbann_comm *comm) override;
+
  protected:
   void set_defaults() override;
   virtual bool replicate_processor(const cv_process& pp);

--- a/include/lbann/data_readers/data_reader_mnist_siamese.hpp
+++ b/include/lbann/data_readers/data_reader_mnist_siamese.hpp
@@ -81,6 +81,11 @@ class data_reader_mnist_siamese : public data_reader_multi_images {
   /// Fetch this mini-batch's labels into Y by calling the new overloaded fetch_label()
   int fetch_labels(Mat& Y) override;
   
+  /** sets up a data_store. @todo: must modify this method
+   *  anytime you derive a class from generic_data_store
+   */
+  void setup_data_store(model *m, lbann_comm *comm) override;
+
  protected:
   /**
    * Set the default configuration such as the width, height, and number of

--- a/include/lbann/data_readers/data_reader_multi_images.hpp
+++ b/include/lbann/data_readers/data_reader_multi_images.hpp
@@ -96,6 +96,11 @@ class data_reader_multi_images : public imagenet_reader {
     return m_num_img_srcs;
   }
 
+  /** sets up a data_store. @todo: must modify this method
+   *  anytime you derive a class from generic_data_store
+   */
+  void setup_data_store(model *m, lbann_comm *comm) override;
+
  protected:
   void set_defaults() override;
   virtual std::vector<::Mat> create_datum_views(::Mat& X, const int mb_idx) const;

--- a/include/lbann/data_readers/data_reader_pilot2_molecular.hpp
+++ b/include/lbann/data_readers/data_reader_pilot2_molecular.hpp
@@ -132,6 +132,11 @@ class pilot2_molecular_reader : public generic_data_reader {
     return m_neighbors_data_size;
   }
 
+  /** sets up a data_store. @todo: must modify this method
+   *  anytime you derive a class from generic_data_store
+   */
+  void setup_data_store(model *m, lbann_comm *comm) override;
+
  protected:
   /// Fetch a molecule and its neighbors.
   bool fetch_datum(Mat& X, int data_id, int mb_idx, int tid) override;

--- a/include/lbann/data_readers/data_reader_triplet.hpp
+++ b/include/lbann/data_readers/data_reader_triplet.hpp
@@ -78,6 +78,10 @@ class data_reader_triplet : public data_reader_multi_images {
     return m_samples.get_sample(idx);
   }
 
+  /** sets up a data_store. @todo: must modify this method
+   *  anytime you derive a class from generic_data_store
+   */
+  void setup_data_store(model *m, lbann_comm *comm) override;
 
  protected:
   void set_defaults() override;

--- a/include/lbann/data_store/data_store_multi_images.hpp
+++ b/include/lbann/data_store/data_store_multi_images.hpp
@@ -63,6 +63,8 @@ class data_store_multi_images : public data_store_imagenet {
   void read_files() override;
 
   void setup_extended_testing() override;
+
+  virtual std::vector<std::string> get_sample(size_t idx) const;
 };
 
 }  // namespace lbann

--- a/include/lbann/data_store/data_store_triplet.hpp
+++ b/include/lbann/data_store/data_store_triplet.hpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef __DATA_STORE_TRIPLET_HPP__
+#define __DATA_STORE_TRIPLET_HPP__
+
+#include "lbann/data_store/data_store_multi_images.hpp"
+
+namespace lbann {
+
+/**
+ * todo
+ */
+
+class data_store_triplet : public data_store_multi_images {
+ public:
+
+  //! ctor
+  data_store_triplet(lbann_comm *comm, generic_data_reader *reader, model *m) :
+    data_store_multi_images(comm, reader, m) {}
+
+  //! copy ctor
+  data_store_triplet(const data_store_triplet&) = default;
+
+  //! operator=
+  data_store_triplet& operator=(const data_store_triplet&) = default;
+
+  data_store_triplet * copy() const override { return new data_store_triplet(*this); }
+
+  //! dtor
+  ~data_store_triplet() override {};
+
+  void setup() override;
+
+ protected :
+
+  std::vector<std::string> get_sample(size_t idx) const override;
+};
+
+}  // namespace lbann
+
+#endif  // __DATA_STORE_TRIPLET_HPP__

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -26,15 +26,8 @@
 // lbann_data_reader .hpp .cpp - Input data base class for training, testing
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann/data_readers/data_reader_imagenet.hpp"
-#include "lbann/data_readers/data_reader_multi_images.hpp"
-#include "lbann/data_readers/data_reader_merge_samples.hpp"
-#include "lbann/data_readers/data_reader_pilot2_molecular.hpp"
-
-#include "lbann/data_store/data_store_imagenet.hpp"
-#include "lbann/data_store/data_store_multi_images.hpp"
-#include "lbann/data_store/data_store_merge_samples.hpp"
-#include "lbann/data_store/data_store_pilot2_molecular.hpp"
+#include "lbann/data_readers/data_reader.hpp"
+#include "lbann/data_store/generic_data_store.hpp"
 #include <omp.h>
 namespace lbann {
 
@@ -496,46 +489,6 @@ double generic_data_reader::get_use_percent() const {
 
 void generic_data_reader::setup_data_store(model *m, lbann_comm *comm) {
   m_data_store = nullptr;
-  generic_data_reader *the_reader = nullptr;
-
-  //note: ordering is important here; since data_store_multi_images is 
-  //      descended from data_store_imagenet, it must be first
-  if (dynamic_cast<data_reader_multi_images*>(this) != nullptr) {
-    the_reader = dynamic_cast<data_reader_multi_images*>(this);
-    m_data_store = new data_store_multi_images(comm, this, m);
-  }
-  else if (dynamic_cast<pilot2_molecular_reader*>(this) != nullptr) {
-    the_reader = dynamic_cast<pilot2_molecular_reader*>(this);
-    m_data_store = new data_store_pilot2_molecular(comm, this, m);
-  }
-  else if (dynamic_cast<imagenet_reader*>(this) != nullptr) {
-    the_reader = dynamic_cast<imagenet_reader*>(this);
-    m_data_store = new data_store_imagenet(comm, this, m);
-  }
-  /*
-  else if (dynamic_cast<data_reader_merge_samples*>(this) != nullptr) {
-    the_reader = dynamic_cast<data_reader_merge_samples*>(this);
-    m_data_store = new data_store_merge_samples(comm, this, m);
-  }
-  */
-
-  //note: this is not an error, since data readers for a single model
-  //      may be of different types (e.g, pilot2 has merge_samples and
-  //      pilot2 readers), and it's possible that we don't want to use
-  //      data store for one of these (possibly because the code
-  //      has not been written. @todo revisit in future: should this
-  //      be considered an error condition with thrown exception?
-  if (the_reader == nullptr) {
-    if (m_master) {
-      std::cerr << "WARNING: " << __FILE__ << " " << __LINE__
-                << " dynamic_cast<...> failed; NOT using data_store for role: " 
-                << get_role() << "\n";
-    }
-    return;
-  }
-
-  m_data_store->setup();
-
 }
 
 }  // namespace lbann

--- a/src/data_readers/data_reader_imagenet.cpp
+++ b/src/data_readers/data_reader_imagenet.cpp
@@ -154,4 +154,14 @@ bool imagenet_reader::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
   return true;
 }
 
+void imagenet_reader::setup_data_store(model *m, lbann_comm *comm) {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+  }
+  m_data_store = new data_store_imagenet(comm, this, m);
+  if (m_data_store != nullptr) {
+    m_data_store->setup();
+  }
+}
+
 }  // namespace lbann

--- a/src/data_readers/data_reader_mnist_siamese.cpp
+++ b/src/data_readers/data_reader_mnist_siamese.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/data_readers/data_reader_mnist_siamese.hpp"
 #include "lbann/data_readers/image_utils.hpp"
-#include "lbann/data_store/data_store_imagenet.hpp"
+#include "lbann/data_store/data_store_multi_images.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include <fstream>
 #include <sstream>
@@ -314,6 +314,16 @@ void data_reader_mnist_siamese::shuffle_indices() {
                  get_data_seq_generator());
     std::shuffle(m_shuffled_indices2.begin(), m_shuffled_indices2.end(),
                  get_data_seq_generator());
+  }
+}
+
+void data_reader_mnist_siamese::setup_data_store(model *m, lbann_comm *comm) {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+  }
+  m_data_store = new data_store_multi_images(comm, this, m);
+  if (m_data_store != nullptr) {
+    m_data_store->setup();
   }
 }
 

--- a/src/data_readers/data_reader_multi_images.cpp
+++ b/src/data_readers/data_reader_multi_images.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/data_readers/data_reader_multi_images.hpp"
 #include "lbann/data_readers/image_utils.hpp"
-#include "lbann/data_store/data_store_imagenet.hpp"
+#include "lbann/data_store/data_store_multi_images.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include <fstream>
 #include <sstream>
@@ -212,6 +212,16 @@ void data_reader_multi_images::load() {
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
 
   select_subset_of_data();
+}
+
+void data_reader_multi_images::setup_data_store(model *m, lbann_comm *comm) {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+  }
+  m_data_store = new data_store_multi_images(comm, this, m);
+  if (m_data_store != nullptr) {
+    m_data_store->setup();
+  }
 }
 
 }  // namespace lbann

--- a/src/data_readers/data_reader_pilot2_molecular.cpp
+++ b/src/data_readers/data_reader_pilot2_molecular.cpp
@@ -225,4 +225,14 @@ void pilot2_molecular_reader::fetch_molecule(Mat& X, int data_id, int idx,
   }
 }
 
+void pilot2_molecular_reader::setup_data_store(model *m, lbann_comm *comm) {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+  }
+  m_data_store = new data_store_pilot2_molecular(comm, this, m);
+  if (m_data_store != nullptr) {
+    m_data_store->setup();
+  }
+}
+
 }  // namespace lbann

--- a/src/data_readers/data_reader_triplet.cpp
+++ b/src/data_readers/data_reader_triplet.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/data_readers/data_reader_triplet.hpp"
 #include "lbann/data_readers/image_utils.hpp"
-#include "lbann/data_store/data_store_imagenet.hpp"
+#include "lbann/data_store/data_store_triplet.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include <fstream>
 #include <sstream>
@@ -173,6 +173,16 @@ void data_reader_triplet::load() {
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
 
   select_subset_of_data();
+}
+
+void data_reader_triplet::setup_data_store(model *m, lbann_comm *comm) {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+  }
+  m_data_store = new data_store_triplet(comm, this, m);
+  if (m_data_store != nullptr) {
+    m_data_store->setup();
+  }
 }
 
 }  // namespace lbann

--- a/src/data_store/CMakeLists.txt
+++ b/src/data_store/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   generic_data_store.cpp
   data_store_image.cpp
   data_store_multi_images.cpp
+  data_store_triplet.cpp
   data_store_imagenet.cpp
   data_store_merge_samples.cpp
   data_store_pilot2_molecular.cpp

--- a/src/data_store/data_store_triplet.cpp
+++ b/src/data_store/data_store_triplet.cpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/data_store/data_store_triplet.hpp"
+#include "lbann/data_readers/data_reader_triplet.hpp"
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/options.hpp"
+#include "lbann/utils/timer.hpp"
+
+namespace lbann {
+
+std::vector<std::string> data_store_triplet::get_sample(size_t idx) const {
+  const data_reader_triplet *reader = dynamic_cast<data_reader_triplet*>(m_reader);
+  data_reader_triplet::sample_t sample = reader->get_sample(idx);
+  return sample.first;
+}
+
+void data_store_triplet::setup() {
+  double tm1 = get_time();
+  if (m_rank == 0) {
+    std::cerr << "starting data_store_triplet::setup() for data reader with role: " << m_reader->get_role() << std::endl;
+  }
+
+  //sanity check
+  data_reader_triplet *reader = dynamic_cast<data_reader_triplet*>(m_reader);
+  if (reader == nullptr) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "dynamic_cast<data_reader_triplet*>(m_reader) failed";
+    throw lbann_exception(err.str());
+  }
+
+  //@todo needs to be designed and implemented!
+  if (! m_in_memory) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "not yet implemented";
+    throw lbann_exception(err.str());
+  } 
+  
+  else {
+    data_store_multi_images::setup();
+
+    if (m_rank == 0) {
+      std::cerr << "data_store_triplet setup time: " << get_time() - tm1 << std::endl;
+    }
+  }
+}
+
+}  // namespace lbann


### PR DESCRIPTION
data_store extension for data_reader_triplet.
- modification to data_reader_multi_images to make this extension easier while reusing the code as much as possible.  The requirement for data_reader_triplet is mostly the same as for data_reader_multiple_images.
  The only difference is the sample type, pair<vector<string>m, label_t>, returned by reader->get_sample(idx).  The label_t is int for multi_images and uint8_t for triplet. 
- addition of data_store_triplet inheriting data_store_multi_images
- override generic_data_reader::setup_data_store() for each derived class such that we do not need to include all the data_reader headers and associated data_store headers in the implementation file of the base class.
- data_store for triplet at least pass the data_store setup() but still crashes