### PR TITLE
Enable testing of debug version of compilers

### DIFF
--- a/bamboo/clean.sh
+++ b/bamboo/clean.sh
@@ -8,6 +8,7 @@ rm ${LBANN_DIR}/bamboo/compiler_tests/*.pyc
 rm -r ${LBANN_DIR}/bamboo/compiler_tests/__pycache__
 rm -r ${LBANN_DIR}/bamboo/compiler_tests/builds/*_debug
 rm -r ${LBANN_DIR}/bamboo/compiler_tests/builds/*_rel
+rm ${LBANN_DIR}/bamboo/compiler_tests/error/*.txt
 rm ${LBANN_DIR}/bamboo/compiler_tests/output/*.txt
 
 # Integration Tests
@@ -16,6 +17,7 @@ rm ${LBANN_DIR}/bamboo/integration_tests/*.prototext*
 rm ${LBANN_DIR}/bamboo/integration_tests/*.pyc
 rm -r ${LBANN_DIR}/bamboo/integration_tests/__pycache__
 rm ${LBANN_DIR}/bamboo/integration_tests/*.tfevents.*
+rm ${LBANN_DIR}/bamboo/integration_tests/error/*.txt
 rm ${LBANN_DIR}/bamboo/integration_tests/output/*.txt
 
 # Unit Tests

--- a/bamboo/common_python/test_tools.py
+++ b/bamboo/common_python/test_tools.py
@@ -5,17 +5,17 @@ import tools
 # Run locally with python -m pytest -s
 
 def test_command_catalyst():
-    actual = tools.get_command(cluster='catalyst', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file')
+    actual = tools.get_command(cluster='catalyst', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
     expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
 def test_command_surface():
-    actual = tools.get_command(cluster='surface', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file')
+    actual = tools.get_command(cluster='surface', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
     expected = 'salloc --nodes=20 --partition=pbatch --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
 def test_command_ray():
-    actual = tools.get_command(cluster='ray', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file')
+    actual = tools.get_command(cluster='ray', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
     expected = 'bsub -x -G guests -Is -n 40 -q pdebug -R "span[ptile=2]" -W 30 mpirun -np 40 -N 2 exe --data_filedir=filedir --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
@@ -23,7 +23,7 @@ def test_command_ray():
 
 def test_blacklisted_substrings():
     try:
-        tools.get_command('ray', 'exe', partition=';', optimizer_path='--model=new_model')
+        tools.get_command('ray', 'exe', partition=';', optimizer_path='--model=new_model', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid character(s): ; contains ; , --model=new_model contains --'
@@ -31,7 +31,7 @@ def test_blacklisted_substrings():
 
 def test_unsupported_cluster():
     try:
-        tools.get_command('quartz', 'exe')
+        tools.get_command('quartz', 'exe', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Unsupported Cluster: quartz'
@@ -39,7 +39,7 @@ def test_unsupported_cluster():
 
 def test_bad_model_1():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_name='name', model_path='path')
+        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_name='name', model_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
@@ -47,7 +47,7 @@ def test_bad_model_1():
 
 def test_bad_model_2():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_path='path')
+        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
@@ -55,7 +55,7 @@ def test_bad_model_2():
 
 def test_bad_model_3():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', model_name='name',  model_path='path')
+        tools.get_command('ray', 'exe', dir_name='dir', model_name='name',  model_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
@@ -63,7 +63,7 @@ def test_bad_model_3():
 
 def test_bad_model_4():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder')
+        tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: model_folder set but not model_name.'
@@ -71,7 +71,7 @@ def test_bad_model_4():
 
 def test_bad_model_5():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', model_name='name')
+        tools.get_command('ray', 'exe', dir_name='dir', model_name='name', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: model_name set but not model_folder.'
@@ -79,7 +79,7 @@ def test_bad_model_5():
 
 def test_bad_data_reader():
     try:
-        tools.get_command('catalyst', 'exe', dir_name='dir', data_reader_name='name', data_reader_path='path')
+        tools.get_command('catalyst', 'exe', dir_name='dir', data_reader_name='name', data_reader_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_path is set but so is data_reader_name'
@@ -87,7 +87,7 @@ def test_bad_data_reader():
 
 def test_bad_optimizer():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', optimizer_name='name', optimizer_path='path')
+        tools.get_command('ray', 'exe', dir_name='dir', optimizer_name='name', optimizer_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: optimizer_path is set but so is optimizer_name'
@@ -95,7 +95,7 @@ def test_bad_optimizer():
 
 def test_bad_dir_name_1():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir')
+        tools.get_command('ray', 'exe', dir_name='dir', check_executable_existance=False)
     except Exception, e:
 	actual = str(e)
 	expected = 'Invalid Usage: dir_name set but none of model_folder, model_name, data_reader_name, optimizer_name are.'
@@ -103,7 +103,7 @@ def test_bad_dir_name_1():
 
 def test_bad_dir_name_2():
     try:
-        tools.get_command('ray', 'exe', model_folder='folder')
+        tools.get_command('ray', 'exe', model_folder='folder', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
@@ -111,7 +111,7 @@ def test_bad_dir_name_2():
 
 def test_bad_dir_name_3():
     try:
-        tools.get_command('ray', 'exe', model_name='name')
+        tools.get_command('ray', 'exe', model_name='name', check_executable_existance=False)
     except Exception, e:
 	actual = str(e)
 	expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
@@ -119,7 +119,7 @@ def test_bad_dir_name_3():
 
 def test_bad_dir_name_4():
     try:
-        tools.get_command('catalyst', 'exe', data_reader_name='name')
+        tools.get_command('catalyst', 'exe', data_reader_name='name', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
@@ -127,7 +127,7 @@ def test_bad_dir_name_4():
 
 def test_bad_dir_name_5():
     try:
-        tools.get_command('ray', 'exe', optimizer_name='name')
+        tools.get_command('ray', 'exe', optimizer_name='name', check_executable_existance=False)
     except Exception, e:
 	actual = str(e)
 	expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
@@ -135,7 +135,8 @@ def test_bad_dir_name_5():
 
 def test_bad_data_filedir_1():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filedir_train_ray='a')
+        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filedir_train_ray='a',
+                          check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -143,7 +144,8 @@ def test_bad_data_filedir_1():
 
 def test_bad_data_filedir_2():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filename_train_ray='b')
+        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filename_train_ray='b',
+                          check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -152,7 +154,8 @@ def test_bad_data_filedir_2():
 
 def test_bad_data_filedir_3():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filedir_test_ray='c')
+        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filedir_test_ray='c',
+                          check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -160,7 +163,8 @@ def test_bad_data_filedir_3():
 
 def test_bad_data_filedir_4():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filename_test_ray='d')
+        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_ray='filedir', data_filename_test_ray='d',
+                          check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -168,7 +172,7 @@ def test_bad_data_filedir_4():
 
 def test_bad_data_filedir_5():
     try:
-        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filedir_train_ray='e')
+        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filedir_train_ray='e', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -176,7 +180,7 @@ def test_bad_data_filedir_5():
 
 def test_bad_data_filedir_6():
     try:
-        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filename_train_ray='f')
+        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filename_train_ray='f', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -185,7 +189,7 @@ def test_bad_data_filedir_6():
 
 def test_bad_data_filedir_7():
     try:
-        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filedir_test_ray='g')
+        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filedir_test_ray='g', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -193,7 +197,7 @@ def test_bad_data_filedir_7():
 
 def test_bad_data_filedir_8():
     try:
-        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filename_test_ray='h')
+        tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_ray='filedir', data_filename_test_ray='h', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_ray set but so is at least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray]'
@@ -201,7 +205,7 @@ def test_bad_data_filedir_8():
 
 def test_bad_data_filedir_9():
     try:
-        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name')
+        tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_name or data_reader_path is set but not data_filedir_ray. If a data reader is provided, an alternative filedir must be available for Ray. Alternatively, all of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] can be set.'
@@ -209,7 +213,7 @@ def test_bad_data_filedir_9():
 
 def test_bad_data_filedir_10():
     try:
-        tools.get_command('ray', 'exe', data_reader_path='path')
+        tools.get_command('ray', 'exe', data_reader_path='path', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_name or data_reader_path is set but not data_filedir_ray. If a data reader is provided, an alternative filedir must be available for Ray. Alternatively, all of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] can be set.'
@@ -217,7 +221,7 @@ def test_bad_data_filedir_10():
 
 def test_bad_data_filedir_11():
     try:
-        tools.get_command('ray', 'exe', data_filedir_ray='filedir')
+        tools.get_command('ray', 'exe', data_filedir_ray='filedir', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: data_filedir_ray set but neither data_reader_name or data_reader_path are.'
@@ -225,7 +229,7 @@ def test_bad_data_filedir_11():
 
 def test_bad_data_filedir_12():
     try:
-        tools.get_command('ray', 'exe', data_filedir_train_ray='a')
+        tools.get_command('ray', 'exe', data_filedir_train_ray='a', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] is set, but neither data_reader_name or data_reader_path are.'
@@ -234,7 +238,7 @@ def test_bad_data_filedir_12():
 
 def test_bad_data_filedir_13():
     try:
-        tools.get_command('ray', 'exe', data_filename_train_ray='b')
+        tools.get_command('ray', 'exe', data_filename_train_ray='b', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] is set, but neither data_reader_name or data_reader_path are.'
@@ -243,7 +247,7 @@ def test_bad_data_filedir_13():
 
 def test_bad_data_filedir_14():
     try:
-        tools.get_command('ray', 'exe', data_filedir_test_ray='c')
+        tools.get_command('ray', 'exe', data_filedir_test_ray='c', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] is set, but neither data_reader_name or data_reader_path are.'
@@ -252,7 +256,7 @@ def test_bad_data_filedir_14():
 
 def test_bad_data_filedir_15():
     try:
-        tools.get_command('ray', 'exe', data_filename_test_ray='e')
+        tools.get_command('ray', 'exe', data_filename_test_ray='e', check_executable_existance=False)
     except Exception, e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_ray, data_filename_train_ray, data_filedir_test_ray, data_filename_test_ray] is set, but neither data_reader_name or data_reader_path are.'

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -18,7 +18,7 @@ def get_command(cluster, executable, num_nodes=None, partition=None,
                 model_folder=None, model_name=None, model_path=None,
                 num_epochs=None, optimizer_name=None, optimizer_path=None,
                 processes_per_model=None, output_file_name=None,
-                error_file_name=None, return_tuple=False):
+                error_file_name=None, return_tuple=False, check_executable_existance=True):
     # Check parameters for black-listed characters like semi-colons that
     # would terminate the command and allow for an extra command
     blacklist = [';', '--']
@@ -30,6 +30,12 @@ def get_command(cluster, executable, num_nodes=None, partition=None,
     invalid_character_errors = check_list(blacklist, strings)
     if invalid_character_errors != []:
         raise Exception('Invalid character(s): %s' % ' , '.join(invalid_character_errors))
+
+    # Check executable existance
+    if check_executable_existance:
+        executable_exists = os.path.exists(executable)
+        if not executable_exists:
+            raise Exception('Executable does not exist: %s' % executable)
 
     # Determine scheduler
     if cluster in ['catalyst', 'surface']:
@@ -118,6 +124,10 @@ def get_command(cluster, executable, num_nodes=None, partition=None,
                 # q => Submits the job to one of the specified queues.
                 option_partition = ' -q %s' % partition
             if time_limit != None:
+                if cluster == 'ray':
+                    max_ray_time = 480
+                    if time_limit > max_ray_time:
+                        time_limit = max_ray_time
                 # W => Sets the runtime limit of the job.
                 option_time_limit = ' -W %d' % time_limit
             command_allocate = '%s%s%s%s%s%s%s%s' % (

--- a/bamboo/compiler_tests/error/README.md
+++ b/bamboo/compiler_tests/error/README.md
@@ -1,0 +1,1 @@
+Subdirectory for test error

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -1,14 +1,38 @@
 import pytest
 import os, re, subprocess
 
-def test_compiler_clang(cluster, dirname):
+def test_compiler_clang4_release(cluster, dirname):
+    skeleton_clang4(cluster, dirname, False)
+
+def test_compiler_clang4_debug(cluster, dirname):
+    skeleton_clang4(cluster, dirname, True)
+
+def test_compiler_gcc4_release(cluster, dirname):
+    skeleton_gcc4(cluster, dirname, False)
+
+def test_compiler_gcc4_debug(cluster, dirname):
+    skeleton_gcc4(cluster, dirname, True)
+
+def test_compiler_gcc7_release(cluster, dirname):
+    skeleton_gcc7(cluster, dirname, False)
+
+def test_compiler_gcc7_debug(cluster, dirname):
+    skeleton_gcc7(cluster, dirname, True)
+
+def test_compiler_intel18_release(cluster, dirname):
+    skeleton_intel18(cluster, dirname, False)
+
+def test_compiler_intel18_debug(cluster, dirname):
+    skeleton_intel18(cluster, dirname, True)
+
+def skeleton_clang4(cluster, dir_name, debug, should_log=False):
     if cluster == 'catalyst':
-        spack_skeleton(dirname, 'clang@4.0.0', 'mvapich2@2.2', False)
-        build_skeleton(dirname, 'clang@4.0.0', 'mvapich2@2.2', False)
+        spack_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
-def test_compiler_gcc4(cluster, dirname):
+def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
     if cluster in ['catalyst', 'ray']:
         if cluster == 'catalyst':
             mpi = 'mvapich2@2.2'
@@ -16,62 +40,76 @@ def test_compiler_gcc4(cluster, dirname):
             mpi = 'spectrum-mpi@10.1.0'
         else:
             raise Exception('Unsupported Cluster %s' % cluster)
-        spack_skeleton(dirname, 'gcc@4.9.3', mpi, False)
-        build_skeleton(dirname, 'gcc@4.9.3', mpi, False)
+        spack_skeleton(dir_name, 'gcc@4.9.3', mpi, debug, should_log)
+        build_skeleton(dir_name, 'gcc@4.9.3', mpi, debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
-def test_compiler_gcc7(cluster, dirname):
+def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
     if cluster == 'catalyst':
-        spack_skeleton(dirname, 'gcc@7.1.0', 'mvapich2@2.2', False)
-        build_skeleton(dirname, 'gcc@7.1.0', 'mvapich2@2.2', False)
+        spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
-def test_compiler_intel(cluster, dirname):
+def skeleton_intel18(cluster, dir_name, debug, should_log=False):
     if cluster == 'catalyst':
-        spack_skeleton(dirname, 'intel@18.0.0', 'mvapich2@2.2', False)
-        build_skeleton(dirname, 'intel@18.0.0', 'mvapich2@2.2', False)
+        spack_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
-def spack_skeleton(dirname, compiler, mpi_lib, should_log, debug=False):
-    output_file_name = '%s/bamboo/compiler_tests/output/%s_spack_output.txt' % (dirname, re.sub('[@\.]', '_', compiler))
-    os.chdir('%s/bamboo/compiler_tests/builds' % dirname)
-    command = '%s/scripts/spack_recipes/build_lbann.sh -c %s -m %s' % (dirname, compiler, mpi_lib)
+def spack_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
+    compiler_underscored = re.sub('[@\.]', '_', compiler)
     if debug:
-        command += ' -d > %s' % output_file_name
+        build_type = 'debug'
     else:
-        command += ' > %s' % output_file_name
+        build_type = 'rel'
+    output_file_name = '%s/bamboo/compiler_tests/output/%s_%s_spack_output.txt' % (dir_name, compiler_underscored, build_type)
+    error_file_name = '%s/bamboo/compiler_tests/error/%s_%s_spack_error.txt' % (dir_name, compiler_underscored, build_type)
+    os.chdir('%s/bamboo/compiler_tests/builds' % dir_name)
+    debug_flag = ''
+    if debug:
+        debug_flag = ' -d'
+    command = '%s/scripts/spack_recipes/build_lbann.sh -c %s -m %s%s > %s 2> %s' % (
+        dir_name, compiler, mpi_lib, debug_flag, output_file_name, error_file_name)
     return_code = os.system(command)
     os.chdir('..')
     if should_log or (return_code != 0):
         output_file = open(output_file_name, 'r')
         for line in output_file:
             print('%s: %s' % (output_file_name, line))
+        error_file = open(error_file_name, 'r')
+        for line in error_file:
+            print('%s: %s' % (error_file_name, line))
     assert return_code == 0
 
-def build_skeleton(dirname, compiler, mpi_lib, should_log, debug=False):
-    output_file_name = '%s/bamboo/compiler_tests/output/%s_build_output.txt' % (dirname, re.sub('[@\.]', '_', compiler))
-    compiler = compiler.replace('@', '-')
-    mpi_lib = mpi_lib.replace('@', '-')
-    cluster = re.sub('[0-9]+\n', '', subprocess.check_output(['hostname']))
+def build_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
+    compiler_underscored = re.sub('[@\.]', '_', compiler)
     if debug:
         build_type = 'debug'
     else:
         build_type = 'rel'
+    output_file_name = '%s/bamboo/compiler_tests/output/%s_%s_build_output.txt' % (dir_name, compiler_underscored, build_type)
+    error_file_name = '%s/bamboo/compiler_tests/error/%s_%s_build_error.txt' % (dir_name, compiler_underscored, build_type)
+    compiler = compiler.replace('@', '-')
+    mpi_lib = mpi_lib.replace('@', '-')
+    cluster = re.sub('[0-9]+\n', '', subprocess.check_output(['hostname']))
     if cluster in ['catalyst', 'surface']:
         architecture = 'x86_64'
     elif cluster == 'ray':
         architecture = 'ppc64le_gpu'
     else:
         raise Exception('Unsupported Cluster %s' % cluster)
-    os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s_%s_openblas_%s/build' % (dirname, cluster, compiler, architecture, mpi_lib, build_type))
-    command = 'make -j all > %s' % output_file_name
+    os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s_%s_openblas_%s/build' % (dir_name, cluster, compiler, architecture, mpi_lib, build_type))
+    command = 'make -j all > %s 2> %s' % (output_file_name, error_file_name)
     return_code = os.system(command)
     os.chdir('../..')
     if should_log or (return_code != 0):
         output_file = open(output_file_name, 'r')
         for line in output_file:
             print('%s: %s' % (output_file_name, line))
+        error_file = open(error_file_name, 'r')
+        for line in error_file:
+            print('%s: %s' % (error_file_name, line))
     assert return_code == 0

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.insert(0, '../common_python')
 import tools
-import csv, os, pprint, re, time
+import collections, csv, os, pprint, re, time
 
 # Set up the command ##########################################################
 def get_command(cluster, dir_name, model_folder, model_name, executable,
@@ -16,8 +16,8 @@ def get_command(cluster, dir_name, model_folder, model_name, executable,
             dir_name=dir_name,
             data_filedir_train_ray='/p/gscratchr/brainusr/datasets/ILSVRC2012/original/train/',
             data_filename_train_ray='/p/gscratchr/brainusr/datasets/ILSVRC2012/labels/train.txt',
-            data_filedir_test_ray='/p/lscratche/brainusr/datasets/ILSVRC2012/original/val/',
-            data_filename_test_ray='/p/lscratche/brainusr/datasets/ILSVRC2012/original/labels/val.txt',
+            data_filedir_test_ray='/p/gscratchr/brainusr/datasets/ILSVRC2012/original/val/',
+            data_filename_test_ray='/p/gscratchr/brainusr/datasets/ILSVRC2012/labels/val.txt',
             data_reader_name='imagenet', data_reader_percent=data_reader_percent,
             model_folder=model_folder, model_name=model_name, num_epochs=20,
             optimizer_name='adagrad', output_file_name=output_file_name,
@@ -47,21 +47,31 @@ def get_command(cluster, dir_name, model_folder, model_name, executable,
 
 # Run LBANN ###################################################################
 
-def run_lbann(command, model_name, output_file_name, error_file_name, should_log):
+def run_lbann(command, model_name, output_file_name, error_file_name, should_log=False):
     print('About to run: %s' % command)
     print('%s began waiting in the queue at ' % model_name + time.strftime('%H:%M:%S', time.localtime()))
-    value = os.system(command)
+    output_value = os.system(command)
     print('%s finished at ' % model_name + time.strftime('%H:%M:%S', time.localtime()))
-    if should_log or (value != 0):
+    lbann_exceptions = []
+    timed_out = False
+    if should_log or (output_value != 0):
         output_file = open(output_file_name, 'r')
         for line in output_file:
             print('%s: %s' % (output_file_name, line))
+            is_match = re.search('This lbann_exception is about to be thrown:(.*)', line)
+            if is_match:
+                lbann_exceptions.append(is_match.group(1))
+            is_match = re.search('CANCELLED AT (.*) DUE TO TIME LIMIT', line)
+            if is_match:
+                timed_out = True
         error_file = open(error_file_name, 'r')
         for line in error_file:
             print('%s: %s' % (error_file_name, line))
-    if value != 0:
-        error_string = 'Model %s crashed with command %s and output value %d' % (model_name, command, value)
+    if output_value != 0:
+        error_string = 'Model %s crashed with output_value=%d, timed_out=%s, and lbann exceptions=%s. Command was: %s' % (
+            model_name, output_value, str(timed_out), str(collections.Counter(lbann_exceptions)), command)
         raise Exception(error_string)
+    return output_value
 
 # Extract data from output ####################################################
 
@@ -154,7 +164,7 @@ def skeleton(cluster, dir_name, executable, model_folder, model_name, data_field
         output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
         error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name)
     command = get_command(cluster, dir_name, model_folder, model_name, executable, output_file_name, error_file_name, compiler_name, weekly=weekly)
-    run_lbann(command, model_name, output_file_name, error_file_name, should_log)
+    run_lbann(command, model_name, output_file_name, error_file_name, should_log) # Don't need return value
     return extract_data(output_file_name, data_fields, should_log)
 
 # Misc. functions  ############################################################

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -5,14 +5,25 @@ def pytest_addoption(parser):
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
-    if cluster in ['catalyst', 'ray']:
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
     if cluster == 'catalyst':
         default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+
+    if cluster == 'ray':
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-10.1.0_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-10.1.0_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+
     if cluster == 'surface':
         default_exes['gcc4'] = default_exes['default']
+
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
     parser.addoption('--dirname', action='store', default=default_dirname,
@@ -29,6 +40,10 @@ def cluster(request):
     return request.config.getoption('--cluster')
 
 @pytest.fixture
+def debug(request):
+    return request.config.getoption('--debug')
+
+@pytest.fixture
 def dirname(request):
     return request.config.getoption('--dirname')
 
@@ -39,3 +54,4 @@ def exes(request):
 @pytest.fixture
 def weekly(request):
     return request.config.getoption('--weekly')
+

--- a/bamboo/integration_tests/expected_values/catalyst/gcc4/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/gcc4/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 63.18,             1.27,          2.62,         0.79,         0.34,           0.00
+alexnet_nightly, 63.18,             1.27,          3.11,         0.79,         0.55,           0.00
 alexnet_weekly,  623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 cache_alexnet,   623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 lenet_mnist,     22.03,             0.04,          0.16,         0.04,         0.01,           98.66

--- a/bamboo/integration_tests/expected_values/catalyst/intel18/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/intel18/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 49.54,             0.96,          3.21,         1.00,         0.37,           0.00
+alexnet_nightly, 49.54,             0.96,          3.21,         1.00,         0.62,           0.00
 alexnet_weekly,  623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 cache_alexnet,   623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 lenet_mnist,     327.97,            0.40,          0.98,         0.26,         0.17,           98.66

--- a/bamboo/integration_tests/expected_values/ray/gcc4/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/ray/gcc4/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 0.00,              0.00,          0.00,         0.00,         0.00,           0.00
+alexnet_nightly, 47.42,             0.95,          3.34,         0.54,         0.59,           0.00
 alexnet_weekly,  623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 cache_alexnet,   623.30,            1.27,          4.98,         0.66,         2.24,           0.57
-lenet_mnist,     21.91,             0.04,          0.16,         0.04,         0.01,           98.66
+lenet_mnist,     260.85,            0.31,          0.88,         0.28,         0.03,           98.66

--- a/bamboo/integration_tests/expected_values/surface/gcc4/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/surface/gcc4/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 39.60,             0.80,          3.28,         0.36,         0.55,           0.00
+alexnet_nightly, 39.60,             0.80,          5.15,         0.37,         0.69,           0.00
 alexnet_weekly,  623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 cache_alexnet,   623.30,            1.27,          4.98,         0.66,         2.24,           0.57
 lenet_mnist,     21.91,             0.04,          1.15,         0.04,         0.04,           98.66

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -1,0 +1,69 @@
+import sys
+sys.path.insert(0, '../common_python')
+import tools
+import pytest
+import os
+import common_code
+
+def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly, debug, should_log=False):
+    # If weekly or debug are true, then run the test.
+    if (not weekly) and (not debug):
+        pytest.skip('Not doing weekly or debug testing')
+    if compiler_name not in executables:
+      pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    model_name = 'lenet_mnist'
+    output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
+    error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name)
+    command = tools.get_command(
+        cluster=cluster, executable=executables[compiler_name], num_nodes=1,
+        partition='pbatch', time_limit=100, dir_name=dir_name,
+        data_filedir_ray='/p/gscratchr/brainusr/datasets/MNIST',
+        data_reader_name='mnist', model_folder='models/' + model_name,
+        model_name=model_name, num_epochs=5, optimizer_name='adagrad',
+        output_file_name=output_file_name, error_file_name=error_file_name)
+    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name)
+    assert output_value == 0
+
+def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly, debug, should_log=False):
+    # If weekly or debug are true, then run the test.                                                                                                                   
+    if (not weekly) and (not debug):
+        pytest.skip('Not doing weekly or debug testing')
+    if cluster == 'ray':
+        pytest.skip('cifar not operational on Ray')
+    if compiler_name not in executables:
+      pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    model_name = 'autoencoder_cifar10'
+    output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
+    error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name)
+    command = tools.get_command(
+        cluster=cluster, executable=executables[compiler_name],	num_nodes=1,
+        partition='pbatch', time_limit=100, dir_name=dir_name,
+        data_reader_name='cifar10', data_reader_percent=0.01, model_folder='models/' + model_name,
+        model_name='conv_' + model_name, num_epochs=5, optimizer_name='adagrad',
+        output_file_name=output_file_name, error_file_name=error_file_name)
+    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name)
+    assert output_value == 0
+
+def test_integration_mnist_clang4_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_mnist_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug)
+
+def test_integration_mnist_gcc4_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_mnist_debug(cluster, dirname, exes, 'gcc4_debug', weekly, debug)
+
+def test_integration_mnist_gcc7_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_mnist_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug)
+
+def test_integration_mnist_intel18_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_mnist_debug(cluster, dirname, exes, 'intel18_debug', weekly, debug)
+
+def test_integration_cifar_clang4_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_cifar_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug)
+
+def test_integration_cifar_gcc4_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_cifar_debug(cluster, dirname, exes, 'gcc4_debug', weekly, debug)
+
+def test_integration_cifar_gcc7_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_cifar_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug)
+
+def test_integration_cifar_intel18_debug(cluster, dirname, exes, weekly, debug):
+    skeleton_cifar_debug(cluster, dirname, exes, 'intel18_debug', weekly, debug)

--- a/bamboo/integration_tests/test_integration_io_buffers.py
+++ b/bamboo/integration_tests/test_integration_io_buffers.py
@@ -5,7 +5,9 @@ import pytest
 import os, sys
 import common_code
 
-def skeleton_io_buffers(cluster, dir_name, executables, compiler_name):
+def skeleton_io_buffers(cluster, dir_name, executables, compiler_name, weekly):
+    if not weekly:
+        pytest.skip('Not doing weekly testing')
     if cluster == 'surface':
         pytest.skip('skeleton_io_buffers does not run on surface')
     if compiler_name not in executables:
@@ -20,6 +22,9 @@ def skeleton_io_buffers(cluster, dir_name, executables, compiler_name):
     accuracies = {}
     errors = []
     all_values = []
+    fatal_errors = []
+    overall_min_partitioned_accuracy = float('inf')
+    overall_min_distributed_accuracy = float('inf')
     for mini_batch_size in [300, 150, 100, 75, 60, 50]:
         num_models = max_mb / mini_batch_size
         for procs_per_model in [1, 2, 3, 4, 5, 6]:
@@ -36,29 +41,46 @@ def skeleton_io_buffers(cluster, dir_name, executables, compiler_name):
                     optimizer_name='adagrad',
                     processes_per_model=procs_per_model,
                     output_file_name=output_file_name, error_file_name=error_file_name)
-                common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
-                accuracy_dict = common_code.extract_data(output_file_name, ['test_accuracy'], should_log)
-                accuracies[model_name] = accuracy_dict['test_accuracy']
-            
-            partitioned_num_models = len(accuracies[partitioned].keys())
-            distributed_num_models = len(accuracies[distributed].keys())
-            assert partitioned_num_models == distributed_num_models
+                try:
+                    common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log) # Don't need return value
+                    accuracy_dict = common_code.extract_data(output_file_name, ['test_accuracy'], should_log)
+                    accuracies[model_name] = accuracy_dict['test_accuracy']
+                except Exception:
+                    # We want to keep running to see if any other mini_batch_size & procs_per_model combination crashes.
+                    # However, it is now pointless to compare accuracies.
+                    fatal_errors.append('Crashed running %s with mini_batch_size=%d, procs_per_model=%d' % (model_name, mini_batch_size, procs_per_model))
+            # End model name loop
+            if fatal_errors == []:
+                partitioned_num_models = len(accuracies[partitioned].keys())
+                distributed_num_models = len(accuracies[distributed].keys())
+                assert partitioned_num_models == distributed_num_models
 
-            min_partitioned_accuracy = float('inf')
-            min_distributed_accuracy = float('inf')
-            for model_num in sorted(accuracies[partitioned].keys()):
-                partitioned_accuracy = accuracies[partitioned][model_num]['overall']
-                distributed_accuracy = accuracies[distributed][model_num]['overall']
-                if partitioned_accuracy < min_partitioned_accuracy:
-                    min_partitioned_accuracy = partitioned_accuracy
-                if distributed_accuracy < min_distributed_accuracy:
-                    min_distributed_accuracy = distributed_accuracy
-                tolerance = 0.05
-                # Are we within tolerance * expected_value?
-                if abs(partitioned_accuracy - distributed_accuracy) > abs(tolerance * min(partitioned_accuracy, distributed_accuracy)):
-                    errors.append('partitioned = %f != %f = distributed; model_num=%s mini_batch_size=%d procs_per_model=%d' % (partitioned_accuracy, distributed_accuracy, model_num, mini_batch_size, procs_per_model))
-                all_values.append('partitioned = %f, %f = distributed; model_num=%s mini_batch_size=%d procs_per_model=%d' % (partitioned_accuracy, distributed_accuracy, model_num, mini_batch_size, procs_per_model))
-
+                min_partitioned_accuracy = float('inf')
+                min_distributed_accuracy = float('inf')
+                for model_num in sorted(accuracies[partitioned].keys()):
+                    partitioned_accuracy = accuracies[partitioned][model_num]['overall']
+                    distributed_accuracy = accuracies[distributed][model_num]['overall']
+                    if partitioned_accuracy < min_partitioned_accuracy:
+                        min_partitioned_accuracy = partitioned_accuracy
+                    if distributed_accuracy < min_distributed_accuracy:
+                        min_distributed_accuracy = distributed_accuracy
+                    tolerance = 0.05
+                    # Are we within tolerance * expected_value?
+                    if abs(partitioned_accuracy - distributed_accuracy) > abs(tolerance * min(partitioned_accuracy, distributed_accuracy)):
+                        errors.append('partitioned = %f != %f = distributed; model_num=%s mini_batch_size=%d procs_per_model=%d' % (partitioned_accuracy, distributed_accuracy, model_num, mini_batch_size, procs_per_model))
+                        all_values.append('partitioned = %f, %f = distributed; model_num=%s mini_batch_size=%d procs_per_model=%d' % (partitioned_accuracy, distributed_accuracy, model_num, mini_batch_size, procs_per_model))
+                # End model_num loop
+                if min_partitioned_accuracy < overall_min_partitioned_accuracy:
+                    overall_min_partitioned_accuracy = min_partitioned_accuracy
+                if min_distributed_accuracy < overall_min_distributed_accuracy:
+                    overall_min_distributed_accuracy = min_distributed_accuracy
+            # End fatal_errors == [] block
+        # End procs_per_model loop
+    # End mini_batch_size loop
+    for fatal_error in fatal_errors:
+        print(fatal_error)
+    assert fatal_errors == []
+    # If there were no fatal errors, archive the accuracies.
     if os.environ['LOGNAME'] == 'lbannusr':
         key = 'bamboo_planKey'
         if key in os.environ:
@@ -66,14 +88,14 @@ def skeleton_io_buffers(cluster, dir_name, executables, compiler_name):
             if plan in ['LBANN-NIGHTD', 'LBANN-WD']:
                 archive_file = '/usr/workspace/wsb/lbannusr/archives/%s/%s/%s/io_buffers.txt' % (plan, cluster, compiler_name)
                 with open(archive_file, 'a') as archive:
-                    archive.write('%s, %f, %f\n' % (os.environ['bamboo_buildNumber'], min_partitioned_accuracy, min_distributed_accuracy))
+                    archive.write('%s, %f, %f\n' % (os.environ['bamboo_buildNumber'], overall_min_partitioned_accuracy, overall_min_distributed_accuracy))
             else:
                 print('The plan %s does not have archiving activated' % plan)
         else:
             print('%s is not in os.environ' % key)
     else:
         print('os.environ["LOGNAME"]=%s' % os.environ['LOGNAME'])
-                
+
     print('Errors for: partitioned_and_distributed (%d)' % len(errors))
     for error in errors:
         print(error)
@@ -83,14 +105,14 @@ def skeleton_io_buffers(cluster, dir_name, executables, compiler_name):
             print(value)
     assert errors == []
 
-def test_integration_io_buffers_clang4(cluster, dirname, exes):
-    skeleton_io_buffers(cluster, dirname, exes, 'clang4')
+def test_integration_io_buffers_clang4(cluster, dirname, exes, weekly):
+    skeleton_io_buffers(cluster, dirname, exes, 'clang4', weekly)
 
-def test_integration_io_buffers_gcc4(cluster, dirname, exes):
-    skeleton_io_buffers(cluster, dirname, exes, 'gcc4')
+def test_integration_io_buffers_gcc4(cluster, dirname, exes, weekly):
+    skeleton_io_buffers(cluster, dirname, exes, 'gcc4', weekly)
 
-def test_integration_io_buffers_gcc7(cluster, dirname, exes):
-    skeleton_io_buffers(cluster, dirname, exes, 'gcc7')
+def test_integration_io_buffers_gcc7(cluster, dirname, exes, weekly):
+    skeleton_io_buffers(cluster, dirname, exes, 'gcc7', weekly)
 
-def test_integration_io_buffers_intel18(cluster, dirname, exes):
-    skeleton_io_buffers(cluster, dirname, exes, 'intel18')
+def test_integration_io_buffers_intel18(cluster, dirname, exes, weekly):
+    skeleton_io_buffers(cluster, dirname, exes, 'intel18', weekly)

--- a/bamboo/integration_tests/test_integration_performance.py
+++ b/bamboo/integration_tests/test_integration_performance.py
@@ -1,5 +1,5 @@
 import pytest
-import os
+import operator, os
 import common_code
 
 def error_if(f, f_symbol, data_field, actual_values, expected_values, model_name, errors, all_values, frequency_str):
@@ -34,8 +34,8 @@ def run_tests(actual_performance, model_name, dir_name, should_log, compiler_nam
   expected_performance = common_code.csv_to_dict('%s/bamboo/integration_tests/expected_values/%s/%s/expected_performance.csv' % (dir_name, cluster, compiler_name))
   errors = []
   all_values = []
-  greater_than = lambda x,y: x > y
-  less_than = lambda x,y: x < y
+  greater_than = operator.gt
+  less_than = operator.lt
   max_run_time = error_if(greater_than, '>', 'training_run_time', actual_performance, expected_performance, model_name, errors, all_values, frequency_str)
   max_mean = error_if(greater_than, '>', 'training_mean', actual_performance, expected_performance, model_name, errors, all_values, frequency_str)
   max_max = error_if(greater_than, '>', 'training_max', actual_performance, expected_performance, model_name, errors, all_values, frequency_str)
@@ -115,7 +115,7 @@ def skeleton_performance_cache_alexnet(cluster, dir_name, executables, weekly, c
     pytest.skip('Ray is unsupported for skeleton_performance_cache_alexnet')
   else:
     raise Exception('Unsupported Cluster %s' % cluster)
-  common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
+  common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log) # Don't need return value
   actual_performance = common_code.extract_data(output_file_name, DATA_FIELDS, should_log)
   run_tests(actual_performance, model_name, dirname, should_log, compiler_name, cluster)
 

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -5,14 +5,18 @@ def pytest_addoption(parser):
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
-    if cluster in ['catalyst', 'ray']:
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
     if cluster == 'catalyst':
         default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+    if cluster == 'ray':
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-10.1.0_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
     if cluster == 'surface':
         default_exes['gcc4'] = default_exes['default']
+
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
     parser.addoption('--dirname', action='store', default=default_dirname,

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -12,6 +12,7 @@ def skeleton_models(cluster, executables, compiler_name):
     host = re.sub("\d+", "", hostname)
     opt = 'adagrad'
     defective_models = []
+    working_models = []
     tell_Dylan = []
     for subdir, dirs, files in os.walk(lbann_dir + '/model_zoo/models/'):
         if 'greedy' in subdir:
@@ -59,14 +60,18 @@ def skeleton_models(cluster, executables, compiler_name):
                         print("Error detected in " + model_path)
                         #defective_models.append(file_name)
                         defective_models.append(cmd)
-    if len(defective_models) != 0:
-        print("ERRORS: The following models exited with errors")
+                    else:
+                       working_models.append(cmd)
+    num_defective = len(defective_models)
+    if num_defective != 0:
+        print('Working models: %d. Defective models: %d', len(working_models), num_defective)
+        print('ERRORS: The following models exited with errors')
         for i in defective_models:
             print('ERRORS', i)
         print('ERRORS: tell Dylan: the following models have unknown data readers:')
         for i in tell_Dylan :
             print('ERRORS', i)
-    assert len(defective_models) == 0
+    assert num_defective == 0
 
 def test_unit_models_clang4(cluster, exes):
     skeleton_models(cluster, exes, 'clang4')

--- a/bamboo/unit_tests/test_unit_lbann_invocation.py
+++ b/bamboo/unit_tests/test_unit_lbann_invocation.py
@@ -5,7 +5,7 @@ import pytest
 import os, sys
 
 def test_unit_no_params_bad(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with no params; lbann should throw exception\n')
     command = tools.get_command(
         cluster=cluster, executable=exe, exit_after_setup=True)
@@ -13,7 +13,7 @@ def test_unit_no_params_bad(cluster, exes, dirname):
     assert return_code != 0
 
 def test_unit_one_model_bad(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with no optimizer or reader; lbann should throw exception\n')
     model_path = 'prototext/model_mnist_simple_1.prototext'
     command = tools.get_command(
@@ -23,7 +23,7 @@ def test_unit_one_model_bad(cluster, exes, dirname):
     assert return_code != 0
 
 def test_unit_two_models_bad(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with two models but no optimizer or reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -33,7 +33,7 @@ def test_unit_two_models_bad(cluster, exes, dirname):
     assert return_code != 0
 
 def test_unit_two_models_bad2(cluster, exes,  dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with two models with missing {; lbann should throw exception\n')
     model_path='prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -43,18 +43,19 @@ def test_unit_two_models_bad2(cluster, exes,  dirname):
     assert return_code != 0
 
 def test_unit_missing_optimizer(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with two models, reader, but no optimizer; lbann should throw exception\n')
     model_path='{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path='prototext/data_reader_mnist.prototext'
     command = tools.get_command(
         cluster=cluster, executable=exe, data_reader_path=data_reader_path,
+        data_filedir_ray='/p/gscratchr/brainusr/datasets/MNIST',
         exit_after_setup=True, model_path=model_path)
     return_code = os.system(command)
     assert return_code != 0
 
 def test_unit_missing_reader(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with two models, reader, but no reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     optimizer_path = 'prototext/opt_sgd.prototext'
@@ -65,20 +66,21 @@ def test_unit_missing_reader(cluster, exes, dirname):
     assert return_code != 0
 
 def test_unit_bad_params(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with ill-formed param (missing -) lbann should throw exception\n')
     (command_allocate, command_run, _, _) = tools.get_command(cluster=cluster, executable=exe, return_tuple=True)
     return_code = os.system('%s%s %s -exit_after_setup --reader=prototext/data_reader_mnist.prototext --model={prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext} --optimizer=prototext/opt_sgd.prototext' % (command_allocate, command_run, exe))
     assert return_code != 0
 
 def test_unit_should_work(cluster, exes, dirname):
-    exe = exes['default']
+    exe = exes['gcc4']
     sys.stderr.write('TESTING: run lbann with two models, reader, and optimizer; lbann should NOT throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path = 'prototext/data_reader_mnist.prototext'
     optimizer_path = 'prototext/opt_sgd.prototext'
     command = tools.get_command(
         cluster=cluster, executable=exe, data_reader_path=data_reader_path,
+        data_filedir_ray='/p/gscratchr/brainusr/datasets/MNIST',
         exit_after_setup=True, model_path=model_path,
         optimizer_path=optimizer_path)
     return_code = os.system(command)


### PR DESCRIPTION
Test models with debug compilers.

- `clean.sh`: Update to remove error files.
- `test_tools.py`, `tools.py`:
  - Check if executable exists when creating a command - as to not waste queue time on a command that cannot run.
  - Take into account Ray's max time limit of 8 hours.
- `error/README.md`: Create folder for compiler test error stream.
- `test_compiler.py`:
  - Add compiler tests of debug mode for each compiler.
  - Add error redirect.
- `common_code.py`:
  - Update Ray file paths.
  - Update `run_lbann` to report LBANN exceptions and timeouts directly (so it is not necessary to read through the logs to find this information).
  - Update `run_lbann` to return `output_value` (which should always be 0, since an exception will be thrown otherwise. Tests can call `run_lbann` followed by `assert output_value == 0`. The detailed exception will then show up in Bamboo instead of just `AssertionError`).
- `integration_tests/conftest.py`:
  - Add debug compilers.
  - Update Ray architecture to be `ppc64le_gpu`, not `x86_64`. Also done for `unit_tests/conftest.py`.
  - Add debug flag (this is for testing purposes - Bamboo will call these tests as part of `--weekly`).
- Update expected performance numbers for Catalyst, Ray and Surface.
- `test_integration_debug.py`: Add weekly tests that simply assert `cifar` and `mnist` can run with the debug compilers.
- `test_integration_io_buffers.py`:
  - Update to run all `mini_batch_size` x `procs_per_model` combinations even if one run crashes (but forgo checking for equality between `distributed` and `partitioned` if any runs crash).
  - Update to be run weekly, not nightly.
- `test_integration_performance.py`: Update to use the `operator` library instead of defining lambdas.
- `test_unit_check_proto_models.py`: Update to also list working models, not just failing ones. 
- `test_unit_lbann_invocation.py`:
  - Update compiler to be `gcc4`, not `default`.
  - Update Ray file paths.