### PR TITLE
Evaluation layers

### DIFF
--- a/include/lbann/layers/activations/power.hpp
+++ b/include/lbann/layers/activations/power.hpp
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef POWER_HPP_INCLUDED
+#define POWER_HPP_INCLUDED
+
+#include "lbann/layers/activations/activation.hpp"
+
+namespace lbann {
+
+/** Power function. */
+template <data_layout T_layout>
+class power_layer : public entrywise_activation_layer {
+ public:
+  power_layer(lbann_comm *comm, EvalType exponent)
+    : entrywise_activation_layer(comm), m_exponent(exponent) {}
+  power_layer* copy() const override { return new power_layer(*this); }
+  std::string get_type() const override { return "power"; }
+  data_layout get_data_layout() const override { return T_layout; }
+
+ protected:
+  DataType activation(DataType z) const override {
+    if (m_exponent == EvalType(2)) {
+      return z * z;
+    } else {
+      return std::pow(z, m_exponent);
+    }
+  }
+  DataType activation_derivative(DataType z) const override {
+    if (m_exponent == EvalType(2)) {
+      return 2 * z;
+    } else {
+      return m_exponent * std::pow(z, m_exponent - EvalType(1));
+    }
+  }
+
+ private:
+
+  /** Exponent for power function. */
+  const EvalType m_exponent;
+
+};
+
+} // namespace lbann
+
+#endif // POWER_HPP_INCLUDED

--- a/include/lbann/layers/transform/constant.hpp
+++ b/include/lbann/layers/transform/constant.hpp
@@ -109,7 +109,16 @@ class constant_layer : public transform_layer {
   #endif // #ifndef LBANN_HAS_CUDNN
   }
 
-  void fp_compute() override {}
+  void fp_compute() override {
+    auto& activations = get_activations();
+    if (m_value == EvalType(0)) {
+      El::Zero(activations);
+    } else {
+      El::Fill(activations, m_value);
+    }
+    
+  }
+
   void bp_compute() override {}
 
  private:

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_EVALUATION_HPP_INCLUDED
+#define LBANN_LAYER_EVALUATION_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+
+namespace lbann {
+
+/** Evaluation layer.
+ *  Computes the average value across a mini-batch. If the input
+ *  tensor has multiple neurons, their values are added together.
+ */
+template <data_layout T_layout = data_layout::DATA_PARALLEL>
+class evaluation_layer : public transform_layer {
+
+ public:
+
+  evaluation_layer(lbann_comm *comm,
+              cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm), m_scale(1), m_value(0) {
+
+    // Evaluation layer has no children
+    m_expected_num_child_layers = 0;
+
+  }
+
+  evaluation_layer* copy() const override { return new evaluation_layer(*this); }
+  std::string get_type() const override { return "evaluation"; }
+  data_layout get_data_layout() const override { return T_layout; }
+
+  /** Returns description. */
+  std::string get_description() const override {
+    std::stringstream s;
+     s << "evaluation_layer  dataLayout: " << this->get_data_layout_string(get_data_layout());
+     return s.str();
+  }
+
+  /** Get scaling factor. */
+  EvalType get_scale() const { return m_scale; }
+  /** Set scaling factor. */
+  void set_scale(EvalType scale) { m_scale = scale; }
+  
+  /** Get evaluated value. */
+  EvalType get_value(bool unscaled = false) const {
+    if (unscaled) {
+      return m_value;
+    } else {
+      return m_scale * m_value;
+    }
+  }
+
+ protected:
+
+  virtual void fp_compute() override {
+    const auto& input = get_prev_activations();
+    const auto& local_input = input.LockedMatrix();
+    const El::Int local_height = local_input.Height();
+    const El::Int local_width = local_input.Width();
+    const auto& mini_batch_size = this->m_model->get_current_mini_batch_size();
+
+    // Compute average value
+    /// @todo Non-blocking allreduce
+    EvalType sum = EvalType(0);
+    #pragma omp parallel for reduction(+:sum) collapse(2)
+    for (El::Int col = 0; col < local_width; ++col) {
+      for (El::Int row = 0; row < local_height; ++row) {
+        sum += local_input(row, col);
+      }
+    }
+    m_value = this->m_comm->allreduce(sum / mini_batch_size,
+                                      input.DistComm());
+
+  }
+  
+  virtual void bp_compute() override {
+    auto& error_signal = get_error_signals();
+    if (m_scale == EvalType(0)) {
+      Zero(error_signal);
+    } else {
+      Fill(error_signal, DataType(m_scale));
+    }
+  }
+
+  /** Scaling factor to apply to evaluated value. */
+  EvalType m_scale;
+  /** Evaluated value. */
+  EvalType m_value;
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_EVALUATION_HPP_INCLUDED

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -100,9 +100,9 @@ class evaluation_layer : public transform_layer {
   virtual void bp_compute() override {
     auto& error_signal = get_error_signals();
     if (m_scale == EvalType(0)) {
-      Zero(error_signal);
+      El::Zero(error_signal);
     } else {
-      Fill(error_signal, DataType(m_scale));
+      El::Fill(error_signal, DataType(m_scale));
     }
   }
 

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -42,7 +42,7 @@ class evaluation_layer : public transform_layer {
 
   evaluation_layer(lbann_comm *comm,
               cudnn::cudnn_manager *cudnn = nullptr)
-    : transform_layer(comm), m_scale(1), m_value(0) {
+    : transform_layer(comm), m_scale(0), m_value(0) {
 
     // Evaluation layer has no children
     m_expected_num_child_layers = 0;

--- a/include/lbann/layers/transform/reduction.hpp
+++ b/include/lbann/layers/transform/reduction.hpp
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_REDUCTION_HPP_INCLUDED
+#define LBANN_LAYER_REDUCTION_HPP_INCLUDED
+
+#include <vector>
+#include "lbann/layers/transform/transform.hpp"
+
+namespace lbann {
+
+enum class reduction_mode {INVALID, SUM, AVERAGE};
+
+/** Reduction layer. */
+template <data_layout T_layout = data_layout::DATA_PARALLEL>
+class reduction_layer : public transform_layer {
+ private:
+
+  /** Reduction mode. */
+  const reduction_mode m_mode;
+
+ public:
+
+  reduction_layer(lbann_comm *comm,
+                  reduction_mode mode,
+                  cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm),
+      m_mode(mode) {
+    static_assert(T_layout == data_layout::DATA_PARALLEL,
+                  "reduction currently only supports DATA_PARALLEL");
+    if (mode == reduction_mode::INVALID) {
+      LBANN_ERROR("invalid reduction mode");
+    }
+    
+    // Initialize neuron tensor dimensions
+    this->m_num_neurons = 1;
+    this->m_num_neuron_dims = 1;
+    this->m_neuron_dims = {1};
+
+  }
+
+  reduction_layer* copy() const override { return new reduction_layer(*this); }
+  std::string get_type() const override { return "reduction"; }
+  data_layout get_data_layout() const override { return T_layout; }
+
+ protected:
+
+  void setup_dims() override {
+    transform_layer::setup_dims();
+    this->m_num_neurons = 1;
+    this->m_num_neuron_dims = 1;
+    this->m_neuron_dims = {1};
+  }
+
+  void fp_compute() override {
+    const auto& local_input = get_local_prev_activations();
+    auto& local_output = get_local_activations();
+    switch (m_mode) {
+    case reduction_mode::SUM:
+      El::ColumnSum(local_input, local_output);
+      break;
+    case reduction_mode::AVERAGE:
+      El::ColumnSum(local_input, local_output);
+      local_output *= DataType(1) / get_num_prev_neurons();
+      break;
+    default:
+      LBANN_ERROR("invalid reduction mode");
+    }
+  }
+
+  void bp_compute() override {
+    const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+    auto& local_gradient_wrt_input = get_local_error_signals();
+    switch (m_mode) {
+    case reduction_mode::SUM:
+      El::IndexDependentMap(local_gradient_wrt_input,
+                            (std::function<DataType(El::Int,El::Int,const DataType&)>)
+                            ([this,&local_gradient_wrt_output]
+                             (El::Int r, El::Int c,const DataType& dx)
+                             ->DataType {
+                              return dx + local_gradient_wrt_output(0, c);
+                            }));
+      break;
+    case reduction_mode::AVERAGE:
+      {
+        const DataType scale = DataType(1) / get_num_prev_neurons();
+        El::IndexDependentMap(local_gradient_wrt_input,
+                              (std::function<DataType(El::Int,El::Int,const DataType&)>)
+                              ([this,&local_gradient_wrt_output,scale]
+                               (El::Int r, El::Int c,const DataType& dx)
+                               ->DataType {
+                                return dx + scale * local_gradient_wrt_output(0, c);
+                              }));
+      }
+      break;
+    default:
+      LBANN_ERROR("invalid reduction mode");
+    }
+  }
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_REDUCTION_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -173,6 +173,7 @@
 #include "lbann/objective_functions/weight_regularization/l2.hpp"
 #include "lbann/objective_functions/weight_regularization/group_lasso.hpp"
 #include "lbann/objective_functions/kl_divergence.hpp"
+#include "lbann/objective_functions/layer_term.hpp"
 
 /// Metrics
 #include "lbann/metrics/categorical_accuracy.hpp"

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -55,6 +55,7 @@
 #include "lbann/layers/activations/softplus.hpp"
 #include "lbann/layers/activations/swish.hpp"
 #include "lbann/layers/activations/tanh.hpp"
+#include "lbann/layers/activations/power.hpp"
 
 /// Learning Layers
 #include "lbann/layers/learning/fully_connected.hpp"
@@ -74,6 +75,8 @@
 #include "lbann/layers/transform/noise.hpp"
 #include "lbann/layers/transform/safe_inv.hpp"
 #include "lbann/layers/transform/hadamard.hpp"
+#include "lbann/layers/transform/reduction.hpp"
+#include "lbann/layers/transform/evaluation.hpp"
 
 /// Regularization layers.
 #include "lbann/layers/regularizers/local_response_normalization.hpp"

--- a/include/lbann/objective_functions/layer_term.hpp
+++ b/include/lbann/objective_functions/layer_term.hpp
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_OBJECTIVE_FUNCTION_LAYER_TERM_HPP_INCLUDED
+#define LBANN_OBJECTIVE_FUNCTION_LAYER_TERM_HPP_INCLUDED
+
+#include "lbann/objective_functions/objective_function_term.hpp"
+#include "lbann/layers/transform/evaluation.hpp"
+
+namespace lbann {
+
+class layer_term : public objective_function_term {
+ public:
+  layer_term(EvalType scale_factor = EvalType(1));
+  layer_term* copy() const override { return new layer_term(*this); } 
+  std::string name() const override { return "evaluation layer term"; }
+
+  void set_evaluation_layer(Layer* l);
+
+  void setup(model& m) override;
+
+  void start_evaluation() override;
+
+  EvalType finish_evaluation() override;
+
+  void differentiate() override;
+  
+  void compute_weight_regularization() override {};
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_OBJECTIVE_FUNCTION_WEIGHT_REGULARIZATION_KL_DIVERGENCE_HPP_INCLUDED

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -14,9 +14,9 @@ model {
 
   objective_function {
     binary_cross_entropy {}
-    kl_divergence {
-      layer1: "z_mean"
-      layer2: "z_log_sigma" 
+    layer_term {
+      scale_factor: 1.0
+      layer: "kl_divergence"
     }
     l2_weight_regularization {
       scale_factor: 1e-4
@@ -55,7 +55,7 @@ model {
   # start of layers
   ###################################################
 
-  # INPUT
+  # Data
   layer {
     name: "data"
     data_layout: "model_parallel"
@@ -64,7 +64,7 @@ model {
     }
   }
 
-  # FULLY_CONNECTED encode1
+  # Encoder
   layer {
     parents: "data"
     name: "encode1"
@@ -75,28 +75,14 @@ model {
       has_bias: true
     }
   }
-
-  # RELU relu1
   layer {
     parents: "encode1"
-    name: "relu1"
+    name: "encode1_relu"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
-
-  #split
   layer {
-    parents: "relu1"
-    name: "split"
-    data_layout: "model_parallel"
-    split {
-    }
-  }
-  
-  # FULLY_CONNECTED z_mean
-  layer {
-    parents: "split"
+    parents: "encode1_relu"
     name: "z_mean"
     data_layout: "model_parallel"
     fully_connected {
@@ -105,23 +91,8 @@ model {
       has_bias: true
     }
   }
-  # Note: This identity layer is a kludgy solution to a bug in the KL divergence.
-  #   The KL divergence adds to the "prev_error_signal" of z_mean, which is the
-  #   "error_signal" of z_mean's child layer. However, z_mean's child layer is a
-  #   sum layer, which has multiple parents and hence multiple error_signal's.
-  #   Putting this identity layer clears up that ambiguity, but it is not a good
-  #   solution to the problem. The objective function paradigm outlined in 
-  #   issue #193 will be a better long-term solution.
   layer {
-    parents: "z_mean"
-    name: "z_mean_id"
-    data_layout: "model_parallel"
-    identity {}
-  }
-
-  # FULLY_CONNECTED z_log_sigma
-  layer {
-    parents: "split"
+    parents: "encode1_relu"
     name: "z_log_sigma"
     data_layout: "model_parallel"
     fully_connected {
@@ -130,58 +101,92 @@ model {
       has_bias: true
     }
   }
-  
-  #scale z_log_sigma by 1/2
+
+  # KL divergence
   layer {
-     parents: "z_log_sigma"
-     name: "const05_zlogsigma"
-     data_layout: "model_parallel"
-     sum {
-       scaling_factors: "0.5"
-     }
-   }
- 
-  # Exponent exp
-  layer {
-    parents: "const05_zlogsigma"
-    name: "exp"
+    name: "kl_one"
     data_layout: "model_parallel"
-    exponential {
+    constant {
+      value: 1.0
+      num_neurons: "2"
     }
   }
-
-  # Noise noise
   layer {
-    name: "noise"
+    parents: "z_mean"
+    name: "kl_z_mean2"
+    data_layout: "model_parallel"
+    power {
+      exponent: 2.0
+    }    
+  }
+  layer {
+    parents: "z_log_sigma"
+    name: "kl_exp"
+    data_layout: "model_parallel"
+    exponential {}
+  }
+  layer {
+    parents: "kl_one z_log_sigma kl_z_mean2 kl_exp"
+    name: "kl_entrywise"
+    data_layout: "model_parallel"
+    sum {
+      scaling_factors: "-0.5 -0.5 0.5 0.5"
+    }
+  }
+  layer {
+    parents: "kl_entrywise"
+    name: "kl_sum"
+    data_layout: "data_parallel"
+    reduction {
+      mode: "sum"
+    }
+  }
+  layer {
+    parents: "kl_sum"
+    name: "kl_divergence"
+    data_layout: "data_parallel"
+    evaluation {}
+  }
+
+  # Sample from latent space
+  layer {
+    parents: "z_log_sigma"
+    name: "sample_half"
+    data_layout: "model_parallel"
+    sum {
+      scaling_factors: "0.5"
+    }    
+  }
+  layer {
+    parents: "sample_half"
+    name: "sample_exp"
+    data_layout: "model_parallel"
+    exponential {}
+  }
+  layer {
+    name: "sample_noise"
     data_layout: "model_parallel"
     noise {
       noise_factor: 1.0
       num_neurons: "2"
     }
   }
-  
- # Hadamad2 exp_noise
   layer {
-    parents: "exp noise"
-    name: "exp_noise"
+    parents: "sample_exp sample_noise"
+    name: "sample_exp_noise"
     data_layout: "model_parallel"
-    hadamard {
-    }
+    hadamard {}
+  }
+  layer {
+    parents: "z_mean sample_exp_noise"
+    name: "sample"
+    data_layout: "model_parallel"
+    sum {}
   }
 
-
-  # Sum sum
+  # Decoder
   layer {
-    parents: "z_mean_id exp_noise"
-    name: "sum"
-    data_layout: "model_parallel"
-    sum {
-    }
-  }
-
-  # FULLY_CONNECTED decode1
-  layer {
-    parents: "sum"
+    parents: "sample"
     name: "decode1"
     data_layout: "model_parallel"
     fully_connected {
@@ -190,17 +195,12 @@ model {
       has_bias: true
     }
   }
-
-  # RELU relu2
   layer {
     parents: "decode1"
     name: "relu2"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
-
-  # FULLY_CONNECTED decode0
   layer {
     parents: "relu2"
     name: "decode0"
@@ -211,8 +211,6 @@ model {
       has_bias: true
     }
   }
-
-  # SIGMOID sigmoid
   layer {
     parents: "decode0"
     name: "sigmoid"
@@ -221,7 +219,7 @@ model {
     }
   }
 
-  # RECONSTRUCTION
+  # Reconstruction
   layer {
     parents: "sigmoid"
     name: "reconstruction"

--- a/src/objective_functions/CMakeLists.txt
+++ b/src/objective_functions/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   kl_divergence.cpp
   objective_function.cpp
   objective_function_term.cpp
+  layer_term.cpp
   )
 
 # Add the subdirectories

--- a/src/objective_functions/layer_term.cpp
+++ b/src/objective_functions/layer_term.cpp
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/objective_functions/layer_term.hpp"
+
+namespace lbann {
+
+layer_term::layer_term(EvalType scale_factor)
+  : objective_function_term(scale_factor) {}
+
+void layer_term::set_evaluation_layer(Layer* l) {
+  this->m_layers.assign(1, l);
+}
+
+void layer_term::setup(model& m) {
+  objective_function_term::setup(m);
+  std::stringstream err;
+
+  // Make sure layer term points to an evaluation layer
+  if (m_layers.size() != 1) {
+    err << "layer term in objective function points to an invalid number of layers "
+        << "(expected 1, found " << m_layers.size() << ")";
+    LBANN_ERROR(err.str());
+  }
+  if (m_layers[0] == nullptr) {
+    LBANN_ERROR("layer term in objective function points to a null pointer");
+  }
+  auto&& eval = dynamic_cast<evaluation_layer<data_layout::DATA_PARALLEL>*>(m_layers[0]);
+  if (eval == nullptr) {
+    err << "layer term in objective function must point to an evaluation layer, "
+        << "but " << m_layers[0]->get_name() << " is type " << m_layers[0]->get_type();
+    LBANN_ERROR(err.str());
+  }
+
+  // Set scaling factor
+  eval->set_scale(m_scale_factor);
+
+}
+
+void layer_term::start_evaluation() {}
+
+EvalType layer_term::finish_evaluation() {
+  if (m_scale_factor == EvalType(0)) { return EvalType(0); }
+  auto&& eval = dynamic_cast<evaluation_layer<data_layout::DATA_PARALLEL>*>(m_layers[0]);
+  eval->set_scale(m_scale_factor);
+  return eval->get_value();
+}
+
+void layer_term::differentiate() {
+  auto&& eval = dynamic_cast<evaluation_layer<data_layout::DATA_PARALLEL>*>(m_layers[0]);
+  eval->set_scale(m_scale_factor);
+}
+
+}  // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -237,6 +237,19 @@ Layer* construct_layer(lbann_comm* comm,
       return new unpooling_layer<data_layout::DATA_PARALLEL>(comm);
     }
   }
+  if (proto_layer.has_reduction()) {
+    const auto& params = proto_layer.reduction();
+    const auto& mode_str = params.mode();
+    reduction_mode mode = reduction_mode::INVALID;
+    if (mode_str == "sum" || mode_str.empty()) { mode = reduction_mode::SUM; }
+    if (mode_str == "average") { mode = reduction_mode::AVERAGE; }
+    if (layout == data_layout::DATA_PARALLEL) {
+      return new reduction_layer<data_layout::DATA_PARALLEL>(comm, mode, cudnn);
+    }
+  }
+  if (proto_layer.has_evaluation()) {
+    return new evaluation_layer<layout>(comm, cudnn);
+  }
 
   // Regularizer layers
   if (proto_layer.has_batch_normalization()) {
@@ -326,6 +339,10 @@ Layer* construct_layer(lbann_comm* comm,
     } else {
       return new selu_layer<layout>(comm);
     }
+  }
+  if (proto_layer.has_power()) {
+    const auto& params = proto_layer.power();
+    return new power_layer<layout>(comm, params.exponent());
   }
 
   // Throw exception if layer has not been constructed

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/proto/factories.hpp"
+#include "lbann/objective_functions/layer_term.hpp"
 
 namespace lbann {
 namespace proto {
@@ -34,9 +35,12 @@ namespace {
 /** Instantiate a model based on prototext. */
 model* instantiate_model(lbann_comm* comm,
                          objective_function* obj,
-                         optimizer* opt,
+                         const lbann_data::Optimizer& proto_opt,
                          const lbann_data::Model& proto_model) {
   std::stringstream err;
+
+  // Default optimizer
+  auto&& opt = construct_optimizer(comm, proto_opt);
 
   // Construct model
   const auto& type = proto_model.name();
@@ -69,6 +73,46 @@ model* instantiate_model(lbann_comm* comm,
   LBANN_ERROR(err.str());
   return nullptr;
 
+}
+
+void assign_layers_to_objective_function(std::vector<Layer*>& layer_list,
+                                         objective_function* obj,
+                                         const lbann_data::ObjectiveFunction& proto_obj) {
+  std::stringstream err;
+
+  // Construct map from layer names to layers
+  std::unordered_map<std::string, Layer*> names_to_layers;
+  for (auto&& l : layer_list) {
+    const auto& name = l->get_name();
+    if (names_to_layers.count(name) > 0) {
+      err << "layer name \"" << name << "\" is not unique";
+      LBANN_ERROR(err.str());
+    }
+    names_to_layers[name] = l;
+  }
+
+  // Assign evaluation layers to layer terms in objective function
+  auto&& obj_terms = obj->get_terms();
+  int num_layer_terms = 0;
+  for (size_t i = 0; i < obj_terms.size(); ++i) {
+    auto&& term = dynamic_cast<layer_term*>(obj_terms[i]);
+    if (term != nullptr) {
+      ++num_layer_terms;
+      if (num_layer_terms > proto_obj.layer_term_size()) { continue; }
+      const auto& params = proto_obj.layer_term(num_layer_terms-1);
+      auto&& eval = names_to_layers[params.layer()];
+      term->set_evaluation_layer(eval);
+    }
+  }
+
+  // Check that layer terms in objective function match prototext
+  if (num_layer_terms != proto_obj.layer_term_size()) {
+    err << "number of layer terms in objective function does not match prototext "
+        << "(expected " << proto_obj.layer_term_size() << ", "
+        << "found " << num_layer_terms << ")";
+    LBANN_ERROR(err.str());
+  }
+  
 }
 
 /** Setup pointers from layers to weights. */
@@ -113,20 +157,19 @@ model* construct_model(lbann_comm* comm,
                        const lbann_data::Optimizer& proto_opt,
                        const lbann_data::Model& proto_model) {
 
-  // Objective function
-  auto&& obj = construct_objective_function(proto_model.objective_function());
-  
-  // Default optimizer
-  auto&& opt = construct_optimizer(comm, proto_opt);
-
-  // Instantiate model
-  auto&& m = instantiate_model(comm, obj, opt, proto_model);
-
   // Add layer graph
   auto&& layer_list = construct_layer_graph(comm,
                                             data_readers,
                                             cudnn,
                                             proto_model);
+
+  // Construct objective function
+  const auto& proto_obj = proto_model.objective_function();
+  auto&& obj = construct_objective_function(proto_obj);
+  assign_layers_to_objective_function(layer_list, obj, proto_obj);
+  
+  // Instantiate model
+  auto&& m = instantiate_model(comm, obj, proto_opt, proto_model);
   for (auto&& l : layer_list) { m->add_layer(l); }
 
   // Add weights and assign to layers

--- a/src/proto/factories/objective_function_factory.cpp
+++ b/src/proto/factories/objective_function_factory.cpp
@@ -92,6 +92,12 @@ objective_function* construct_objective_function(const lbann_data::ObjectiveFunc
     obj->add_term(new kl_divergence(params.layer1(), params.layer2()));
   }
 
+  // Layer terms
+  for (int i=0; i<proto_obj.layer_term_size(); ++i) {
+    const auto& params = proto_obj.layer_term(i);
+    obj->add_term(new layer_term(params.scale_factor()));
+  }
+
   // Return objective function
   return obj;
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -234,6 +234,7 @@ message ObjectiveFunction {
   repeated L2WeightRegularization l2_weight_regularization = 21;
   repeated GroupLassoWeightRegularization group_lasso_weight_regularization = 22;
   repeated KLDivergence kl_divergence = 23;
+  repeated LayerTerm layer_term = 25;
 }
 
 message MeanSquaredError {
@@ -288,6 +289,11 @@ message GroupLassoWeightRegularization {
 message KLDivergence {
   string layer1 = 1;
   string layer2 = 2;
+}
+
+message LayerTerm {
+  double scale_factor = 1;
+  string layer = 2;
 }
 
 //========================================================================

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -696,6 +696,8 @@ message Layer {
    Unpooling unpooling = 304;
    Hadamard hadamard = 308;
    Constant constant = 309;
+   Reduction reduction = 310;
+   Evaluation evaluation = 311;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -727,6 +729,7 @@ message Layer {
    BentIdentity bent_identity = 40;
    Exponential exponential = 41;
    Swish swish = 42;
+   Power power = 43;
 }
 ///////////////////////
 // MotifLayer //
@@ -784,6 +787,10 @@ message Selu {
 }
 
 message Softmax {
+}
+
+message Power {
+  double exponent = 1;
 }
 
 ///////////////////////////
@@ -887,6 +894,14 @@ message Constant {
   double value=1;
   string num_neurons=2;
 }
+
+message Reduction {
+  string mode=1;
+}
+
+message Evaluation {
+}
+
 /////////////////////
 // learning Layers //
 /////////////////////

--- a/viz/properties.txt
+++ b/viz/properties.txt
@@ -20,7 +20,6 @@ layer_names_and_overrides
 learning     convolution             shape=tripleoctagon   color=chartreuse3
 learning     fully_connected 
 learning     deconvolution           shape=octogon
-learning     fully_connected_cuda 
 io           input
 io           target
 io           reconstruction
@@ -35,6 +34,7 @@ activations  softplus
 activations  selu
 activations  tanh
 activations  exponential
+activations  power
 regularizers batch_normalization
 regularizers local_response_normalization
 regularizers dropout
@@ -48,4 +48,7 @@ transform    sum
 transform    noise
 transform    unpooling
 transform    hadamard
+transform    constant
+transform    reduction
+transform    evaluation
 


### PR DESCRIPTION
This pull request makes progress on #193. Major changes:
- Implemented `evaluation_layer`, which computes an average value across a mini-batch.
- Implemented `layer_term`, which is an objective function term that interfaces with an evaluation layer.
- Reproduced the KL divergence term in the MNIST VAE model. This involved implementing `reduction_layer` and `power_layer`.

This MNIST VAE model passes a gradient check.