### PR TITLE
Siamse patch list tool

### DIFF
--- a/include/lbann/data_readers/offline_patches_npz.hpp
+++ b/include/lbann/data_readers/offline_patches_npz.hpp
@@ -81,6 +81,11 @@ class offline_patches_npz {
   /// Return the label of idx-th sample
   label_t get_label(const size_t idx) const;
 
+#ifdef _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
+  std::vector<std::string> get_file_roots() const;
+  size_t count_samples(const size_t num_roots) const;
+#endif // _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
+
  protected:
   /// Check the dimensions of loaded data
   bool check_data() const;

--- a/include/lbann/data_readers/offline_patches_npz.hpp
+++ b/include/lbann/data_readers/offline_patches_npz.hpp
@@ -63,8 +63,12 @@ class offline_patches_npz {
   /**
    * Load the data in the compressed numpy format file.
    * Use only first_n available samples if specified.
+   * keep_file_lists indicates whether to remove file lists loaded
+   * once converting them to vector of strings.
+   * Need to keep it for selecting a range of samples afterwards.
    */
-  bool load(const std::string filename, size_t first_n = 0u);
+  bool load(const std::string filename, size_t first_n = 0u,
+            bool keep_file_lists = false);
   /// Show the description
   std::string get_description() const;
 
@@ -84,6 +88,7 @@ class offline_patches_npz {
 #ifdef _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
   std::vector<std::string> get_file_roots() const;
   size_t count_samples(const size_t num_roots) const;
+  bool select(const std::string out_file, const size_t sample_start, size_t& sample_end);
 #endif // _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
 
  protected:
@@ -109,7 +114,7 @@ class offline_patches_npz {
   std::vector<label_t> m_item_class_list;
   /// The list of common substrings that a file path starts with (dimension is, for example 1000 in case of imagenet data)
   std::vector<std::string> m_file_root_list;
-  
+  /// The list of common substrings for file path variants
   std::vector<std::string> m_file_variant_list;
   /// The text file name of file_root_list
   std::string m_file_root_list_name;
@@ -119,6 +124,28 @@ class offline_patches_npz {
   std::string m_variant_divider;
   /// control how the text dictionary files are loaded: whether to load all at once and parse or to stream in
   bool m_fetch_text_dict_at_once;
+  /**
+   * indicate if the numpy file is reformatted to
+   * - treat an array of character strings as a 2-D character array, of which
+   *   the second dimension is the length of the largest string. This is
+   *   relevant to file_{root,variant}_list.
+   * - convert item_class_list to a list of label_t(uint8_t) instead of a
+   *   list of a charater sequence (two digits).
+   * The reformatting is get around the inability of cnpy library for writing
+   * an array of character strings.
+   */
+  bool m_lbann_format;
+
+  /**
+   * The original data structure for m_file_root_list. It is used by select()
+   * if keep_file_lists was on when loading.
+   */
+  cnpy::NpyArray m_file_root_list_org;
+  /**
+   * The original data structure for m_file_variant_list. It is used by select()
+   * if keep_file_lists was on when loading.
+   */
+  cnpy::NpyArray m_file_variant_list_org;
 };
 
 } // end of namespace lbann

--- a/include/lbann/utils/cnpy_utils.hpp
+++ b/include/lbann/utils/cnpy_utils.hpp
@@ -45,12 +45,14 @@ size_t compute_cnpy_array_offset(const cnpy::NpyArray& na, std::vector<size_t> i
 
 /**
  * If the type T of the numpy array element is something larger than 1 byte in
- * size, the word_size of the numpy array must be the same as sizeof(T),
+ * size, the word_size of the numpy array must be the same as sizeof(T).
  * In such a case, offset to add to a type T pointer is computed as the number
  * of elements up to the position pointed by the indices.
  * If sizeof(T) is 1 byte, then the array may be of char string, or the pointer
  * may be cast to a byte-long type. In such a case, the offset is computed as
  * the number of elements scaled by the word_size of the array.
+ * cnpy treats an array of strings as a 1D array, for which the word_size is
+ * equal to the length of the largest string.
  */
 template<typename T>
 inline size_t ptr_offset(const cnpy::NpyArray& na, std::vector<size_t> indices) {

--- a/include/lbann/utils/cnpy_utils.hpp
+++ b/include/lbann/utils/cnpy_utils.hpp
@@ -81,12 +81,7 @@ inline T& data(const cnpy::NpyArray& na, const std::vector<size_t> indices) {
  */
 template<typename T>
 inline T* data_ptr(const cnpy::NpyArray& na, const std::vector<size_t> indices) {
-  if ((sizeof(T) != na.word_size) && (sizeof(T) != 1u)) {
-    throw lbann_exception("cnpy_utils::data_ptr() : The data type is not consistent with the word size of the array.");
-  }
-  const size_t offset = compute_cnpy_array_offset(na, indices)
-                        * ((sizeof(T) == 1u)? na.word_size : 1u);
-  return (reinterpret_cast<T*>(&(* na.data_holder)[0]) + offset);
+  return (reinterpret_cast<T*>(&(* na.data_holder)[0]) + ptr_offset<T>(na, indices));
 }
 
 template<>

--- a/include/lbann/utils/cnpy_utils.hpp
+++ b/include/lbann/utils/cnpy_utils.hpp
@@ -43,6 +43,25 @@ namespace cnpy_utils {
  */
 size_t compute_cnpy_array_offset(const cnpy::NpyArray& na, std::vector<size_t> indices);
 
+/**
+ * If the type T of the numpy array element is something larger than 1 byte in
+ * size, the word_size of the numpy array must be the same as sizeof(T),
+ * In such a case, offset to add to a type T pointer is computed as the number
+ * of elements up to the position pointed by the indices.
+ * If sizeof(T) is 1 byte, then the array may be of char string, or the pointer
+ * may be cast to a byte-long type. In such a case, the offset is computed as
+ * the number of elements scaled by the word_size of the array.
+ */
+template<typename T>
+inline size_t ptr_offset(const cnpy::NpyArray& na, std::vector<size_t> indices) {
+  if ((sizeof(T) != na.word_size) && (sizeof(T) != 1u)) {
+    throw lbann_exception(std::string("cnpy_utils::ptr_offset() :") +
+           "The data type is not consistent with the word size of the array.");
+  }
+  return (compute_cnpy_array_offset(na, indices)
+           * ((sizeof(T) == 1u)? na.word_size : 1u));
+}
+
 
 /**
  * Allow the access to the data element identified by the indices and the
@@ -50,12 +69,7 @@ size_t compute_cnpy_array_offset(const cnpy::NpyArray& na, std::vector<size_t> i
  */
 template<typename T>
 inline T& data(const cnpy::NpyArray& na, const std::vector<size_t> indices) {
-  if ((sizeof(T) != na.word_size) && (sizeof(T) != 1u)) {
-    throw lbann_exception("cnpy_utils::data() : The data type is not consistent with the word size of the array.");
-  }
-  const size_t offset = compute_cnpy_array_offset(na, indices)
-                        * ((sizeof(T) == 1u)? na.word_size : 1u);
-  return *(reinterpret_cast<T*>(&(* na.data_holder)[0]) + offset);
+  return *(reinterpret_cast<T*>(&(* na.data_holder)[0]) + ptr_offset<T>(na, indices));
 }
 
 

--- a/include/lbann/utils/file_utils.hpp
+++ b/include/lbann/utils/file_utils.hpp
@@ -60,6 +60,7 @@ std::string add_delimiter(const std::string dir);
 std::string modify_file_name(const std::string file_name, const std::string tag, const std::string new_ext="");
 
 bool check_if_file_exists(const std::string& filename);
+bool check_if_dir_exists(const std::string& dirname);
 bool create_dir(const std::string output_dir);
 
 

--- a/src/data_readers/offline_patches_npz.cpp
+++ b/src/data_readers/offline_patches_npz.cpp
@@ -29,15 +29,18 @@
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/cnpy_utils.hpp"
 #include <set>
+#include <algorithm>
 
 namespace lbann {
 
 offline_patches_npz::offline_patches_npz()
-  : m_checked_ok(false), m_num_patches(3u), m_variant_divider(".JPEG.")
+  : m_checked_ok(false), m_num_patches(3u), m_variant_divider(".JPEG."),
+    m_lbann_format(false)
 {}
 
 
-bool offline_patches_npz::load(const std::string filename, size_t first_n) {
+bool offline_patches_npz::load(const std::string filename, size_t first_n,
+  bool keep_file_lists) {
   m_item_class_list.clear();
   m_file_root_list.clear();
   m_file_variant_list.clear();
@@ -58,10 +61,17 @@ bool offline_patches_npz::load(const std::string filename, size_t first_n) {
   }
   cnpy::npz_t dataset = cnpy::npz_load(filename);
 
+  m_lbann_format = false;
+
   // check if all the arrays are included
   for (const auto& np : dataset) {
     if (dict.find(np.first) == dict.end()) {
-      return false;
+      if (np.first == "lbann_format") {
+        cnpy::NpyArray d_lbann_format = dataset["lbann_format"];
+        m_lbann_format = cnpy_utils::data<bool>(d_lbann_format, {0});
+      } else {
+        return false;
+      }
     }
   }
 
@@ -72,8 +82,6 @@ bool offline_patches_npz::load(const std::string filename, size_t first_n) {
   // Set the array of index sequences for root type
   m_item_root_list = dataset["item_root_list"];
 
-  if (first_n > 0u) { // to use only first_n samples
-  }
   // Set the array of index sequences for variant type
   m_item_variant_list = dataset["item_variant_list"];
 
@@ -83,10 +91,15 @@ bool offline_patches_npz::load(const std::string filename, size_t first_n) {
     if (m_checked_ok) {
       // In case of shrinking to first_n, make sure the size is consistent
       const size_t num_samples = m_item_root_list.shape[0];
-      m_item_class_list.resize(num_samples);
-      for (size_t i=0u; i < num_samples; ++i) {
-        std::string digits(cnpy_utils::data_ptr<char>(d_item_class_list, {i}), d_item_class_list.word_size);
-        m_item_class_list[i] = static_cast<label_t>(atoi(digits.c_str()));
+      if (m_lbann_format) {
+        const label_t* ptr = cnpy_utils::data_ptr<label_t>(d_item_class_list, {0});
+        m_item_class_list.assign(ptr, ptr + num_samples);
+      } else {
+        m_item_class_list.resize(num_samples);
+        for (size_t i=0u; i < num_samples; ++i) {
+          std::string digits(cnpy_utils::data_ptr<char>(d_item_class_list, {i}), d_item_class_list.word_size);
+          m_item_class_list[i] = static_cast<label_t>(atoi(digits.c_str()));
+        }
       }
     }
     cnpy::npz_t::iterator it = dataset.find("item_class_list");
@@ -95,33 +108,53 @@ bool offline_patches_npz::load(const std::string filename, size_t first_n) {
 
   { // load the array of dictionary substrings of root type
     cnpy::NpyArray d_file_root_list = dataset["file_root_list"];
-    m_checked_ok = m_checked_ok && (d_file_root_list.shape.size() == 1u);
+    m_checked_ok = m_checked_ok &&
+                   ( (d_file_root_list.shape.size() == 1u) ||
+                    ((d_file_root_list.shape.size() == 2u) && m_lbann_format));
     if (m_checked_ok) {
       const size_t num_roots = d_file_root_list.shape[0];
       m_file_root_list.resize(num_roots);
+
+      const size_t len = (m_lbann_format? d_file_root_list.shape[1]
+                                        : d_file_root_list.word_size);
+
       for (size_t i=0u; i < num_roots; ++i) {
-        std::string file_root(cnpy_utils::data_ptr<char>(d_file_root_list, {i}), d_file_root_list.word_size);
-        m_file_root_list[i] = std::string(file_root.c_str());
+        std::string file_root(cnpy_utils::data_ptr<char>(d_file_root_list, {i}), len);
+        m_file_root_list[i] = std::string(file_root.c_str()); // to remove the trailing spaces
       }
     }
-    cnpy::npz_t::iterator it = dataset.find("file_root_list");
-    dataset.erase(it); // to keep memory footprint as low as possible
+    if (keep_file_lists) {
+      m_file_root_list_org = d_file_root_list;
+    } else {
+      cnpy::npz_t::iterator it = dataset.find("file_root_list");
+      dataset.erase(it); // to keep memory footprint as low as possible
+    }
   }
   //for (const auto& fl: m_file_root_list) std::cout << fl << std::endl;
 
   { // load the array of dictionary substrings of variant type
     cnpy::NpyArray d_file_variant_list = dataset["file_variant_list"];
-    m_checked_ok = m_checked_ok && (d_file_variant_list.shape.size() == 1u);
+    m_checked_ok = m_checked_ok &&
+                   ( (d_file_variant_list.shape.size() == 1u) ||
+                    ((d_file_variant_list.shape.size() == 2u) && m_lbann_format));
     if (m_checked_ok) {
       const size_t num_variants = d_file_variant_list.shape[0];
       m_file_variant_list.resize(num_variants);
+
+      const size_t len = (m_lbann_format? d_file_variant_list.shape[1]
+                                        : d_file_variant_list.word_size);
+
       for (size_t i=0u; i < num_variants; ++i) {
-        std::string file_variant(cnpy_utils::data_ptr<char>(d_file_variant_list, {i}), d_file_variant_list.word_size);
+        std::string file_variant(cnpy_utils::data_ptr<char>(d_file_variant_list, {i}), len);
         m_file_variant_list[i] = std::string(file_variant.c_str());
       }
     }
-    cnpy::npz_t::iterator it = dataset.find("file_variant_list");
-    dataset.erase(it); // to keep memory footprint as low as possible
+    if (keep_file_lists) {
+      m_file_root_list_org = d_file_variant_list;
+    } else {
+      cnpy::npz_t::iterator it = dataset.find("file_variant_list");
+      dataset.erase(it); // to keep memory footprint as low as possible
+    }
   }
   //for (const auto& fl: m_file_variant_list) std::cout << fl << std::endl;
 
@@ -244,6 +277,145 @@ std::vector<std::string> offline_patches_npz::get_file_roots() const {
     root_names.push_back(file_name);
   }
   return root_names;
+}
+
+
+bool offline_patches_npz::select(const std::string out_file, const size_t sample_start, size_t& sample_end) {
+  if ( sample_start >= sample_end) {
+    std::cerr << "sample_end (" << sample_end
+              << ") is not larger than sample_start ("
+              << sample_start << ")." << std::endl;
+    return false;
+  }
+
+  // Set the array of index sequences for root type
+  const size_t num_samples_org = m_item_root_list.shape[0];
+  if (sample_end > num_samples_org) {
+    std::cerr << "sample_end exceed the number of of samples in data."
+              << "Adjusting it to the number of existing samples." << std::endl;
+    sample_end = num_samples_org;
+  }
+
+  { // create output directory if needed
+    std::string out_dir;
+    std::string out_filename;
+    parse_path(out_file, out_dir, out_filename);
+
+    if (!check_if_dir_exists(out_dir)) {
+      create_dir(out_dir);
+    }
+  }
+
+  std::pair<size_t, size_t> file_root_range;
+  std::pair<size_t, size_t> file_variant_range;
+
+  { // write item_root_list
+    std::vector<size_t> out_shape = m_item_root_list.shape;
+    out_shape[0] = sample_end - sample_start;
+    const size_t* data_ptr = cnpy_utils::data_ptr<size_t>(m_item_root_list, {sample_start});
+    const size_t* data_ptr_end = cnpy_utils::data_ptr<size_t>(m_item_root_list, {sample_end});
+    cnpy::npz_save(out_file, "item_root_list", data_ptr, out_shape, "w");
+    auto result = std::minmax_element(data_ptr, data_ptr_end);
+    file_root_range = std::make_pair(*result.first, *result.second + 1);
+  }
+
+  { // write item_variant_list
+    std::vector<size_t> out_shape = m_item_variant_list.shape;
+    out_shape[0] = sample_end - sample_start;
+    const size_t* data_ptr = cnpy_utils::data_ptr<size_t>(m_item_variant_list, {sample_start});
+    const size_t* data_ptr_end = cnpy_utils::data_ptr<size_t>(m_item_variant_list, {sample_end});
+    cnpy::npz_save(out_file, "item_variant_list", data_ptr, out_shape, "a");
+    auto result = std::minmax_element(data_ptr, data_ptr_end);
+    file_variant_range = std::make_pair(*result.first, *result.second + 1);
+  }
+
+  { // write item_class_list
+    const label_t* data_ptr = &(m_item_class_list[sample_start]);
+    cnpy::npz_save(out_file, "item_class_list", data_ptr, {sample_end - sample_start}, "a");
+  }
+
+  { // load the array of dictionary substrings of root type
+    cnpy::NpyArray org_list = m_file_root_list_org;
+    bool org_readable = (((!m_lbann_format && (org_list.shape.size() == 1u)) &&
+                           ( m_lbann_format && (org_list.shape.size() == 2u))) &&
+                          (org_list.shape[0] > 0u));
+
+    std::vector<size_t> out_shape(2u);
+    const size_t id_start = file_root_range.first;
+    const size_t id_end = file_root_range.second;
+    out_shape[0] = id_end - id_start;
+    size_t len = 0u;
+
+    std::vector<char> tmp;
+    char* data_ptr = nullptr;
+
+    if (org_readable) {
+      len = (m_lbann_format? org_list.shape[1] : org_list.word_size);
+      data_ptr = cnpy_utils::data_ptr<char>(org_list, {id_start});
+    } else {
+      for (size_t i = id_start; i < id_end; ++i) {
+        size_t sz = m_file_root_list[i].size();
+        if (len < sz) {
+          len = sz;
+        }
+      }
+      tmp.resize((id_end - id_start)*len, '\0');
+      data_ptr = &(tmp[0]);
+      for (size_t i = id_start; i < id_end; ++i) {
+        const std::string& str = m_file_root_list[i];
+        std::copy(str.begin(), str.end(), data_ptr);
+        data_ptr += len;
+      }
+      data_ptr = &(tmp[0]);
+    }
+    out_shape[1] = len;
+    cnpy::npz_save(out_file, "file_root_list", data_ptr, out_shape, "a");
+  }
+
+  { // load the array of dictionary substrings of variant type
+    cnpy::NpyArray org_list = m_file_variant_list_org;
+    bool org_readable = (((!m_lbann_format && (org_list.shape.size() == 1u)) &&
+                           ( m_lbann_format && (org_list.shape.size() == 2u))) &&
+                          (org_list.shape[0] > 0u));
+
+    std::vector<size_t> out_shape(2u);
+    const size_t id_start = file_variant_range.first;
+    const size_t id_end = file_variant_range.second;
+    out_shape[0] = id_end - id_start;
+    size_t len = 0u;
+
+    std::vector<char> tmp;
+    char* data_ptr = nullptr;
+
+    if (org_readable) {
+      len = (m_lbann_format? org_list.shape[1] : org_list.word_size);
+      data_ptr = cnpy_utils::data_ptr<char>(org_list, {id_start});
+    } else {
+      for (size_t i = id_start; i < id_end; ++i) {
+        size_t sz = m_file_variant_list[i].size();
+        if (len < sz) {
+          len = sz;
+        }
+      }
+      tmp.resize((id_end - id_start)*len, '\0');
+      data_ptr = &(tmp[0]);
+      for (size_t i = id_start; i < id_end; ++i) {
+        const std::string& str = m_file_variant_list[i];
+        std::copy(str.begin(), str.end(), data_ptr);
+        data_ptr += len;
+      }
+      data_ptr = &(tmp[0]);
+    }
+    out_shape[1] = len;
+    cnpy::npz_save(out_file, "file_variant_list", data_ptr, out_shape, "a");
+  }
+
+  {
+    bool lbann_format = true;
+    cnpy::npz_save(out_file, "lbann_format", &lbann_format, {1}, "a");
+  }
+
+  return true;
 }
 #endif // _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
 

--- a/src/data_readers/offline_patches_npz.cpp
+++ b/src/data_readers/offline_patches_npz.cpp
@@ -208,4 +208,43 @@ offline_patches_npz::label_t offline_patches_npz::get_label(const size_t idx) co
   return m_item_class_list[idx];
 }
 
+
+#ifdef _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
+/// count samples of first n roots
+size_t offline_patches_npz::count_samples(const size_t num_roots) const {
+  if (!m_checked_ok || num_roots > m_file_root_list.size()) {
+    throw lbann_exception("invalid sample index");
+  }
+
+  std::vector<std::string> file_names;
+  size_t num_samples = 0u;
+  const size_t total_samples = get_num_samples();
+
+  for (size_t s = 0u; s < total_samples; ++s) {
+    const size_t root = cnpy_utils::data<size_t>(m_item_root_list, {s, 0});
+    if (root >= m_file_root_list.size()) {
+      throw lbann_exception("invalid file_root_list index");
+    }
+    if (root >= num_roots) break;
+    num_samples ++;
+  }
+  return num_samples;
+}
+
+std::vector<std::string> offline_patches_npz::get_file_roots() const {
+  std::vector<std::string> root_names;
+  const size_t num_samples = get_num_samples();
+  root_names.reserve(num_samples);
+  for (size_t i = 0u; i < num_samples; ++i) {
+    const size_t root = cnpy_utils::data<size_t>(m_item_root_list, {i, 0});
+    if (root >= m_file_root_list.size()) {
+      throw lbann_exception("invalid file_root_list index");
+    }
+    std::string file_name = m_file_root_list.at(root);
+    root_names.push_back(file_name);
+  }
+  return root_names;
+}
+#endif // _OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_
+
 } // end of namespace lbann

--- a/src/utils/cnpy_utils.cpp
+++ b/src/utils/cnpy_utils.cpp
@@ -40,7 +40,9 @@ size_t compute_cnpy_array_offset(
   size_t offset = 0u;
 
   for (size_t i = indices.size(); ok && (i-- > 0u); ) {
-    ok = (indices[i] < na.shape[i]);
+    ok = (indices[i] < na.shape[i]) ||
+        // relax to allow representing the exclusive upper bound
+        ((i == 0u) && (indices[i] == na.shape[i]));
     offset += indices[i] * unit_stride;
     unit_stride *= na.shape[i];
   }

--- a/tools/compute_mean/CMakeLists.txt
+++ b/tools/compute_mean/CMakeLists.txt
@@ -3,9 +3,10 @@ cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0015 NEW)
 
 set(COMPILER "gnu")
-set(CLUSTER "surface")
+#set(CLUSTER "surface")
+set(CLUSTER "catalyst")
 set(LBANN_DIR ../..)
-set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.${CLUSTER}.llnl.gov/install)
+set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
 include(${LBANN_DIR}/cmake/modules/SetupMPI.cmake)
 include(${LBANN_DIR}/cmake/modules/SetupOpenMP.cmake)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -53,7 +54,7 @@ file(GLOB COMPUTE_MEAN_DEPEND_SRCS
      mean_image.cpp
      process_images.cpp
      lbann/utils/random.cpp
-     lbann/utils/file_utils.cpp
+     ${LBANN_DIR}/src//utils/file_utils.cpp
      ${LBANN_DIR}/src/data_readers/cv_augmenter.cpp
      ${LBANN_DIR}/src/data_readers/cv_colorizer.cpp
      ${LBANN_DIR}/src/data_readers/cv_cropper.cpp
@@ -70,11 +71,11 @@ file(GLOB COMPUTE_MEAN_DEPEND_SRCS
      ${LBANN_DIR}/src/data_readers/patchworks/patchworks_stats.cpp)
 
 file(GLOB UNIFORM_MEAN_DEPEND_SRCS
-     lbann/utils/file_utils.cpp
+     ${LBANN_DIR}/src//utils/file_utils.cpp
      ${LBANN_DIR}/src/data_readers/cv_transform.cpp
      ${LBANN_DIR}/src/data_readers/cv_subtractor.cpp)
 
 add_executable(${COMPUTE_MEAN_EXE} ${COMPUTE_MEAN_SRCS} ${COMPUTE_MEAN_DEPEND_SRCS})
-target_link_libraries(${COMPUTE_MEAN_EXE} ${OpenCV_LIBS} ${Elemental_LIBS} ${MPI_CXX_LIBRARIES})
+target_link_libraries(${COMPUTE_MEAN_EXE} ${OpenCV_LIBS} ${Elemental_LIBS} ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
 add_executable(${UNIFORM_MEAN_EXE} ${UNIFORM_MEAN_SRCS} ${UNIFORM_MEAN_DEPEND_SRCS})
-target_link_libraries(${UNIFORM_MEAN_EXE} ${OpenCV_LIBS})
+target_link_libraries(${UNIFORM_MEAN_EXE} ${OpenCV_LIBS} ${OpenMP_CXX_LIBRARIES})

--- a/tools/compute_mean/Mat.hpp
+++ b/tools/compute_mean/Mat.hpp
@@ -12,6 +12,8 @@ class ElMatLike {
   std::vector<T> m_buf;
 
  public:
+  using Int = long long;
+
   ElMatLike() : m_width(0), m_height(0) {}
 
   int Width() const {
@@ -25,6 +27,8 @@ class ElMatLike {
   void Resize(int w, int h);
   T *Buffer();
   const T *LockedBuffer() const;
+
+  void Set(Int r, Int c, T);
 };
 
 template<typename T>
@@ -56,6 +60,17 @@ inline const T *ElMatLike<T>::LockedBuffer() const {
   return (&(m_buf[0]));
 }
 
+template<typename T>
+inline void ElMatLike<T>::Set(ElMatLike::Int r, ElMatLike::Int c, T d) {
+  if ((r < m_height) && (c < m_width) && (0 <= r) && ( 0 <= c)) {
+    m_buf[m_height*(c - 1) + r] = d;
+  }
+}
+
 using Mat = ElMatLike<lbann::DataType>;
+
+namespace El {
+using Int = ::ElMatLike<lbann::DataType>::Int;
+}
 
 #endif // _TOOLS_MAT_HPP_

--- a/tools/compute_mean/lbann/utils/cnpy_utils.hpp
+++ b/tools/compute_mean/lbann/utils/cnpy_utils.hpp
@@ -1,0 +1,1 @@
+../../../../include/lbann/utils/cnpy_utils.hpp

--- a/tools/compute_mean/lbann/utils/file_utils.cpp
+++ b/tools/compute_mean/lbann/utils/file_utils.cpp
@@ -1,1 +1,0 @@
-../../../../src/utils/file_utils.cpp

--- a/tools/siamese_patch_list/CMakeLists.txt
+++ b/tools/siamese_patch_list/CMakeLists.txt
@@ -1,0 +1,47 @@
+project(siamese_patches)
+cmake_minimum_required(VERSION 2.8)
+cmake_policy(SET CMP0015 NEW)
+
+set(COMPILER "gnu")
+set(CLUSTER "catalyst")
+#set(CLUSTER "surface")
+#set(CLUSTER "quartz")
+set(LBANN_DIR ../..)
+set(LBANN_INSTALL_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+set(SIAMESE_PATCHES_EXE siamese_patches)
+set(SIAMESE_PATCHES_SRCS siamese_patches.cpp)
+set(WITH_OPENCL OFF)
+
+add_definitions(-Wall)
+add_definitions(-O2)
+add_definitions(-g)
+add_definitions(-std=c++11)
+add_definitions(-D_OFFLINE_PATCHES_NPZ_OFFLINE_TOOL_MODE_)
+
+
+list(APPEND CNPY_DIR /usr)
+find_package(CNPY QUIET HINTS ${CNPY_DIR})
+message(STATUS "CNPY_DIR: ${CNPY_DIR}")
+
+if(NOT CNPY_FOUND)
+  set(CNPY_DIR ${LBANN_INSTALL_DIR})
+  set(CNPY_LIBS "libcnpy.so;libz.so")
+  set(CNPY_INCLUDE_DIRS "${CNPY_DIR}/include")
+  set(CNPY_LIB_DIR "${CNPY_DIR}/lib")
+  message(STATUS "CNPY_DIR: ${CNPY_DIR}")
+endif()
+
+include_directories(SYSTEM ${CNPY_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+link_directories(${CNPY_LIB_DIR})
+
+
+
+file(GLOB SIAMESE_PATCHES_DEPEND_SRCS
+     ${LBANN_DIR}/src/utils/file_utils.cpp
+     ${LBANN_DIR}/src/utils/cnpy_utils.cpp
+     ${LBANN_DIR}/src/data_readers/offline_patches_npz.cpp)
+
+add_executable(${SIAMESE_PATCHES_EXE} ${SIAMESE_PATCHES_SRCS} ${SIAMESE_PATCHES_DEPEND_SRCS})
+target_link_libraries(${SIAMESE_PATCHES_EXE} ${CNPY_LIBS})

--- a/tools/siamese_patch_list/lbann
+++ b/tools/siamese_patch_list/lbann
@@ -1,0 +1,1 @@
+../compute_mean/lbann

--- a/tools/siamese_patch_list/mem.hpp
+++ b/tools/siamese_patch_list/mem.hpp
@@ -1,0 +1,26 @@
+
+#include <sys/sysinfo.h>
+#include <limits>
+#include <fstream>
+
+unsigned long long getTotalSystemMemory() {
+    std::string token;
+    std::ifstream file("/proc/meminfo", std::ifstream::in);
+    while(file >> token) {
+        if(token == "MemFree:") {
+            unsigned long mem;
+            if(file >> mem) {
+                return mem;
+            } else {
+                return 0;       
+            }
+        }
+        // ignore rest of the line
+        file.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    }
+    return 0; // nothing found
+}
+
+void print_mem(std::string tag) {
+  std::cout << tag << ' ' << getTotalSystemMemory() << std::endl;
+}

--- a/tools/siamese_patch_list/siamese_patches.cpp
+++ b/tools/siamese_patch_list/siamese_patches.cpp
@@ -26,17 +26,20 @@ void print_all_samples(const offline_patches_npz& data) {
   }
 }
 
-void load(const std::string& file_name, offline_patches_npz& data, const size_t n_first = 0u) {
-  if (!data.load(file_name, n_first)) {
+void load(const std::string& file_name, offline_patches_npz& data, const int out_mode, const size_t n_first = 0u) {
+  const bool keep_file_lists = ((out_mode == 4)? true : false);
+
+  if (!data.load(file_name, n_first, keep_file_lists)) {
     std::cerr << "Failed to load " << file_name << std::endl;
     exit(0);
   }
 }
 
+
 int main(int argc, char** argv)
 {
-  if ((argc < 4) || (argc > 6)) {
-    std::cout << "Uasge: > " << argv[0] << " npz_file in_mode out_mode [arg1 [arg2]]" << std::endl;
+  if ((argc < 4) || (argc > 7)) {
+    std::cout << "Uasge: > " << argv[0] << " npz_file in_mode out_mode [arg1 [arg2 [out_file]]]" << std::endl;
     std::cout << "         in_mode 0: load all data" << std::endl;
     std::cout << "         in_mode 1: load first n(arg1) samples" << std::endl;
     std::cout << "         in_mode 2: load all data and proceed to out_mode 2" << std::endl;
@@ -44,6 +47,9 @@ int main(int argc, char** argv)
     std::cout << "        out_mode 1: print the list of samples to stdout" << std::endl;
     std::cout << "        out_mode 2: print the number of samples in first n(arg1) sub directories" << std::endl;
     std::cout << "        out_mode 3: print the subdirectory names of samples to stdout" << std::endl;
+    std::cout << "        out_mode 4: write samples selected by the id range, between id_start(arg1) and id_end(arg2)" << std::endl;
+    std::cout << "                    The chosen samples are written to out_file" << std::endl;
+    std::cout << "                    id_start is inclusive, and id_end is exclusive." << std::endl;
     return 0;
   }
 
@@ -58,22 +64,24 @@ int main(int argc, char** argv)
 
   switch (in_mode) {
     case 0: { // load all data
-      load(file_name, data);
+      load(file_name, data, out_mode);
     } break;
     case 1: { // load first_n samples
       n_first = static_cast<size_t>(atoi(argv[4]));
-      load(file_name, data, n_first);
+      load(file_name, data, out_mode, n_first);
     } break;
     case 2: {
-      load(file_name, data);
-      num_subdirs = static_cast<size_t>(atoi(argv[4]));
       if (out_mode != 2) {
         std::cout << "Changing out_mode to 2, to count the number of samples in first "
                   << num_subdirs << " directories" << std::endl;
         out_mode = 2;
       }
-    } break;
-    case 3: {
+      load(file_name, data, out_mode);
+      if (argc != 5) {
+        std::cout << "The number of subdir argument (arg1)  is missing" << std::endl;
+        exit(0);
+      }
+      num_subdirs = static_cast<size_t>(atoi(argv[4]));
     } break;
     default:
       std::cout << "Invalid in_mode: " << in_mode << std::endl;
@@ -92,13 +100,33 @@ int main(int argc, char** argv)
       if (in_mode != 2) {
         std::cout << "in_mode was not 2 but " << in_mode << std::endl;
       } else {
-        std::cout << "Number of samples " << data.count_samples(num_subdirs) << std::endl;
+        std::cout << "Number of subdirs: " << num_subdirs << std::endl;
+        std::cout << "Number of samples: " << data.count_samples(num_subdirs) << std::endl;
       }
     } break;
     case 3: { // print the subdirectory names of samples
       const std::vector<std::string> root_names = data.get_file_roots();
       for(auto&& r: root_names) {
         std::cout << r << std::endl;
+      }
+    } break;
+    case 4: { // write selected samples into a new file
+      if (argc != 7) {
+        std::cout << "Requires the arguments: id_start, id_end, and out_file." << std::endl;
+        exit(0);
+      }
+      size_t id_start = static_cast<size_t>(atoi(argv[4]));
+      size_t id_end= static_cast<size_t>(atoi(argv[5]));
+      std::string out_file(argv[6]);
+
+      if (out_file == file_name) {
+        std::cout << "Cannot overwrite the data file" << std::endl;
+        exit(0);
+      }
+      bool ok = data.select(out_file, id_start, id_end);
+      if (!ok) {
+        std::cout << "Failed to select [" << id_start << ", " << id_end << std::endl;
+        exit(0);
       }
     } break;
     default:

--- a/tools/siamese_patch_list/siamese_patches.cpp
+++ b/tools/siamese_patch_list/siamese_patches.cpp
@@ -1,0 +1,110 @@
+#include <iostream>
+#include <string>
+#include <set>
+#include <vector>
+#include <cstdlib> // exit
+#include "mem.hpp"
+#include "lbann/data_readers/offline_patches_npz.hpp"
+
+using namespace lbann;
+
+void print_all_samples(const offline_patches_npz& data) {
+  const size_t num_samples = data.get_num_samples();
+  for(size_t i=0u; i < num_samples; ++i) {
+    offline_patches_npz::sample_t sample = data.get_sample(i);
+#if 0
+    std::cout << "(['" << sample.first[0] << "', '"
+                       << sample.first[1] << "', '"
+                       << sample.first[2] << "'], '"
+              << static_cast<unsigned int>(sample.second) << "')" << std::endl;
+#else
+    std::cout << sample.first[0] << ' '
+              << sample.first[1] << ' '
+              << sample.first[2] << ' '
+              << static_cast<unsigned int>(sample.second) << std::endl;
+#endif
+  }
+}
+
+void load(const std::string& file_name, offline_patches_npz& data, const size_t n_first = 0u) {
+  if (!data.load(file_name, n_first)) {
+    std::cerr << "Failed to load " << file_name << std::endl;
+    exit(0);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  if ((argc < 4) || (argc > 6)) {
+    std::cout << "Uasge: > " << argv[0] << " npz_file in_mode out_mode [arg1 [arg2]]" << std::endl;
+    std::cout << "         in_mode 0: load all data" << std::endl;
+    std::cout << "         in_mode 1: load first n(arg1) samples" << std::endl;
+    std::cout << "         in_mode 2: load all data and proceed to out_mode 2" << std::endl;
+    std::cout << "        out_mode 0: show data description" << std::endl;
+    std::cout << "        out_mode 1: print the list of samples to stdout" << std::endl;
+    std::cout << "        out_mode 2: print the number of samples in first n(arg1) sub directories" << std::endl;
+    std::cout << "        out_mode 3: print the subdirectory names of samples to stdout" << std::endl;
+    return 0;
+  }
+
+  std::string file_name(argv[1]);
+  int in_mode = atoi(argv[2]);
+  int out_mode = atoi(argv[3]);
+  size_t num_subdirs = 0u;
+  size_t n_first = 0u;
+
+  offline_patches_npz data;
+
+
+  switch (in_mode) {
+    case 0: { // load all data
+      load(file_name, data);
+    } break;
+    case 1: { // load first_n samples
+      n_first = static_cast<size_t>(atoi(argv[4]));
+      load(file_name, data, n_first);
+    } break;
+    case 2: {
+      load(file_name, data);
+      num_subdirs = static_cast<size_t>(atoi(argv[4]));
+      if (out_mode != 2) {
+        std::cout << "Changing out_mode to 2, to count the number of samples in first "
+                  << num_subdirs << " directories" << std::endl;
+        out_mode = 2;
+      }
+    } break;
+    case 3: {
+    } break;
+    default:
+      std::cout << "Invalid in_mode: " << in_mode << std::endl;
+      return 0;
+  }
+
+  switch (out_mode) {
+    case 0: { // show data description
+      print_mem("Memory status :");
+      std::cout << data.get_description() << std::endl;
+    } break;
+    case 1: { // print the list of samples to stdout
+      print_all_samples(data);
+    } break;
+    case 2: { // print the number of samples in first n sub directories
+      if (in_mode != 2) {
+        std::cout << "in_mode was not 2 but " << in_mode << std::endl;
+      } else {
+        std::cout << "Number of samples " << data.count_samples(num_subdirs) << std::endl;
+      }
+    } break;
+    case 3: { // print the subdirectory names of samples
+      const std::vector<std::string> root_names = data.get_file_roots();
+      for(auto&& r: root_names) {
+        std::cout << r << std::endl;
+      }
+    } break;
+    default:
+      std::cout << "Invalid out_mode: " << in_mode << std::endl;
+      return 0;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This PR is to create an offline tool that enables selection of Siamese patch samples to run.
For example, if we want to selectively use samples from 30th to 65th out of total 100 samples, we need to create a list that only contains those samples. The sample list is packed in a numpy-based data structure compressed by using dictionaries. Each entry of a sample consists of kyes to multiple dictionaries from which values are extracted and concatenated to reconstuct the file path.

This tool helps creating a list of selected samples identified by a range from an existing list file.
This tools will probabaly only be used by myself, and barely touches the LBANN code base.
I have tested it for my use cases. Also find with not pushing this into the main branch depending on what people think.