### PR TITLE
Debugging LTFB

### DIFF
--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -22,8 +22,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_ltfb .hpp .cpp - Manage LTFB training for a model
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef __LBANN_CALLBACKS_CALLBACK_LTFB_HPP_INCLUDED
@@ -49,51 +47,31 @@ namespace lbann {
  */
 class lbann_callback_ltfb : public lbann_callback {
  public:
-  /**
-   * Initialize LFTB.
-   * @param round_size The number of minibatches in each round.
-   * @param remote_model A duplicate of the model being trained (temp workaround).
+
+  /** Constructor.
+   *  @param round_size The number of minibatches in each round.
    */
-  lbann_callback_ltfb(uint round_size,
-                      lbann_summary *summarizer = nullptr);
+  lbann_callback_ltfb(int round_size, lbann_summary* summarizer = nullptr);
   lbann_callback_ltfb(const lbann_callback_ltfb& other);
   lbann_callback_ltfb& operator=(const lbann_callback_ltfb& other);
   ~lbann_callback_ltfb() override;
   lbann_callback_ltfb* copy() const override { return new lbann_callback_ltfb(*this); }
+  std::string name() const override { return "ltfb"; }
+
   /** Set up LTFB. */
   void setup(model *m) override;
-  /**
-   * Potentially run an LTFB round.
-   */
+  /** Potentially run an LTFB round. */
   void on_batch_begin(model *m) override;
 
-  std::string name() const override { return "ltfb"; }
  private:
+
+  /** LBANN communicator. */
   lbann_comm *m_comm;
   /** Number of minibatches in a round. */
-  uint m_round_size;
-  /** Second model for doing the tournament. */
-  model *m_remote_model = nullptr;
+  int m_round_size;
+  /** Weights from local model. */
+  std::vector<weights*> m_local_weights;
 
-  /**
-   * Global operation that selects partners for the current tournament.
-   * This generates unique pairs (i.e. each model competes with only one other
-   * model). If there is an odd number of models, one of them sits out.
-   * @return The local rank's partner.
-   */
-  int select_partner();
-  /**
-   * Exchange local model data with partner's.
-   */
-  void exchange(model *m, int partner);
-  /**
-   * Evaluate a model on tournament data and return its accuracy.
-   */
-  EvalType evaluate(model *m);
-  /**
-   * Replace the local model m with the remote model data.
-   */
-  void replace_with_remote(model *m);
 };
 
 }  // namespace lbann

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -577,8 +577,8 @@ class lbann_comm {
     bytes_sent += sizeof(T) * send_count;
     bytes_received += sizeof(T) * recv_count;
     El::mpi::SendRecv(snd, send_count, get_world_rank(send_model, send_rank),
-                  rcv, recv_count, get_world_rank(recv_model, recv_rank),
-                  get_world_comm());
+                      rcv, recv_count, get_world_rank(recv_model, recv_rank),
+                      get_world_comm());
   }
   template <typename T>
   void sendrecv(const T *snd, int send_count, int send_model,

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -172,11 +172,13 @@ class generic_input_layer : public io_layer {
     // Determine model mini-batch size and effective mini-batch size
     // Note: If inter-model communication is activated, the effective
     // mini-batch is equal to the global mini-batch size.
+    /// @todo This functionality should probably be moved elsewhere
     mini_batch_size = get_current_mini_batch_size();
     int effective_mini_batch_size = mini_batch_size;
     for (auto&& cb : this->m_model->get_callbacks()) {
       if (dynamic_cast<lbann_callback_imcomm*>(cb) != nullptr) {
         effective_mini_batch_size = get_current_global_mini_batch_size();
+        break;
       }
     }
 

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -279,6 +279,7 @@ const AbsDistMat& weights::get_values() {
   // Copy weights matrix from GPU if needed
   if (m_cudnn != nullptr) {
     m_cudnn->copy_from_gpu(0, m_values->Matrix(), m_values_d[0]);
+    m_cudnn->synchronize();
   }
   #endif // LBANN_HAS_CUDNN
 
@@ -301,7 +302,8 @@ void weights::set_values(const AbsDistMat& values) {
   #ifdef LBANN_HAS_CUDNN
   // Copy weights matrix to GPU if needed
   if (m_cudnn != nullptr) {
-    m_cudnn->broadcast_to_gpus(m_values_d, m_values->Matrix());
+    m_cudnn->broadcast_to_gpus(m_values_d, m_values->LockedMatrix());
+    m_cudnn->synchronize();
   }
   #endif // LBANN_HAS_CUDNN
 


### PR DESCRIPTION
This fixes several problems I found in the LTFB callback:
- We used to get an infinite recursion under certain circumstances (models contain callbacks and the LTFB callback contains a model). To avoid this, LTFB maintains a list of weights rather than a model instance. We'll need to think of a workaround when we want LTFB with multiple model types.
- LTFB correctly resets the execution mode after evaluating the model on the validation set.
- The weights class synchronizes GPUs after CPU-GPU memory transfers.
- The effective mini-batch is only equal to the global mini-batch size when inter-model communication is enabled.
- We now throw an error if inter-model communication and LTFB are enabled at the same time.

LTFB on LeNet and AlexNet now appears to run reasonably.