### PR TITLE
GPU performance optimization

### DIFF
--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -41,6 +41,18 @@ class identity_layer : public activation_layer {
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
 
+  void setup_gpu() override {
+    activation_layer::setup_gpu();
+#ifdef HYDROGEN_HAVE_CUB
+    // Set output matrix to use CUB GPU memory pool
+    // Note: During each forward prop, the output matrix is resized to
+    // the mini-batch size and cleared to obtain a matrix view. To
+    // avoid expensive GPU memory allocations and deallocations, we
+    // use CUB's GPU memory pool.
+    get_local_activations().SetMemoryMode(1);
+#endif
+  }
+
   void fp_compute() override {
     El::LockedView(get_activations(), get_prev_activations());
   }

--- a/include/lbann/layers/activations/sigmoid.hpp
+++ b/include/lbann/layers/activations/sigmoid.hpp
@@ -121,7 +121,7 @@ class sigmoid_layer : public entrywise_activation_layer {
   #else
     sigmoid_cuda::fp(*m_cudnn,
                      get_num_neurons(),
-                     m_mini_batch_size_per_gpu,
+                     get_prev_activations().LocalWidth(),
                      get_prev_activations().LockedBuffer(),
                      get_prev_activations().LDim(),
                      get_activations().Buffer(),
@@ -136,7 +136,7 @@ class sigmoid_layer : public entrywise_activation_layer {
   #else
     sigmoid_cuda::bp(*m_cudnn,
                      get_num_neurons(),
-                     m_mini_batch_size_per_gpu,
+                     get_prev_activations().LocalWidth(),
                      get_prev_activations().LockedBuffer(),
                      get_prev_activations().LDim(),
                      get_prev_error_signals().LockedBuffer(),

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -484,11 +484,6 @@ class Layer {
 
 #ifdef LBANN_HAS_CUDNN
 
-  /** Number of mini-batch samples per GPU. */
-  int m_mini_batch_size_per_gpu;
-  /** Maximum number of mini-batch samples per GPU. */
-  int m_max_mini_batch_size_per_gpu;
-
   /** cuDNN descriptor for first previous activation tensor. */
   cudnnTensorDescriptor_t m_prev_activations_cudnn_desc;
   /** cuDNN descriptor for first activations tensor. */

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -297,13 +297,9 @@ class batch_normalization : public regularizer_layer {
       DataType* running_var = m_weights[3]->get_values().Buffer();
 
       // Compute sums and sums of squares on the GPUs
-      CHECK_CUDA(cudaSetDevice(this->m_cudnn->get_gpu()));
-      const int col_start = std::min(0, local_width);
-      const int col_end = std::min(this->m_mini_batch_size_per_gpu, local_width);
-      const int current_width = col_end - col_start;
       batch_normalization_cuda
         ::channel_sums_and_sqsums(height,
-                                  current_width,
+                                  local_width,
                                   num_channels,
                                   get_prev_activations().LockedBuffer(),
                                   get_prev_activations().LDim(),
@@ -346,13 +342,9 @@ class batch_normalization : public regularizer_layer {
                            m_weights[3]->get_values().LockedBuffer());
 
     // Perform batch normalization with each GPU
-    CHECK_CUDA(cudaSetDevice(this->m_cudnn->get_gpu()));
-    const int col_start = std::min(0, local_width);
-    const int col_end = std::min(this->m_mini_batch_size_per_gpu, local_width);
-    const int current_width = col_end - col_start;
     batch_normalization_cuda
       ::batch_normalization(height,
-                            current_width,
+                            local_width,
                             num_channels,
                             get_prev_activations().LockedBuffer(),
                             get_prev_activations().LDim(),
@@ -394,13 +386,9 @@ class batch_normalization : public regularizer_layer {
     const int num_channels = this->m_neuron_dims[0];
 
     // Compute local gradient contributions
-    CHECK_CUDA(cudaSetDevice(this->m_cudnn->get_gpu()));
-    const int col_start = std::min(0, local_width);
-    const int col_end = std::min(this->m_mini_batch_size_per_gpu, local_width);
-    const int current_width = col_end - col_start;
     batch_normalization_cuda
       ::batch_normalization_backprop1(height,
-                                      current_width,
+                                      local_width,
                                       num_channels,
                                       get_prev_activations().LockedBuffer(),
                                       get_prev_activations().LDim(),
@@ -444,13 +432,9 @@ class batch_normalization : public regularizer_layer {
     }
 
     // Compute error signal
-    CHECK_CUDA(cudaSetDevice(this->m_cudnn->get_gpu()));
-    // const int col_start = std::min(0, local_width);
-    // const int col_end = std::min(this->m_mini_batch_size_per_gpu, local_width);
-    // const int current_width = col_end - col_start;
     batch_normalization_cuda
       ::batch_normalization_backprop2(height,
-                                      current_width,
+                                      local_width,
                                       m_use_global_stats ? width : local_width,
                                       num_channels,
                                       get_prev_activations().LockedBuffer(),

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -51,11 +51,15 @@ class dropout : public regularizer_layer {
     : regularizer_layer(comm),
       m_keep_prob(keep_prob) {
 
-  #if defined(LBANN_HAS_CUDNN) && !defined(LBANN_SEQUENTIAL_CONSISTENCY)
     // Initialize GPU memory if using GPU
-    /// @todo GPU implementation of dropout with sequential consistency
     this->m_cudnn = cudnn;
-  #endif // LBANN_HAS_CUDNN
+  #if defined(LBANN_HAS_CUDNN) && defined(LBANN_SEQUENTIAL_CONSISTENCY)
+    /// @todo GPU implementation of dropout with sequential consistency
+    if (Dev == El::Device::GPU && get_comm()->am_model_master()) {
+      std::err << "Warning: GPU dropout currently does not guarantee "
+               << "sequential consistency" << std::endl;
+    }
+  #endif
 
   }
 

--- a/include/lbann/layers/transform/reshape.hpp
+++ b/include/lbann/layers/transform/reshape.hpp
@@ -82,13 +82,31 @@ class reshape_layer : public transform_layer {
                                               this->m_neuron_dims.end(),
                                               1,
                                               std::multiplies<int>())) {
-      std::string num_neurons = " {";
-      for(int n: m_neuron_dims) num_neurons += " " + std::to_string(n);
-      num_neurons += " }";
-      throw lbann_exception("reshape_layer: invalid neuron dimensions, " +
-                             std::to_string(m_num_neurons) + " != " + num_neurons);
+      std::stringstream err;
+      err << "input neuron dimensions (";
+      for (size_t i = 0; i < this->m_prev_neuron_dims.size(); ++i) {
+        err << (i > 0 ? "x" : "") << this->m_prev_neuron_dims[i];
+      }
+      err << ") do not match output neuron dimensions (";
+      for (size_t i = 0; i < this->m_neuron_dims.size(); ++i) {
+        err << (i > 0 ? "x" : "") << this->m_neuron_dims[i];
+      }
+      err << ")";
+      LBANN_ERROR(err.str());
     }
 
+  }
+
+  void setup_gpu() override {
+    transform_layer::setup_gpu();
+#ifdef HYDROGEN_HAVE_CUB
+    // Set output matrix to use CUB GPU memory pool
+    // Note: During each forward prop, the output matrix is resized to
+    // the mini-batch size and cleared to obtain a matrix view. To
+    // avoid expensive GPU memory allocation and deallocation, we use
+    // CUB's GPU memory pool.
+    get_local_activations().SetMemoryMode(1);
+#endif
   }
 
   void fp_compute() override {

--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -42,8 +42,7 @@ namespace lbann {
 class l2_weight_regularization : public objective_function_term {
  public:
 
-  l2_weight_regularization(EvalType scale_factor = EvalType(1))
-    : objective_function_term(scale_factor) {}
+  l2_weight_regularization(EvalType scale_factor = EvalType(1));
   l2_weight_regularization* copy() const override { return new l2_weight_regularization(*this); }
   std::string name() const override { return "L2 weight regularization"; }
   void setup(model& m) override;
@@ -65,16 +64,16 @@ class l2_weight_regularization : public objective_function_term {
 
  private:
 
-  /** Holds intermediate terms for each weights. */
-  std::vector<EvalType> m_sqsums;
-  /** Holds an allreduce request for each weights. */
-  std::vector<Al::request> m_allreduce_reqs;
-  /** Whether an allreduce is needed for each weights. */
-  std::vector<bool> m_allreduce_started;
+  /** Holds intermediate term for local contributions. */
+  EvalType m_sqsum;
+  /** Aluminum request for local contribution aggregation. */
+  Al::request m_allreduce_req;
+  /** Whether local contribution aggregation has started. */
+  bool m_allreduce_started;
 
 #ifdef LBANN_HAS_CUDNN
   /** Reference to cuDNN manager. */
-  cudnn::cudnn_manager* m_cudnn = nullptr;
+  cudnn::cudnn_manager* m_cudnn;
 #endif // LBANN_HAS_CUDNN
 
 };

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -170,6 +170,8 @@ class weights {
 
   /** Get the weight matrix. */
   AbsDistMat& get_values();
+  /** Get the weight matrix (const). */
+  const AbsDistMat& get_values() const;
   /** Set the weight matrix. */
   void set_values(const AbsDistMat& values);
 

--- a/src/layers/activations/softmax.cpp
+++ b/src/layers/activations/softmax.cpp
@@ -128,7 +128,7 @@ void softmax_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
   softmax_cuda::fp_cutoff(*this->m_cudnn,
                           activations.Buffer(),
                           get_num_neurons(),
-                          this->m_mini_batch_size_per_gpu,
+                          activations.LocalWidth(),
                           m_min_output);
 #endif // LBANN_ENABLE_SOFTMAX_CUTOFF
 
@@ -171,7 +171,7 @@ void softmax_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
                           activations.LockedBuffer(),
                           error_signals.Buffer(),
                           get_num_neurons(),
-                          this->m_mini_batch_size_per_gpu,
+                          error_signals.LocalWidth(),
                           this->m_min_output);
 #endif // LBANN_ENABLE_SOFTMAX_CUTOFF
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -376,48 +376,44 @@ AbsDistMat& Layer::get_error_signals(int parent_index) {
 const AbsDistMat& Layer::get_prev_activations(int parent_index) const {
   if (parent_index < 0 || parent_index >= (int) m_prev_activations.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access invalid previous activation matrix "
+    err << "attempted to access invalid previous activation matrix "
         << "from " << m_name << " "
         << "(requested index " << parent_index << ", but there are "
         << m_prev_activations.size() << " previous activation matrices)";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   return *m_prev_activations[parent_index];
 }
 const AbsDistMat& Layer::get_activations(int child_index) const {
   if (child_index < 0 || child_index >= (int) m_activations.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access invalid activation matrix "
+    err << "attempted to access invalid activation matrix "
         << "from " << m_name << " "
         << "(requested index " << child_index << ", but there are "
         << m_activations.size() << " activation matrices)";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   return *m_activations[child_index];
 }
 const AbsDistMat& Layer::get_prev_error_signals(int child_index) const {
   if (child_index < 0 || child_index >= (int) m_prev_error_signals.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access invalid previous error signal matrix "
+    err << "attempted to access invalid previous error signal matrix "
         << "from " << m_name << " "
         << "(requested index " << child_index << ", but there are "
         << m_prev_error_signals.size() << " previous error signal matrices)";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   return *m_prev_error_signals[child_index];
 }
 const AbsDistMat& Layer::get_error_signals(int parent_index) const {
   if (parent_index < 0 || parent_index >= (int) m_error_signals.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access invalid error signal matrix "
+    err << "attempted to access invalid error signal matrix "
         << "from " << m_name << " "
         << "(requested index " << parent_index << ", but there are "
         << m_error_signals.size() << " error signal matrices)";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   return *m_error_signals[parent_index];
 }
@@ -447,10 +443,7 @@ const AbsMat& Layer::get_local_error_signals(int parent_index) const {
 }
 
 void Layer::clear_error_signals(int mini_batch_size) {
-  // Note: matrices are cleared (without deallocating memory) in case
-  // they are matrix views.
   for (int i = 0; i < get_num_parents(); ++i) {
-    get_error_signals(i).Empty(false);
     El::Zeros(get_error_signals(i), get_num_prev_neurons(i), mini_batch_size);
   }
 }
@@ -472,7 +465,7 @@ void Layer::unfreeze() {
 bool Layer::is_frozen() const {
   for(auto& w : m_weights) {
     if (w->is_frozen() != m_frozen) {
-      throw lbann_exception("layer and weights of them are inconsistently frozen");
+      LBANN_ERROR("layer and weights of them are inconsistently frozen");
     }
   }
   return m_frozen;
@@ -486,9 +479,8 @@ void Layer::setup() {
   if (using_gpus()) {
     if(m_cudnn == nullptr) {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer " << m_name << " is trying to use GPUs but has an invalid pointer to the cudnn object";
-      throw lbann_exception(err.str());
+      err << "layer " << m_name << " is trying to use GPUs but has an invalid pointer to the cudnn object";
+      LBANN_ERROR(err.str());
     }
     setup_gpu();
   }
@@ -500,20 +492,18 @@ void Layer::setup_pointers() {
   if(m_expected_num_parent_layers >= 0
      && get_num_parents() != m_expected_num_parent_layers) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "layer " << m_name << " has an invalid number of parent layers "
+    err << "layer " << m_name << " has an invalid number of parent layers "
         << "(expected " << m_expected_num_parent_layers << ", "
         << "but found " << m_parent_layers.size() << ")";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   if(m_expected_num_child_layers >= 0
      && get_num_children() != m_expected_num_child_layers) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "layer " << m_name << " has an invalid number of child layers "
+    err << "layer " << m_name << " has an invalid number of child layers "
         << "(expected " << m_expected_num_child_layers << ", "
         << "but found " << m_child_layers.size() << ")";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 
 }
@@ -615,10 +605,7 @@ void Layer::setup_matrices(const El::Grid& grid) {
       instantiate_matrices<data_layout::MODEL_PARALLEL, El::Device::GPU>(grid); break;
 #endif // LBANN_HAS_GPU
     default:
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "invalid matrix data allocation";
-      throw lbann_exception(err.str());
+      LBANN_ERROR("invalid matrix data allocation");
     }
     break;
   case data_layout::DATA_PARALLEL:
@@ -630,17 +617,11 @@ void Layer::setup_matrices(const El::Grid& grid) {
       instantiate_matrices<data_layout::DATA_PARALLEL, El::Device::GPU>(grid); break;
 #endif // LBANN_HAS_GPU
     default:
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "invalid matrix data allocation";
-      throw lbann_exception(err.str());
+      LBANN_ERROR("invalid matrix data allocation");
     }
     break;
   default:
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "invalid distributed matrix layout";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("invalid distributed matrix layout");
   }
 
 }
@@ -754,72 +735,65 @@ void Layer::check_setup() {
   const int num_children = get_num_children();
   if ((int) m_prev_activations.size() != num_parents
       || (int) m_activations.size() != num_children) {
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "layer " << m_name << " has an invalid number of "
+    err << "layer " << m_name << " has an invalid number of "
         << "forward prop matrices (expected "
         << num_parents << " input and " << num_children << " output, "
         << "but found " << m_prev_activations.size() << " and "
         << m_activations.size() << " respectively) ";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   if ((int) m_prev_error_signals.size() != num_children
       || (int) m_error_signals.size() != num_parents) {
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "layer " << m_name << " has an invalid number of "
+    err << "layer " << m_name << " has an invalid number of "
         << "backward prop matrices (expected "
         << num_children << " input and " << num_parents << " output. "
         << "but found " << m_prev_error_signals.size() << " and "
         << m_error_signals.size() << " respectively) ";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 
   // Check that matrices are initialized
   for (const auto& m : m_prev_activations) {
     if (m == nullptr) {
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer " << m_name << " has an uninitialized previous activation matrix";
-      throw lbann_exception(err.str());
+      err << "layer " << m_name << " has an uninitialized previous activation matrix";
+      LBANN_ERROR(err.str());
     }
   }
   for (const auto& m : m_activations) {
     if (m == nullptr) {
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer " << m_name << " has an uninitialized activation matrix";
-      throw lbann_exception(err.str());
+      err << "layer " << m_name << " has an uninitialized activation matrix";
+      LBANN_ERROR(err.str());
     }
   }
   for (const auto& m : m_prev_error_signals) {
     if (m == nullptr) {
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer " << m_name << " has an uninitialized previous error signal matrix";
-      throw lbann_exception(err.str());
+      err << "layer " << m_name << " has an uninitialized previous error signal matrix";
+      LBANN_ERROR(err.str());
     }
   }
   for (const auto& m : m_error_signals) {
     if (m == nullptr) {
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer " << m_name << " has an uninitialized error signal matrix";
-      throw lbann_exception(err.str());
+      err << "layer " << m_name << " has an uninitialized error signal matrix";
+      LBANN_ERROR(err.str());
     }
   }
 
   // Check that number of neurons is greater than zero
   if (m_num_neurons <= 0) {
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "layer " << m_name << " has invalid output dimensions "
+    err << "layer " << m_name << " has invalid output dimensions "
         << "(" << m_neuron_dims[0];
     for (size_t i = 1; i < m_neuron_dims.size(); ++i) {
       err << "x" << m_neuron_dims[i];
     }
     err << ")";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 
 }
 
 void Layer::replace_weights(Layer* other_layer) {
   if (other_layer == nullptr) {
-    throw lbann_exception("Layer::replace_weights: Attempted to add null pointer as a replacement layer.");
+    LBANN_ERROR("attempted to add null pointer as a replacement layer");
   }
 
   const std::vector<weights *> other_layer_weights = other_layer->get_weights();
@@ -906,10 +880,7 @@ void Layer::fp_setup_data(int mini_batch_size) {
   }
 
   // Initialize activations
-  // Note: matrices are cleared (without deallocating memory) in case
-  // they are matrix views.
   for (int i = 0; i < get_num_children(); ++i) {
-    get_activations(i).Empty(false);
     get_activations(i).Resize(get_num_neurons(i), mini_batch_size);
   }
 
@@ -975,13 +946,12 @@ void Layer::bp_setup_data(int mini_batch_size) {
     if (bp_input.Height() != expected_height
         || bp_input.Width() != mini_batch_size) {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "layer \"" << get_name() << "\" expected a "
+      err << "layer \"" << get_name() << "\" expected a "
           << expected_height << " x " << mini_batch_size
           << " input matrix from layer \"" << child->get_name() << "\""
           << " during backward prop, but got a "
           << bp_input.Height() << " x " << bp_input.Width() << " matrix";
-      throw lbann_exception(err.str());
+      LBANN_ERROR(err.str());
     }
 
   }
@@ -1072,10 +1042,9 @@ void Layer::get_fp_output(AbsDistMat& output, const Layer* child) const {
                               - m_child_layers.begin());
   if (child_index >= m_child_layers.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << get_name() << " has no forward prop output corresponding to "
+    err << get_name() << " has no forward prop output corresponding to "
         << child->get_name();
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   auto& activation = const_cast<Layer*>(this)->get_activations(child_index);
 
@@ -1100,10 +1069,9 @@ void Layer::get_bp_output(AbsDistMat& output, const Layer* parent) const {
                                - m_parent_layers.begin());
   if (parent_index >= m_parent_layers.size()) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << get_name() << " has no backward prop output corresponding to "
+    err << get_name() << " has no backward prop output corresponding to "
         << parent->get_name();
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
   auto& error_signal = const_cast<Layer*>(this)->get_error_signals(parent_index);
 
@@ -1124,9 +1092,7 @@ std::string Layer::get_data_layout_string(data_layout d) const {
   case data_layout::MODEL_PARALLEL:
     return "model_parallel";
   default:
-    throw lbann_exception(
-      std::string {} + __FILE__ + " " + std::to_string(__LINE__) + " :: " +
-      "Layer: invalid data layout");
+    LBANN_ERROR("invalid data layout");
   }
 }
 
@@ -1139,9 +1105,7 @@ std::string Layer::get_device_allocation_string(El::Device dev) const {
     return "gpu";
 #endif // LBANN_HAS_GPU
   default:
-    throw lbann_exception(
-      std::string {} + __FILE__ + " " + std::to_string(__LINE__) + " :: " +
-      "Layer: invalid device allocation");
+    LBANN_ERROR("invalid device allocation");
   }
 }
 
@@ -1154,9 +1118,7 @@ std::string Layer::get_device_allocation_string_short(El::Device dev) const {
     return "G";
 #endif // LBANN_HAS_GPU
   default:
-    throw lbann_exception(
-      std::string {} + __FILE__ + " " + std::to_string(__LINE__) + " :: " +
-      "Layer: invalid device allocation");
+    LBANN_ERROR("invalid device allocation");
   }
 }
 
@@ -1204,9 +1166,7 @@ std::vector<Layer*> Layer::get_layer_pointers() {
 
 void Layer::set_layer_pointers(std::vector<Layer*> layers) {
   if(layers.size() != m_parent_layers.size() + m_child_layers.size()) {
-    throw lbann_exception(
-      std::string {} + __FILE__ + " " + std::to_string(__LINE__) + " :: " +
-      "Layer: attempted to set layer pointers with an invalid number of pointers");
+    LBANN_ERROR("attempted to set layer pointers with an invalid number of pointers");
   }
   size_t pos = 0;
   for(const Layer*& parent: m_parent_layers) {

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -64,6 +64,12 @@ namespace {
 
 namespace lbann {
 
+l2_weight_regularization::l2_weight_regularization(EvalType scale_factor)
+  : objective_function_term(scale_factor),
+    m_sqsum(0),
+    m_allreduce_started(false),
+    m_cudnn(nullptr) {}
+
 void l2_weight_regularization::setup(model& m) {
   objective_function_term::setup(m);
 
@@ -80,11 +86,6 @@ void l2_weight_regularization::setup(model& m) {
       }
     }
   }
-  m_sqsums.resize(m_weights.size(), EvalType(0));
-  m_allreduce_started.resize(m_weights.size(), false);
-  for (size_t i = 0; i < m_weights.size(); ++i) {
-    m_allreduce_reqs.emplace_back();
-  }
 
 #ifdef LBANN_HAS_CUDNN
   // Get cuDNN manager
@@ -99,56 +100,81 @@ void l2_weight_regularization::setup(model& m) {
 
 void l2_weight_regularization::start_evaluation() {
   if (m_scale_factor == EvalType(0)) { return; }
-
-  // Reset terms for each weights
   const int num_weights = m_weights.size();
-  std::fill(m_sqsums.begin(), m_sqsums.end(), EvalType(0));
+
+  // Each weights' local contribution to L2 regularization term
+  CPUMat sqsums;
+  El::Zeros(sqsums, num_weights, 1);
 
 #ifdef LBANN_HAS_CUDNN
-  // Compute terms for GPU weights
   if (m_cudnn != nullptr) {
-    CHECK_CUDA(cudaSetDevice(m_cudnn->get_gpu()));
+
+    // Set cuBLAS to device pointer mode to allow pipelined calls
     auto&& handle = m_cudnn->get_cublas_handle();
+    CHECK_CUDA(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE));
+
+    // Compute local contributions on GPU
+    // Note: Only compute local contribution on one process in each
+    // redundant communicator.
+    GPUMat sqsums_d;
+#ifdef HYDROGEN_HAVE_CUB
+    sqsums_d.SetMemoryMode(1); // CUB memory pool
+#endif
+    El::Zeros(sqsums_d, num_weights, 1);
     for (int i = 0; i < num_weights; ++i) {
-      const auto& w = m_weights[i];
-      if (w->get_cudnn_manager() != nullptr) {
-        const auto& values = w->get_values();
-        // Use a local Dot on each GPU and non-blocking reductions to aggregate results later
-        m_sqsums[i] = cublas::dot(handle, values.LocalHeight() * values.LocalWidth(), values.LockedBuffer(), 1, values.LockedBuffer(), 1);
-        get_comm().nb_allreduce(&(m_sqsums[i]), 1, values.DistComm(),
-                                m_allreduce_reqs[i], El::mpi::SUM);
-        m_allreduce_started[i] = true;
+      const auto& vals = m_weights[i]->get_values();
+      if (vals.Participating()
+          && vals.GetLocalDevice() == El::Device::GPU
+          && vals.RedundantRank() == i % vals.RedundantSize()) {
+        /// @todo Support general case
+        if (vals.LDim() != vals.LocalHeight()) {
+          LBANN_ERROR("we currently assume weights matrices are contiguous");
+        }
+        cublas::dot(handle,
+                    vals.LocalHeight() * vals.LocalWidth(),
+                    vals.LockedBuffer(), 1,
+                    vals.LockedBuffer(), 1,
+                    sqsums_d.Buffer(i, 0));
       }
     }
+
+    // Reset cuBLAS mode and copy results to CPU
+    CHECK_CUDA(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST));
+    El::Copy(sqsums_d, sqsums);
+
   }
 #endif // LBANN_HAS_CUDNN
 
-  // Compute terms for CPU weights
-  std::fill(m_allreduce_started.begin(), m_allreduce_started.end(), false);
+  // Compute local contributions on CPU
+  // Note: Only compute local contribution on one process in each
+  // redundant communicator.
+  m_sqsum = EvalType(0);
   for (int i = 0; i < num_weights; ++i) {
-    const auto& w = m_weights[i];
-    if (w->get_cudnn_manager() == nullptr) {
-      const auto& values = w->get_values();
-      m_sqsums[i] = sum_of_squares(values.LockedMatrix());
-      get_comm().nb_allreduce(&(m_sqsums[i]), 1, values.DistComm(),
-                              m_allreduce_reqs[i], El::mpi::SUM);
-      m_allreduce_started[i] = true;
+    const auto& vals = m_weights[i]->get_values();
+    if (vals.Participating()
+        && vals.GetLocalDevice() == El::Device::CPU
+        && vals.RedundantRank() == i % vals.RedundantSize()) {
+      sqsums(i, 0) = sum_of_squares(vals.LockedMatrix());      
     }
+    m_sqsum += sqsums(i, 0);
   }
+
+  // Start aggregating local contributions
+  get_comm().nb_allreduce(&m_sqsum,
+                          1,
+                          get_comm().get_model_comm(),
+                          m_allreduce_req);
+  m_allreduce_started = true;
 
 }
 
 EvalType l2_weight_regularization::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
-  for (size_t i = 0; i < m_weights.size(); ++i) {
-    if (m_allreduce_started[i]) {
-      get_comm().wait(m_allreduce_reqs[i]);
-    }
+  if (m_allreduce_started) {
+    get_comm().wait(m_allreduce_req);
   }
-  const auto& sqsum = std::accumulate(m_sqsums.begin(),
-                                      m_sqsums.end(),
-                                      EvalType(0));
-  return m_scale_factor * sqsum / 2;
+  m_allreduce_started = false;
+  return m_scale_factor * m_sqsum / 2;
 }
 
 void l2_weight_regularization::compute_weight_regularization() {

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -135,8 +135,7 @@ void weights::setup(std::vector<int> matrix_height_dims,
       return;
     } else {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "attempted to setup " << m_name << " as a "
+      err << "attempted to setup " << m_name << " as a "
           << get_dims_string(matrix_height_dims, matrix_width_dims) << " "
           << "weights matrix with "
           << "col_dist=" << col_dist << ", "
@@ -146,7 +145,7 @@ void weights::setup(std::vector<int> matrix_height_dims,
           << "matrix with "
           << "col_dist=" << dist_data.colDist << ", "
           << "row_dist=" << dist_data.rowDist;
-      throw lbann_exception(err.str());
+      LBANN_ERROR(err.str());
     }
   } else {
     // Check that tensor dimensions are valid
@@ -159,11 +158,10 @@ void weights::setup(std::vector<int> matrix_height_dims,
     }
     if (!dims_are_valid) {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "attempted to setup " << m_name << " as a "
+      err << "attempted to setup " << m_name << " as a "
           << get_dims_string(matrix_height_dims, matrix_width_dims) << " "
           << "weights matrix";
-      throw lbann_exception(err.str());
+      LBANN_ERROR(err.str());
     }
   }
 
@@ -216,15 +214,16 @@ void weights::set_optimizer(optimizer* opt) {
 }
 
 AbsDistMat& weights::get_values() {
-
-  // Check if weights matrix has been setup
   if (m_values == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to access values of weights before they are setup";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to access values of weights before they are setup");
   }
+  return *m_values;
+}
 
+const AbsDistMat& weights::get_values() const {
+  if (m_values == nullptr) {
+    LBANN_ERROR("attempted to access values of weights before they are setup");
+  }
   return *m_values;
 }
 
@@ -232,10 +231,7 @@ void weights::set_values(const AbsDistMat& values) {
 
   // Check if weights matrix has been setup
   if (m_values == nullptr) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to set values of weights before they are setup";
-    throw lbann_exception(err.str());
+    LBANN_ERROR("attempted to set values of weights before they are setup");
   }
 
   // Copy input to weights matrix
@@ -249,10 +245,9 @@ void weights::set_value(DataType value, int index) {
   const auto& size = get_size();
   if (index < 0 || index >= size) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to set weight value at index " << index << ", "
+    err << "attempted to set weight value at index " << index << ", "
         << "but there are " << size << " values";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 #endif // LBANN_DEBUG
 
@@ -279,8 +274,7 @@ void weights::set_value(DataType value, std::vector<int> pos) {
   }
   if (!pos_is_valid) {
     std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to set weight value at position (";
+    err << "attempted to set weight value at position (";
     for (size_t i = 0 ; i < pos.size(); ++i) {
       err << (i > 0 ? "x" : "") << pos[i];
     }
@@ -288,7 +282,7 @@ void weights::set_value(DataType value, std::vector<int> pos) {
     for (size_t i = 0 ; i < dims.size(); ++i) {
       err << (i > 0 ? "x" : "") << dims[i];
     }
-    throw lbann_exception(err.str());
+    LBANN_ERROR(err.str());
   }
 #endif // LBANN_DEBUG
 
@@ -310,11 +304,10 @@ void weights::set_value(DataType value, int row, int col) {
     const auto& width = get_matrix_width();
     if (row < 0 || row >= height || col < 0 || col > width ) {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "attempted to set weights value at entry "
+      err << "attempted to set weights value at entry "
           << "(" << row << "," << col << ") "
           << "in a " << height << "x" << width << " matrix";
-      throw lbann_exception(err.str());
+      LBANN_ERROR(err.str());
     }
   }
 #endif // LBANN_DEBUG


### PR DESCRIPTION
This PR whittles away at performance bottlenecks when I run Resnet-50 with GPUs on Surface gpgpu:
- Stop allocating unnecessary memory for forward prop and backward prop inputs. This should hopefully halve our GPU memory requirements.
- Use the CUB memory pool when it is convenient to repeatedly allocate/deallocate GPU matrices, e.g. when a matrix often switches between owning data and being a matrix view.
- Pipeline cuBLAS calls when computing the L2 regularization term and divide work amongst GPUs (restoring functionality from #266). This implementation also only requires one allreduce instead of an allreduce for each set of weights.

Note that this requires the bugfixes in https://github.com/LLNL/Elemental/pull/6.