### PR TITLE
flexible JAG reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ if (LBANN_HAS_ALUMINUM)
 endif ()
 
 if (LBANN_HAS_CONDUIT)
-  target_link_libraries(lbann PUBLIC ${CONDUIT_LIBRARIES})
+  target_link_libraries(lbann PUBLIC CONDUIT::CONDUIT)
 endif ()
 
 #== FIXME HERE DOWN ==

--- a/include/lbann/data_readers/data_reader_jag.hpp
+++ b/include/lbann/data_readers/data_reader_jag.hpp
@@ -50,8 +50,9 @@ class data_reader_jag : public generic_data_reader {
    * - JAG_Image: simulation output images
    * - JAG_Scalar: simulation output scalars
    * - JAG_Input: simulation input parameters
+   * - Undefined: the default
    */
-  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input};
+  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input, Undefined};
 
   data_reader_jag(bool shuffle = true);
   // TODO: copy constructor and assignment operator for deep-copying if needed

--- a/include/lbann/data_readers/data_reader_jag.hpp
+++ b/include/lbann/data_readers/data_reader_jag.hpp
@@ -44,13 +44,14 @@ class data_reader_jag : public generic_data_reader {
   using data_t = double;
   using scalar_t = double;
   using input_t = double;
+
   /**
-   * Mode of modeling.
-   * - Inverse: image to input param
-   * - AutoI: image to image
-   * - AutoS: scalar to scalar  
+   * Dependent/indepdendent variable types
+   * - JAG_Image: simulation output images
+   * - JAG_Scalar: simulation output scalars
+   * - JAG_Input: simulation input parameters
    */
-  enum model_mode_t {Inverse, AutoI, AutoS};
+  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input};
 
   data_reader_jag(bool shuffle = true);
   // TODO: copy constructor and assignment operator for deep-copying if needed
@@ -64,8 +65,15 @@ class data_reader_jag : public generic_data_reader {
     return "data_reader_jag";
   }
 
-  /// Set the modeling mode: Inverse, AutoI, or AutoS
-  void set_model_mode(const model_mode_t mm);
+  /// Choose which data to use for independent variable
+  void set_independent_variable_type(const variable_t independent);
+  /// Choose which data to use for dependent variable
+  void set_dependent_variable_type(const variable_t dependent);
+
+  /// Tell which data to use for independent variable
+  variable_t get_independent_variable_type() const;
+  /// Tell which data to use for dependent variable
+  variable_t get_dependent_variable_type() const;
 
   /// Set normalization mode: 0 = none, 1 = dataset-wise, 2 = image-wise
   void set_normalization_mode(int mode);
@@ -145,8 +153,11 @@ class data_reader_jag : public generic_data_reader {
   data_t get_image_min() const;
 
  protected:
-  /// The current mode of modeling
-  model_mode_t m_model_mode;
+  /// independent variable type
+  variable_t m_independent;
+  /// dependent variable type
+  variable_t m_dependent;
+
   /// Whether image output data have been loaded
   bool m_image_loaded; 
   /// Whether scalar output data have been loaded

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -27,6 +27,8 @@
 #ifndef _DATA_READER_JAG_CONDUIT_HPP_
 #define _DATA_READER_JAG_CONDUIT_HPP_
 
+#include "lbann_config.hpp" // may define LBANN_HAS_CONDUIT
+
 #ifdef LBANN_HAS_CONDUIT
 #include "lbann/data_readers/opencv.hpp"
 #include "data_reader.hpp"
@@ -45,12 +47,13 @@ class data_reader_jag_conduit : public generic_data_reader {
   using input_t = double; ///< jag input parameter type
 
   /**
-   * Mode of modeling.
-   * - Inverse: image to input param
-   * - AutoI: image to image
-   * - AutoS: scalar to scalar  
+   * Dependent/indepdendent variable types
+   * - JAG_Image: simulation output images
+   * - JAG_Scalar: simulation output scalars
+   * - JAG_Input: simulation input parameters
+   * - Undefined: the default
    */
-  enum model_mode_t {Inverse, AutoI, AutoS};
+  enum variable_t {JAG_Image, JAG_Scalar, JAG_Input, Undefined};
 
   data_reader_jag_conduit(bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&) = default;
@@ -62,8 +65,15 @@ class data_reader_jag_conduit : public generic_data_reader {
     return "data_reader_jag_conduit";
   }
 
-  /// Set the modeling mode: Inverse, AutoI, or AutoS
-  void set_model_mode(const model_mode_t mm);
+  /// Choose which data to use for independent variable
+  void set_independent_variable_type(const variable_t independent);
+  /// Choose which data to use for dependent variable
+  void set_dependent_variable_type(const variable_t dependent);
+
+  /// Tell which data to use for independent variable
+  variable_t get_independent_variable_type() const;
+  /// Tell which data to use for dependent variable
+  variable_t get_dependent_variable_type() const;
 
   /// Set the image dimension
   void set_image_dims(const int width, const int height);
@@ -164,8 +174,10 @@ class data_reader_jag_conduit : public generic_data_reader {
   std::vector< std::pair<size_t, const ch_t*> > get_image_ptrs(const size_t i) const;
 
  protected:
-  /// The current mode of modeling
-  model_mode_t m_model_mode;
+  /// independent variable type
+  variable_t m_independent;
+  /// dependent variable type
+  variable_t m_dependent;
 
   /// The linearized size of an image
   size_t m_linearized_image_size;
@@ -174,9 +186,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   int m_image_width; ///< image width
   int m_image_height; ///< image height
 
-  /// keys to select a set of scalar simulation outputs to use
+  /// Keys to select a set of scalar simulation outputs to use. By default, use all.
   std::vector<std::string> m_scalar_keys;
-  /// keys to select a set of simulation input parameters to use
+  /// Keys to select a set of simulation input parameters to use. By default, use all.
   std::vector<std::string> m_input_keys;
 
   /// Whether data have been loaded

--- a/model_zoo/models/jag/data_reader_jag.prototext
+++ b/model_zoo/models/jag/data_reader_jag.prototext
@@ -9,8 +9,9 @@ data_reader {
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
 
-    # 0: Inverse,  1: AutoI,  2: AutoS
-    modeling_mode: 0
+    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
+    independent: 0
+    dependent: 2
 
     image_preprocessor {
       raw_width: 50
@@ -31,8 +32,9 @@ data_reader {
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
 
-    # 0: Inverse,  1: AutoI,  2: AutoS
-    modeling_mode: 0
+    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
+    independent: 0
+    dependent: 2
 
     image_preprocessor {
       raw_width: 50

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -38,7 +38,8 @@
 namespace lbann {
 
 data_reader_jag::data_reader_jag(bool shuffle)
-  : generic_data_reader(shuffle), m_model_mode(Inverse),
+  : generic_data_reader(shuffle),
+    m_independent(JAG_Image), m_dependent(JAG_Input),
     m_image_loaded(false), m_scalar_loaded(false),
     m_input_loaded(false), m_num_samples(0u),
     m_linearized_image_size(0u),
@@ -54,12 +55,30 @@ data_reader_jag::data_reader_jag(bool shuffle)
 data_reader_jag::~data_reader_jag() {
 }
 
-void data_reader_jag::set_model_mode(const model_mode_t mm) {
-  if (static_cast<int>(AutoS) < static_cast<int>(mm)) {
+void data_reader_jag::set_independent_variable_type(
+  const data_reader_jag::variable_t independent) {
+  if (!(independent == JAG_Image || independent == JAG_Scalar || independent == JAG_Input)) {
     throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: unrecognized mode " + std::to_string(static_cast<int>(mm)));
+      " :: unrecognized variable type " + std::to_string(static_cast<int>(independent)));
   }
-  m_model_mode = mm;
+  m_independent = independent;
+}
+
+void data_reader_jag::set_dependent_variable_type(
+  const data_reader_jag::variable_t dependent) {
+  if (!(dependent == JAG_Image || dependent == JAG_Scalar || dependent == JAG_Input)) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
+      " :: unrecognized variable type " + std::to_string(static_cast<int>(dependent)));
+  }
+  m_dependent = dependent;
+}
+
+data_reader_jag::variable_t data_reader_jag::get_independent_variable_type() const {
+  return m_independent;
+}
+
+data_reader_jag::variable_t data_reader_jag::get_dependent_variable_type() const {
+  return m_dependent;
 }
 
 void data_reader_jag::set_normalization_mode(int mode) {
@@ -142,46 +161,46 @@ void data_reader_jag::set_linearized_input_size() {
 }
 
 int data_reader_jag::get_linearized_data_size() const {
-  switch (m_model_mode) {
-    case Inverse:
+  switch (m_independent) {
+    case JAG_Image:
       return static_cast<int>(m_linearized_image_size);
-    case AutoI:
-      return static_cast<int>(m_linearized_image_size);
-    case AutoS:
+    case JAG_Scalar:
       return static_cast<int>(m_linearized_scalar_size);
+    case JAG_Input:
+      return static_cast<int>(m_linearized_input_size);
     default: {
-      throw lbann_exception("data_reader_jag::get_linearized_data_size() : unknown mode");
+      throw lbann_exception("data_reader_jag::get_linearized_data_size() : unknown variable type");
     }
   }
   return 0;
 }
 
 int data_reader_jag::get_linearized_response_size() const {
-  switch (m_model_mode) {
-    case Inverse:
-      return static_cast<int>(m_linearized_input_size);
-    case AutoI:
+  switch (m_dependent) {
+    case JAG_Image:
       return static_cast<int>(m_linearized_image_size);
-    case AutoS:
+    case JAG_Scalar:
       return static_cast<int>(m_linearized_scalar_size);
+    case JAG_Input:
+      return static_cast<int>(m_linearized_input_size);
     default: {
-      throw lbann_exception("data_reader_jag::get_linearized_response_size() : unknown mode");
+      throw lbann_exception("data_reader_jag::get_linearized_response_size() : unknown variable type");
     }
   }
   return 0;
 }
 
 const std::vector<int> data_reader_jag::get_data_dims() const {
-  switch (m_model_mode) {
-    case Inverse:
+  switch (m_independent) {
+    case JAG_Image:
       return {1, m_image_height, m_image_width};
       //return {static_cast<int>(m_linearized_image_size)};
-    case AutoI:
-      return {static_cast<int>(m_linearized_image_size)};
-    case AutoS:
+    case JAG_Scalar:
       return {static_cast<int>(m_linearized_scalar_size)};
+    case JAG_Input:
+      return {static_cast<int>(m_linearized_input_size)};
     default: {
-      throw lbann_exception("data_reader_jag::get_data_dims() : unknown mode");
+      throw lbann_exception("data_reader_jag::get_data_dims() : unknown variable type");
     }
   }
   return {};
@@ -228,15 +247,15 @@ void data_reader_jag::load(const std::string image_file,
             const std::string scalar_file,
             const std::string input_file,
             const size_t first_n) {
-  if ((m_model_mode == Inverse || m_model_mode == AutoI) &&
+  if ((m_independent == JAG_Image || m_dependent == JAG_Image) &&
       !image_file.empty() && !check_if_file_exists(image_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + image_file);
   }
-  if ((m_model_mode == AutoS) &&
+  if ((m_independent == JAG_Scalar || m_dependent == JAG_Scalar) &&
       !scalar_file.empty() && !check_if_file_exists(scalar_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + scalar_file);
   }
-  if ((m_model_mode == Inverse) &&
+  if ((m_independent == JAG_Input || m_dependent == JAG_Input) &&
       !input_file.empty() && !check_if_file_exists(input_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + input_file);
   }
@@ -245,7 +264,8 @@ void data_reader_jag::load(const std::string image_file,
   m_num_samples = 0u;
 
   // read in only those that will be used
-  if ((m_model_mode == Inverse || m_model_mode == AutoI) && !image_file.empty()) {
+  if ((m_independent == JAG_Image || m_dependent == JAG_Image) &&
+      !image_file.empty()) {
     m_images  = cnpy::npy_load(image_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_images, first_n);
@@ -253,7 +273,8 @@ void data_reader_jag::load(const std::string image_file,
     m_image_loaded = true;
     set_linearized_image_size();
   }
-  if ((m_model_mode == AutoS) && !scalar_file.empty()) {
+  if ((m_independent == JAG_Scalar || m_dependent == JAG_Scalar) &&
+      !scalar_file.empty()) {
     m_scalars = cnpy::npy_load(scalar_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_scalars, first_n);
@@ -261,7 +282,8 @@ void data_reader_jag::load(const std::string image_file,
     m_scalar_loaded = true;
     set_linearized_scalar_size();
   }
-  if ((m_model_mode == Inverse) && !input_file.empty()) {
+  if ((m_independent == JAG_Input || m_dependent == JAG_Input) &&
+      !input_file.empty()) {
     m_inputs  = cnpy::npy_load(input_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_inputs, first_n);
@@ -336,18 +358,14 @@ bool data_reader_jag::check_data(size_t& num_samples) const {
   if (!ok) {
     num_samples = 0u;
   } else {
-    switch (m_model_mode) {
-      case Inverse:
-        ok = m_image_loaded && m_input_loaded;
-        break;
-      case AutoI:
-        ok = m_image_loaded;
-        break;
-      case AutoS:
-        ok = m_scalar_loaded;
-        break;
-      default:
-        throw lbann_exception("data_reader_jag::check_data() : unknown mode");
+    if (m_independent == JAG_Image || m_dependent == JAG_Image) {
+      ok = ok && m_image_loaded;
+    }
+    if (m_independent == JAG_Scalar || m_dependent == JAG_Scalar) {
+      ok = ok && m_scalar_loaded;
+    }
+    if (m_independent == JAG_Input || m_dependent == JAG_Input) {
+      ok = ok && m_input_loaded;
     }
   }
 
@@ -359,7 +377,8 @@ std::string data_reader_jag::get_description() const {
   using std::string;
   using std::to_string;
   string ret = string("data_reader_jag:\n")
-    + " - mode: " + to_string(static_cast<int>(m_model_mode)) + "\n"
+    + " - independent: " + to_string(static_cast<int>(m_independent)) + "\n"
+    + " - dependent: " + to_string(static_cast<int>(m_dependent)) + "\n"
     + " - images: "   + cnpy_utils::show_shape(m_images) + "\n"
     + " - scalars: "  + cnpy_utils::show_shape(m_scalars) + "\n"
     + " - inputs: "   + cnpy_utils::show_shape(m_inputs) + "\n";
@@ -478,48 +497,48 @@ std::vector<DataType> data_reader_jag::get_input(const size_t i) const {
 
 
 bool data_reader_jag::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
-  switch (m_model_mode) {
-    case Inverse: {
+  switch (m_independent) {
+    case JAG_Image: {
       const data_t* ptr = get_image_ptr(data_id);
       set_minibatch_item<data_t>(X, mb_idx, ptr, m_linearized_image_size);
       break;
     }
-    case AutoI: {
-      const data_t* ptr = get_image_ptr(data_id);
-      set_minibatch_item<data_t>(X, mb_idx, ptr, m_linearized_image_size);
-      break;
-    }
-    case AutoS: {
+    case JAG_Scalar: {
       const scalar_t* ptr = get_scalar_ptr(data_id);
       set_minibatch_item<scalar_t>(X, mb_idx, ptr, m_linearized_scalar_size);
       break;
     }
+    case JAG_Input: {
+      const input_t* ptr = get_input_ptr(data_id);
+      set_minibatch_item<input_t>(X, mb_idx, ptr, m_linearized_input_size);
+      break;
+    }
     default: {
-      throw lbann_exception("data_reader_jag::fetch_datum() : unknown mode");
+      throw lbann_exception("data_reader_jag::fetch_datum() : unknown variable type");
     }
   }
   return true;
 }
 
 bool data_reader_jag::fetch_response(Mat& Y, int data_id, int mb_idx, int tid) {
-  switch (m_model_mode) {
-    case Inverse: {
-      const input_t* ptr = get_input_ptr(data_id);
-      set_minibatch_item<input_t>(Y, mb_idx, ptr, m_linearized_input_size);
-      break;
-    }
-    case AutoI: {
+  switch (m_dependent) {
+    case JAG_Image: {
       const data_t* ptr = get_image_ptr(data_id);
       set_minibatch_item<data_t>(Y, mb_idx, ptr, m_linearized_image_size);
       break;
     }
-    case AutoS: {
+    case JAG_Scalar: {
       const scalar_t* ptr = get_scalar_ptr(data_id);
       set_minibatch_item<scalar_t>(Y, mb_idx, ptr, m_linearized_scalar_size);
       break;
     }
+    case JAG_Input: {
+      const input_t* ptr = get_input_ptr(data_id);
+      set_minibatch_item<input_t>(Y, mb_idx, ptr, m_linearized_input_size);
+      break;
+    }
     default: {
-      throw lbann_exception("data_reader_jag::fetch_response() : unknown mode");
+      throw lbann_exception("data_reader_jag::fetch_response() : unknown variable type");
     }
   }
   return true;

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -25,14 +25,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifdef LBANN_HAS_CONDUIT
 #ifndef _JAG_OFFLINE_TOOL_MODE_
-#include "lbann/utils/file_utils.hpp"
 #include "lbann/data_readers/data_reader_jag_conduit.hpp"
+#include "lbann/utils/file_utils.hpp" // for add_delimiter() in load()
 #else
 #include "data_reader_jag_conduit.hpp"
 #endif // _JAG_OFFLINE_TOOL_MODE_
 
+#ifdef LBANN_HAS_CONDUIT
 #include "lbann/data_readers/opencv_extensions.hpp"
 #include <limits>     // numeric_limits
 #include <algorithm>  // max_element
@@ -42,11 +42,19 @@
 #include <set>
 #include <map>
 
+
 // This macro may be moved to a global scope
 #define _THROW_LBANN_EXCEPTION_(_CLASS_NAME_,_MSG_) { \
   std::stringstream err; \
   err << __FILE__ << ' '  << __LINE__ << " :: " \
-      << _CLASS_NAME_ << "::" << _MSG_; \
+      << (_CLASS_NAME_) << "::" << (_MSG_); \
+  throw lbann_exception(err.str()); \
+}
+
+#define _THROW_LBANN_EXCEPTION2_(_CLASS_NAME_,_MSG1_,_MSG2_) { \
+  std::stringstream err; \
+  err << __FILE__ << ' '  << __LINE__ << " :: " \
+      << (_CLASS_NAME_) << "::" << (_MSG1_) << (_MSG2_); \
   throw lbann_exception(err.str()); \
 }
 
@@ -57,7 +65,8 @@
 namespace lbann {
 
 data_reader_jag_conduit::data_reader_jag_conduit(bool shuffle)
-  : generic_data_reader(shuffle), m_model_mode(Inverse),
+  : generic_data_reader(shuffle),
+    m_independent(Undefined), m_dependent(Undefined),
     m_linearized_image_size(0u),
     m_num_views(2u),
     m_image_width(0u), m_image_height(0u),
@@ -74,12 +83,32 @@ const conduit::Node& data_reader_jag_conduit::get_conduit_node(const std::string
 }
 
 
-void data_reader_jag_conduit::set_model_mode(const model_mode_t mm) {
-  if (static_cast<int>(AutoS) < static_cast<int>(mm)) {
-    _THROW_LBANN_EXCEPTION_(_CN_, "set_model_mode() : unrecognized mode " \
-                     + std::to_string(static_cast<int>(mm)));
+void data_reader_jag_conduit::set_independent_variable_type(
+  const data_reader_jag_conduit::variable_t independent) {
+  if (!(independent == JAG_Image || independent == JAG_Scalar ||
+        independent == JAG_Input || independent == Undefined)) {
+    _THROW_LBANN_EXCEPTION_(_CN_, "unrecognized independent variable type ");
   }
-  m_model_mode = mm;
+  m_independent = independent;
+}
+
+void data_reader_jag_conduit::set_dependent_variable_type(
+  const data_reader_jag_conduit::variable_t dependent) {
+  if (!(dependent == JAG_Image || dependent == JAG_Scalar ||
+        dependent == JAG_Input || dependent == Undefined)) {
+    _THROW_LBANN_EXCEPTION_(_CN_, "unrecognized dependent variable type ");
+  }
+  m_dependent = dependent;
+}
+
+data_reader_jag_conduit::variable_t
+data_reader_jag_conduit::get_independent_variable_type() const {
+  return m_independent;
+}
+
+data_reader_jag_conduit::variable_t
+data_reader_jag_conduit::get_dependent_variable_type() const {
+  return m_dependent;
 }
 
 void data_reader_jag_conduit::set_image_dims(const int width, const int height) {
@@ -91,8 +120,19 @@ void data_reader_jag_conduit::set_image_dims(const int width, const int height) 
   }
 }
 
+/**
+ * To use no key, set 'Undefined' to the corresponding variable type,
+ * or call this with an empty vector argument after loading data.
+ */
 void data_reader_jag_conduit::set_scalar_choices(const std::vector<std::string>& keys) {
   m_scalar_keys = keys;
+  // If this call is made after loading data, check the keys
+  if (m_is_data_loaded) {
+    check_scalar_keys();
+  } else if (keys.empty()) {
+    _THROW_LBANN_EXCEPTION2_(_CN_, "set_scalar_choices() : ", \
+                                   "empty keys not allowed before data loading");
+  }
 }
 
 void data_reader_jag_conduit::set_all_scalar_choices() {
@@ -113,8 +153,19 @@ const std::vector<std::string>& data_reader_jag_conduit::get_scalar_choices() co
 }
 
 
+/**
+ * To use no key, set 'Undefined' to the corresponding variable type,
+ * or call this with an empty vector argument after loading data.
+ */
 void data_reader_jag_conduit::set_input_choices(const std::vector<std::string>& keys) {
   m_input_keys = keys;
+  // If this call is made after loading data, check the keys
+  if (m_is_data_loaded) {
+    check_input_keys();
+  } else if (keys.empty()) {
+    _THROW_LBANN_EXCEPTION2_(_CN_, "set_input_choices() : ", \
+                                   "empty keys not allowed before data loading");
+  }
 }
 
 void data_reader_jag_conduit::set_all_input_choices() {
@@ -287,8 +338,18 @@ void data_reader_jag_conduit::load_conduit(const std::string conduit_file_path) 
   set_num_views();
   set_linearized_image_size();
   check_image_size();
-  check_scalar_keys();
-  check_input_keys();
+
+  if (!m_is_data_loaded) {
+    if (m_scalar_keys.size() == 0u) {
+      set_all_scalar_choices(); // use all by default if none is specified
+    }
+    check_scalar_keys();
+
+    if (m_input_keys.size() == 0u) {
+      set_all_input_choices(); // use all by default if none is specified
+    }
+    check_input_keys();
+  }
 
   m_is_data_loaded = true;
 }
@@ -316,46 +377,49 @@ size_t data_reader_jag_conduit::get_linearized_input_size() const {
 
 
 int data_reader_jag_conduit::get_linearized_data_size() const {
-  switch (m_model_mode) {
-    case Inverse:
+  switch (m_independent) {
+    case JAG_Image:
       return static_cast<int>(get_linearized_image_size());
-    case AutoI:
-      return static_cast<int>(get_linearized_image_size());
-    case AutoS:
+    case JAG_Scalar:
       return static_cast<int>(get_linearized_scalar_size());
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_linearized_data_size() : unknown mode");
+    case JAG_Input:
+      return static_cast<int>(get_linearized_input_size());
+    default: { // includes Unefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_linearized_data_size() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return 0;
 }
 
 int data_reader_jag_conduit::get_linearized_response_size() const {
-  switch (m_model_mode) {
-    case Inverse:
-      return static_cast<int>(get_linearized_input_size());
-    case AutoI:
+  switch (m_dependent) {
+    case JAG_Image:
       return static_cast<int>(get_linearized_image_size());
-    case AutoS:
+    case JAG_Scalar:
       return static_cast<int>(get_linearized_scalar_size());
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_linearized_response_size() : unknown mode");
+    case JAG_Input:
+      return static_cast<int>(get_linearized_input_size());
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_linearized_response_size() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return 0;
 }
 
 const std::vector<int> data_reader_jag_conduit::get_data_dims() const {
-  switch (m_model_mode) {
-    case Inverse:
-      return {static_cast<int>(m_num_views), m_image_height, m_image_width};
+  switch (m_independent) {
+    case JAG_Image:
+      return {static_cast<int>(get_num_views()), m_image_height, m_image_width};
       //return {static_cast<int>(get_linearized_image_size())};
-    case AutoI:
-      return {static_cast<int>(get_linearized_image_size())};
-    case AutoS:
+    case JAG_Scalar:
       return {static_cast<int>(get_linearized_scalar_size())};
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "get_data_dims() : unknown mode");
+    case JAG_Input:
+      return {static_cast<int>(get_linearized_input_size())};
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION2_(_CN_, "get_data_dims() : ", \
+                                     "unknown or undefined variable type");
     }
   }
   return {};
@@ -366,7 +430,8 @@ std::string data_reader_jag_conduit::get_description() const {
   using std::string;
   using std::to_string;
   string ret = string("data_reader_jag_conduit:\n")
-    + " - mode: " + to_string(static_cast<int>(m_model_mode)) + "\n"
+    + " - independent: " + to_string(static_cast<int>(m_independent)) + "\n"
+    + " - dependent: " + to_string(static_cast<int>(m_dependent)) + "\n"
     + " - images: "   + to_string(m_num_views) + 'x'
                       + to_string(m_image_width) + 'x'
                       + to_string(m_image_height) + "\n"
@@ -513,48 +578,50 @@ int data_reader_jag_conduit::check_exp_success(const size_t sample_id) const {
 
 
 bool data_reader_jag_conduit::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
-  switch (m_model_mode) {
-    case Inverse: {
+  switch (m_independent) {
+    case JAG_Image: {
+      // TODO: use get_image_ptrs() and views of matrix X to avoid data copying
       const std::vector<ch_t> images(get_images(data_id));
       set_minibatch_item<ch_t>(X, mb_idx, images.data(), get_linearized_image_size());
       break;
     }
-    case AutoI: {
-      const std::vector<ch_t> images(get_images(data_id));
-      set_minibatch_item<ch_t>(X, mb_idx, images.data(), get_linearized_image_size());
-      break;
-    }
-    case AutoS: {
+    case JAG_Scalar: {
       const std::vector<scalar_t> scalars(get_scalars(data_id));
       set_minibatch_item<scalar_t>(X, mb_idx, scalars.data(), get_linearized_scalar_size());
       break;
     }
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_datum() : unknown mode");
+    case JAG_Input: {
+      const std::vector<input_t> inputs(get_inputs(data_id));
+      set_minibatch_item<input_t>(X, mb_idx, inputs.data(), get_linearized_input_size());
+      break;
+    }
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_datum() : unknown or undefined variable type");
     }
   }
   return true;
 }
 
 bool data_reader_jag_conduit::fetch_response(Mat& Y, int data_id, int mb_idx, int tid) {
-  switch (m_model_mode) {
-    case Inverse: {
-      const std::vector<input_t> inputs(get_inputs(data_id));
-      set_minibatch_item<input_t>(Y, mb_idx, inputs.data(), get_linearized_input_size());
-      break;
-    }
-    case AutoI: {
+  switch (m_dependent) {
+    case JAG_Image: {
+      // TODO: use get_image_ptrs() and views of matrix Y to avoid data copying
       const std::vector<ch_t> images(get_images(data_id));
       set_minibatch_item<ch_t>(Y, mb_idx, images.data(), get_linearized_image_size());
       break;
     }
-    case AutoS: {
+    case JAG_Scalar: {
       const std::vector<scalar_t> scalars(get_scalars(data_id));
       set_minibatch_item<scalar_t>(Y, mb_idx, scalars.data(), get_linearized_scalar_size());
       break;
     }
-    default: {
-      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_response() : unknown mode");
+    case JAG_Input: {
+      const std::vector<input_t> inputs(get_inputs(data_id));
+      set_minibatch_item<input_t>(Y, mb_idx, inputs.data(), get_linearized_input_size());
+      break;
+    }
+    default: { // includes Undefined case
+      _THROW_LBANN_EXCEPTION_(_CN_, "fetch_response() : unknown or undefined variable type");
     }
   }
   return true;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -32,7 +32,8 @@ message Reader {
   bool gan_labelling = 201;
   int32 gan_label_value = 202;
   ImagePreprocessor image_preprocessor = 13;
-  int32 modeling_mode = 98; // only for jag
+  int32 independent = 97; // only for jag
+  int32 dependent = 98; // only for jag
   int32 num_labels = 99; //for imagenet
   int64 num_samples = 100; //only for synthetic
   int64 num_features = 101; //only for synthetic

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -78,6 +78,20 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       reader_jag->set_normalization_mode(pb_preproc.early_normalization());
       reader = reader_jag;
       set_up_generic_preprocessor = false;
+#ifdef LBANN_HAS_CONDUIT
+    } else if (name == "jag_conduit") {
+      auto* reader_jag = new data_reader_jag_conduit(shuffle);
+      const data_reader_jag_conduit::variable_t independent_type
+             = static_cast<data_reader_jag_conduit::variable_t>(readme.independent());
+      reader_jag->set_independent_variable_type(independent_type);
+      const data_reader_jag_conduit::variable_t dependent_type
+             = static_cast<data_reader_jag_conduit::variable_t>(readme.dependent());
+      reader_jag->set_dependent_variable_type(dependent_type);
+      const lbann_data::ImagePreprocessor& pb_preproc = readme.image_preprocessor();
+      reader_jag->set_image_dims(pb_preproc.raw_width(), pb_preproc.raw_height());
+      reader = reader_jag;
+      set_up_generic_preprocessor = false;
+#endif // LBANN_HAS_CONDUIT
     } else if (name == "nci") {
       reader = new data_reader_nci(shuffle);
     } else if (name == "csv") {

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -67,7 +67,12 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       set_up_generic_preprocessor = false;
     } else if (name == "jag") {
       auto* reader_jag = new data_reader_jag(shuffle);
-      reader_jag->set_model_mode(static_cast<data_reader_jag::model_mode_t>(readme.modeling_mode()));
+      const data_reader_jag::variable_t independent_type
+             = static_cast<data_reader_jag::variable_t>(readme.independent());
+      reader_jag->set_independent_variable_type(independent_type);
+      const data_reader_jag::variable_t dependent_type
+             = static_cast<data_reader_jag::variable_t>(readme.dependent());
+      reader_jag->set_dependent_variable_type(dependent_type);
       const lbann_data::ImagePreprocessor& pb_preproc = readme.image_preprocessor();
       reader_jag->set_image_dims(pb_preproc.raw_width(), pb_preproc.raw_height());
       reader_jag->set_normalization_mode(pb_preproc.early_normalization());


### PR DESCRIPTION
Make the JAG data reader more flexible to accommodate new modeling modes such as Cycle GAN.
Instead of requiring the modeling mode to choose independent/dependent variable types, allow users to directly specify the types.
