### PR TITLE
set num_neurons in FC to num_labels from data_reader

### DIFF
--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -157,6 +157,11 @@ class fully_connected_layer : public learning_layer {
 
   std::string get_type() const override { return "fully connected"; }
 
+  void set_num_neurons(int n) { 
+    m_num_neurons = n; 
+    this->m_neuron_dims.assign(1, this->m_num_neurons);
+  }
+
   data_layout get_data_layout() const override { return T_layout; }
 
   El::Device get_device_allocation() const override { return Dev; }

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -259,7 +259,7 @@ model {
     name: "fc8"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons: 1000
+      num_neurons_is_num_labels: true
       has_bias: false
     }
   }

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -252,13 +252,15 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
     if (layout_str == "data_parallel")  { layout = data_layout::DATA_PARALLEL; }
     if (layout_str == "model_parallel") { layout = data_layout::MODEL_PARALLEL; }
     const auto& num_parallel_readers = proto_model.num_parallel_readers();
-
     const auto& device_allocation_str = proto_layer.device_allocation();
-    El::Device default_device_allocation = El::Device::CPU;
+    El::Device device_allocation = El::Device::CPU;
 #ifdef LBANN_HAS_GPU
-    if (cudnn != nullptr) { default_device_allocation = El::Device::GPU; }
+    if (cudnn != nullptr) { device_allocation = El::Device::GPU; }
 #endif // LBANN_HAS_GPU
-    El::Device device_allocation = default_device_allocation;
+    if (device_allocation_str == "cpu") { device_allocation = El::Device::CPU; }
+#ifdef LBANN_HAS_GPU
+    if (device_allocation_str == "gpu") { device_allocation = El::Device::GPU; }
+#endif // LBANN_HAS_GPU
     if (device_allocation_str.empty()
         && (proto_layer.has_input() || proto_layer.has_target()
             || proto_layer.has_reconstruction() || proto_layer.has_softmax())) {
@@ -266,76 +268,31 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
       // allowed on the GPUs force the default to be the CPU
       device_allocation = El::Device::CPU;
     }
-    if (device_allocation_str == "cpu") { device_allocation = El::Device::CPU; }
-#ifdef LBANN_HAS_GPU
-    if (device_allocation_str == "gpu") { device_allocation = El::Device::GPU; }
-#endif // LBANN_HAS_GPU
+    cudnn::cudnn_manager* layer_cudnn = cudnn;
+    if (device_allocation == El::Device::CPU) {
+      layer_cudnn = nullptr;
+    }
 
     // Construct layer
     Layer* l = nullptr;
-    switch (layout) {
-    case data_layout::DATA_PARALLEL:
-      switch (device_allocation) {
-      case El::Device::CPU:
-        l = construct_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(
-              comm,
-              data_readers,
-              num_parallel_readers,
-              nullptr,
-              proto_layer
-            );
-        break;
+#define TEMPLATE_INSTANTIATION(T_layout, T_device)                      \
+    do {                                                                \
+      if (layout == T_layout && device_allocation == T_device) {        \
+        l = construct_layer<T_layout, T_device>(                        \
+              comm,                                                     \
+              data_readers,                                             \
+              num_parallel_readers,                                     \
+              layer_cudnn,                                              \
+              proto_layer);                                             \
+      }                                                                 \
+    } while (0)
+    TEMPLATE_INSTANTIATION(data_layout::DATA_PARALLEL, El::Device::CPU);
+    TEMPLATE_INSTANTIATION(data_layout::MODEL_PARALLEL, El::Device::CPU);
 #ifdef LBANN_HAS_GPU
-      case El::Device::GPU:
-        l = construct_layer<data_layout::DATA_PARALLEL, El::Device::GPU>(
-              comm,
-              data_readers,
-              num_parallel_readers,
-              cudnn,
-              proto_layer
-            );
-        break;
+    TEMPLATE_INSTANTIATION(data_layout::DATA_PARALLEL, El::Device::GPU);
+    TEMPLATE_INSTANTIATION(data_layout::MODEL_PARALLEL, El::Device::GPU);
 #endif // LBANN_HAS_GPU
-      default:
-        err << "layer " << name << " has an invalid device allocation "
-            << "(" << device_allocation_str << ")";
-        LBANN_ERROR(err.str());
-      }
-      break;
-    case data_layout::MODEL_PARALLEL:
-      switch (device_allocation) {
-      case El::Device::CPU:
-        l = construct_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>(
-              comm,
-              data_readers,
-              num_parallel_readers,
-              nullptr,
-              proto_layer
-            );
-        break;
-#ifdef LBANN_HAS_GPU
-      case El::Device::GPU:
-        l = construct_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>(
-              comm,
-              data_readers,
-              num_parallel_readers,
-              cudnn,
-              proto_layer
-            );
-        break;
-#endif // LBANN_HAS_GPU
-      default:
-        err << "layer " << name << " has an invalid device allocation "
-            << "(" << device_allocation_str << ")";
-        LBANN_ERROR(err.str());
-      }
-      break;
-    case data_layout::invalid:
-    default:
-      err << "layer " << name << " has an invalid data layout "
-          << "(" << layout_str << ")";
-      LBANN_ERROR(err.str());
-    }
+#undef TEMPLATE_INSTANTIATION
 
     // Check that layer has been constructed
     if (l == nullptr) {
@@ -378,7 +335,6 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
   return layers;
 
 }
-
 
 } // namespace proto
 } // namespace lbann

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -710,6 +710,7 @@ message Layer {
 
    // input Layers
    Input input = 2;
+   RepeatedInput repeated_input = 6; // @todo Remove when possible
 
    // transform Layers
    Reshape reshape = 306;
@@ -727,6 +728,9 @@ message Layer {
    Gaussian gaussian = 312;
    Bernoulli bernoulli = 313;
    Uniform uniform = 314;
+   Crop crop = 318;
+   CategoricalRandom categorical_random = 316;
+   DiscreteRandom discrete_random = 317;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -759,6 +763,7 @@ message Layer {
    Exponential exponential = 41;
    Swish swish = 42;
    Power power = 43;
+   Log log = 44;
 }
 ///////////////////////
 // MotifLayer //
@@ -822,6 +827,10 @@ message Power {
   double exponent = 1;
 }
 
+message Log {
+  double base = 1;
+}
+
 ///////////////////////////
 // Regularization Layers //
 ///////////////////////////
@@ -857,6 +866,13 @@ message Input {
   bool data_set_per_model = 1;  //default: false
   string io_buffer = 2;
   bool for_regression = 3; //default: false
+}
+
+/// @todo Remove when possible
+message RepeatedInput {
+  bool data_set_per_model = 1;  //default: false
+  bool for_regression = 2; //default: false
+  int64 num_steps = 3;
 }
 
 //////////////////////
@@ -947,6 +963,18 @@ message Uniform {
   double min = 1;
   double max = 2;
   string neuron_dims = 3;
+}
+
+message Crop {
+  string dims = 3;
+}
+
+message CategoricalRandom {
+}
+
+message DiscreteRandom {
+  string values = 1;
+  string dims = 2;
 }
 
 /////////////////////

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -710,7 +710,6 @@ message Layer {
 
    // input Layers
    Input input = 2;
-   RepeatedInput repeated_input = 6; // @todo Remove when possible
 
    // transform Layers
    Reshape reshape = 306;
@@ -728,9 +727,6 @@ message Layer {
    Gaussian gaussian = 312;
    Bernoulli bernoulli = 313;
    Uniform uniform = 314;
-   Crop crop = 318;
-   CategoricalRandom categorical_random = 316;
-   DiscreteRandom discrete_random = 317;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -763,7 +759,6 @@ message Layer {
    Exponential exponential = 41;
    Swish swish = 42;
    Power power = 43;
-   Log log = 44;
 }
 ///////////////////////
 // MotifLayer //
@@ -827,10 +822,6 @@ message Power {
   double exponent = 1;
 }
 
-message Log {
-  double base = 1;
-}
-
 ///////////////////////////
 // Regularization Layers //
 ///////////////////////////
@@ -866,13 +857,6 @@ message Input {
   bool data_set_per_model = 1;  //default: false
   string io_buffer = 2;
   bool for_regression = 3; //default: false
-}
-
-/// @todo Remove when possible
-message RepeatedInput {
-  bool data_set_per_model = 1;  //default: false
-  bool for_regression = 2; //default: false
-  int64 num_steps = 3;
 }
 
 //////////////////////
@@ -965,18 +949,6 @@ message Uniform {
   string neuron_dims = 3;
 }
 
-message Crop {
-  string dims = 3;
-}
-
-message CategoricalRandom {
-}
-
-message DiscreteRandom {
-  string values = 1;
-  string dims = 2;
-}
-
 /////////////////////
 // learning Layers //
 /////////////////////
@@ -988,6 +960,7 @@ message FullyConnected {
   double l2_regularization_factor = 5; //default: 0
   double group_lasso_regularization_factor = 6; //default: 0
   bool transpose = 7;
+  bool num_neurons_is_num_labels = 8;
 }
 
 message Convolution {


### PR DESCRIPTION
This PR replaces #357, since that PR included changes to data_store classes that should not have been included. Please see Sam and Tim's comments on #357 before reviewing this PR.

This PR adds functionality for FC layers that precede softmax layers to set num_neurons to be the number of labels in the data reader. Previously, if the two numbers differ an exception was thrown, so making this auto-magic makes sense (to me). The new proto field in FullyConnected layer is: "num_neurons_is_num_labels: true" This field will over-ride the num_neurons field (if it exists).
Without this PR, we had to modify model_alexnet.prototext when switching between imagenet, imagement22K, etc.

I've only added "num_neurons_is_num_labels: true" to model_alexnet.prototext  
I propose we modify all applicable model_XX.prototext files, but Tim's comments (on PR 357) indicate more discussion is warranted prior to making those changes.