### PR TITLE
Bamboo updates

### DIFF
--- a/bamboo/clean.sh
+++ b/bamboo/clean.sh
@@ -4,24 +4,24 @@
 LBANN_DIR=$(git rev-parse --show-toplevel)
 
 # Compiler Tests
-rm ${LBANN_DIR}/bamboo/compiler_tests/*.pyc
-rm -r ${LBANN_DIR}/bamboo/compiler_tests/__pycache__
-rm -r ${LBANN_DIR}/bamboo/compiler_tests/builds/*_debug
-rm -r ${LBANN_DIR}/bamboo/compiler_tests/builds/*_rel
-rm ${LBANN_DIR}/bamboo/compiler_tests/error/*.txt
-rm ${LBANN_DIR}/bamboo/compiler_tests/output/*.txt
+rm -f ${LBANN_DIR}/bamboo/compiler_tests/*.pyc
+rm -rf ${LBANN_DIR}/bamboo/compiler_tests/__pycache__
+rm -rf ${LBANN_DIR}/bamboo/compiler_tests/builds/*_debug
+rm -rf ${LBANN_DIR}/bamboo/compiler_tests/builds/*_rel
+rm -f ${LBANN_DIR}/bamboo/compiler_tests/error/*.txt
+rm -f ${LBANN_DIR}/bamboo/compiler_tests/output/*.txt
 
 # Integration Tests
-rm ${LBANN_DIR}/bamboo/integration_tests/*.pgm
-rm ${LBANN_DIR}/bamboo/integration_tests/*.prototext*
-rm ${LBANN_DIR}/bamboo/integration_tests/*.pyc
-rm -r ${LBANN_DIR}/bamboo/integration_tests/__pycache__
-rm ${LBANN_DIR}/bamboo/integration_tests/*.tfevents.*
-rm ${LBANN_DIR}/bamboo/integration_tests/error/*.txt
-rm ${LBANN_DIR}/bamboo/integration_tests/output/*.txt
+rm -f ${LBANN_DIR}/bamboo/integration_tests/*.pgm
+rm -f ${LBANN_DIR}/bamboo/integration_tests/*.prototext*
+rm -f ${LBANN_DIR}/bamboo/integration_tests/*.pyc
+rm -rf ${LBANN_DIR}/bamboo/integration_tests/__pycache__
+rm -f ${LBANN_DIR}/bamboo/integration_tests/*.tfevents.*
+rm -f ${LBANN_DIR}/bamboo/integration_tests/error/*.txt
+rm -f ${LBANN_DIR}/bamboo/integration_tests/output/*.txt
 
 # Unit Tests
-rm ${LBANN_DIR}/bamboo/unit_tests/*.prototext*
-rm ${LBANN_DIR}/bamboo/unit_tests/*.pyc
-rm -r ${LBANN_DIR}/bamboo/unit_tests/__pycache__
-rm ${LBANN_DIR}/bamboo/unit_tests/*.tfevents.*
+rm -f ${LBANN_DIR}/bamboo/unit_tests/*.prototext*
+rm -f ${LBANN_DIR}/bamboo/unit_tests/*.pyc
+rm -rf ${LBANN_DIR}/bamboo/unit_tests/__pycache__
+rm -f ${LBANN_DIR}/bamboo/unit_tests/*.tfevents.*

--- a/bamboo/common_python/test_tools.py
+++ b/bamboo/common_python/test_tools.py
@@ -9,6 +9,16 @@ def test_command_catalyst():
     expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
+def test_command_pascal():
+    actual = tools.get_command(cluster='pascal', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
+    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
+    assert actual == expected
+
+def test_command_quartz():
+    actual = tools.get_command(cluster='quartz', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
+    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
+    assert actual == expected
+    
 def test_command_surface():
     actual = tools.get_command(cluster='surface', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_ray='filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existance=False)
     expected = 'salloc --nodes=20 --partition=pbatch --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -38,7 +38,7 @@ def get_command(cluster, executable, num_nodes=None, partition=None,
             raise Exception('Executable does not exist: %s' % executable)
 
     # Determine scheduler
-    if cluster in ['catalyst', 'surface']:
+    if cluster in ['catalyst', 'pascal', 'quartz', 'surface']:
         scheduler = 'slurm'
     elif cluster == 'ray':
         scheduler = 'lsf'

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -40,14 +40,14 @@ def test_compiler_intel18_debug(cluster, dirname):
     skeleton_intel18(cluster, dirname, True)
 
 def skeleton_clang4(cluster, dir_name, debug, should_log=False):
-    if cluster == 'catalyst':
+    if cluster in ['catalyst', 'pascal', 'quartz']:
         spack_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
         build_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'ray']:
+    if cluster in ['catalyst', 'pascal', 'quartz', 'ray']:
         if cluster == 'catalyst':
             mpi = 'mvapich2@2.2'
         elif cluster == 'ray':
@@ -60,14 +60,14 @@ def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
-    if cluster == 'catalyst':
+    if cluster in ['catalyst', 'pascal', 'quartz']:
         spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
         build_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_intel18(cluster, dir_name, debug, should_log=False):
-    if cluster == 'catalyst':
+    if cluster in ['catalyst', 'pascal', 'quartz']:
         spack_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
         build_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
     else:

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -5,7 +5,7 @@ def pytest_addoption(parser):
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
-    if cluster == 'catalyst':
+    if cluster in ['catalyst', 'quartz']:
         default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
@@ -15,6 +15,17 @@ def pytest_addoption(parser):
         default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+
+    if cluster == 'pascal':
+        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'ray':
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-10.1.0_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -5,11 +5,17 @@ def pytest_addoption(parser):
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
-    if cluster == 'catalyst':
+    if cluster in ['catalyst', 'quartz']:
         default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+    if cluster == 'pascal':
+        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'ray':
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-10.1.0_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)

--- a/scripts/spack_recipes/build_lbann.sh
+++ b/scripts/spack_recipes/build_lbann.sh
@@ -95,7 +95,7 @@ ARCH=`uname -m`
 
 PLATFORM=
 FEATURE=
-if [ "${GPU}" == "1" -o "${CLUSTER}" == "surface" -o "${CLUSTER}" == "ray" ]; then
+if [ "${GPU}" == "1" -o "${CLUSTER}" == "surface" -o "${CLUSTER}" == "ray" -o "${CLUSTER}" == "pascal" ]; then
   if [ "${CLUSTER}" == "flash" ]; then
     PLATFORM="+gpu ^cuda@7.5 ^cudnn@5.1"
     FEATURE="_gpu_cuda-7.5_cudnn-5.1"
@@ -234,6 +234,6 @@ if [ ! -z ${PATH_TO_SRC} -a -d ${PATH_TO_SRC}/src ]; then
 fi
 
 # Deal with the fact that spack should not install a package when doing setup"
-FIX="spack uninstall -y lbann %${COMPILER}"
+FIX="spack uninstall -y lbann %${COMPILER} build_type=${BUILD_TYPE}"
 echo $FIX
 eval $FIX


### PR DESCRIPTION
Bamboo updates

- Add `-f` flag in `clean.sh` to suppress warnings of removing files that don't exist.
- Add Pascal and Quartz tests to `test_tools.py`.
- Add Pascal and Quartz to `tools.py`, `test_compiler.py`, `integration_tests/conftest.py`, and `unit_tests/conftest.py`.
- Add Pascal to `build_lbann.sh`.
- Fix compiler error (not knowing whether to install release or debug version) by adding `build_type` specifier in `build_lbann.sh`.

Not part of this pull request:
- Adding support for Quartz data file paths (which are different than Catalyst data file paths).