### PR TITLE
Default data-parallel softmax on GPU

### DIFF
--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -263,8 +263,9 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
 #endif // LBANN_HAS_GPU
     if (device_allocation_str.empty()
         && (proto_layer.has_input() || proto_layer.has_target()
-            || proto_layer.has_reconstruction() || proto_layer.has_softmax())) {
-      // Input, Target, Reconstruction, and Softmax layers are not
+            || proto_layer.has_reconstruction()
+            || (proto_layer.has_softmax() && layout == data_layout::MODEL_PARALLEL))) {
+      // Input, Target, Reconstruction, and model-parallel Softmax layers are not
       // allowed on the GPUs force the default to be the CPU
       device_allocation = El::Device::CPU;
     }


### PR DESCRIPTION
We used to default the data-parallel softmax to running on GPU when GPU support is present. This restores that behavior.