### PR TITLE
Non-blocking objective function interface

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -51,6 +51,7 @@ namespace Al {
 class dummy_backend {
 public:
   using req_type = int;
+  static constexpr req_type null_req = 0;
 };
 
 // Define aliases for Aluminum backends
@@ -68,10 +69,10 @@ using nccl_backend = lbann::Al::dummy_backend;
 
 // Wrapper for Aluminum non-blocking routine requests
 struct request {
-  std::unique_ptr<mpi_backend::req_type> mpi_req;
+  mpi_backend::req_type mpi_req = mpi_backend::null_req;
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
-  std::unique_ptr<nccl_backend::req_type> nccl_req;
+  nccl_backend::req_type nccl_req = nccl_backend::null_req;
 #endif // LBANN_HAS_NCCL2
 };
 
@@ -459,6 +460,24 @@ class lbann_comm {
                     Al::request& req,
                     El::mpi::Op op = El::mpi::SUM,
                     std::type_index t = std::type_index(typeid(Al::mpi_backend)));
+  /** Non-blocking in-place scalar-array allreduce.
+   *  If LBANN has not been built with Aluminum, then this calls a blocking
+   *  allreduce.
+   *  This currently only supports host pointers (i.e. the MPI backend).
+   */
+  template <typename T>
+  void nb_allreduce(T *data, int count, const El::mpi::Comm c, Al::request& req,
+                    El::mpi::Op op = El::mpi::SUM) {
+#ifdef LBANN_HAS_ALUMINUM
+    bytes_sent += count * sizeof(T);
+    req.mpi_req = Al::mpi_backend::null_req;
+    allreduces::NonblockingAllreduce<allreduces::MPIBackend>(
+      data, count, mpi_op_to_al_op(op), *get_al_comm(c), req.mpi_req);
+    bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
+#else
+    allreduce(data, count, c, op);
+#endif  // LBANN_HAS_ALUMINUM
+  }
 
   /** Wait for a non-blocking request to complete. */
   template <typename T>

--- a/include/lbann/objective_functions/kl_divergence.hpp
+++ b/include/lbann/objective_functions/kl_divergence.hpp
@@ -63,8 +63,9 @@ class kl_divergence : public objective_function_term {
   /** Setup KL divergence regularization term. */
   void setup(model& m) override;
 
+  void start_evaluation() override;
   /** Get the value of the KL divergence regularization term. */
-  EvalType evaluate() override;
+  EvalType finish_evaluation() override;
 
   /** Regularization terms are applied to the objective function.
   *Add kl_loss to gradient/error signal.*/

--- a/include/lbann/objective_functions/loss_functions/binary_cross_entropy.hpp
+++ b/include/lbann/objective_functions/loss_functions/binary_cross_entropy.hpp
@@ -59,8 +59,12 @@ class binary_cross_entropy : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the binary cross entropy across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  /** Finish evaluation. */
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the binary cross entropy objective function.
    *  Given a prediction \f$\hat{y}\f$ and ground truth \f$y\f$, the

--- a/include/lbann/objective_functions/loss_functions/cross_entropy.hpp
+++ b/include/lbann/objective_functions/loss_functions/cross_entropy.hpp
@@ -61,8 +61,11 @@ class cross_entropy : public loss_function {
    *  the predictions and ground truth matrices should have
    *  non-negative entries that add up to one.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override;
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the cross entropy objective function.
    *  Given a predicted distribution \f$y\f$ and ground truth
@@ -76,6 +79,11 @@ class cross_entropy : public loss_function {
                              const AbsDistMat& ground_truth,
                              AbsDistMat& gradient) override;
 
+ private:
+  /** Sum of the cross-entropy terms. */
+  EvalType m_sum;
+  /** Non-blocking allreduce request. */
+  Al::request m_allreduce_req;
 };
 
 } // namespace lbann

--- a/include/lbann/objective_functions/loss_functions/cross_entropy_with_uncertainty.hpp
+++ b/include/lbann/objective_functions/loss_functions/cross_entropy_with_uncertainty.hpp
@@ -65,8 +65,11 @@ class cross_entropy_with_uncertainty : public loss_function {
    *  the predictions matrix should have non-negative entries that add up 
    *  to one.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the cross entropy objective function.
    *  Given a predicted distribution \f$y\f$ and ground truth

--- a/include/lbann/objective_functions/loss_functions/geom_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/geom_negloglike.hpp
@@ -59,8 +59,11 @@ class geom_negloglike : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean squared error across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Geometric negative log-likelihood objective function.
    *  Given a prediction \f$y\f$ and ground truth \f$\hat{y}\f$, the

--- a/include/lbann/objective_functions/loss_functions/loss_function.hpp
+++ b/include/lbann/objective_functions/loss_functions/loss_function.hpp
@@ -50,8 +50,10 @@ class loss_function : public objective_function_term {
   /** Setup objective function term. */
   virtual void setup(model& m) override;
 
-  /** Evaluate the objective function term. */
-  EvalType evaluate() override;
+  /** Start evaluation of the objective function term. */
+  void start_evaluation() override;
+  /** Finish evaluation of the objective function term. */
+  EvalType finish_evaluation() override;
 
   /** Compute the gradient of the objective function term.
    *  The gradient is computed w.r.t. the objective function term
@@ -64,11 +66,17 @@ class loss_function : public objective_function_term {
    */
   void compute_weight_regularization() override {};
 
-  /** Evaluate the loss function.
+  /** Start evaluation the loss function.
    *  This should not include the scale factor.
    */
-  virtual double evaluate_compute(const AbsDistMat& prediction,
-                                  const AbsDistMat& ground_truth) = 0;
+  virtual void start_evaluate_compute(const AbsDistMat& prediction,
+                                      const AbsDistMat& ground_truth) = 0;
+
+  /** Finish evaluation of the loss function.
+   *  This should not include the scale factor.
+   */
+  virtual EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                           const AbsDistMat& ground_truth) = 0;
 
   /** Compute the loss function gradient.
    *  The gradient should be w.r.t. the prediction vector. This should

--- a/include/lbann/objective_functions/loss_functions/mean_absolute_deviation.hpp
+++ b/include/lbann/objective_functions/loss_functions/mean_absolute_deviation.hpp
@@ -63,8 +63,11 @@ class mean_absolute_deviation_loss : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean absolute deviation across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the mean absolution deviation gradient.
    *  The gradient is w.r.t. the prediction vector.

--- a/include/lbann/objective_functions/loss_functions/mean_absolute_error.hpp
+++ b/include/lbann/objective_functions/loss_functions/mean_absolute_error.hpp
@@ -63,8 +63,11 @@ class mean_absolute_error_loss : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean absolute deviation across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the mean absolute error objective function.
    *  Given a prediction \f$\hat{y}\f$ and ground truth \f$y\f$, the

--- a/include/lbann/objective_functions/loss_functions/mean_squared_error.hpp
+++ b/include/lbann/objective_functions/loss_functions/mean_squared_error.hpp
@@ -63,8 +63,11 @@ class mean_squared_error_loss : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the mean absolute deviation across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override;
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the mean squared error objective function.
    *  Given a prediction \f$\hat{y}\f$ and ground truth \f$y\f$, the
@@ -77,6 +80,11 @@ class mean_squared_error_loss : public loss_function {
                              const AbsDistMat& ground_truth,
                              AbsDistMat& gradient) override;
 
+ private:
+  /** Sum of the the squared errors. */
+  EvalType m_sum;
+  /** Non-blocking allreduce request. */
+  Al::request m_allreduce_req;
 };
 
 } // namespace lbann

--- a/include/lbann/objective_functions/loss_functions/poisson_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/poisson_negloglike.hpp
@@ -59,8 +59,11 @@ class poisson_negloglike : public loss_function {
    *  This function updates the objective function value with the mean
    *  value of the Poisson negative log-likelihood across the mini-batch.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Poisson negative log-likelihood objective function.
    *  Given a prediction \f$\hat{y}\f$ and ground truth \f$y\f$, the

--- a/include/lbann/objective_functions/loss_functions/polya_negloglike.hpp
+++ b/include/lbann/objective_functions/loss_functions/polya_negloglike.hpp
@@ -65,8 +65,11 @@ class polya_negloglike : public loss_function {
    *  the predictions and ground truth matrices should have
    *  non-negative entries.
    */
-  EvalType evaluate_compute(const AbsDistMat& prediction,
-                            const AbsDistMat& ground_truth) override;
+  void start_evaluate_compute(const AbsDistMat& prediction,
+                              const AbsDistMat& ground_truth) override {}
+
+  EvalType finish_evaluate_compute(const AbsDistMat& prediction,
+                                   const AbsDistMat& ground_truth) override;
 
   /** Compute the gradient of the Polya negative log-likelihood objective function.
    *  Given the parameters \f$(\alpha_1,\dots,\alpha_K)\f$ of the predicted Polya distribution, the ground 

--- a/include/lbann/objective_functions/objective_function.hpp
+++ b/include/lbann/objective_functions/objective_function.hpp
@@ -59,14 +59,19 @@ class objective_function {
   /** Setup objective function. */
   void setup(model& m);
 
-  /** Evaluate the objective function.
+  /** Start evaluating the objective function.
    *  This function takes the model's current mini-batch size. If
    *  multiple models are being trained, the current mini-batch size
-   *  may be different from the effective mini-batch size. The result
-   *  is stored in history.
+   *  may be different from the effective mini-batch size.
+   *  The result is not guaranteed to be available until finish_evaluation is
+   *  called.
    */
-  EvalType evaluate(execution_mode mode,
-                    int mini_batch_size);
+  void start_evaluation(execution_mode mode, int mini_batch_size);
+
+  /** Complete evaluation of the objective function.
+   *  The result is stored in history.
+   */
+  EvalType finish_evaluation(execution_mode mode, int mini_batch_size);
 
   /** Compute the objective function gradient.
    *  The gradient is with respect to the objective function inputs

--- a/include/lbann/objective_functions/objective_function_term.hpp
+++ b/include/lbann/objective_functions/objective_function_term.hpp
@@ -55,10 +55,14 @@ class objective_function_term {
   /** Setup objective function term. */
   virtual void setup(model& m);
 
-  /** Evaluate the objective function term.
-   *  This should include the scaling factor.
+  /** Start evaluation of the objective function term.
+   *  This should include the scaling factor. The result is not available until
+   *  finish_evaluation has been called.
    */
-  virtual EvalType evaluate() = 0;
+  virtual void start_evaluation() = 0;
+
+  /** Complete evaluation of the objective function term. */
+  virtual EvalType finish_evaluation() = 0;
 
   /** Compute the gradient of the objective function term.
    *  The gradient is computed w.r.t. the objective function term

--- a/include/lbann/objective_functions/weight_regularization/group_lasso.hpp
+++ b/include/lbann/objective_functions/weight_regularization/group_lasso.hpp
@@ -53,8 +53,9 @@ class group_lasso_weight_regularization : public objective_function_term {
   /** Setup group lasso regularization term. */
   void setup(model& m) override;
 
+  void start_evaluation() override;
   /** Get the value of the group lasso regularization term. */
-  EvalType evaluate() override;
+  EvalType finish_evaluation() override;
 
   /** Weight regularization terms are not applied to the objective
    *  functions w.r.t. the activations

--- a/include/lbann/objective_functions/weight_regularization/l1.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l1.hpp
@@ -53,8 +53,9 @@ class l1_weight_regularization : public objective_function_term {
   /** Setup L2 regularization term. */
   void setup(model& m) override;
 
+  void start_evaluation() override;
   /** Get the value of the L1 regularization term. */
-  EvalType evaluate() override;
+  EvalType finish_evaluation() override;
 
   /** Weight regularization terms are not applied to the objective
    *  functions w.r.t. the activations

--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -47,7 +47,8 @@ class l2_weight_regularization : public objective_function_term {
   l2_weight_regularization* copy() const override { return new l2_weight_regularization(*this); }
   std::string name() const override { return "L2 weight regularization"; }
   void setup(model& m) override;
-  EvalType evaluate() override;
+  void start_evaluation() override;
+  EvalType finish_evaluation() override;
 
   /** Compute the gradient w.r.t. the activations. 
    *  L2 weight regularization is independent of the activations.
@@ -62,6 +63,13 @@ class l2_weight_regularization : public objective_function_term {
    */
   void compute_weight_regularization() override;
 
+ private:
+  /** Holds intermediate terms for each weights. */
+  std::vector<EvalType> m_sqsums;
+  /** Holds an allreduce request for each weights. */
+  std::vector<Al::request> m_allreduce_reqs;
+  /** Whether an allreduce is needed for each weights. */
+  std::vector<bool> m_allreduce_started;
 };
 
 } // namespace lbann

--- a/src/callbacks/callback_gradient_check.cpp
+++ b/src/callbacks/callback_gradient_check.cpp
@@ -185,8 +185,10 @@ DataType lbann_callback_gradient_check::compute_objective_function(model *m) {
   for (size_t l = 1; l < layers.size(); l++) {
     layers[l]->forward_prop();
   }
-  return obj_fn->evaluate(m->get_execution_mode(),
-                          m->get_current_mini_batch_size());
+  obj_fn->start_evaluation(m->get_execution_mode(),
+                           m->get_current_mini_batch_size());
+  return obj_fn->finish_evaluation(m->get_execution_mode(),
+                                   m->get_current_mini_batch_size());
 }
 
 }  // namespace lbann

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -186,27 +186,26 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
     throw lbann_exception("Aluminum does not support allreduces on"
                           " non-contiguous matrices");
   }
-  req = Al::request(); // Reset request
   auto&& comm = get_al_comm(c, t);
   if (t == std::type_index(typeid(allreduces::MPIBackend))) {
-    req.mpi_req.reset(new Al::mpi_backend::req_type);
+    req.mpi_req = Al::mpi_backend::null_req;
     allreduces::NonblockingAllreduce<allreduces::MPIBackend>(
       m.Buffer(),
       local_size,
       mpi_op_to_al_op(op),
       *comm,
-      *req.mpi_req);
+      req.mpi_req);
   }
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(allreduces::NCCLBackend))) {
-    req.nccl_req.reset(new Al::nccl_backend::req_type);
+    req.nccl_req = Al::nccl_backend::null_req;
     allreduces::NonblockingAllreduce<allreduces::NCCLBackend>(
       m.Buffer(),
       local_size,
       mpi_op_to_al_op(op),
       *static_cast<allreduces::NCCLCommunicator*>(comm),
-      *req.nccl_req);
+      req.nccl_req);
   }
 #endif // LBANN_HAS_NCCL2
   bytes_received += sizeof(DataType) * local_size * (El::mpi::Size(c) - 1);
@@ -217,29 +216,30 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
 
 void lbann_comm::wait(Al::request& req) {
 #ifdef LBANN_HAS_ALUMINUM
-  if (req.mpi_req.get() != nullptr) {
-    allreduces::Wait<allreduces::MPIBackend>(*req.mpi_req);
+  if (req.mpi_req != Al::mpi_backend::null_req) {
+    allreduces::Wait<allreduces::MPIBackend>(req.mpi_req);
+    req.mpi_req = Al::mpi_backend::null_req;  // Reset.
   }
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
-  if (req.nccl_req.get() != nullptr) {
-    allreduces::Wait<allreduces::NCCLBackend>(*req.nccl_req);
+  if (req.nccl_req != Al::nccl_backend::null_req) {
+    allreduces::Wait<allreduces::NCCLBackend>(req.nccl_req);
+    req.nccl_req = Al::nccl_backend::null_req;  // Reset.
   }
 #endif // LBANN_HAS_NCCL2
 #endif // LBANN_HAS_ALUMINUM
-  req = Al::request(); // Reset request
 }
 
 bool lbann_comm::test(Al::request& req) {
   bool req_test = true;
 #ifdef LBANN_HAS_ALUMINUM
-  if (req.mpi_req.get() != nullptr) {
-    req_test = req_test && allreduces::Test<allreduces::MPIBackend>(*req.mpi_req);
+  if (req.mpi_req != Al::mpi_backend::null_req) {
+    req_test = req_test && allreduces::Test<allreduces::MPIBackend>(req.mpi_req);
   }
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
-  if (req.nccl_req.get() != nullptr) {
-    req_test = req_test && allreduces::Test<allreduces::NCCLBackend>(*req.nccl_req);
+  if (req.nccl_req != Al::nccl_backend::null_req) {
+    req_test = req_test && allreduces::Test<allreduces::NCCLBackend>(req.nccl_req);
   }
 #endif // LBANN_HAS_NCCL2
 #endif // LBANN_HAS_ALUMINUM

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -188,7 +188,6 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
   }
   auto&& comm = get_al_comm(c, t);
   if (t == std::type_index(typeid(allreduces::MPIBackend))) {
-    req.mpi_req = Al::mpi_backend::null_req;
     allreduces::NonblockingAllreduce<allreduces::MPIBackend>(
       m.Buffer(),
       local_size,
@@ -199,7 +198,6 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(allreduces::NCCLBackend))) {
-    req.nccl_req = Al::nccl_backend::null_req;
     allreduces::NonblockingAllreduce<allreduces::NCCLBackend>(
       m.Buffer(),
       local_size,
@@ -218,13 +216,11 @@ void lbann_comm::wait(Al::request& req) {
 #ifdef LBANN_HAS_ALUMINUM
   if (req.mpi_req != Al::mpi_backend::null_req) {
     allreduces::Wait<allreduces::MPIBackend>(req.mpi_req);
-    req.mpi_req = Al::mpi_backend::null_req;  // Reset.
   }
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (req.nccl_req != Al::nccl_backend::null_req) {
     allreduces::Wait<allreduces::NCCLBackend>(req.nccl_req);
-    req.nccl_req = Al::nccl_backend::null_req;  // Reset.
   }
 #endif // LBANN_HAS_NCCL2
 #endif // LBANN_HAS_ALUMINUM

--- a/src/objective_functions/kl_divergence.cpp
+++ b/src/objective_functions/kl_divergence.cpp
@@ -56,7 +56,11 @@ void kl_divergence::setup(model& m) {
   }
 }
 
-EvalType kl_divergence::evaluate() {
+void kl_divergence::start_evaluation() {
+
+}
+
+EvalType kl_divergence::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
   
   // Matrices

--- a/src/objective_functions/loss_functions/binary_cross_entropy.cpp
+++ b/src/objective_functions/loss_functions/binary_cross_entropy.cpp
@@ -68,8 +68,8 @@ namespace binary_cross_entropy_debug {
 } // namespace binary_cross_entropy_debug
 #endif // LBANN_DEBUG
 
-EvalType binary_cross_entropy::evaluate_compute(const AbsDistMat& predictions,
-                                                const AbsDistMat& ground_truth) {
+EvalType binary_cross_entropy::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Local matrices
   const Mat& predictions_local = predictions.LockedMatrix();

--- a/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
+++ b/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
@@ -71,8 +71,8 @@ void cross_entropy_with_uncertainty::setup(model& m) {
 
 }
 
-EvalType cross_entropy_with_uncertainty::evaluate_compute(const AbsDistMat& predictions,
-                                                          const AbsDistMat& ground_truth) {
+EvalType cross_entropy_with_uncertainty::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Initialize workspace
   m_prediction_sums->Resize(1, predictions.Width());

--- a/src/objective_functions/loss_functions/geom_negloglike.cpp
+++ b/src/objective_functions/loss_functions/geom_negloglike.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-EvalType geom_negloglike::evaluate_compute(const AbsDistMat& predictions,
-                                           const AbsDistMat& ground_truth) {
+EvalType geom_negloglike::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Local matrices
   const Mat& predictions_local = predictions.LockedMatrix();

--- a/src/objective_functions/loss_functions/loss_function.cpp
+++ b/src/objective_functions/loss_functions/loss_function.cpp
@@ -111,12 +111,19 @@ void loss_function::setup(model& m) {
 
 }
 
-EvalType loss_function::evaluate() {
+void loss_function::start_evaluation() {
+  auto *target = (generic_target_layer*) m_layers[0];
+  const AbsDistMat& prediction = target->get_prediction();
+  const AbsDistMat& ground_truth = target->get_ground_truth();
+  start_evaluate_compute(prediction, ground_truth);
+}
+
+EvalType loss_function::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
   auto *target = (generic_target_layer*) m_layers[0];
   const AbsDistMat& prediction = target->get_prediction();
   const AbsDistMat& ground_truth = target->get_ground_truth();
-  return m_scale_factor * evaluate_compute(prediction, ground_truth);
+  return m_scale_factor * finish_evaluate_compute(prediction, ground_truth);
 }
 
 void loss_function::differentiate() {

--- a/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
+++ b/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-EvalType mean_absolute_deviation_loss::evaluate_compute(const AbsDistMat& predictions,
-                                                        const AbsDistMat& ground_truth) {
+EvalType mean_absolute_deviation_loss::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Local matrices
   const Mat& predictions_local = predictions.LockedMatrix();

--- a/src/objective_functions/loss_functions/mean_absolute_error.cpp
+++ b/src/objective_functions/loss_functions/mean_absolute_error.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-EvalType mean_absolute_error_loss::evaluate_compute(const AbsDistMat& predictions,
-                                                    const AbsDistMat& ground_truth) {
+EvalType mean_absolute_error_loss::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Local matrices
   const Mat& predictions_local = predictions.LockedMatrix();

--- a/src/objective_functions/loss_functions/poisson_negloglike.cpp
+++ b/src/objective_functions/loss_functions/poisson_negloglike.cpp
@@ -28,8 +28,8 @@
 
 namespace lbann {
 
-EvalType poisson_negloglike::evaluate_compute(const AbsDistMat& predictions,
-                                              const AbsDistMat& ground_truth) {
+EvalType poisson_negloglike::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Local matrices
   const Mat& predictions_local = predictions.LockedMatrix();

--- a/src/objective_functions/loss_functions/polya_negloglike.cpp
+++ b/src/objective_functions/loss_functions/polya_negloglike.cpp
@@ -126,8 +126,8 @@ void polya_negloglike::setup(model& m) {
 
 }
 
-EvalType polya_negloglike::evaluate_compute(const AbsDistMat& predictions,
-                                            const AbsDistMat& ground_truth) {
+EvalType polya_negloglike::finish_evaluate_compute(
+  const AbsDistMat& predictions, const AbsDistMat& ground_truth) {
 
   // Initialize workspace
   m_counts->Resize(1, predictions.Width());

--- a/src/objective_functions/objective_function.cpp
+++ b/src/objective_functions/objective_function.cpp
@@ -72,12 +72,21 @@ void objective_function::setup(model& m) {
   }
 }
 
-EvalType objective_function::evaluate(execution_mode mode,
-                                      int mini_batch_size) {
+void objective_function::start_evaluation(execution_mode mode,
+                                          int mini_batch_size) {
+  const auto start_time = get_time();
+  for (const auto& term : m_terms) {
+    term->start_evaluation();
+  }
+  m_evaluation_time += get_time() - start_time;
+}
+
+EvalType objective_function::finish_evaluation(execution_mode mode,
+                                               int mini_batch_size) {
   const auto start_time = get_time();
   EvalType value = EvalType(0);
   for (const auto& term : m_terms) {
-    value += term->evaluate();
+    value += term->finish_evaluation();
   }
   m_statistics[mode].add_value(mini_batch_size * value,
                                mini_batch_size);

--- a/src/objective_functions/weight_regularization/group_lasso.cpp
+++ b/src/objective_functions/weight_regularization/group_lasso.cpp
@@ -51,7 +51,11 @@ void group_lasso_weight_regularization::setup(model& m) {
 
 }
 
-EvalType group_lasso_weight_regularization::evaluate() {
+void group_lasso_weight_regularization::start_evaluation() {
+
+}
+
+EvalType group_lasso_weight_regularization::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
   EvalType value = EvalType(0);
   Mat sqsums;

--- a/src/objective_functions/weight_regularization/l1.cpp
+++ b/src/objective_functions/weight_regularization/l1.cpp
@@ -51,7 +51,11 @@ void l1_weight_regularization::setup(model& m) {
 
 }
 
-EvalType l1_weight_regularization::evaluate() {
+void l1_weight_regularization::start_evaluation() {
+
+}
+
+EvalType l1_weight_regularization::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
   EvalType value = EvalType(0);
   for (weights* w : m_weights) {


### PR DESCRIPTION
This splits the calculation of objective functions in forward propagation into two phases, which enables communication to be overlapped with computation, since the values of objective functions are not needed until the end of a mini-batch. (Indeed, they're not actually needed at all for training, but are useful to report.)

Instead of implementing `evaluate`, you now implement `start_evaluation`, which is called at the end of forward propagation, and `finish_evaluation`, which is called after backprop completes. The cross-entropy, MSE, and L2 weight regularization objectives have been updated to take advantage of this. Other objectives just had all their work moved to `finish_evaluation` for simplicity.

This also updates the LBANN Aluminum interface to not use `unique_ptr` and add a non-blocking scalar-array allreduce.

Computed loss function on AlexNet exactly matches the old version (up to the number of digits printed), and this passes gradient checking.