### PR TITLE
Optimizing GPU L2 regularization term.

### DIFF
--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -65,15 +65,17 @@ class l2_weight_regularization : public objective_function_term {
 
  private:
 
-  /** Reference to cuDNN manager. */
-  cudnn::cudnn_manager* m_cudnn = nullptr;
-
   /** Holds intermediate terms for each weights. */
   std::vector<EvalType> m_sqsums;
   /** Holds an allreduce request for each weights. */
   std::vector<Al::request> m_allreduce_reqs;
   /** Whether an allreduce is needed for each weights. */
   std::vector<bool> m_allreduce_started;
+
+#ifdef LBANN_HAS_CUDNN
+  /** Reference to cuDNN manager. */
+  cudnn::cudnn_manager* m_cudnn = nullptr;
+#endif // LBANN_HAS_CUDNN
 
 };
 

--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -64,12 +64,17 @@ class l2_weight_regularization : public objective_function_term {
   void compute_weight_regularization() override;
 
  private:
+
+  /** Reference to cuDNN manager. */
+  cudnn::cudnn_manager* m_cudnn = nullptr;
+
   /** Holds intermediate terms for each weights. */
   std::vector<EvalType> m_sqsums;
   /** Holds an allreduce request for each weights. */
   std::vector<Al::request> m_allreduce_reqs;
   /** Whether an allreduce is needed for each weights. */
   std::vector<bool> m_allreduce_started;
+
 };
 
 } // namespace lbann

--- a/include/lbann/utils/cublas_wrapper.hpp
+++ b/include/lbann/utils/cublas_wrapper.hpp
@@ -63,6 +63,19 @@ void axpy(cublasHandle_t const& handle,
           DataType alpha,
           DataType const* x, int incx,
           DataType * y, int incy);
+void dot(cublasHandle_t const& handle,
+         int n,
+         DataType const* x, int incx,
+         DataType const* y, int incy,
+         DataType * result);
+DataType dot(cublasHandle_t const& handle,
+             int n,
+             DataType const* x, int incx,
+             DataType const* y, int incy);
+void nrm2(cublasHandle_t const& handle,
+          int n,
+          DataType const* x, int incx,
+          DataType * result);
 DataType nrm2(cublasHandle_t const& handle,
               int n,
               DataType const* x, int incx);

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -112,7 +112,6 @@ void l2_weight_regularization::start_evaluation() {
     cudnn::matrix sqsums_d(m_cudnn);
     sqsums_d.attach_to_work_spaces(1, weights_per_gpu);
     sqsums_d.zero();
-    #pragma omp parallel for
     for (int gpu = 0; gpu < num_gpus; ++gpu) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(gpu)));
       auto&& handle = m_cudnn->get_cublas_handle(gpu);

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -139,7 +139,7 @@ void l2_weight_regularization::start_evaluation() {
 
   // Compute terms for CPU weights
   std::fill(m_allreduce_started.begin(), m_allreduce_started.end(), false);
-  for (size_t i = 0; i < m_weights.size(); ++i) {
+  for (int i = 0; i < num_weights; ++i) {
     const auto& w = m_weights[i];
     if (w->get_cudnn_manager() == nullptr) {
       const auto& values = w->get_values();

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -308,7 +308,6 @@ void optimizer::add_to_gradient(const cudnn::matrix& gradient_d,
     LBANN_ERROR("attempted to add to GPU gradient, but GPU is not set up");
   }
   if (scale != DataType(0)) {
-    #pragma omp parallel for
     for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       cublas::axpy(m_cudnn->get_cublas_handle(i),
@@ -386,7 +385,6 @@ void optimizer::add_to_gradient_staging(const cudnn::matrix& gradient_d,
     m_gradient_allreduce_needed = true;
 
     // Add to staging matrix
-    #pragma omp parallel for
     for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       cublas::axpy(m_cudnn->get_cublas_handle(i),

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -116,10 +116,7 @@ std::string optimizer::get_description() const {
 
 weights& optimizer::get_weights() {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access the weights being optimized before they are set";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access the weights being optimized before they are set");
   }
   return *m_weights;
 }
@@ -128,10 +125,7 @@ const AbsDistMat& optimizer::get_gradient() {
 
   // Check if gradient is initialized
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
 
   // Perform allreduce on staging matrix if needed
@@ -174,27 +168,20 @@ const cudnn::matrix& optimizer::get_gradient_gpu() {
 
   // Check if gradient is initialized
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
   if (m_cudnn == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to get GPU gradient, but GPU is not set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to get GPU gradient, but GPU is not set up");
   }
 
   // Check if all gradient sources have made contributions
   m_gradient_sources.erase(nullptr);
   if (!m_gradient_sources.empty()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradient before all gradient sources "
+    err << "attempted to access gradient before all gradient sources "
         << "have made contributions "
         << "(missing " << m_gradient_sources.size() << " sources)";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 
   // Perform allreduce on staging matrix if needed
@@ -233,17 +220,14 @@ void optimizer::start_gradient_staging_allreduce() {
     m_gradient_allreduce_finished = false;
   } else {
     #ifndef LBANN_HAS_CUDNN
-    throw lbann_exception("optimizer: cuDNN not detected");
+    LBANN_ERROR("cuDNN not detected");
     #else
     #if defined(LBANN_HAS_ALUMINUM) && defined(LBANN_HAS_NCCL2)
     // Non-blocking GPU allreduce with NCCL
     // Note: We assume each process has one GPU and that the gradient
     // is in STAR,STAR distribution.
     if (m_cudnn->get_num_gpus() != 1) {
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "non-blocking GPU allreduce with NCCL assumes one GPU per process";
-      throw lbann_exception(err.str());
+      LBANN_ERROR("non-blocking GPU allreduce with NCCL assumes one GPU per process");
     }
     StarMat gradient_staging_d;
     gradient_staging_d.Attach(m_gradient_staging_d.get_height(),
@@ -295,17 +279,14 @@ void optimizer::clear_gradient() {
 void optimizer::add_to_gradient(const AbsDistMat& gradient,
                                 DataType scale) {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
   if (scale != DataType(0)) {
     if (m_cudnn == nullptr) {
       El::Axpy(scale, gradient, *m_gradient);
     } else {
       #ifndef LBANN_HAS_CUDNN
-      throw lbann_exception("optimizer: cuDNN not detected");
+      LBANN_ERROR("cuDNN not detected");
       #else
       cudnn::matrix gradient_d(m_cudnn);
       gradient_d.attach_to_work_spaces(gradient.LocalHeight(),
@@ -321,18 +302,13 @@ void optimizer::add_to_gradient(const AbsDistMat& gradient,
 void optimizer::add_to_gradient(const cudnn::matrix& gradient_d,
                                 DataType scale) {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
   if (m_cudnn == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to add to GPU gradient, but GPU is not set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to add to GPU gradient, but GPU is not set up");
   }
   if (scale != DataType(0)) {
+    #pragma omp parallel for
     for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       cublas::axpy(m_cudnn->get_cublas_handle(i),
@@ -347,16 +323,10 @@ void optimizer::add_to_gradient(const cudnn::matrix& gradient_d,
 void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
                                         DataType scale) {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
   if (m_gradient_allreduce_started) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to add to staging matrix after gradient accumulation has started";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to add to staging matrix after gradient accumulation has started");
   }
   if (scale != DataType(0)) {
 
@@ -366,7 +336,7 @@ void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
         El::Zero(*m_gradient_staging);
       } else {
         #ifndef LBANN_HAS_CUDNN
-        throw lbann_exception("optimizer: cuDNN not detected");
+        LBANN_ERROR("cuDNN not detected");
         #else
         m_gradient_staging_d.zero();
         #endif // LBANN_HAS_CUDNN
@@ -379,7 +349,7 @@ void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
       El::Axpy(scale, gradient, *m_gradient_staging);
     } else {
       #ifndef LBANN_HAS_CUDNN
-      throw lbann_exception("optimizer: cuDNN not detected");
+      LBANN_ERROR("cuDNN not detected");
       #else
       cudnn::matrix gradient_d(m_cudnn,
                                gradient.LocalHeight(),
@@ -399,22 +369,13 @@ void optimizer::add_to_gradient_staging(const AbsDistMat& gradient,
 void optimizer::add_to_gradient_staging(const cudnn::matrix& gradient_d,
                                         DataType scale) {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access gradients before they are set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access gradients before they are set up");
   }
   if (m_gradient_allreduce_started) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to add to staging matrix after gradient accumulation has started";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to add to staging matrix after gradient accumulation has started");
   }
   if (m_cudnn == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to add to GPU gradient, but GPU is not set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to add to GPU gradient, but GPU is not set up");
   }
   if (scale != DataType(0)) {
 
@@ -425,6 +386,7 @@ void optimizer::add_to_gradient_staging(const cudnn::matrix& gradient_d,
     m_gradient_allreduce_needed = true;
 
     // Add to staging matrix
+    #pragma omp parallel for
     for(int i = 0; i < m_cudnn->get_num_gpus(); ++i) {
       CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu(i)));
       cublas::axpy(m_cudnn->get_cublas_handle(i),
@@ -453,10 +415,7 @@ void optimizer::remove_gradient_source(const void* source) {
 
 void optimizer::setup(weights& w) {
   if (is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to setup an optimizer that is already set up";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to setup an optimizer that is already set up");
   }
   set_weights(w);
 
@@ -486,10 +445,7 @@ void optimizer::setup(weights& w) {
 
 void optimizer::step() {
   if (!is_initialized()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "optimizer must be set up before performing optimization step";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("optimizer must be set up before performing optimization step");
   }
 
   double step_start = get_time();

--- a/src/utils/cublas_wrapper.cpp
+++ b/src/utils/cublas_wrapper.cpp
@@ -43,6 +43,7 @@ struct cuBLAS_Caller;
 template <>
 struct cuBLAS_Caller<float> {
   WRAP_CUBLAS(cublasSaxpy, axpy)
+  WRAP_CUBLAS(cublasSdot , dot )
   WRAP_CUBLAS(cublasSnrm2, nrm2)
   WRAP_CUBLAS(cublasSscal, scal)
   WRAP_CUBLAS(cublasSgemv, gemv)
@@ -53,6 +54,7 @@ struct cuBLAS_Caller<float> {
 template <>
 struct cuBLAS_Caller<double> {
   WRAP_CUBLAS(cublasDaxpy, axpy)
+  WRAP_CUBLAS(cublasDdot , dot )
   WRAP_CUBLAS(cublasDnrm2, nrm2)
   WRAP_CUBLAS(cublasDscal, scal)
   WRAP_CUBLAS(cublasDgemv, gemv)
@@ -100,12 +102,37 @@ void axpy(cublasHandle_t const& handle,
   cuBLAS_Caller<DataType>{}.axpy(handle, n, &alpha, x, incx, y, incy);
 }
 
+void dot(cublasHandle_t const& handle,
+         int n,
+         DataType const* x, int incx,
+         DataType const* y, int incy,
+         DataType * result) {
+  cuBLAS_Caller<DataType>{}.dot(handle, n, x, incx, y, incy, result);
+}
+
+DataType dot(cublasHandle_t const& handle,
+             int n,
+             DataType const* x, int incx,
+             DataType const* y, int incy) {
+  DataType result;
+  dot(handle, n, x, incx, y, incy, &result);
+  return result;
+}
+
+void nrm2(cublasHandle_t const& handle,
+          int n,
+          DataType const* x, int incx,
+          DataType * result) {
+  cuBLAS_Caller<DataType>{}.nrm2(handle, n, x, incx, result);
+}
+
 DataType nrm2(cublasHandle_t const& handle,
               int n,
               DataType const* x, int incx) {
   DataType result;
-  cuBLAS_Caller<DataType>{}.nrm2(handle, n, x, incx, &result);
+  nrm2(handle, n, x, incx, &result);
   return result;
+
 }
 
 void scal(cublasHandle_t const& handle,

--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -351,6 +351,7 @@ cudnn_manager::cudnn_manager(lbann::lbann_comm *_comm, int max_num_gpus, bool nc
         FORCE_CHECK_CUDNN(cudnnSetStream(m_handles.back(), m_streams.back()));
         FORCE_CHECK_CUBLAS(cublasCreate(&m_cublas_handles.back()));
         FORCE_CHECK_CUBLAS(cublasSetStream(m_cublas_handles.back(), m_streams.back()));
+        FORCE_CHECK_CUBLAS(cublasSetPointerMode(m_cublas_handles.back(), CUBLAS_POINTER_MODE_HOST));
     }
 
     // Get number of GPUs for current MPI rank


### PR DESCRIPTION
I am attempting to reduce the time spent in forward prop for the L2 regularization term on GPU. Changes:
- Using the cuBLAS `dot` routine instead of `nrm2`, which uses a numerically stable algorithm that is likely excessive for our use case.
- Running cuBLAS kernels asynchronously w.r.t. the host.
- Using all available GPUs.
