### PR TITLE
Input switch

### DIFF
--- a/include/lbann/layers/transform/CMakeLists.txt
+++ b/include/lbann/layers/transform/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
   concatenation.hpp
-  noise.hpp
   pooling.hpp
   reshape.hpp
   safe_inv.hpp
@@ -13,6 +12,9 @@ set_full_path(THIS_DIR_HEADERS
   constant.hpp
   dummy.hpp
   hadamard.hpp
+  gaussian.hpp
+  bernoulli.hpp
+  uniform.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/transform/gaussian.hpp
+++ b/include/lbann/layers/transform/gaussian.hpp
@@ -1,0 +1,109 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_GAUSSIAN_HPP_INCLUDED
+#define LBANN_LAYER_GAUSSIAN_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+
+/** Activations are drawn from Gaussian distribution.
+ *  During validation and testing, the layer outputs the distribution
+ *  mean.
+ */
+template <data_layout T_layout = data_layout::DATA_PARALLEL>
+class gaussian_layer : public transform_layer {
+ private:
+  /** Gaussian distribution mean. */
+  DataType m_mean;
+  /** Gaussian distribution standard deviation. */
+  DataType m_stdev;
+
+ public:
+  gaussian_layer(lbann_comm *comm,
+                 const std::vector<int>& neuron_dims,
+                 DataType mean = DataType(0),
+                 DataType stdev = DataType(1),
+                 cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm), m_mean(mean), m_stdev(stdev) {
+
+    // Record neuron dimensions
+    this->m_neuron_dims = neuron_dims;
+    this->m_num_neuron_dims = neuron_dims.size();
+    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
+                                          neuron_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
+
+    // Gaussian layer has no parents
+    m_expected_num_parent_layers = 0;
+
+  }
+  gaussian_layer* copy() const override { return new gaussian_layer(*this); }
+  std::string get_type() const override { return "Gaussian"; }
+  data_layout get_data_layout() const override { return T_layout; }
+
+  /** Returns description of ctor params */
+  std::string get_description() const override {
+    std::stringstream ss;
+    ss << "gaussian_layer" << "  "
+       << "mean: " << m_mean << " "
+       << "stdev: " << m_stdev << " "
+       << "dataLayout: " << this->get_data_layout_string(get_data_layout());
+     return ss.str();
+  }
+
+ protected:
+
+  void setup_dims() override {
+    const auto neuron_dims = this->m_neuron_dims;
+    transform_layer::setup_dims();
+    this->m_neuron_dims = neuron_dims;
+    this->m_num_neuron_dims = neuron_dims.size();
+    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
+                                          neuron_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
+  }
+
+  void fp_compute() override {
+    auto& output = get_activations();
+    if (this->m_model->get_execution_mode() == execution_mode::training) {
+      gaussian_fill(output, output.Height(), output.Width(), m_mean, m_stdev);
+    } else {
+      El::Fill(output, m_mean);
+    }
+  }
+
+  void bp_compute() override {}
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_GAUSSIAN_HPP_INCLUDED

--- a/include/lbann/layers/transform/uniform.hpp
+++ b/include/lbann/layers/transform/uniform.hpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_UNIFORM_HPP_INCLUDED
+#define LBANN_LAYER_UNIFORM_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+
+/** Activations are drawn from uniform distribution.
+ *  During validation and testing, the layer outputs the distribution
+ *  mean.
+ */
+template <data_layout T_layout = data_layout::DATA_PARALLEL>
+class uniform_layer : public transform_layer {
+ private:
+  /** Uniform distribution mean. */
+  DataType m_min;
+  /** Uniform distribution standard deviation. */
+  DataType m_max;
+
+ public:
+  uniform_layer(lbann_comm *comm,
+                 const std::vector<int>& neuron_dims,
+                 DataType min = DataType(0),
+                 DataType max = DataType(1),
+                 cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm), m_min(min), m_max(max) {
+
+    // Record neuron dimensions
+    this->m_neuron_dims = neuron_dims;
+    this->m_num_neuron_dims = neuron_dims.size();
+    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
+                                          neuron_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
+
+    // Uniform layer has no parents
+    m_expected_num_parent_layers = 0;
+
+  }
+  uniform_layer* copy() const override { return new uniform_layer(*this); }
+  std::string get_type() const override { return "uniform"; }
+  data_layout get_data_layout() const override { return T_layout; }
+
+  /** Returns description of ctor params */
+  std::string get_description() const override {
+    std::stringstream ss;
+    ss << "uniform_layer" << "  "
+       << "min: " << m_min << " "
+       << "max: " << m_max << " "
+       << "dataLayout: " << this->get_data_layout_string(get_data_layout());
+     return ss.str();
+  }
+
+ protected:
+
+  void setup_dims() override {
+    const auto neuron_dims = this->m_neuron_dims;
+    transform_layer::setup_dims();
+    this->m_neuron_dims = neuron_dims;
+    this->m_num_neuron_dims = neuron_dims.size();
+    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
+                                          neuron_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
+  }
+
+  void fp_compute() override {
+    const auto& mean = (m_max + m_min) / 2;
+    const auto& radius = (m_max - m_min) / 2;
+    auto& output = get_activations();
+    if (this->m_model->get_execution_mode() == execution_mode::training) {
+      uniform_fill(output, output.Height(), output.Width(), mean, radius);
+    } else {
+      El::Fill(output, mean);
+    }
+  }
+
+  void bp_compute() override {}
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_UNIFORM_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -71,9 +71,11 @@
 #include "lbann/layers/transform/concatenation.hpp"
 #include "lbann/layers/transform/constant.hpp"
 #include "lbann/layers/transform/dummy.hpp"
-#include "lbann/layers/transform/noise.hpp"
 #include "lbann/layers/transform/safe_inv.hpp"
 #include "lbann/layers/transform/hadamard.hpp"
+#include "lbann/layers/transform/gaussian.hpp"
+#include "lbann/layers/transform/bernoulli.hpp"
+#include "lbann/layers/transform/uniform.hpp"
 
 /// Regularization layers.
 #include "lbann/layers/regularizers/local_response_normalization.hpp"

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -154,9 +154,10 @@ model {
   layer {
     name: "noise"
     data_layout: "model_parallel"
-    noise {
-      noise_factor: 1.0
-      num_neurons: "2"
+    gaussian {
+      mean: 0.0
+      stdev: 1.0
+      neuron_dims: "2"
     }
   }
   

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -237,9 +237,10 @@ model {
   layer {
     name: "noise"
     data_layout: "model_parallel"
-    noise {
-      noise_factor: 1.0
-      num_neurons: "5"
+    gaussian {
+      mean: 0.0
+      stdev: 1.0
+      neuron_dims: "5"
     }
   }
   

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -199,10 +199,31 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& dims = parse_list<int>(params.num_neurons());
     return new constant_layer<layout>(comm, params.value(), dims, cudnn);
   }
-  if (proto_layer.has_noise()) {
-    const auto& params = proto_layer.noise();
-    const auto& dims = parse_list<int>(params.num_neurons());
-    return new noise_layer<layout>(comm, dims, params.noise_factor(), cudnn);
+  if (proto_layer.has_gaussian()) {
+    const auto& params = proto_layer.gaussian();
+    const auto& dims = parse_list<int>(params.neuron_dims());
+    return new gaussian_layer<layout>(comm,
+                                      dims,
+                                      params.mean(),
+                                      params.stdev(),
+                                      cudnn);
+  }
+  if (proto_layer.has_bernoulli()) {
+    const auto& params = proto_layer.bernoulli();
+    const auto& dims = parse_list<int>(params.neuron_dims());
+    return new bernoulli_layer<layout>(comm,
+                                       dims,
+                                       params.prob(),
+                                       cudnn);
+  }
+  if (proto_layer.has_uniform()) {
+    const auto& params = proto_layer.uniform();
+    const auto& dims = parse_list<int>(params.neuron_dims());
+    return new uniform_layer<layout>(comm,
+                                     dims,
+                                     params.min(),
+                                     params.max(),
+                                     cudnn);
   }
   if (proto_layer.has_pooling()) {
     const auto& params = proto_layer.pooling();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -692,10 +692,12 @@ message Layer {
    Slice slice = 301;
    Split split = 302;
    Sum sum = 303;
-   Noise noise = 307;
    Unpooling unpooling = 304;
    Hadamard hadamard = 308;
    Constant constant = 309;
+   Gaussian gaussian = 310;
+   Bernoulli bernoulli = 311;
+   Uniform uniform = 312;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -875,11 +877,6 @@ message Sum {
   string scaling_factors = 1; //should be a space-separated list of doubles, e.g. "1.0 2.0 -1.0"
 }
 
-message Noise {
-  double noise_factor=1;
-  string num_neurons=2;
-}
-
 message Hadamard {
 }
 
@@ -887,6 +884,24 @@ message Constant {
   double value=1;
   string num_neurons=2;
 }
+
+message Gaussian {
+  double mean = 1;
+  double stdev = 2;
+  string neuron_dims = 3;
+}
+
+message Bernoulli {
+  double prob = 1;
+  string neuron_dims = 2;
+}
+
+message Uniform {
+  double min = 1;
+  double max = 2;
+  string neuron_dims = 3;
+}
+
 /////////////////////
 // learning Layers //
 /////////////////////

--- a/viz/properties.txt
+++ b/viz/properties.txt
@@ -45,7 +45,9 @@ transform    concatenation
 transform    slice
 transform    split arrow=red
 transform    sum
-transform    noise
 transform    unpooling
 transform    hadamard
+transform    gaussian
+transform    bernoulli
+transform    uniform
 

--- a/viz/properties_rect.txt
+++ b/viz/properties_rect.txt
@@ -44,7 +44,9 @@ transform    concatenation
 transform    slice
 transform    split
 transform    sum
-transform    noise
 transform    unpooling
 transform    hadamard
+transform    gaussian
+transform    bernoulli
+transform    uniform
 


### PR DESCRIPTION
This pull request is intended to provide functionality so that a model can choose between two possible inputs. Changes:
- Implemented `gaussian_layer` (replacing `noise_layer`), `bernoulli_layer`, and `uniform_layer`.

Input switch implementation:
```
# Input layers with N neurons
layer { name: "input1" }
layer { name: "input2" }

# Randomly choose input1 or input2
layer {
  name: "switch1"
  bernoulli {
    prob: 0.5
    neuron_dims: "1"
  }
}
layer {
  name: "ones"
  constant {
    value: 1
    num_neurons: "1"
  }
}
layer {
  parents: "ones switch1"
  name: "switch2"
  sum { scaling_factors: "1 -1" }
}

# Apply switch
weights {
  name: "ones"
  optimizer {} # Disable optimizer
  constant_initializer { value: 1 }
}
layer {
  parents: "switch1"
  name: "switch1_full"
  weights: "ones"
  fully_connected {
    num_neurons: N
    has_bias: false
  }
}
layer {
  parents: "switch2"
  name: "switch2_full"
  weights: "ones"
  fully_connected {
    num_neurons: N
    has_bias: false
  }
}
layer {
  parents: "input1 switch1_full"
  name: "input1_hadamard"
  hadamard {}
}
layer {
  parents: "input2 switch2_full"
  name: "input2_hadamard"
  hadamard {}
}
layer {
  parents: "input1_hadamard input2_hadamard"
  name: "switch"
  sum {}
}
```