### PR TITLE
Summarize metric times

### DIFF
--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -146,6 +146,13 @@ class metric {
   /** Set list of pointers to layers. */
   void set_layer_pointers(std::vector<Layer*> layers);
 
+  /** Get the time spent in evaluation for this metric. */
+  double get_evaluate_time() const { return m_evaluate_time; }
+  /** Reset timing counters. */
+  void reset_counters() {
+    m_evaluate_time = 0.0;
+  }
+
   /** Save metric state to checkpoint. */
   virtual bool save_to_checkpoint_shared(persist& p);
   /** Load metric state from checkpoint. */
@@ -173,6 +180,9 @@ class metric {
 
   /** Metric statistics. */
   std::map<execution_mode,metric_statistics> m_statistics;
+
+  /** Runtime for the metric evaluation. */
+  double m_evaluate_time = 0.0;
 
 };
 

--- a/scripts/plotting/plot_comp_times.py
+++ b/scripts/plotting/plot_comp_times.py
@@ -15,13 +15,14 @@ def plot_times(files, names, output_name):
   for f in files:
     results.append(load_events.load_values(
       f,
-      event_names=['objective_time', 'objective_evaluation_time', 'objective_differentiation_time'],
+      event_names=['objective_time', 'objective_evaluation_time',
+                   'objective_differentiation_time', 'metric_evaluation_time'],
       layer_event_names=['fp_time', 'bp_time', 'update_time', 'imcomm_time', 'opt_time'],
       model=0))
   fig, ax = plt.subplots(1, 1)
   bar_width = 0.35
   labels = ['{0}'.format(x) for x in results[0]['fp_time'].keys()]
-  labels += ['obj']
+  labels += ['obj', 'metrics']
   starts = np.arange(len(labels))*(bar_width*len(files)+0.3) + 1
   for i in range(len(results)):
     result = results[i]
@@ -50,11 +51,14 @@ def plot_times(files, names, output_name):
     if 'objective_evaluation_time' in result:
       obj_val_tot = np.sum(result['objective_evaluation_time'])
       obj_grad_tot = np.sum(result['objective_differentiation_time'])
-    fp_tot = np.array(list(fp_tot.values()) + [obj_val_tot])
-    bp_tot = np.array(list(bp_tot.values()) + [obj_grad_tot])
-    update_tot = np.array(list(update_tot.values()) + [0.0])
-    imcomm_tot = np.array(list(imcomm_tot.values()) + [0.0])
-    opt_tot = np.array(list(opt_tot.values()) + [0.0])
+    metric_tot = 0.0
+    if 'metric_evaluation_time' in result:
+      metric_tot = np.sum(result['metric_evaluation_time'])
+    fp_tot = np.array(list(fp_tot.values()) + [obj_val_tot, metric_tot])
+    bp_tot = np.array(list(bp_tot.values()) + [obj_grad_tot, 0.0])
+    update_tot = np.array(list(update_tot.values()) + [0.0, 0.0])
+    imcomm_tot = np.array(list(imcomm_tot.values()) + [0.0, 0.0])
+    opt_tot = np.array(list(opt_tot.values()) + [0.0, 0.0])
     ax.bar(starts + i*bar_width, fp_tot, bar_width, color='blue')
     ax.bar(starts + i*bar_width, bp_tot, bar_width, bottom=fp_tot,
            color='green')
@@ -72,8 +76,9 @@ def plot_times(files, names, output_name):
   ax.set_ylabel('Time (s)')
   ax.set_xticks(starts + bar_width*(len(results)/2))
   ax.set_xticklabels(labels, rotation='vertical')
-  #for label in ax.xaxis.get_ticklabels():
-  #  label.set_fontsize(3)
+  if len(fp_tot) > 35:
+    for label in ax.xaxis.get_ticklabels():
+      label.set_fontsize(3)
   #for label in ax.xaxis.get_ticklabels()[::2]:
   #  label.set_visible(False)
   ax.set_title('Per-layer runtime breakdown')

--- a/src/metrics/metric.cpp
+++ b/src/metrics/metric.cpp
@@ -27,6 +27,7 @@
 #include "lbann/metrics/metric.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/layers/io/target/generic_target_layer.hpp"
+#include "lbann/utils/timer.hpp"
 
 namespace lbann {
 
@@ -113,8 +114,10 @@ EvalType metric::evaluate(execution_mode mode,
   }
 
   // Evaluate objective function
+  double start = get_time();
   const EvalType total_value = evaluate_compute(m_target_layer->get_prediction(),
                                                 m_target_layer->get_ground_truth());
+  m_evaluate_time += get_time() - start;
 
   // Record result in statistics and return
   m_statistics[mode].add_value(total_value, mini_batch_size);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1064,6 +1064,15 @@ void model::summarize_stats(lbann_summary& summarizer) {
     m_objective_function->get_differentiation_time(),
     get_cur_step());
   m_objective_function->reset_counters();
+  double total_metric_time = 0.0;
+  for (auto&& m : m_metrics) {
+    total_metric_time += m->get_evaluate_time();
+    m->reset_counters();
+  }
+  summarizer.reduce_scalar(
+    "metric_evaluation_time",
+    total_metric_time,
+    get_cur_step());
 }
 
 void model::summarize_matrices(lbann_summary& summarizer) {


### PR DESCRIPTION
This adds support for logging the time spent in metrics (in aggregate, for now) to the summarizer.

Now we can see how much time we waste providing feedback to the user! (Spoiler: A lot.)