### PR TITLE
clang approved version of broadcast interfaces

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -42,6 +42,7 @@
 #endif // LBANN_HAS_ALUMINUM
 #include <Al.hpp>
 #endif // LBANN_HAS_ALUMINUM
+#include "detect_El_mpi.hpp"
 
 namespace lbann {
 
@@ -193,48 +194,55 @@ class lbann_comm {
   /** Broadcast mat over the inter-model communicator starting from root. */
   void intermodel_broadcast_matrix(Mat& mat, int root);
   void intermodel_broadcast_matrix(AbsDistMat& mat, int root);
-  /**
-   * Broadcast over an arbitrary communicator, returns the broadcast value
-   */
+
+  /// Broadcast a scalar value over an arbitrary communicator
+  template < typename T, bool S = is_instantiated_El_mpi_type<T>::value >
+  void broadcast(int root, T& val, const El::mpi::Comm c);
+
   template <typename T>
-  void broadcast(int root, T& val, const El::mpi::Comm c) {
-    if (El::mpi::TypeMap<T>() == MPI_DATATYPE_NULL) {
-      const int bytes =  static_cast<int>(sizeof(T));
-      El::mpi::Broadcast<unsigned char>(reinterpret_cast<unsigned char*>(&val), bytes, root, c); // or std::byte in c++17
-    } else {
-      El::mpi::Broadcast(&val, 1, root, c);
-    }
-    count_bytes_broadcast(sizeof(T), El::mpi::Rank(c), root);
+  void broadcast_custom(int root, T& val, const El::mpi::Comm c) const;
+  template <typename T>
+  void broadcast_native(int root, T& val, const El::mpi::Comm c) const;
+
+  /// World broadcast of a scalar.
+  template <typename T>
+  void world_broadcast(int root, T& val) {
+    broadcast(root, val, get_world_comm());
   }
-  /**
-   * Inter-model broadcast, returns the broadcast value.
-   * Root process specifies root and val, other processes just root.
-   */
+  /// Inter-model broadcast of a scalar.
   template <typename T>
   void intermodel_broadcast(int root, T& val) {
-    broadcast(root, val, intermodel_comm);
+    broadcast(root, val, get_intermodel_comm());
   }
-  /**
-   * Within-model broadcast, returns the broadcast value.
-   * Root process specifies root and val, other processes just root.
-   */
+  /// Within-model broadcast of a scalar.
   template <typename T>
   void model_broadcast(int root, T& val) {
-    broadcast(root, val, model_comm);
+    broadcast(root, val, get_model_comm());
   }
+
   /**
    * Broadcast a buffer over an arbitrary communicator assuming that
    * the buffer space is already allocated.
    */
+  template < typename T, bool S = is_instantiated_El_mpi_type<T>::value >
+  void broadcast(const int root, T* data, const int count, const El::mpi::Comm c);
+
+  /// World broadcast of a buffer.
   template <typename T>
-  void broadcast(const int root, T* data, const int count, const El::mpi::Comm c) {
-    if (El::mpi::TypeMap<T>() == MPI_DATATYPE_NULL) {
-      El::mpi::Broadcast<unsigned char>(reinterpret_cast<unsigned char*>(data), sizeof(T)*count, root, c);
-    } else {
-      El::mpi::Broadcast(data, count, root, c);
-    }
-    count_bytes_broadcast(sizeof(T)*count, El::mpi::Rank(c), root);
+  void world_broadcast(const int root, T* data, const int count) {
+    broadcast(root, data, count, get_world_comm());
   }
+  /// Inter-model broadcast of a buffer.
+  template <typename T>
+  void intermodel_broadcast(const int root, T* data, const int count) {
+    broadcast(root, data, count, get_intermodel_comm());
+  }
+  /// Within-model broadcast of a buffer.
+  template <typename T>
+  void model_broadcast(const int root, T* data, const int count) {
+    broadcast(root, data, count, get_model_comm());
+  }
+
   /**
    * Resize vector<> over an arbitrary communicator to match the one on root.
    */
@@ -246,6 +254,7 @@ class lbann_comm {
     data.resize(count);
     return count;
   }
+
   /**
    * Broadcast vector<> over an arbitrary communicator;
    * vector<> for non-root processes will be resized as needed.
@@ -258,22 +267,22 @@ class lbann_comm {
     }
     broadcast<T>(root, data.data(), count, c);
   }
-  /**
-   * Broadcast vector<> to world;
-   * vector<> for non-root processes will be resized as needed.
-   */
+  /// Broadcast vector<> to world.
   template <typename T>
   void world_broadcast(int root, std::vector<T> &data) {
     broadcast(root, data, get_world_comm());
   }
-  /**
-   * Broadcast vector<> within model;
-   * vector<> for non-root processes will be resized as needed.
-   */
+  /// Broadcast vector<> across models.
+  template <typename T>
+  void intermodel_broadcast(int root, std::vector<T> &data) {
+    broadcast(root, data, get_intermodel_comm());
+  }
+  /// Broadcast vector<> within model.
   template <typename T>
   void model_broadcast(int root, std::vector<T> &data) {
     broadcast(root, data, get_model_comm());
   }
+
   /**
    * Keep track of the number of broadcast bytes transmitted and received
    */
@@ -1065,6 +1074,43 @@ class lbann_comm {
   uint8_t *get_collective_buffer(size_t size, size_t idx = 0);
 
 };
+
+template <typename T, bool S>
+void lbann_comm::broadcast(int root, T& val, const El::mpi::Comm c) {
+  if (S) {
+    // Avoid linking error from uninstantiated El::mpi routine if !S by converting T to El::byte
+    using TT = typename interpret_as_byte_if_needed<S, T>::type;
+    broadcast_native<TT>(root, reinterpret_cast<TT&>(val), c);
+  } else {
+    broadcast_custom(root, val, c);
+  }
+  count_bytes_broadcast(sizeof(T), El::mpi::Rank(c), root);
 }
+
+template <typename T>
+void lbann_comm::broadcast_native(int root, T& val, const El::mpi::Comm c) const {
+  El::mpi::Broadcast(val, root, c);
+}
+
+template <typename T>
+void lbann_comm::broadcast_custom(int root, T& val, const El::mpi::Comm c) const {
+ const int bytes =  static_cast<int>(sizeof(T));
+ El::mpi::Broadcast<El::byte>(reinterpret_cast<El::byte*>(&val), bytes, root, c);
+}
+
+template <typename T, bool S>
+void lbann_comm::broadcast(const int root, T* data, const int count, const El::mpi::Comm c) {
+  const int size = static_cast<int>(S? count : sizeof(T)*count);
+  // Avoid linking error from uninstantiated El::mpi routine if !S by converting T to El::byte
+  using TT = typename interpret_as_byte_if_needed<S, T>::type;
+  El::mpi::Broadcast<TT>(reinterpret_cast<TT*>(data), size, root, c);
+  count_bytes_broadcast(sizeof(T)*count, El::mpi::Rank(c), root);
+}
+
+/// Broadcast std::string over an arbitrary communicator.
+template<>
+void lbann_comm::broadcast<std::string>(const int root, std::string& str, const El::mpi::Comm c);
+
+} // namespace lbann
 
 #endif  // LBANN_COMM_HPP_INCLUDED

--- a/include/lbann/detect_El_mpi.hpp
+++ b/include/lbann/detect_El_mpi.hpp
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// detect_El_mpi .hpp .cpp - detect the existence of the instantiations
+//               of the overloaded El::mpi wrappers for a data type
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_DETECT_EL_MPI_HPP_INCLUDED
+#define LBANN_DETECT_EL_MPI_HPP_INCLUDED
+
+#include "base.hpp"
+#include <type_traits>
+
+namespace lbann {
+
+template<typename... Ts>
+struct make_void {
+  using type = void;
+};
+
+/// Alternative to c++17 std::void_t for older compilers.
+template<typename... Ts>
+using void_t = typename make_void<Ts...>::type;
+
+
+/// By default, assume no instantiation for the type T in El::mpi.
+template<typename T, typename = void>
+struct is_instantiated_El_mpi_type : std::false_type {};
+
+/**
+ * Detect instantiated types in El::mpi. This should match the instantiations
+ * of El::mpi::Types<> in hydrogen/src/src/core/mpi_register.cpp.
+ */
+template<typename T>
+struct is_instantiated_El_mpi_type<
+         T,
+         void_t<typename std::enable_if< std::is_same<T, El::byte>::value ||
+                                         std::is_same<T, short>::value ||
+                                         std::is_same<T, int>::value ||
+                                         std::is_same<T, unsigned>::value ||
+                                         std::is_same<T, long int>::value ||
+                                         std::is_same<T, unsigned long>::value ||
+#ifdef EL_HAVE_MPI_LONG_LONG
+                                         std::is_same<T, long long int>::value ||
+                                         std::is_same<T, unsigned long long>::value ||
+#endif
+                                         std::is_same<T, float>::value ||
+                                         std::is_same<T, double>::value ||
+                                         std::is_same<T, El::Complex<float>>::value ||
+                                         std::is_same<T, El::Complex<double>>::value
+                                       >::type
+               >
+       >
+  : std::true_type {};
+
+
+/**
+ * Set to use El::byte as type except if the first template argument B is true
+ * and the second argument T is non-void, in which case the non-void type is used.
+ * The first template argument B should indicate if Elemental has instantiated
+ * MPI wrappers for the type T.
+ */
+template<bool B, class T = void>
+struct interpret_as_byte_if_needed {
+  using type = El::byte; 
+};
+
+/// Use type T as is if Elemental has instantiated MPI wrappers for type T.
+template<class T>
+struct interpret_as_byte_if_needed<true, T> {
+  using type = T;
+};
+
+/// For void pointers
+template<>
+struct interpret_as_byte_if_needed<true, void> {
+  using type = El::byte;
+};
+
+} // namespace lbann
+
+#endif // LBANN_DETECT_EL_MPI_HPP_INCLUDED

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -250,6 +250,13 @@ void lbann_comm::intermodel_broadcast_matrix(AbsDistMat& mat, int root) {
   El::Broadcast(mat, intermodel_comm, root);
 }
 
+template<>
+void lbann_comm::broadcast<std::string>(const int root, std::string& str, const El::mpi::Comm c) {
+  std::vector<char> data(str.begin(), str.end());
+  broadcast(root, data, c);
+  str.assign(data.begin(), data.end());
+}
+
 void lbann_comm::intermodel_barrier() {
   ++num_intermodel_barriers;
   barrier(intermodel_comm);


### PR DESCRIPTION
Clang compatible broadcast wrapper interfaces.
When an instantiation of El::mpi::Broadcast<T>() of a custom type T is not reachable in a conditional branch, clang compiler still instantiates it, and results in a linking error while looking for the implementation of the function not desired/intended to be instantiated.
gcc conveniently ignores such cases, but clang does not.
This PR addresses this by first checking if the Broadcast<T>() is supposed to be instantiated by El, and when it is not, change the type T in the conditional branches that are not reachable to the one that has been instantiated for.