### PR TITLE
Bugfixes for "Xavier" initializers

### DIFF
--- a/include/lbann/weights/fan_in_fan_out_initializers.hpp
+++ b/include/lbann/weights/fan_in_fan_out_initializers.hpp
@@ -124,7 +124,6 @@ class he_normal_initializer : public fan_in_fan_out_initializer {
 
 };
 
-
 /** He uniform initializer. */
 class he_uniform_initializer : public fan_in_fan_out_initializer {
  public:
@@ -138,6 +137,46 @@ class he_uniform_initializer : public fan_in_fan_out_initializer {
   /** Create a copy. */
   he_uniform_initializer* copy() const override {
     return new he_uniform_initializer(*this);
+  }
+  
+  /** Initialize weights matrix entries. */
+  void initialize_entries(AbsDistMat& weights_matrix) const override;
+
+};
+
+/** LeCun normal initializer. */
+class lecun_normal_initializer : public fan_in_fan_out_initializer {
+ public:
+
+  /** Constructor. */
+  lecun_normal_initializer(lbann_comm* comm) 
+    : fan_in_fan_out_initializer(comm) {}
+  /** Destructor. */
+  ~lecun_normal_initializer() override = default;
+
+  /** Create a copy. */
+  lecun_normal_initializer* copy() const override {
+    return new lecun_normal_initializer(*this);
+  }
+  
+  /** Initialize weights matrix entries. */
+  void initialize_entries(AbsDistMat& weights_matrix) const override;
+
+};
+
+/** LeCun uniform initializer. */
+class lecun_uniform_initializer : public fan_in_fan_out_initializer {
+ public:
+
+  /** Constructor. */
+  lecun_uniform_initializer(lbann_comm* comm) 
+    : fan_in_fan_out_initializer(comm) {}
+  /** Destructor. */
+  ~lecun_uniform_initializer() override = default;
+
+  /** Create a copy. */
+  lecun_uniform_initializer* copy() const override {
+    return new lecun_uniform_initializer(*this);
   }
   
   /** Initialize weights matrix entries. */

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -607,6 +607,8 @@ message Weights {
   GlorotUniformInitializer glorot_uniform_initializer = 24;
   HeNormalInitializer he_normal_initializer = 25;
   HeUniformInitializer he_uniform_initializer = 26;
+  LeCunNormalInitializer lecun_normal_initializer = 27;
+  LeCunUniformInitializer lecun_uniform_initializer = 28;
 
 }
 
@@ -626,6 +628,8 @@ message GlorotNormalInitializer {}
 message GlorotUniformInitializer {}
 message HeNormalInitializer {}
 message HeUniformInitializer {}
+message LeCunNormalInitializer {}
+message LeCunUniformInitializer {}
 
 //note: I'd like to put this enum inside of Layer, but if I do the enum values
 //      become, e.g, Layer_Imcomm_EXCLUDE, which is just ugly
@@ -945,7 +949,7 @@ message Uniform {
 /////////////////////
 message FullyConnected {
   int64 num_neurons = 1;
-  string weight_initialization = 2;
+  string weight_initialization = 2;    //DEPRECATED
   bool has_bias = 3;                   //default: true
   double bias_initial_value = 4;       //default: 0
   double l2_regularization_factor = 5; //default: 0
@@ -968,7 +972,7 @@ message Convolution {
   int64 conv_pads_i = 60;
   int64 conv_strides_i = 70;
 
-  string weight_initialization = 9;
+  string weight_initialization = 9;     //DEPRECATED
   bool has_bias = 10;                   //default: true
   double bias_initial_value = 11;       //default: 0
   double l2_regularization_factor = 12; //default: 0
@@ -990,7 +994,7 @@ message Deconvolution {
   int64 conv_pads_i = 60;
   int64 conv_strides_i = 70;
 
-  string weight_initialization = 9;
+  string weight_initialization = 9;     //DEPRECATED
   bool has_bias = 10;                   //default: true
   double bias_initial_value = 11;       //default: 0
   double l2_regularization_factor = 12; //default: 0

--- a/src/weights/fan_in_fan_out_initializers.cpp
+++ b/src/weights/fan_in_fan_out_initializers.cpp
@@ -95,4 +95,36 @@ void he_uniform_initializer::initialize_entries(AbsDistMat& weights_matrix) cons
                std::sqrt(3*variance));
 }
 
+void lecun_normal_initializer::initialize_entries(AbsDistMat& weights_matrix) const {
+  if (m_fan_in <= 0 || m_fan_out <= 0) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "invalid dimensions for LeCun normal initialization "
+        << "(fan_in=" << this->m_fan_in << ",fan_out=" << this->m_fan_out << ")";
+    throw lbann_exception(err.str());
+  }
+  const DataType variance = DataType(1) / m_fan_in;
+  gaussian_fill(weights_matrix,
+                weights_matrix.Height(),
+                weights_matrix.Width(),
+                DataType(0),
+                std::sqrt(variance));
+}
+
+void lecun_uniform_initializer::initialize_entries(AbsDistMat& weights_matrix) const {
+  if (m_fan_in <= 0 || m_fan_out <= 0) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "invalid dimensions for LeCun uniform initialization "
+        << "(fan_in=" << this->m_fan_in << ",fan_out=" << this->m_fan_out << ")";
+    throw lbann_exception(err.str());
+  }
+  const DataType variance = DataType(1) / m_fan_in;
+  uniform_fill(weights_matrix,
+               weights_matrix.Height(),
+               weights_matrix.Width(),
+               DataType(0),
+               std::sqrt(3*variance));
+}
+
 }  // namespace lbann

--- a/src/weights/fan_in_fan_out_initializers.cpp
+++ b/src/weights/fan_in_fan_out_initializers.cpp
@@ -56,11 +56,11 @@ void glorot_uniform_initializer::initialize_entries(AbsDistMat& weights_matrix) 
     throw lbann_exception(err.str());
   }
   const DataType variance = DataType(2) / (m_fan_in + m_fan_out);
-  gaussian_fill(weights_matrix,
-                weights_matrix.Height(),
-                weights_matrix.Width(),
-                DataType(0),
-                std::sqrt(3*variance));
+  uniform_fill(weights_matrix,
+               weights_matrix.Height(),
+               weights_matrix.Width(),
+               DataType(0),
+               std::sqrt(3*variance));
 }
 
 void he_normal_initializer::initialize_entries(AbsDistMat& weights_matrix) const {
@@ -71,7 +71,7 @@ void he_normal_initializer::initialize_entries(AbsDistMat& weights_matrix) const
         << "(fan_in=" << this->m_fan_in << ",fan_out=" << this->m_fan_out << ")";
     throw lbann_exception(err.str());
   }
-  const DataType variance = DataType(1) / m_fan_in;
+  const DataType variance = DataType(2) / m_fan_in;
   gaussian_fill(weights_matrix,
                 weights_matrix.Height(),
                 weights_matrix.Width(),
@@ -87,12 +87,12 @@ void he_uniform_initializer::initialize_entries(AbsDistMat& weights_matrix) cons
         << "(fan_in=" << this->m_fan_in << ",fan_out=" << this->m_fan_out << ")";
     throw lbann_exception(err.str());
   }
-  const DataType variance = DataType(1) / m_fan_in;
-  gaussian_fill(weights_matrix,
-                weights_matrix.Height(),
-                weights_matrix.Width(),
-                DataType(0),
-                std::sqrt(3*variance));
+  const DataType variance = DataType(2) / m_fan_in;
+  uniform_fill(weights_matrix,
+               weights_matrix.Height(),
+               weights_matrix.Width(),
+               DataType(0),
+               std::sqrt(3*variance));
 }
 
 }  // namespace lbann


### PR DESCRIPTION
Bugs:
- He initializer wasn't following the paper, but was using LeCun initialization instead.
- He uniform and Glorot uniform initializers weren't actually drawing from uniform distributions.

This PR also adds LeCun initialization. Note that Caffe's "xavier" weight filler is equivalent to a LeCun uniform initializer.
