### PR TITLE
More Bamboo Updates

### DIFF
--- a/bamboo/README.md
+++ b/bamboo/README.md
@@ -35,7 +35,7 @@ Unlike Nightly Develop, the individual plans are triggered to run by polling you
 
 ## Navigating Bamboo
 
-From the [list of build projects](https://lc.llnl.gov/bamboo/browse/LBANN "https://lc.llnl.gov/bamboo/browse/LBANN"), click on a build project. From there, click on a build (builds are listed under "Recent History" and can also be accessed from the pass/fail marks in the top right, to the left of the "Run" button). This will bring you to a certain build's page. The most relevant tabs are "Tests" and "Logs". It is recommended to look at failures first in the "Tests" tab, as the build logs can be difficult to parse through. The build's "Tests" tab shows "New test failures", "Existing test failures", "Fixed tests", and "Skipped Tests".
+From the [LBANN Project Summary](https://lc.llnl.gov/bamboo/browse/LBANN "https://lc.llnl.gov/bamboo/browse/LBANN"), click on a build project. From there, click on a build (builds are listed under "Recent History" and can also be accessed from the pass/fail marks in the top right, to the left of the "Run" button). This will bring you to a certain build's page. The most relevant tabs are "Tests" and "Logs". It is recommended to look at failures first in the "Tests" tab, as the build logs can be difficult to parse through. The build's "Tests" tab shows "New test failures", "Existing test failures", "Fixed tests", and "Skipped Tests".
 
 From the build's page, you can also click on individual	jobs, which have the same tabs. The "Tests" tabs of the individual jobs have two sub-tabs, "Failed tests" and "Successful tests". They do not display skipped tests. The Bamboo agent that ran the job can be found by looking at the "Agent" field under the "Job Summary" tab. Alternatively, you can determine the agent from one of the first lines in the build logs: `Build working directory is /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>`.
 
@@ -73,7 +73,7 @@ Currently, it is not possible to run a test with a different executable. We plan
 
 First, run `sudo lbannusr`.
 
-To look at output and error from previous builds: `cd /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>/bamboo/<compiler_tests or integration_tests>/<error or output>`
+To look at output and error from previous builds: `cd /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>/bamboo/<compiler_tests, integration_tests, or unit_tests>/<error or output>`
 
 To look at archived results from previous builds: `cd /usr/workspace/wsb/lbannusr/archives/<build-plan>`
 

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -48,7 +48,7 @@ def skeleton_clang4(cluster, dir_name, debug, should_log=False):
 
 def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
     if cluster in ['catalyst', 'pascal', 'quartz', 'ray']:
-        if cluster == 'catalyst':
+        if cluster in ['catalyst', 'pascal', 'quartz']:
             mpi = 'mvapich2@2.2'
         elif cluster == 'ray':
             mpi = 'spectrum-mpi@2018.04.27'

--- a/bamboo/unit_tests/error/README.md
+++ b/bamboo/unit_tests/error/README.md
@@ -1,0 +1,1 @@
+Subdirectory for test error

--- a/bamboo/unit_tests/output/README.md
+++ b/bamboo/unit_tests/output/README.md
@@ -1,0 +1,1 @@
+Subdirectory for test output

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -4,17 +4,14 @@ import tools
 import pytest
 import os, re, subprocess, sys
 
-def skeleton_models(cluster, executables, compiler_name):
+def skeleton_models(cluster, dir_name, executables, compiler_name):
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
-    lbann_dir = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
-    hostname = subprocess.check_output('hostname'.split()).strip()
-    host = re.sub("\d+", "", hostname)
     opt = 'adagrad'
     defective_models = []
     working_models = []
     tell_Dylan = []
-    for subdir, dirs, files in os.walk(lbann_dir + '/model_zoo/models/'):
+    for subdir, dirs, files in os.walk(dir_name + '/model_zoo/models/'):
         if 'greedy' in subdir:
             print('Skipping greedy_layerwise_autoencoder_mnist, kills bamboo agent')
             continue            
@@ -50,16 +47,19 @@ def skeleton_models(cluster, executables, compiler_name):
                 if (cluster == 'ray') and (data_reader_name in ['cifar10', 'ascii']):
                     print('Skipping %s because data is not available on ray' % model_path)
                 else:
+                    output_file_name = '%s/bamboo/unit_tests/output/check_proto_models_%s_%s_output.txt' % (dir_name, file_name, compiler_name)
+                    error_file_name = '%s/bamboo/unit_tests/error/check_proto_models_%s_%s_error.txt' % (dir_name, file_name, compiler_name)
                     cmd = tools.get_command(
                         cluster=cluster, executable=executables[compiler_name], num_nodes=1,
-                        partition='pdebug', time_limit=1, dir_name=lbann_dir,
+                        partition='pdebug', time_limit=1, dir_name=dir_name,
                         data_filedir_default=data_filedir_default,
                         data_filedir_train_default=data_filedir_train_default,
                         data_filename_train_default=data_filename_train_default,
                         data_filedir_test_default=data_filedir_test_default,
                         data_filename_test_default=data_filename_test_default,
                         data_reader_name=data_reader_name, exit_after_setup=True,
-                        model_path=model_path, optimizer_name=opt)
+                        model_path=model_path, optimizer_name=opt,
+                        output_file_name=output_file_name, error_file_name=error_file_name)
                     if os.system(cmd) != 0:
                         print("Error detected in " + model_path)
                         #defective_models.append(file_name)
@@ -69,22 +69,22 @@ def skeleton_models(cluster, executables, compiler_name):
     num_defective = len(defective_models)
     if num_defective != 0:
         print('Working models: %d. Defective models: %d', len(working_models), num_defective)
-        print('ERRORS: The following models exited with errors')
-        for i in defective_models:
-            print('ERRORS', i)
-        print('ERRORS: tell Dylan: the following models have unknown data readers:')
-        for i in tell_Dylan :
-            print('ERRORS', i)
+        print('Errors for: The following models exited with errors')
+        for model in defective_models:
+            print(model)
+        print('Errors for: tell Dylan: the following models have unknown data readers:')
+        for model in tell_Dylan :
+            print(model)
     assert num_defective == 0
 
-def test_unit_models_clang4(cluster, exes):
-    skeleton_models(cluster, exes, 'clang4')
+def test_unit_models_clang4(cluster, dirname, exes):
+    skeleton_models(cluster, dirname, exes, 'clang4')
 
-def test_unit_models_gcc4(cluster, exes):
-    skeleton_models(cluster, exes, 'gcc4')
+def test_unit_models_gcc4(cluster, dirname, exes):
+    skeleton_models(cluster, dirname, exes, 'gcc4')
 
-def test_unit_models_gcc7(cluster, exes):
-    skeleton_models(cluster, exes, 'gcc7')
+def test_unit_models_gcc7(cluster, dirname, exes):
+    skeleton_models(cluster, exes, dirname, 'gcc7')
 
-def test_unit_models_intel18(cluster, exes):
-    skeleton_models(cluster, exes, 'intel18')
+def test_unit_models_intel18(cluster, dirname, exes):
+    skeleton_models(cluster, dirname, exes, 'intel18')

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -8,35 +8,44 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name, compiler_na
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
     exe = executables[compiler_name]
+    output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_shared_no_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_shared_no_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests',
-        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd')
+        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_nockpt = os.system(command)
     if return_code_nockpt != 0:
         sys.stderr.write('LeNet (no checkpoint) execution failed, exiting with error')
         sys.exit(1)
     os.system('mv ckpt ckpt_baseline')
 
+    output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_shared_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_shared_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests',
-        model_name='lenet_mnist_ckpt', num_epochs=1, optimizer_name='sgd')
+        model_name='lenet_mnist_ckpt', num_epochs=1, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_ckpt_1 = os.system(command)
     if return_code_ckpt_1 != 0:
         sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
         sys.exit(1)
 
+    output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_shared_restart_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_shared_restart_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests',
-        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd')
+        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_ckpt_2 = os.system(command)
     if return_code_ckpt_2 != 0:
         sys.stderr.write('LeNet execution (restart from checkpoint) failed, exiting with error')
@@ -46,39 +55,48 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name, compiler_na
     os.system('rm -rf ckpt*')
     assert diff_test == 0
 
-def skeleton_checkpoint_lenet_dist(cluster, executables, dir_name, compiler_name):
+def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compiler_name):
      if compiler_name not in executables:
        pytest.skip('default_exes[%s] does not exist' % compiler_name)
      exe = executables[compiler_name]
+     output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_distributed_no_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+     error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_distributed_no_checkpoint_%s_error.txt' % (dir_name, compiler_name)
      command = tools.get_command(
          cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd')
+         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_nockpt = os.system(command)
      if return_code_nockpt != 0:
          sys.stderr.write('LeNet (no checkpoint) execution failed, exiting with error')
          sys.exit(1)
      os.system('mv ckpt ckpt_baseline')
 
+     output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_distributed_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+     error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_distributed_checkpoint_%s_error.txt' % (dir_name, compiler_name)
      command = tools.get_command(
          cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=1, optimizer_name='sgd')
+         model_name='lenet_mnist_ckpt_dist', num_epochs=1, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_1 = os.system(command)
      if return_code_ckpt_1 != 0:
          sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
          sys.exit(1)
 
+     output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_distributed_restart_%s_output.txt' % (dir_name, compiler_name)
+     error_file_name  = '%s/bamboo/unit_tests/error/checkpoint_lenet_distributed_restart_%s_error.txt' % (dir_name, compiler_name)
      command = tools.get_command(
          cluster=cluster, executable=exe, num_nodes=1, num_processes=2,
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd')
+         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_2 = os.system(command)
      if return_code_ckpt_2 != 0:
          sys.stderr.write('LeNet execution (restart from checkpoint) failed, exiting with error')

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -7,13 +7,17 @@ import os, sys
 def test_unit_lbann2_reload(cluster, exes, dirname):
     lbann2  = exes['gcc4'] + '2'
     model_path = '{../../model_zoo/models/lenet_mnist/model_lenet_mnist.prototext,../../model_zoo/tests/model_lenet_mnist_lbann2ckpt.prototext}'
+    output_file_name = '%s/bamboo/unit_tests/output/lbann2_no_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/lbann2_no_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=lbann2, data_reader_name='mnist',
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         dir_name=dirname, 
         model_path=model_path,
         optimizer_name='sgd',
-        num_epochs=2)
+        num_epochs=2,
+        output_file_name=output_file_name,
+        error_file_name=error_file_name)
     return_code = os.system(command)
     if return_code != 0:
         sys.stderr.write('LBANN2 LeNet execution failed, exiting with error')
@@ -22,23 +26,32 @@ def test_unit_lbann2_reload(cluster, exes, dirname):
     
     os.system('mv lbann2_ckpt lbann2_nockpt')
 
+    output_file_name = '%s/bamboo/unit_tests/output/lbann2_checkpoint_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/lbann2_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=exe, num_nodes=1, num_processes=1,
         dir_name=dirname,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests',
-        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd')   
+        model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
+        output_file_name=output_file_name,
+        error_file_name=error_file_name)   
     return_code_ckpt_1 = os.system(command)
     if return_code_ckpt_1 != 0:
         sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
         sys.exit(1)
-    
+
+    output_file_name = '%s/bamboo/unit_tests/output/lbann2_restart_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/lbann2_restart_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=lbann2, num_nodes=1, num_processes=1,
         dir_name=dirname,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist',
-        model_path='../../model_zoo/tests/model_lenet_mnist_lbann2ckpt.prototext', num_epochs=2, optimizer_name='sgd', ckpt_dir='ckpt/')
+        model_path='../../model_zoo/tests/model_lenet_mnist_lbann2ckpt.prototext',
+        num_epochs=2, optimizer_name='sgd', ckpt_dir='ckpt/',
+        output_file_name=output_file_name,
+        error_file_name=error_file_name)
     return_code_ckpt_2 = os.system(command)
     if return_code_ckpt_2 != 0:
         sys.stderr.write('LBANN2 LeNet weight reload failed, exiting with error')

--- a/bamboo/unit_tests/test_unit_resnet.py
+++ b/bamboo/unit_tests/test_unit_resnet.py
@@ -7,11 +7,15 @@ import os
 def skeleton_gradient_check_resnet(cluster, executables, dir_name, compiler_name):
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    output_file_name = '%s/bamboo/unit_tests/output/gradient_check_resnet_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/gradient_check_resnet_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=executables[compiler_name], num_nodes=1, num_processes=1,
         dir_name=dir_name, data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests', model_name='mnist_resnet',
-        optimizer_name='adam')
+        optimizer_name='adam',
+        output_file_name=output_file_name,
+        error_file_name=error_file_name)
     return_code = os.system(command)
     assert return_code == 0
 

--- a/bamboo/unit_tests/test_unit_ridge_regression.py
+++ b/bamboo/unit_tests/test_unit_ridge_regression.py
@@ -7,10 +7,13 @@ import os
 def skeleton_gradient_check(cluster, executables, dir_name, compiler_name):
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    output_file_name = '%s/bamboo/unit_tests/output/gradient_check_ridge_regression_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/gradient_check_ridge_regression_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
         cluster=cluster, executable=executables[compiler_name], num_nodes=1, num_processes=1, dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST', data_reader_name='mnist',
-        model_folder='tests', model_name='mnist_ridge_regression', optimizer_name='adam')
+        model_folder='tests', model_name='mnist_ridge_regression', optimizer_name='adam',
+        output_file_name=output_file_name, error_file_name=error_file_name)
     return_code = os.system(command)
     assert return_code == 0
 


### PR DESCRIPTION
More Bamboo Updates

- Updated project summary link text in README.
- Updated README to specify that unit tests now have output and error directories.
- Added Pascal and Quartz to the supported clusters for mpi versions in `test_compiler.py`.
- Updated error printing in `test_unit_check_proto_models.py` to match error printing in integration tests (`Errors for` instead of `ERRORS`).
- Added output and error file printing to unit tests (except for `lbann_invocation` tests, since those exit after setup anyway)
- Updated `test_unit_check_proto_models.py` to use `dirname` instead of computing the LBANN directory itself. Also removed the unused `hostname` and `host` variables.