### PR TITLE
Fix GPU Aluminum allreduces

### DIFF
--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -141,11 +141,17 @@ void optimizer::start_gradient_staging_allreduce() {
   }
 
   m_gradient_allreduce_started = true;
+  std::type_index t = std::type_index(typeid(Al::mpi_backend));
+#ifdef LBANN_HAS_GPU
+  if (m_gradient_staging->GetLocalDevice() == El::Device::GPU) {
+    t = std::type_index(typeid(Al::nccl_backend));
+  }
+#endif
   m_comm->nb_allreduce(*m_gradient_staging,
                        m_gradient_staging->RedundantComm(),
                        m_gradient_allreduce_req,
                        El::mpi::SUM,
-                       std::type_index(typeid(Al::mpi_backend)));
+                       t);
   m_gradient_allreduce_finished = false;
 }
 


### PR DESCRIPTION
Don't always use the MPI backend for Aluminum in the optimizer.