### PR TITLE
Ensure CUDA v8.0 is used by default on Ray

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -542,7 +542,8 @@ if [ "${CLUSTER}" == "surface" ] || [ "${CLUSTER}" == "ray" ] ||
         . /usr/share/[mM]odules/init/bash		
 		CUDA_TOOLKIT_MODULE=cudatoolkit/9.1
 	elif [ "${CLUSTER}" == "ray" ]; then
-		CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
+		module del cuda		
+		CUDA_TOOLKIT_MODULE=${CUDA_TOOLKIT_MODULE:-cuda/8.0}
 	fi
 fi
 

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -572,7 +572,7 @@ if [ "${WITH_CUDA}" == "ON" ]; then
 
 	# CUDNN
 	if [ -z "${CUDNN_DIR}" ]; then
-		CUDNN_DIR=/usr/gapps/brain/cudnn/cudnn-7.1.1/cuda-${CUDA_TOOLKIT_VERSION}_${ARCH}
+		CUDNN_DIR=/usr/workspace/wsb/brain/cudnn/cudnn-7.1.1/cuda-${CUDA_TOOLKIT_VERSION}_${ARCH}
 	fi
 	if [ ! -d "${CUDNN_DIR}" ]; then
 		echo "Could not find cuDNN at $CUDNN_DIR"


### PR DESCRIPTION
Now that the default CUDA version is upgraded, so /usr/local/cuda is no longer CUDA 8. Since we still do not have the corresponding NCCL2, we can't use the path with NCCL enabled. This PR makes sure we use v8 by default. It can still be overridden with environment variables such as CUDA_TOOLKIT_MODULE.
