### PR TITLE
fix clang compiler warnings promoted to errors

### DIFF
--- a/include/lbann/data_readers/data_reader_imagenet_patches.hpp
+++ b/include/lbann/data_readers/data_reader_imagenet_patches.hpp
@@ -54,7 +54,7 @@ class imagenet_reader_patches : public image_data_reader {
     return {m_num_patches*m_image_num_channels, m_image_height, m_image_width};
   }
 
-  void setup_data_store(model *m);
+  void setup_data_store(model *m) override;
 
  protected:
   void set_defaults() override;

--- a/include/lbann/data_store/data_store_merge_features.hpp
+++ b/include/lbann/data_store/data_store_merge_features.hpp
@@ -58,11 +58,11 @@ class data_store_merge_features : public generic_data_store {
 
   void get_data_buf(int data_id, std::vector<unsigned char> *&buf, int multi_idx = 0) override {}
 
-  void setup() override{};
+  void setup() override {};
 
  protected :
 
-  void exchange_data() {}
+  void exchange_data() override {}
 
   /// this contains a concatenation of the indices in m_minibatch_indices
   /// (see: generic_data_reader.hpp)

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -83,7 +83,7 @@ void l2_weight_regularization::setup(model& m) {
   m_sqsums.resize(m_weights.size(), EvalType(0));
   m_allreduce_started.resize(m_weights.size(), false);
   for (size_t i = 0; i < m_weights.size(); ++i) {
-    m_allreduce_reqs.push_back(std::move(Al::request()));
+    m_allreduce_reqs.emplace_back();
   }
 
 #ifdef LBANN_HAS_CUDNN


### PR DESCRIPTION
- missing override keywords for virtual functions
- std::move on temporary ojbect: replaced with emplace_back to constuct the object in place