### PR TITLE
Adds a callback to print GPU memory usage at the beginning of each epoch

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -25,6 +25,7 @@ set_full_path(THIS_DIR_HEADERS
   callback_timer.hpp
   callback_variable_minibatch.hpp
   profiler.hpp
+  callback_gpu_memory_usage.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/callbacks/callback_gpu_memory_usage.hpp
+++ b/include/lbann/callbacks/callback_gpu_memory_usage.hpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_callback .hpp - Base class for LBANN callbacks
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef __LBANN_CALLBACKS_CALLBACK_GPU_MEMORY_USAGE_HPP_INCLUDED
+#define __LBANN_CALLBACKS_CALLBACK_GPU_MEMORY_USAGE_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+
+#ifdef LBANN_HAS_CUDA
+
+namespace lbann {
+/** Callback hooks for gradient check. */
+class lbann_callback_gpu_memory_usage : public lbann_callback {
+ public:
+  
+  /** Constructor.
+   */
+  lbann_callback_gpu_memory_usage() = default;
+  lbann_callback_gpu_memory_usage(const lbann_callback_gpu_memory_usage&) = default;
+  lbann_callback_gpu_memory_usage& operator=(const lbann_callback_gpu_memory_usage&) = default;
+  lbann_callback_gpu_memory_usage* copy() const override { return new lbann_callback_gpu_memory_usage(*this); }
+  void on_epoch_begin(model *m) override;
+  std::string name() const override { return "GPU memory usage"; }
+};
+
+}  // namespace lbann
+
+#endif // LBANN_HAS_CUDA
+
+#endif  // __LBANN_CALLBACKS_CALLBACK_GPU_MEMORY_USAGE_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -158,6 +158,7 @@
 #include "lbann/callbacks/callback_timeline.hpp"
 #include "lbann/callbacks/callback_checkpoint.hpp"
 #include "lbann/callbacks/callback_save_model.hpp"
+#include "lbann/callbacks/callback_gpu_memory_usage.hpp"
 
 /// Weights and weight initializers
 #include "lbann/weights/weights.hpp"

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -49,6 +49,7 @@ model {
       amt: 0.1
     }
   }
+  callback { gpu_memory_usage {} }
 
   ###################################################
   # start of layers

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -26,7 +26,8 @@ set_full_path(THIS_DIR_SOURCES
   callback_timer.cpp
   callback_variable_minibatch.cpp
   profiler.cpp
-  )
+  callback_gpu_memory_usage.cpp
+)
 
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/callbacks/callback_gpu_memory_usage.cpp
+++ b/src/callbacks/callback_gpu_memory_usage.cpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_callback_summary .hpp .cpp - Callback hooks to summarize to Tensorboard
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_gpu_memory_usage.hpp"
+#include <iomanip>
+
+namespace lbann {
+
+void lbann_callback_gpu_memory_usage::on_epoch_begin(model *m) {
+#ifdef LBANN_HAS_CUDA
+  size_t available;
+  size_t total;
+  FORCE_CHECK_CUDA(cudaMemGetInfo(&available, &total));
+  size_t used = total - available;
+  std::cout << "GPU memory usage at epoch " << m->get_cur_epoch()
+            << " of model " << m->get_comm()->get_model_rank()
+            << " at rank " << m->get_comm()->get_rank_in_model()
+            << ": " << used << " bytes ("
+            << std::setprecision(3)
+            << (used / 1024.0 / 1024.0 / 1024.0) << " GiB) used out of "
+            << total << " bytes ("
+            << std::setprecision(3)      
+            << (total / 1024.0 / 1024.0 / 1024.0)
+            << " GiB)" << std::endl;
+#endif
+}
+
+}  // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -310,8 +310,14 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                              params.fail_on_error());
   }
 
+  //////////////////////////////////////////////////////////////////
+  // GPU memory profiling
+  //////////////////////////////////////////////////////////////////
+  if (proto_cb.has_gpu_memory_usage()) {
+    return new lbann_callback_gpu_memory_usage();
+  }
+  
   return nullptr;
-
 }
 
 lbann_summary* construct_summarizer(lbann_comm* comm,

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -434,6 +434,7 @@ message Callback {
    CallbackCheckpoint checkpoint = 28;
    CallbackSaveModel save_model = 29;
    CallbackPolyLearningRate poly_learning_rate = 30;
+   CallbackGPUMemoryUsage gpu_memory_usage = 31;
 }
 
 message CallbackLTFB {
@@ -594,6 +595,9 @@ message CallbackCheckpoint {
 message CallbackSaveModel {
   string dir = 1;
   string extension = 2;
+}
+
+message CallbackGPUMemoryUsage {
 }
 
 //========================================================================


### PR DESCRIPTION
This PR is to address #351. It simply prints out the size of the total allocated memory at the beginning of each epoch. For example, here's what it looks like with AlexNet on Pascal with 2 ranks:

```
--------------------------------------------------------------------------------
[0] Epoch : stats formated [tr/v/te] iter/epoch = [451/51/2]
            global MB = [ 256/ 256/ 256] global last MB = [ 105  /  11  / 244  ]
             local MB = [ 256/ 256/ 256]  local last MB = [ 105+0/  11+0/ 244+0]
--------------------------------------------------------------------------------
GPU memory usage at epoch 0 of model 0 at rank 1: 3463446528 bytes (3.23 GiB) used out of 17071734784 bytes (15.9 GiB)
GPU memory usage at epoch 0 of model 0 at rank 0: 3463446528 bytes (3.23 GiB) used out of 17071734784 bytes (15.9 GiB)
```
Let me know if the output looks OK.