### PR TITLE
Precomputed scaling

### DIFF
--- a/src/data_readers/cv_subtractor.cpp
+++ b/src/data_readers/cv_subtractor.cpp
@@ -286,7 +286,23 @@ std::ostream& cv_subtractor::print(std::ostream& os) const {
      << " - configuration of the image to subtract: "
      << m_img_to_sub.cols << 'x' << m_img_to_sub.rows
      << 'x' << m_img_to_sub.channels()
-     << '-' << m_img_to_sub.depth() << std::endl;
+     << '-' << m_img_to_sub.depth() << std::endl
+     << " - configuration of the image to divide: "
+     << m_img_to_div.cols << 'x' << m_img_to_div.rows
+     << 'x' << m_img_to_div.channels()
+     << '-' << m_img_to_div.depth() << std::endl;
+#if 0
+  if (!m_img_to_sub.empty()) {
+    cv::Mat img_sub;
+    m_img_to_sub.convertTo(img_sub, CV_8U, f, 0.0);
+    cv::imwrite("img_sub.png", img_sub);
+  }
+  if (!m_img_to_div.empty()) {
+    cv::Mat img_div;
+    m_img_to_div.convertTo(img_div, CV_8U, f, 0.0);
+    cv::imwrite("img_div.png", img_div);
+  }
+#endif
   return os;
 }
 

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -72,9 +72,52 @@ void init_image_preprocessor(const lbann_data::Reader& pb_readme, const bool mas
       // If every image in the dataset is a color image, this is not needed
       std::unique_ptr<lbann::cv_subtractor> subtractor(new(lbann::cv_subtractor));
       subtractor->set_name(subtractor_name);
-      subtractor->set(pb_subtractor.image_to_sub());
-      pp->add_normalizer(std::move(subtractor));
-      if (master) std::cout << "image processor: " << subtractor_name << " subtractor is set" << std::endl;
+
+      bool is_set = false;
+
+      if (!pb_subtractor.image_to_sub().empty()) {
+        subtractor->set_mean(pb_subtractor.image_to_sub());
+        is_set = true;
+      }
+      else if (pb_subtractor.channel_mean_size() > 0) {
+        const int _width = pb_subtractor.width()? pb_subtractor.width() : width;
+        const int _height = pb_subtractor.height()? pb_subtractor.height() : height;
+
+        const size_t n = pb_subtractor.channel_mean_size();
+        std::vector<lbann::DataType> ch_mean(n);
+        for(size_t i = 0u; i < n; ++i) {
+          ch_mean[i] = static_cast<lbann::DataType>(pb_subtractor.channel_mean(i));
+        }
+
+        subtractor->set_mean(_width, _height, ch_mean);
+        is_set = true;
+      }
+
+      if (! pb_subtractor.image_to_div().empty()) {
+        subtractor->set_stddev(pb_subtractor.image_to_div());
+        is_set = true;
+      }
+      else if (pb_subtractor.channel_stddev_size() > 0) {
+        const int _width = pb_subtractor.width()? pb_subtractor.width() : width;
+        const int _height = pb_subtractor.height()? pb_subtractor.height() : height;
+
+        const size_t n = pb_subtractor.channel_stddev_size();
+        std::vector<lbann::DataType> ch_stddev(n);
+        for(size_t i = 0u; i < n; ++i) {
+          ch_stddev[i] = static_cast<lbann::DataType>(pb_subtractor.channel_stddev(i));
+        }
+
+        subtractor->set_stddev(_width, _height, ch_stddev);
+        is_set = true;
+      }
+
+      if (is_set) {
+        pp->add_normalizer(std::move(subtractor));
+        if (master) std::cout << "image processor: " << subtractor_name << " subtractor is set" << std::endl;
+      } else {
+        if (master) std::cout << "image processor: " << subtractor_name
+                              << " subtractor needs at least either of 'image_to_sub' or 'image_to_div'." << std::endl;
+      }
     }
   }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -106,6 +106,11 @@ message ImagePreprocessor {
     string name = 1;
     bool disable = 2;
     string image_to_sub = 3;
+    string image_to_div = 4;
+    repeated float channel_mean = 5 [packed = true];
+    repeated float channel_stddev = 6 [packed = true];
+    int32 width = 7;
+    int32 height = 8;
   }
 
   message PatchExtractor {

--- a/tests/test_img_pipeline/CMakeLists.txt
+++ b/tests/test_img_pipeline/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 set(COMPILER "gnu")
 set(CLUSTER "surface")
 set(LBANN_DIR ../..)
-set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.${CLUSTER}.llnl.gov/install)
+set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
 include(${LBANN_DIR}/cmake/modules/SetupMPI.cmake)
 include(${LBANN_DIR}/cmake/modules/SetupOpenMP.cmake)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -55,7 +55,7 @@ set(Hydrogen_LIBS "${Hydrogen_LIBRARIES};-lHydrogen;-lpmrrr;-lopenblas;-lpthread
 
 file(GLOB IMGPIPE_DEPEND_SRCS
      lbann/utils/random.cpp
-     lbann/utils/file_utils.cpp
+     ${LBANN_DIR}/src//utils/file_utils.cpp
      ${LBANN_DIR}/src/data_readers/image_utils.cpp
      ${LBANN_DIR}/src/data_readers/cv_augmenter.cpp
      ${LBANN_DIR}/src/data_readers/cv_colorizer.cpp

--- a/tests/test_img_pipeline/main.cpp
+++ b/tests/test_img_pipeline/main.cpp
@@ -229,12 +229,19 @@ bool test_image_io(const std::string filename,
         pp.add_normalizer(std::move(normalizer));
       } else {
         std::unique_ptr<lbann::cv_subtractor> normalizer(new(lbann::cv_subtractor));
+#if 1
         cv::Mat img_to_sub = cv::imread(mp.m_mean_image_name);
         if (img_to_sub.empty()) {
           std::cout << mp.m_mean_image_name << " does not exist" << std::endl;
           return false;
         }
-        normalizer->set(img_to_sub);
+#else
+        cv::Scalar px = {0.40625, 0.45703, 0.48047};
+        cv::Mat img_to_sub(rp.m_crop_sz.second, rp.m_crop_sz.first,
+                           lbann::cv_image_type<lbann::DataType>::T(3), px);
+        normalizer->set_stddev(img_to_sub.cols, img_to_sub.rows, {0.3, 0.5, 0.3});
+#endif
+        normalizer->set_mean(img_to_sub);
         pp.add_normalizer(std::move(normalizer));
       }
       transform_idx ++;

--- a/tests/test_patchworks/CMakeLists.txt
+++ b/tests/test_patchworks/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0015 NEW)
 set(COMPILER "gnu")
 set(CLUSTER "surface")
 set(LBANN_DIR ../..)
-set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.${CLUSTER}.llnl.gov/install)
+set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
 include(${LBANN_DIR}/cmake/modules/SetupMPI.cmake)
 include(${LBANN_DIR}/cmake/modules/SetupOpenMP.cmake)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -55,7 +55,7 @@ set(Hydrogen_LIBS "${Hydrogen_LIBRARIES};-lHydrogen;-lpmrrr;-lopenblas;-lpthread
 
 file(GLOB PATCHWORKS_DEPEND_SRCS
      lbann/utils/random.cpp
-     lbann/utils/file_utils.cpp
+     ${LBANN_DIR}/src//utils/file_utils.cpp
      ${LBANN_DIR}/src/data_readers/image_utils.cpp
      ${LBANN_DIR}/src/data_readers/cv_augmenter.cpp
      ${LBANN_DIR}/src/data_readers/cv_colorizer.cpp


### PR DESCRIPTION
To address the issue #358 'Dataset-wide scaling'.

The mean/variance can be represented either in an typical image with the depth of 8-bit/16-bit unsigned integer that is recognized by opencv (e.g., *.png, *.jpg), or in a matrix of floating point values. In case of the latter, the custom tool under toosls/compute_mean can help produce the binary dump file of the mean. The file does not have a header, and the file name serves for the purpose. For example, the file name "anyname-WxHxC-D.bin" indicates that the image has width W, height H, the number of channels C, and the OpenCV depth code D.

For channel-wise normalization, which is a special case of the pixel-wise normalization (with uniform pixels), an additional mechanism is provided here to allows specifying the mean and variance for each channel via the prototext interface.

- added 'image_to_div' to subtractor's prototext interface for enabling z-score or unit-variance.
- added 'channel_mean' for making channel-wise mean subtraction easier without requiring the mean as an inpuit image as with 'image_to_sub', 
- added 'channel_stddev' to support a similar channel-wise mechanism for z-score/unit-variance without requiring the variance as an inpuit image as with 'image_to_sub', 

In case of 'channel_mean' or 'channel_stddev', the number are expected as floating point scaled to the [0 1] range. For example, for an image of 8-bit unsigned integer, 1/255 can be multiplied for this scaling.
Also, in these case, the image size must be defined via the prototext interface as below('width', 'height').

```
image_preprocessor {
    subtractor {
        disable: false
        # the image size before cropping
        width: 256
        height: 256
        disable: false
        # the channel order below is [B, G, R]
        channel_mean: [0.40625, 0.45703, 0.48047]
        channel_stddev: [0.1, 0.1, 0.1]
        #image_to_sub: "mean-256x256x3-6.bin"
        #image_to_sub: "mean.png"
        #image_to_div: "var-256x256x3-6.bin"
        #image_to_div: "var.png"
    }
}
```
