### PR TITLE
Support building on the LC Pascal cluster

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -10,6 +10,12 @@ ARCH=$(uname -m)
 ################################################################
 
 COMPILER=gnu
+if [ "${CLUSTER}" == "pascal" ]; then
+	# The latest GCC version on Pascal is 7, which is not supported by nvcc.
+	# Version 6.1.0 does not work with CUDA 9.1, either. 
+	COMPILER=gnu
+	module load gcc/4.9.3
+fi
 if [ "${ARCH}" == "x86_64" ]; then
     MPI=mvapich2
 elif [ "${ARCH}" == "ppc64le" ]; then
@@ -514,7 +520,8 @@ fi
 # Initialize GPU libraries
 ################################################################
 
-if [ "${CLUSTER}" == "surface" ] || [ "${CLUSTER}" == "ray" ]; then
+if [ "${CLUSTER}" == "surface" ] || [ "${CLUSTER}" == "ray" ] ||
+   [ "${CLUSTER}" == "pascal" ]; then
     HAS_GPU=1
     WITH_CUDA=${WITH_CUDA:-ON}
     WITH_CUDNN=ON
@@ -526,28 +533,48 @@ if [ "${CLUSTER}" == "surface" ] || [ "${CLUSTER}" == "ray" ]; then
         export NCCL_DIR=/usr/workspace/wsb/brain/nccl2/nccl_2.1.15-1+cuda9.1_x86_64
 
     fi
-    if [ "${ARCH}" == "ppc64le" ]; then
-        export CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
-        CUDATOOLKIT_VERSION=$(ls -l ${CUDA_TOOLKIT_ROOT_DIR} | awk '{print $NF}' | cut -d '-' -f 2)
-    elif [ -n "${CUDA_PATH}" ]; then
-        CUDATOOLKIT_VERSION=$(basename "$CUDA_PATH" | sed 's/cudatoolkit-//')
-       export CUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}
-    else
-        CUDATOOLKIT_VERSION=9.1
-        if [ ${USE_MODULES} -ne 0 ]; then
-            module load cudatoolkit/${CUDATOOLKIT_VERSION}
-        fi
-        export CUDA_TOOLKIT_ROOT_DIR=/opt/cudatoolkit-${CUDATOOLKIT_VERSION}
-    fi
-    # Hack for surface
-    if [ "${CLUSTER}" == "surface" ]; then
-        CUDATOOLKIT_VERSION=9.1
-        . /usr/share/[mM]odules/init/bash
-        module load cudatoolkit/${CUDATOOLKIT_VERSION}
-        
-        export CUDA_TOOLKIT_ROOT_DIR=/opt/cudatoolkit-${CUDATOOLKIT_VERSION}
-    fi
-	export CUDNN_DIR=/usr/gapps/brain/cudnn/cudnn-7.1.1/cuda-${CUDATOOLKIT_VERSION}_${ARCH}	
+	
+    # Hack for surface	
+	if [ "${CLUSTER}" == "surface" ]; then
+        . /usr/share/[mM]odules/init/bash		
+		CUDA_TOOLKIT_MODULE=cudatoolkit/9.1
+	elif [ "${CLUSTER}" == "ray" ]; then
+		CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
+	fi
+fi
+
+if [ "${WITH_CUDA}" == "ON" ]; then
+	# Defines CUDA_TOOLKIT_ROOT_DIR
+	if [ -z "${CUDA_TOOLKIT_ROOT_DIR}" ]; then
+		if [ -n "${CUDA_PATH}" ]; then
+			CUDA_TOOLKIT_ROOT_DIR=${CUDA_PATH}
+		elif [ -n "${CUDA_HOME}" ]; then
+			CUDA_TOOLKIT_ROOT_DIR=${CUDA_HOME}
+		elif [ -n "${CUDA_TOOLKIT_MODULE}" -o ${USE_MODULES} -ne 0 ]; then
+			CUDA_TOOLKIT_MODULE=${CUDA_TOOLKIT_MODULE:-cuda}
+			module load ${CUDA_TOOLKIT_MODULE}
+			CUDA_TOOLKIT_ROOT_DIR=${CUDA_HOME:-${CUDA_PATH}}
+		fi
+	fi
+	if [ -n "${CUDA_TOOLKIT_ROOT_DIR}" -a -d "${CUDA_TOOLKIT_ROOT_DIR}" ]; then
+		export CUDA_TOOLKIT_ROOT_DIR
+	else
+		echo "Could not find CUDA"
+		exit 1
+	fi
+	# Defines CUDA_TOOLKIT_VERSION
+	#CUDA_TOOLKIT_VERSION=$(ls -l ${CUDA_TOOLKIT_ROOT_DIR} | awk '{print $NF}' | cut -d '-' -f 2)
+	CUDA_TOOLKIT_VERSION=$(${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc --version | grep -oE "V[0-9]+\.[0-9]+" | sed 's/V//')
+
+	# CUDNN
+	if [ -z "${CUDNN_DIR}" ]; then
+		CUDNN_DIR=/usr/gapps/brain/cudnn/cudnn-7.1.1/cuda-${CUDA_TOOLKIT_VERSION}_${ARCH}
+	fi
+	if [ ! -d "${CUDNN_DIR}" ]; then
+		echo "Could not find cuDNN at $CUDNN_DIR"
+		exit 1
+	fi
+	export CUDNN_DIR
 else
     HAS_GPU=0
     WITH_CUDA=${WITH_CUDA:-OFF}


### PR DESCRIPTION
Cleaned up the GPU configuration part of the build_lc_lbann.sh script.

The GCC version for Pascal is still 4.9. There are versions 6 and 7, but none of them seem to work with CUDA 9.1. GCC 6 fails to find some header files, and GCC 7 is explicitly rejected by nvcc.