### PR TITLE
Freezer

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -345,6 +345,10 @@ class Layer {
   /** Get reference to cuDNN manager. */
   cudnn::cudnn_manager* get_cudnn_manager() { return m_cudnn; }
 
+  void freeze();
+  void unfreeze();
+  bool is_frozen() const;
+
  protected:
 
   /** Reference to LBANN communicator. */
@@ -481,6 +485,9 @@ class Layer {
 
   /** Reference to cuDNN manager. */
   cudnn::cudnn_manager *m_cudnn;
+
+  /** Avoid back prop if frozen */
+  bool m_frozen;
 
 #ifdef LBANN_HAS_CUDNN
 

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -254,6 +254,14 @@ class base_convolution_layer : public learning_layer {
               this->m_weights[1]->get_matrix_height(),
               this->m_weights[1]->get_matrix_width());
 
+    if (m_frozen) {
+      this->m_weights[0]->freeze();
+      this->m_weights[1]->freeze();
+    } else {
+      if (this->m_weights[0]->is_frozen() || this->m_weights[1]->is_frozen()) {
+        throw lbann_exception("base_convolution_layer: layer is not frozen but weights are");
+      }
+    }
   }
 
   /// Initialize GPU objects

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -239,6 +239,14 @@ class fully_connected_layer : public learning_layer {
               this->m_weights[1]->get_matrix_height(),
               this->m_weights[1]->get_matrix_width());
 
+    if (m_frozen) {
+      this->m_weights[0]->freeze();
+      this->m_weights[1]->freeze();
+    } else {
+      if (this->m_weights[0]->is_frozen() || this->m_weights[1]->is_frozen()) {
+        throw lbann_exception("fully_connected_layer: layer is not frozen but weights are");
+      }
+    }
   }
 
   void setup_gpu() override {

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -269,6 +269,18 @@ class batch_normalization : public regularizer_layer {
     this->m_weights[2]->setup(this->m_neuron_dims[0]);
     this->m_weights[3]->setup(this->m_neuron_dims[0]);
 
+    if (m_frozen) {
+      this->m_weights[0]->freeze();
+      this->m_weights[1]->freeze();
+      this->m_weights[2]->freeze();
+      this->m_weights[3]->freeze();
+    } else {
+      if (this->m_weights[0]->is_frozen() || this->m_weights[1]->is_frozen() ||
+          this->m_weights[2]->is_frozen() || this->m_weights[3]->is_frozen()) {
+        throw lbann_exception("batch_normalization: layer is not frozen but weights are");
+      }
+    }
+
     // Initialize matrices
     El::Zeros(*m_mean, this->m_neuron_dims[0], 1);
     El::Zeros(*m_var, this->m_neuron_dims[0], 1);

--- a/include/lbann/models/directed_acyclic_graph.hpp
+++ b/include/lbann/models/directed_acyclic_graph.hpp
@@ -61,12 +61,17 @@ class directed_acyclic_graph_model : public model {
 
  protected:
 
+  /** For general DAG models, users need to manually specify each layer to
+   *  freeze in the model description prototext.
+   */
+  void freeze_layers_under_frozen_surface() override {}
+
   /** Set up layer execution order.
    *  Called in setup function. A topological sort applied is to the
    *  layer list so that we can traverse a directed acyclic graph
    *  without violating dependencies.
    */
-  virtual void setup_layer_execution_order() override;
+  void setup_layer_execution_order() override;
 
 };
 

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -288,6 +288,13 @@ class model {
   virtual void remap_pointers(const std::unordered_map<Layer *,Layer *>& layer_map,
                               const std::unordered_map<weights *,weights *>& weights_map);
 
+  /** In case that a layer is frozen, also freeze layers that precede it if that
+   *  makes senses for the particular model, such as sequential or siamese.
+   *  For othe models, users can manually control the behaivor by indicating
+   *  whether to freeze each layer in the model description prototext.
+   */
+  virtual void freeze_layers_under_frozen_surface();
+
   /** Set up topology of layer graph.
    *  Called in setup function. All layers in connected component of
    *  layer graph are added to the model and all parent/child

--- a/include/lbann/models/recurrent.hpp
+++ b/include/lbann/models/recurrent.hpp
@@ -60,6 +60,9 @@ class recurrent_model : public model {
   /** Get model name. */
   std::string name() const override { return "recurrent_model"; }
 
+  //** TODO: Not implemented */
+  void freeze_layers_under_frozen_surface() override {}
+
  protected:
 
   void setup_layer_topology() override;

--- a/include/lbann/models/siamese.hpp
+++ b/include/lbann/models/siamese.hpp
@@ -58,6 +58,12 @@ class siamese_model : public directed_acyclic_graph_model {
 
  protected:
 
+  /** For Siamese models, users specify only the last layer to freeze in the
+   *  model description prototext. Then, the layers that precedes it will
+   *  automatically be frozen as well.
+   */
+  void freeze_layers_under_frozen_surface() override;
+
   /** Set up topology of Siamese network.
    *  Called in setup function. Determines the network's master head
    *  and duplicates it.

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -189,6 +189,10 @@ class weights {
   std::vector<DataType*> get_values_gpu();
 #endif // LBANN_HAS_CUDNN
 
+  void freeze() { m_frozen = true; }
+  void unfreeze() { m_frozen = false; }
+  bool is_frozen() const { return m_frozen; }
+
   bool save_to_checkpoint_shared(persist& p);
   bool load_from_checkpoint_shared(persist& p);
   
@@ -231,6 +235,9 @@ class weights {
   /** GPU memory for weights matrix. */
   std::vector<DataType*> m_values_d;
 #endif // LBANN_HAS_CUDNN
+
+  /** Avoid weight update if frozen */
+  bool m_frozen;
 
   /** Setup GPU objects for weights. */
   virtual void setup_gpu();

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -157,9 +157,9 @@ class weights {
   void set_initializer(weights_initializer* initializer);
 
   /** Get weights optimizer. */
-  optimizer* get_optimizer() { return m_optimizer; }
+  optimizer* get_optimizer() { return (m_frozen? nullptr : m_optimizer); }
   /** Get weights optimizer (const). */
-  const optimizer* get_optimizer() const { return m_optimizer; }
+  const optimizer* get_optimizer() const { return (m_frozen? nullptr : m_optimizer); }
   /** Set weights optimizer.
    *  This takes ownership of the optimizer and deallocates it during
    *  destruction.

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -275,9 +275,6 @@ void Layer::forward_prop() {
 }
 
 void Layer::back_prop() {
-  if (m_frozen) {
-    return;
-  }
   const auto bp_start = get_time();
 
   // Setup matrix data, e.g. input matrices

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -303,6 +303,9 @@ std::string model::print_layer_description(const Layer* layer) const {
   if(s != "") {
     os << " (" << s << ")";
   }
+  if (layer->is_frozen()) {
+    os << " frozen";
+  }
   return os.str();
 }
 
@@ -761,6 +764,9 @@ void model::backward_prop() {
     // Terminate early if all gradients have been computed
     bool all_gradients_computed = true;
     for (auto&& w : m_weights) {
+      if (w->is_frozen()) {
+        continue;
+      }
       auto&& opt = w->get_optimizer();
       if (opt != nullptr && opt->get_num_gradient_sources() != 0) {
         all_gradients_computed = false;
@@ -776,6 +782,9 @@ void model::backward_prop() {
 void model::update_weights() {
   do_model_optimize_begin_cbs();
   for (const auto& w : m_weights) {
+    if (w->is_frozen()) {
+      continue;
+    }
     optimizer* opt = w->get_optimizer();
     if (opt != nullptr) {
       do_weight_optimize_begin_cbs(w);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -361,6 +361,24 @@ void model::remap_pointers(const std::unordered_map<Layer *,Layer *>& layer_map,
 
 }
 
+void model::freeze_layers_under_frozen_surface() {
+  bool freezing = false;
+  for (size_t i = m_layers.size(); i-- > 0u; ) {
+    auto& l = m_layers[i];
+    if (dynamic_cast<io_layer*>(l) != nullptr) {
+      if (l->is_frozen()) {
+        throw lbann_exception("Frozen io_layer!");
+      }
+      continue;
+    }
+    if (!freezing) {
+      freezing = l->is_frozen();
+    } else {
+      l->freeze();
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////
 // Setup
 ////////////////////////////////////////////////////////////

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -782,9 +782,6 @@ void model::backward_prop() {
     // Terminate early if all gradients have been computed
     bool all_gradients_computed = true;
     for (auto&& w : m_weights) {
-      if (w->is_frozen()) {
-        continue;
-      }
       auto&& opt = w->get_optimizer();
       if (opt != nullptr && opt->get_num_gradient_sources() != 0) {
         all_gradients_computed = false;
@@ -800,9 +797,6 @@ void model::backward_prop() {
 void model::update_weights() {
   do_model_optimize_begin_cbs();
   for (const auto& w : m_weights) {
-    if (w->is_frozen()) {
-      continue;
-    }
     optimizer* opt = w->get_optimizer();
     if (opt != nullptr) {
       do_weight_optimize_begin_cbs(w);

--- a/src/models/sequential.cpp
+++ b/src/models/sequential.cpp
@@ -61,6 +61,7 @@ void sequential_model::setup_layer_topology() {
     throw lbann_exception(err.str());
   }
 
+  freeze_layers_under_frozen_surface();
 }
 
 bool sequential_model::save_to_checkpoint(int fd, const char *filename, size_t *bytes) {

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -237,6 +237,12 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
     }
     names_to_layers[name] = l;
 
+    if (proto_layer.freeze()) {
+      if (comm->am_world_master()) {
+        std::cout << "freezing " << l->get_name() << std::endl;
+      }
+      l->freeze();
+    }
     // Add layer to list
     layers.push_back(l);
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -661,6 +661,7 @@ message Layer {
    string data_layout = 52;
    string weights = 54;
    bool num_neurons_from_data_reader = 53;
+   bool freeze = 5;
 
    repeated WeightsData weights_data = 153;
    string top = 154;

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -35,7 +35,8 @@ namespace lbann {
 weights::weights(lbann_comm* comm,
                  cudnn::cudnn_manager* cudnn)
   : m_comm(comm),
-    m_cudnn(cudnn) {
+    m_cudnn(cudnn),
+    m_frozen(false) {
 
   // Initialize weights name
   static int num_weights = 0;
@@ -55,7 +56,8 @@ weights::weights(const weights& other)
     m_matrix_width_dims(other.m_matrix_width_dims),
     m_values(other.m_values),
     m_initializer(other.m_initializer),
-    m_optimizer(other.m_optimizer) {
+    m_optimizer(other.m_optimizer),
+    m_frozen(other.m_frozen) {
 
   // Create deep copy of pointers
   if (m_values != nullptr)      { m_values = m_values->Copy(); }
@@ -103,6 +105,8 @@ weights& weights::operator=(const weights& other) {
                                get_matrix_width());
   }
   #endif // LBANN_HAS_CUDNN
+
+  m_frozen = other.m_frozen;
 
   return *this;
 }


### PR DESCRIPTION
To avoid gradient computation and weight updates with pre-trained layers, provide 'freeze' interface.
- layers and weights get new freeze(), unfreeze(), and is_frozen() methods.
- 'freeze: true' in the prototext block of a layer freezes the layer.
- The default is unfrozen.
- When a layer gets frozen, it also freezes the weights associated with it.
- If a weight is shared, and one layer relying on it is frozen and another is not, throw exception.
- Given a frozen layer, freeze layers that precede it if that makes senses for the particular model, such as sequential or siamese. For othe models, users can manually control the behaivor by indicating whether to freeze each layer in the model description prototext.