### PR TITLE
Jag conduit

### DIFF
--- a/include/lbann/data_readers/image_utils.hpp
+++ b/include/lbann/data_readers/image_utils.hpp
@@ -46,6 +46,16 @@ class image_utils {
   static bool loadIMG(const std::string& Imagefile, int& Width, int& Height, bool Flip, unsigned char *&Pixels);
   static bool saveIMG(const std::string& Imagefile, int Width, int Height, bool Flip, unsigned char *Pixels);
 
+#ifdef LBANN_HAS_OPENCV
+  // The other load/import methods rely on these core methods
+  /// process an image and put it into an LBANN Mat data block
+  static bool process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process& pp, ::Mat& out);
+  /// process an image and put it into a serialized buffer
+  static bool process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& out);
+  /// process an image and put it into an LBANN Mat data blocks
+  static bool process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& out);
+#endif // LBANN_HAS_OPENCV
+
   // load/save an image into/from a temporary buffer
   /// Load an image from a file and put it into a serialized buffer
   static bool load_image(const std::string& filename, int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& buf);

--- a/src/data_readers/image_utils.cpp
+++ b/src/data_readers/image_utils.cpp
@@ -29,8 +29,16 @@
 #include "lbann/data_readers/image_utils.hpp"
 #include "lbann/utils/exception.hpp"
 
+#define _THROW_EXCEPTION_NO_OPENCV_() { \
+  std::stringstream err; \
+  err << __FILE__ << " " << __LINE__ \
+      << " :: not compiled with LBANN_ENABLE_OPENCV!"; \
+  throw lbann_exception(err.str()); \
+}
 
-bool lbann::image_utils::loadIMG(const std::string& Imagefile, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
+namespace lbann {
+
+bool image_utils::loadIMG(const std::string& Imagefile, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imread(Imagefile, _LBANN_CV_COLOR_);
   if (image.empty()) {
@@ -52,11 +60,12 @@ bool lbann::image_utils::loadIMG(const std::string& Imagefile, int& Width, int& 
 
   return true;
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif
 }
 
-bool lbann::image_utils::loadIMG(std::vector<unsigned char>& image_buf, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
+bool image_utils::loadIMG(std::vector<unsigned char>& image_buf, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imdecode(image_buf, _LBANN_CV_COLOR_);
   //cv::Mat image = cv::imdecode(image_buf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
@@ -79,11 +88,12 @@ bool lbann::image_utils::loadIMG(std::vector<unsigned char>& image_buf, int& Wid
 
   return true;
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif
 }
 
-bool lbann::image_utils::saveIMG(const std::string& Imagefile, int Width, int Height, bool Flip, unsigned char *Pixels) {
+bool image_utils::saveIMG(const std::string& Imagefile, int Width, int Height, bool Flip, unsigned char *Pixels) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::Mat(Height, Width, CV_8UC3);
 
@@ -101,30 +111,97 @@ bool lbann::image_utils::saveIMG(const std::string& Imagefile, int Width, int He
 
   return true;
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif
 }
 
-bool lbann::image_utils::load_image(const std::string& filename,
-                                    int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& buf) {
+
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
-  bool ok = !image.empty() && pp.preprocess(image);
-  ok = ok && cv_utils::copy_cvMat_to_buf(image, buf, pp);
+bool image_utils::process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process& pp, ::Mat& out) {
+  bool ok1 = !image.empty() && pp.preprocess(image);
+  bool ok2 = ok1 && cv_utils::copy_cvMat_to_buf(image, out, pp);
+  // Disabling normalizer is needed because normalizer is not necessarily
+  // called during preprocessing but implicitly applied during data copying to
+  // reduce overhead.
   pp.disable_lazy_normalizer();
 
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
+  if (!ok2) {
+    throw lbann_exception(std::string("image_utils::process_image(): image ") +
+      (image.empty()? "is empty." :
+                      (ok1? "copying failed." :
+                            "preprocessing failed.")));
+  }
 
   Width  = image.cols;
   Height = image.rows;
   Type   = image.type();
-  return ok;
+
+  return ok2;
+}
+
+bool image_utils::process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& out) {
+  bool ok1 = !image.empty() && pp.preprocess(image);
+  bool ok2 = ok1 && cv_utils::copy_cvMat_to_buf(image, out, pp);
+  pp.disable_lazy_normalizer();
+
+  if (!ok2) {
+    throw lbann_exception(std::string("image_utils::process_image(): image ") +
+      (image.empty()? "is empty." :
+                      (ok1? "copying failed." :
+                            "preprocessing failed.")));
+  }
+
+  Width  = image.cols;
+  Height = image.rows;
+  Type   = image.type();
+
+  return ok2;
+}
+
+bool image_utils::process_image(cv::Mat& image, int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& out) {
+  std::vector<cv::Mat> patches;
+  bool ok1 = !image.empty() && pp.preprocess(image, patches);
+  bool ok2 = ok1 && (patches.size() != 0u) && (patches.size() == out.size());
+  bool ok3 = ok2;
+
+  for(size_t i=0u; ok3 && (i < patches.size()); ++i) {
+    ok3 = cv_utils::copy_cvMat_to_buf(patches[i], out[i], pp);
+  }
+  pp.disable_lazy_normalizer();
+
+  if (!ok3) {
+    throw lbann_exception(std::string("image_utils::process_image(): image ") +
+      (image.empty()? "is empty." :
+                      (ok1? (ok2? "copying failed." :
+                                  "extracted to invalid number of patches: " +
+                                   std::to_string(patches.size()) + " != " +
+                                   std::to_string(out.size())) :
+                            "preprocessing failed.")));
+  }
+
+  Width  = patches[0].cols;
+  Height = patches[0].rows;
+  Type   = patches[0].type();
+
+  return ok3;
+}
+#endif // LBANN_HAS_OPENCV
+
+
+bool image_utils::load_image(const std::string& filename,
+                                    int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& buf) {
+#ifdef LBANN_HAS_OPENCV
+  cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+
+  return process_image(image, Width, Height, Type, pp, buf);
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
 
-bool lbann::image_utils::save_image(const std::string& filename,
+bool image_utils::save_image(const std::string& filename,
                                     const int Width, const int Height, const int Type, cv_process& pp, const std::vector<uint8_t>& buf) {
 #ifdef LBANN_HAS_OPENCV
   pp.determine_inverse_lazy_normalization();
@@ -135,6 +212,7 @@ bool lbann::image_utils::save_image(const std::string& filename,
 
   return (ok && cv::imwrite(filename, image));
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -147,24 +225,14 @@ bool lbann::image_utils::save_image(const std::string& filename,
  *  @param pp       The pre-processing parameters
  *  @param data     The pre-processed image data to be stored in El::Matrix<DataType> format
  */
-bool lbann::image_utils::load_image(const std::string& filename,
+bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process& pp, ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
-  bool ok = !image.empty() && pp.preprocess(image);
-  ok = ok && cv_utils::copy_cvMat_to_buf(image, data, pp);
-  // Disabling normalizer is needed because normalizer is not necessarily
-  // called during preprocessing but implicitly applied during data copying to
-  // reduce overhead.
-  pp.disable_lazy_normalizer();
 
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = image.cols;
-  Height = image.rows;
-  Type   = image.type();
-  return ok;
+  return process_image(image, Width, Height, Type, pp, data);
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -177,33 +245,14 @@ bool lbann::image_utils::load_image(const std::string& filename,
  *  @param pp       The pre-processing parameters
  *  @param data     The pre-processed image data to be stored in El::Matrix<DataType> format
  */
-bool lbann::image_utils::load_image(const std::string& filename,
+bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& data) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
-  std::vector<cv::Mat> patches;
-  bool ok = !image.empty() && pp.preprocess(image, patches);
-  if ((patches.size() == 0u) || (patches.size() != data.size())) {
-    return false;
-  }
-
-  for(size_t i=0u; ok && (i < patches.size()); ++i) {
-    ok = cv_utils::copy_cvMat_to_buf(patches[i], data[i], pp);
-  }
-
-  // Disabling normalizer is needed because normalizer is not necessarily
-  // called during preprocessing but implicitly applied during data copying to
-  // reduce overhead.
-  pp.disable_lazy_normalizer();
-
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = patches[0].cols;
-  Height = patches[0].rows;
-  Type   = patches[0].type();
-  return ok;
+  return process_image(image, Width, Height, Type, pp, data);
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -217,35 +266,18 @@ bool lbann::image_utils::load_image(const std::string& filename,
  *  @param pp       The pre-processing parameters
  *  @param data     The pre-processed image data to be stored in El::Matrix<DataType> format
  */
-bool lbann::image_utils::load_image(std::vector<unsigned char>& image_buf,
+bool image_utils::load_image(std::vector<unsigned char>& image_buf,
                                     int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& data) {
+/*
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imdecode(image_buf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
-  std::vector<cv::Mat> patches;
-  bool ok = !image.empty() && pp.preprocess(image, patches);
-  if ((patches.size() == 0u) || (patches.size() != data.size())) {
-    return false;
-  }
-
-  for(size_t i=0u; ok && (i < patches.size()); ++i) {
-    ok = cv_utils::copy_cvMat_to_buf(patches[i], data[i], pp);
-  }
-
-  // Disabling normalizer is needed because normalizer is not necessarily
-  // called during preprocessing but implicitly applied during data copying to
-  // reduce overhead.
-  pp.disable_lazy_normalizer();
-
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = patches[0].cols;
-  Height = patches[0].rows;
-  Type   = patches[0].type();
-  return ok;
+  return process_image(image, Width, Height, Type, pp, data);
 #else
   return false;
 #endif // LBANN_HAS_OPENCV
+*/
+  return import_image(image_buf, Width, Height, Type, pp, data);
 }
 
 /**
@@ -256,7 +288,7 @@ bool lbann::image_utils::load_image(std::vector<unsigned char>& image_buf,
  *  @param pp       The post-processing parameters
  *  @param data     The image data in El::Matrix<DataType> format to post-process and write
  */
-bool lbann::image_utils::save_image(const std::string& filename,
+bool image_utils::save_image(const std::string& filename,
                                     const int Width, const int Height, const int Type, cv_process& pp, const ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
   pp.determine_inverse_lazy_normalization();
@@ -267,6 +299,7 @@ bool lbann::image_utils::save_image(const std::string& filename,
 
   return (ok && cv::imwrite(filename, image));
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -281,21 +314,14 @@ bool lbann::image_utils::save_image(const std::string& filename,
  *  @param pp      The pre-processing parameters
  *  @param data    The pre-processed image data. A set of sub-matrix Views can be used to store the data.
  */
-bool lbann::image_utils::import_image(cv::InputArray inbuf,
+bool image_utils::import_image(cv::InputArray inbuf,
                                       int& Width, int& Height, int& Type, cv_process& pp, ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imdecode(inbuf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
-  bool ok = !image.empty() && pp.preprocess(image);
-  ok = ok && cv_utils::copy_cvMat_to_buf(image, data, pp);
-  pp.disable_lazy_normalizer();
 
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = image.cols;
-  Height = image.rows;
-  Type   = image.type();
-  return ok;
+  return process_image(image, Width, Height, Type, pp, data);
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -310,30 +336,14 @@ bool lbann::image_utils::import_image(cv::InputArray inbuf,
  *  @param pp      The pre-processing parameters
  *  @param data    The pre-processed image data. A set of sub-matrix Views can be used to store the data.
  */
-bool lbann::image_utils::import_image(cv::InputArray inbuf,
+bool image_utils::import_image(cv::InputArray inbuf,
                                       int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& data) {
 #ifdef LBANN_HAS_OPENCV
   cv::Mat image = cv::imdecode(inbuf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
-  std::vector<cv::Mat> patches;
-  bool ok = !image.empty() && pp.preprocess(image, patches);
-  if ((patches.size() == 0u) || (patches.size() != data.size())) {
-    return false;
-  }
-
-  for(size_t i=0u; ok && (i < patches.size()); ++i) {
-    ok = cv_utils::copy_cvMat_to_buf(patches[i], data[i], pp);
-  }
-
-  pp.disable_lazy_normalizer();
-
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = patches[0].cols;
-  Height = patches[0].rows;
-  Type   = patches[0].type();
-  return ok;
+  return process_image(image, Width, Height, Type, pp, data);
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
@@ -347,7 +357,7 @@ bool lbann::image_utils::import_image(cv::InputArray inbuf,
  *  @param pp      The post-processing parameters
  *  @param data    The image data. A sub-matrix View can be passed instead of the entire matrix.
  */
-bool lbann::image_utils::export_image(const std::string& fileExt, std::vector<uchar>& outbuf,
+bool image_utils::export_image(const std::string& fileExt, std::vector<uchar>& outbuf,
                                       const int Width, const int Height, const int Type, cv_process& pp, const ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
   pp.determine_inverse_lazy_normalization();
@@ -369,51 +379,16 @@ bool lbann::image_utils::export_image(const std::string& fileExt, std::vector<uc
 
   return (ok && cv::imencode(ext, image, outbuf));
 #else
+  _THROW_EXCEPTION_NO_OPENCV_();
   return false;
 #endif // LBANN_HAS_OPENCV
 }
 
 
 
-
-bool lbann::image_utils::load_image(std::vector<unsigned char>& image_buf,
+bool image_utils::load_image(std::vector<unsigned char>& image_buf,
                                     int& Width, int& Height, int& Type, cv_process& pp, ::Mat& data) {
-#ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imdecode(image_buf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
-  if (image.empty()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: image is empty";
-    throw lbann_exception(err.str());
-  }
-  bool pp_test = pp.preprocess(image);
-  if (! pp_test) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: pp.preprocess(image) failed";
-    throw lbann_exception(err.str());
-  }
-  //bool ok = !image.empty() && pp.preprocess(image);
-  bool ok = cv_utils::copy_cvMat_to_buf(image, data, pp);
-  if (! ok) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: cv_utils::copy_cvMat_to_buf() failed";
-    throw lbann_exception(err.str());
-  }
-  // Disabling normalizer is needed because normalizer is not necessarily
-  // called during preprocessing but implicitly applied during data copying to
-  // reduce overhead.
-  pp.disable_lazy_normalizer();
-
-  _LBANN_MILD_EXCEPTION(!ok, "Image preprocessing or copying failed.", false)
-
-  Width  = image.cols;
-  Height = image.rows;
-  Type   = image.type();
-  return ok;
-#else
-  std::stringstream err;
-  err << __FILE__ << " " << __LINE__
-      << " :: not compiled with LBANN_ENABLE_OPENCV!";
-  throw lbann_exception(err.str());
-  return false;
-#endif // LBANN_HAS_OPENCV
+  return import_image(image_buf, Width, Height, Type, pp, data);
 }
+
+} // namespace lbann

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -270,7 +270,7 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
 
   std::shared_ptr<cv_process> pp;
   // set up the image preprocessor
-  if ((name == "imagenet") || (name == "imagenet_single") ||
+  if ((name == "imagenet") || (name == "imagenet_single") || (name == "jag_conduit") ||
       (name == "triplet") || (name == "mnist_siamese") || (name == "multi_images")) {
     pp = std::make_shared<cv_process>();
   } else if (name == "imagenet_patches") {
@@ -304,6 +304,24 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
     reader = new data_reader_multi_images(pp, shuffle);
   } else if (name == "imagenet_single") { // imagenet_single
     reader = new imagenet_reader_single(pp, shuffle);
+#ifdef LBANN_HAS_CONDUIT
+  } else if (name =="jag_conduit") {
+    data_reader_jag_conduit* reader_jag = new data_reader_jag_conduit(pp, shuffle);
+
+    reader_jag->set_image_dims(width, height);
+
+    const data_reader_jag_conduit::variable_t independent_type
+           = static_cast<data_reader_jag_conduit::variable_t>(pb_readme.independent());
+    reader_jag->set_independent_variable_type(independent_type);
+
+    const data_reader_jag_conduit::variable_t dependent_type
+           = static_cast<data_reader_jag_conduit::variable_t>(pb_readme.dependent());
+    reader_jag->set_dependent_variable_type(dependent_type);
+
+    reader = reader_jag;
+    if (master) std::cout << reader->get_type() << " is set" << std::endl;
+    return;
+#endif // LBANN_HAS_CONDUIT
   }
 
   auto* image_data_reader_ptr = dynamic_cast<image_data_reader*>(reader);

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -83,16 +83,7 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       set_up_generic_preprocessor = false;
 #ifdef LBANN_HAS_CONDUIT
     } else if (name == "jag_conduit") {
-      auto* reader_jag = new data_reader_jag_conduit(shuffle);
-      const data_reader_jag_conduit::variable_t independent_type
-             = static_cast<data_reader_jag_conduit::variable_t>(readme.independent());
-      reader_jag->set_independent_variable_type(independent_type);
-      const data_reader_jag_conduit::variable_t dependent_type
-             = static_cast<data_reader_jag_conduit::variable_t>(readme.dependent());
-      reader_jag->set_dependent_variable_type(dependent_type);
-      const lbann_data::ImagePreprocessor& pb_preproc = readme.image_preprocessor();
-      reader_jag->set_image_dims(pb_preproc.raw_width(), pb_preproc.raw_height());
-      reader = reader_jag;
+      init_image_data_reader(readme, master, reader);
       set_up_generic_preprocessor = false;
 #endif // LBANN_HAS_CONDUIT
     } else if (name == "nci") {


### PR DESCRIPTION
This PR refactors data_reader_jag_conduit to use image pre-processing pipeline.
- It is to take advantage of existing normalization mechanisms.
- This required to add a new interface in image_utils to expose the core image preprocessing operation, separated from image file loading.
- In this process, removed some of the redundant code