### PR TITLE
 Add ability to create reader with role:validate in data reader prototext 

### DIFF
--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -255,8 +255,8 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
     } else {
       reader->set_role("error");
     }
-    if (readme.role() == "train" && !separate_validation) {
-      if (create_tarball) {
+    if (readme.role() == "train") {
+      if (create_tarball || separate_validation) {
         reader->set_validation_percent( 0. );
       } else {
         reader->set_validation_percent( readme.validation_percent() );


### PR DESCRIPTION
This minor change will allow a user to create a separate reader with role:validate in the data reader prototext. Currently, the validation reader is created as a percentage of samples used for the train set; however, it is common for datasets to have explicit validation and test sets which are separate from the train set. This change will allow users to measure train, validation, and test performance in the typical fashion, and to create deterministic comparisons between different training scenarios (e.g., cross-framework benchmarking).

In src/proto/proto_common.cpp, a local flag (separate_validation) was added to test if the user has specified a separate validation set. A scan of all readers and their roles is done before the main reader loop to check for a reader with role:validate. This flag is tested later to avoid creating a validation set as a percentage of the train set. Otherwise, the process for creating a validation reader was simply copied from the train and test reader setup.

The change was tested both with and without a separate validation reader, and no issues were found.

Note: This is my first pull request to lbann, so please let me know if there is a mistake or anything could be done better.

