### PR TITLE
Fix ResNet50 max-pooling padding

### DIFF
--- a/model_zoo/models/resnet50/model_resnet50.prototext
+++ b/model_zoo/models/resnet50/model_resnet50.prototext
@@ -92,7 +92,7 @@ model {
     pooling {
       num_dims: 2
       pool_dims_i: 3
-      pool_pads_i: 0
+      pool_pads_i: 1
       pool_strides_i: 2
       pool_mode: "max"
     }

--- a/model_zoo/models/resnet50/model_resnet50_motif.prototext
+++ b/model_zoo/models/resnet50/model_resnet50_motif.prototext
@@ -256,7 +256,7 @@ model {
     pooling {
       num_dims: 2
       pool_dims_i: 3
-      pool_pads_i: 0
+      pool_pads_i: 1
       pool_strides_i: 2
       pool_mode: "max"
     }

--- a/model_zoo/models/resnet50/model_resnet50_sequential.prototext
+++ b/model_zoo/models/resnet50/model_resnet50_sequential.prototext
@@ -112,7 +112,7 @@ model {
     pooling {
       num_dims: 2
       pool_dims_i: 3
-      pool_pads_i: 0
+      pool_pads_i: 1
       pool_strides_i: 2
       pool_mode: "max"
     }


### PR DESCRIPTION
The max-pooling layer in ResNet should have padding 1.

It looks like the [original Caffe implementation](https://github.com/KaimingHe/deep-residual-networks) used 0 padding, but more recent implementations ([TensorFlow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/examples/learn/resnet.py), [PyTorch](https://github.com/pytorch/vision/blob/master/torchvision/models/resnet.py)) use padding 1.

This also avoids shrinking the image unnecessarily, and avoids going from even to odd dimensions.