### PR TITLE
Sync Hydrogen before Al/NCCL allreduce

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -29,6 +29,7 @@
 #include "lbann/comm.hpp"
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/cudnn_wrapper.hpp"
 #include "mpi.h"
 #include "omp.h"
 #include <sstream>
@@ -161,7 +162,7 @@ void lbann_comm::allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(::Al::NCCLBackend))) {
-    cudaStreamSynchronize(El::GPUManager::Stream());
+    CHECK_CUDA(cudaStreamSynchronize(El::GPUManager::Stream()));
     ::Al::Allreduce<::Al::NCCLBackend>(
       m.Buffer(),
       local_size,
@@ -199,7 +200,7 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(::Al::NCCLBackend))) {
-    cudaStreamSynchronize(El::GPUManager::Stream());
+    CHECK_CUDA(cudaStreamSynchronize(El::GPUManager::Stream()));
     ::Al::NonblockingAllreduce<::Al::NCCLBackend>(
       m.Buffer(),
       local_size,

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -161,6 +161,7 @@ void lbann_comm::allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(::Al::NCCLBackend))) {
+    cudaStreamSynchronize(El::GPUManager::Stream());
     ::Al::Allreduce<::Al::NCCLBackend>(
       m.Buffer(),
       local_size,
@@ -198,6 +199,7 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef LBANN_HAS_NCCL2
   if (t == std::type_index(typeid(::Al::NCCLBackend))) {
+    cudaStreamSynchronize(El::GPUManager::Stream());
     ::Al::NonblockingAllreduce<::Al::NCCLBackend>(
       m.Buffer(),
       local_size,


### PR DESCRIPTION
Hydrogen synchronizes its internal streams before doing MPI operations. Aluminum/NCCL uses separate internal streams, and so the Hydrogen stream needs to be synchronized before performing Aluminum operations, to ensure the data is ready.

This is a quick hack to do this and ensure correctness. We should replace it with a more elegant API in the future.