### PR TITLE
set num_neurons in FC to num_labels

### DIFF
--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -150,6 +150,11 @@ class fully_connected_layer : public learning_layer {
 
   std::string get_type() const override { return "fully connected"; }
 
+  void set_num_neurons(int n) { 
+    m_num_neurons = n; 
+    this->m_neuron_dims.assign(1, this->m_num_neurons);
+  }
+
   data_layout get_data_layout() const override { return T_layout; }
 
   El::Device get_device_allocation() const override { return Dev; }

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -259,7 +259,7 @@ model {
     name: "fc8"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons: 1000
+      num_neurons_is_num_labels: true
       has_bias: false
     }
   }

--- a/model_zoo/models/imagenet/model_imagenet.prototext
+++ b/model_zoo/models/imagenet/model_imagenet.prototext
@@ -65,7 +65,7 @@ model {
   #############################################
   layer {
     fully_connected {
-      num_neurons: 1000
+      num_neurons_is_num_labels: true
     }
     name: "5"
     parents: "4"

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -987,6 +987,7 @@ message FullyConnected {
   double bias_initial_value = 4;       //default: 0
   double l2_regularization_factor = 5; //default: 0
   double group_lasso_regularization_factor = 6; //default: 0
+  bool num_neurons_is_num_labels = 7;
 }
 
 message Convolution {


### PR DESCRIPTION
This PR replaces #357, since that PR included changes to data_store classes that should not have been included. Please see Sam and Tim's comments on #357 before reviewing this PR.

This PR adds  functionality for FC layers that precede softmax layers to set num_neurons to be the number of labels in the data reader.
If the two numbers differ an exception is thrown, so making this
auto-magic makes sense (to me). The new proto field in
FullyConnected layer is: "num_neurons_is_num_labels: true"
 This field will over-ride the num_neurons field, if it exists.

I've only modified two model_XX.prototext files that use imagenet,
so we don't have to remember to modify these files when switching
between, e.g, imagenet and imagenet22K. 

I propose we modify all applicable model_XX.prototext files, but Tim's comments (on PR 357) indicate more discussion is warranted prior to making those changes.