### PR TITLE
Layers in DAG models can be specified in arbitrary order.

### DIFF
--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -304,7 +304,7 @@ class model {
   /** Set up layer execution order.
    *  Called in setup function.
    */
-  virtual void setup_layer_execution_order() {}
+  virtual void setup_layer_execution_order();
   /** Set up layers.
    *  Called in setup function.
    */

--- a/src/callbacks/callback_check_dataset.cpp
+++ b/src/callbacks/callback_check_dataset.cpp
@@ -79,12 +79,13 @@ void lbann_callback_check_dataset::on_epoch_end(model *m) {
   std::cout << "Training [" << comm->get_rank_in_model() <<
     "] : I have processed " << training_set.size() << " elements" << std::endl;
 
-  const std::vector<Layer *>& layers = m->get_layers();
-  auto *input = (generic_input_layer *) dynamic_cast<generic_input_layer *> (layers[0]);
-  if (!input) {
-    throw lbann_exception(
-      "lbann_callback_check_dataset: could not get input layer");
+  // Get first input layer in model
+  generic_input_layer* input = nullptr;
+  for (auto&& l : m->get_layers()) {
+    input = dynamic_cast<generic_input_layer*>(l);
+    if (input != nullptr) { break; }
   }
+  if (input == nullptr) { LBANN_ERROR("could not get input layer"); }
 
   int num_samples = training_set.size();
   std::vector<int> vec_num_samples(comm->get_procs_per_model());

--- a/src/callbacks/callback_debug_io.cpp
+++ b/src/callbacks/callback_debug_io.cpp
@@ -85,21 +85,26 @@ void lbann::lbann_callback_debug_io::print_fp_start(model *m, generic_input_laye
 
 //  179i @ 300s (=5m*60s) + 1i @ 100s (=5m*45s):offset <- num models
 void lbann::lbann_callback_debug_io::print_phase_start(model *m, execution_mode mode) {
-  const std::vector<Layer *>layers = m->get_layers();
-  auto *input = dynamic_cast<generic_input_layer*>(layers[0]);
-  generic_data_reader *data_reader=input->get_data_reader(mode);
+
+  // Get data reader from first input layer in model
+  generic_data_reader* data_reader = nullptr;
+  for (auto&& l : m->get_layers()) {
+    auto&& input = dynamic_cast<generic_input_layer*>(l);
+    if (input != nullptr) {
+      data_reader = input->get_data_reader(mode);
+      break;
+    }
+  }
+  if (data_reader == nullptr) { return; }
 
   int64_t step;
   switch(mode) {
   case execution_mode::training:
-    step = m->get_cur_step();
-    break;
+    step = m->get_cur_step(); break;
   case execution_mode::validation:
-    step = m->get_cur_validation_step();
-    break;
+    step = m->get_cur_validation_step(); break;
   case execution_mode::testing:
-    step = m->get_cur_testing_step();
-    break;
+    step = m->get_cur_testing_step(); break;
   default:
     throw lbann_exception("Illegal execution mode in evaluate forward prop function");
   }

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -46,60 +46,68 @@ void lbann_callback_print::setup(model *m) {
 void lbann_callback_print::on_epoch_begin(model *m) {
   lbann_comm *comm = m->get_comm();
   if (comm->am_world_master()) {
-    const std::vector<Layer *>layers = m->get_layers();
-    auto *layer = dynamic_cast<generic_input_layer*>(layers[0]);
+
+    // Get first input layer in model
+    generic_input_layer* input = nullptr;
+    for (auto&& l : m->get_layers()) {
+      input = dynamic_cast<generic_input_layer*>(l);
+      if (input != nullptr) { break; }
+    }
+    if (input == nullptr) { LBANN_ERROR("could not get input layer"); }
+
+    // Print message
     std::cout << "--------------------------------------------------------------------------------"
               << std::endl;
     std::cout << "[" << m->get_cur_epoch() << "] Epoch : stats formated [tr/v/te]"
               << " iter/epoch ="
               << " ["
-              << layer->get_num_iterations_per_epoch(execution_mode::training)
+              << input->get_num_iterations_per_epoch(execution_mode::training)
               << "/"
-              << layer->get_num_iterations_per_epoch(execution_mode::validation)
+              << input->get_num_iterations_per_epoch(execution_mode::validation)
               << "/"
-              << layer->get_num_iterations_per_epoch(execution_mode::testing)
+              << input->get_num_iterations_per_epoch(execution_mode::testing)
               << "]"
               << std::endl;
     std::cout << std::setfill(' ') << std::setw(23)
               << " global MB ="
               << " ["
-              << std::setw(4) << layer->get_global_mini_batch_size(execution_mode::training)
+              << std::setw(4) << input->get_global_mini_batch_size(execution_mode::training)
               << "/"
-              << std::setw(4) << layer->get_global_mini_batch_size(execution_mode::validation)
+              << std::setw(4) << input->get_global_mini_batch_size(execution_mode::validation)
               << "/"
-              << std::setw(4) << layer->get_global_mini_batch_size(execution_mode::testing)
+              << std::setw(4) << input->get_global_mini_batch_size(execution_mode::testing)
               << "]"
               << " global last MB ="
               << " ["
-              << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::training)
+              << std::setw(4) << input->get_global_last_mini_batch_size(execution_mode::training)
               << std::setw(2) << " "
               << "/"
-              << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::validation)
+              << std::setw(4) << input->get_global_last_mini_batch_size(execution_mode::validation)
               << std::setw(2) << " "
               << "/"
-              << std::setw(4) << layer->get_global_last_mini_batch_size(execution_mode::testing)
+              << std::setw(4) << input->get_global_last_mini_batch_size(execution_mode::testing)
               << std::setw(2) << " "
               << "]"
               << std::endl;
     std::cout << std::setfill(' ') << std::setw(23)
               << "  local MB ="
               << " ["
-              << std::setw(4) << layer->get_mini_batch_size(execution_mode::training)
+              << std::setw(4) << input->get_mini_batch_size(execution_mode::training)
               << "/"
-              << std::setw(4) << layer->get_mini_batch_size(execution_mode::validation)
+              << std::setw(4) << input->get_mini_batch_size(execution_mode::validation)
               << "/"
-              << std::setw(4) << layer->get_mini_batch_size(execution_mode::testing)
+              << std::setw(4) << input->get_mini_batch_size(execution_mode::testing)
               << "]"
               << "  local last MB ="
               << " ["
-              << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::training)
-              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::training)
+              << std::setw(4) << input->get_last_mini_batch_size(execution_mode::training)
+              << "+" << input->get_world_master_mini_batch_adjustment(execution_mode::training)
               << "/"
-              << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::validation)
-              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::validation)
+              << std::setw(4) << input->get_last_mini_batch_size(execution_mode::validation)
+              << "+" << input->get_world_master_mini_batch_adjustment(execution_mode::validation)
               << "/"
-              << std::setw(4) << layer->get_last_mini_batch_size(execution_mode::testing)
-              << "+" << layer->get_world_master_mini_batch_adjustment(execution_mode::testing)
+              << std::setw(4) << input->get_last_mini_batch_size(execution_mode::testing)
+              << "+" << input->get_world_master_mini_batch_adjustment(execution_mode::testing)
               << "]"
               << std::endl;
     std::cout << "--------------------------------------------------------------------------------"

--- a/src/callbacks/callback_variable_minibatch.cpp
+++ b/src/callbacks/callback_variable_minibatch.cpp
@@ -39,13 +39,16 @@ lbann_callback_variable_minibatch::lbann_callback_variable_minibatch(
 
 void lbann_callback_variable_minibatch::on_train_begin(model *m) {
   // Avoid issues with the train method being called multiple times.
-  if (m->get_cur_epoch() != 0) {
-    return;
+  if (m->get_cur_epoch() != 0) { return; }
+
+  // Get first input layer in model
+  generic_input_layer* input = nullptr;
+  for (auto&& l : m->get_layers()) {
+    input = dynamic_cast<generic_input_layer*>(l);
+    if (input != nullptr) { break; }
   }
-  auto* input = dynamic_cast<generic_input_layer*>(m->get_layers()[0]);
-  if (!input) {
-    throw lbann_exception("variable_minibatch: could not get input layer");
-  }
+  if (input == nullptr) { LBANN_ERROR("could not get input layer"); }
+
   if (m_starting_mbsize > m->get_max_mini_batch_size()) {
     throw lbann_exception(
       "variable_minibatch: starting mini-batch size is larger than max");
@@ -61,7 +64,15 @@ void lbann_callback_variable_minibatch::on_train_begin(model *m) {
 }
 
 void lbann_callback_variable_minibatch::on_epoch_end(model *m) {
-  auto* input = dynamic_cast<generic_input_layer*>(m->get_layers()[0]);
+
+  // Get first input layer in model
+  generic_input_layer* input = nullptr;
+  for (auto&& l : m->get_layers()) {
+    input = dynamic_cast<generic_input_layer*>(l);
+    if (input != nullptr) { break; }
+  }
+  if (input == nullptr) { LBANN_ERROR("could not get input layer"); }
+
   lbann_comm *comm = m->get_comm();
   int new_mbsize = 0;
   float new_lr = 0.0f;

--- a/src/models/directed_acyclic_graph.cpp
+++ b/src/models/directed_acyclic_graph.cpp
@@ -39,12 +39,12 @@ directed_acyclic_graph_model::directed_acyclic_graph_model(lbann_comm *comm,
   : model(comm, mini_batch_size, obj_fn, default_optimizer) {}
 
 void directed_acyclic_graph_model::setup_layer_execution_order() {
-  model::setup_layer_execution_order();
   std::set<int> nodes;
   std::map<int,std::set<int>> edges;
   construct_layer_graph(nodes, edges);
   const auto& sorted_order = graph::topological_sort(nodes, edges);
   permute_layers(sorted_order);
+  model::setup_layer_execution_order();
 }
 
 }  // namespace lbann


### PR DESCRIPTION
The execution order will be chosen so input layers are processed first. This closes #280.

We still assume there is exactly one input layer.