### PR TITLE
Jag conduit data reader for cycle_gan

### DIFF
--- a/include/lbann/data_readers/data_reader_jag.hpp
+++ b/include/lbann/data_readers/data_reader_jag.hpp
@@ -211,7 +211,6 @@ class data_reader_jag : public generic_data_reader {
   int m_image_normalization;
   int m_image_width; ///< image width
   int m_image_height; ///< image height
-  
 
   /// List of jag output images
   cnpy::NpyArray m_images;

--- a/include/lbann/data_readers/data_reader_jag.hpp
+++ b/include/lbann/data_readers/data_reader_jag.hpp
@@ -139,8 +139,8 @@ class data_reader_jag : public generic_data_reader {
   /// Return the dimension of a particular JAG variable type
   const std::vector<int> get_dims(const variable_t t) const;
 
-  virtual std::vector<::Mat>
-    create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const;
+  virtual std::vector<CPUMat>
+    create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const;
 
   bool fetch(CPUMat& X, int data_id, int mb_idx, int tid,
              const data_reader_jag::variable_t vt, const std::string tag);

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -113,11 +113,16 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// Return the linearized size of inputs
   size_t get_linearized_input_size() const;
 
-  /// Return the linearized size of data of the current modeling mode
+  /// Return the total linearized size of data
   int get_linearized_data_size() const override;
-  /// Return the linearized size of response of the current modeling mode
+  /// Return the total linearized size of response
   int get_linearized_response_size() const override;
-  /// Return the data dimension of the current modeling mode
+  /// Return the per-source linearized sizes of composite data
+  std::vector<size_t> get_linearized_data_sizes() const;
+  /// Return the per-source linearized sizes of composite response
+  std::vector<size_t> get_linearized_response_sizes() const;
+
+  /// Return the dimension of data
   const std::vector<int> get_data_dims() const override;
 
   /// Show the description
@@ -171,7 +176,8 @@ class data_reader_jag_conduit : public generic_data_reader {
   static std::string to_string(const std::vector<variable_t>& vec);
 
 
-  virtual std::vector<::Mat> create_datum_views(::Mat& X, const int mb_idx) const;
+  virtual std::vector<::Mat>
+    create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const;
 
   bool fetch(Mat& X, int data_id, int mb_idx, int tid,
              const variable_t vt, const std::string tag);

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -125,6 +125,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// Return the dimension of data
   const std::vector<int> get_data_dims() const override;
 
+  int get_num_labels() const override;
+  int get_linearized_label_size() const override;
+
   /// Show the description
   std::string get_description() const;
 
@@ -183,6 +186,7 @@ class data_reader_jag_conduit : public generic_data_reader {
              const variable_t vt, const std::string tag);
   bool fetch_datum(Mat& X, int data_id, int mb_idx, int tid) override;
   bool fetch_response(Mat& Y, int data_id, int mb_idx, int tid) override;
+  bool fetch_label(Mat& X, int data_id, int mb_idx, int tid) override;
 
 #ifndef _JAG_OFFLINE_TOOL_MODE_
   /// Load a conduit-packed hdf5 data file
@@ -226,6 +230,8 @@ class data_reader_jag_conduit : public generic_data_reader {
 
   /// Whether data have been loaded
   bool m_is_data_loaded;
+
+  int m_num_labels; ///< number of labels
 
   /// Keys to select a set of scalar simulation outputs to use. By default, use all.
   std::vector<std::string> m_scalar_keys;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -179,14 +179,14 @@ class data_reader_jag_conduit : public generic_data_reader {
   static std::string to_string(const std::vector<variable_t>& vec);
 
 
-  virtual std::vector<::Mat>
-    create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const;
+  virtual std::vector<CPUMat>
+    create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const;
 
-  bool fetch(Mat& X, int data_id, int mb_idx, int tid,
+  bool fetch(CPUMat& X, int data_id, int mb_idx, int tid,
              const variable_t vt, const std::string tag);
-  bool fetch_datum(Mat& X, int data_id, int mb_idx, int tid) override;
-  bool fetch_response(Mat& Y, int data_id, int mb_idx, int tid) override;
-  bool fetch_label(Mat& X, int data_id, int mb_idx, int tid) override;
+  bool fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) override;
+  bool fetch_response(CPUMat& Y, int data_id, int mb_idx, int tid) override;
+  bool fetch_label(CPUMat& X, int data_id, int mb_idx, int tid) override;
 
 #ifndef _JAG_OFFLINE_TOOL_MODE_
   /// Load a conduit-packed hdf5 data file

--- a/model_zoo/models/jag/data_reader_jag.prototext
+++ b/model_zoo/models/jag/data_reader_jag.prototext
@@ -9,9 +9,9 @@ data_reader {
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
 
-    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
-    independent: 0
-    dependent: 2
+    # 1: JAG_Image,  2: JAG_Scalar,  3: JAG_Input
+    independent: [1, 2]
+    dependent: [3]
 
     image_preprocessor {
       raw_width: 50
@@ -32,9 +32,9 @@ data_reader {
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
 
-    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
-    independent: 0
-    dependent: 2
+    # 1: JAG_Image,  2: JAG_Scalar,  3: JAG_Input
+    independent: [1, 2]
+    dependent: [3]
 
     image_preprocessor {
       raw_width: 50

--- a/model_zoo/models/jag/data_reader_jag_conduit.prototext
+++ b/model_zoo/models/jag/data_reader_jag_conduit.prototext
@@ -12,11 +12,39 @@ data_reader {
     # Currently, JAG input has 111 parameters, scalar has 22 parameters, and
     # there are two 64x64 images selected out of 10 images per sample.
 
-    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
-    independent: [0, 1]
-    dependent: 2
+    # 1: JAG_Image,  2: JAG_Scalar,  3: JAG_Input
+    independent: [1, 2]
+    dependent: [3]
 
-    num_labels: 111
+    # An empty list indicates to use all
+    jag_scalar_keys:
+      [ "BWx",
+        "BT",
+#        "tMAXt",
+        "BWn",
+        "MAXpressure",
+        "BAte",
+        "MAXtion",
+        "tMAXpressure",
+#        "BAt",
+        "Yn",
+        "Ye",
+        "Yx",
+#        "tMAXte",
+        "BAtion",
+        "MAXte",
+#        "tMAXtion",
+        "BTx",
+#        "MAXt",
+        "BTn",
+        "BApressure",
+        "tMINradius"
+#        "MINradius"
+      ]
+
+    #jag_input_keys:
+
+    num_labels: 256
 
     image_preprocessor {
       # assume fixed size of input images if cropper is not used
@@ -59,11 +87,39 @@ data_reader {
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
 
-    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
-    independent: [0, 1]
-    dependent: 2
+    # 1: JAG_Image,  2: JAG_Scalar,  3: JAG_Input
+    independent: [1, 2]
+    dependent: [3]
 
-    num_labels: 111
+    # An empty list indicates to use all
+    jag_scalar_keys:
+      [ "BWx",
+        "BT",
+#        "tMAXt",
+        "BWn",
+        "MAXpressure",
+        "BAte",
+        "MAXtion",
+        "tMAXpressure",
+#        "BAt",
+        "Yn",
+        "Ye",
+        "Yx",
+#        "tMAXte",
+        "BAtion",
+        "MAXte",
+#        "tMAXtion",
+        "BTx",
+#        "MAXt",
+        "BTn",
+        "BApressure",
+        "tMINradius"
+#        "MINradius"
+      ]
+
+    #jag_input_keys:
+
+    num_labels: 256
 
     image_preprocessor {
       # assume fixed size of input images if cropper is not used

--- a/model_zoo/models/jag/data_reader_jag_conduit.prototext
+++ b/model_zoo/models/jag/data_reader_jag_conduit.prototext
@@ -1,0 +1,98 @@
+data_reader {
+  reader {
+    name: "jag_conduit"
+    role: "train"
+    shuffle: true
+    data_filedir: "/p/lscratchh/brainusr/datasets/jag/bundle_100_10/"
+    data_filename: "samples100-200.bundle"
+    validation_percent: 0.01
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+
+    # Currently, JAG input has 111 parameters, scalar has 22 parameters, and
+    # there are two 64x64 images selected out of 10 images per sample.
+
+    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
+    independent: [0, 1]
+    dependent: 2
+
+    num_labels: 111
+
+    image_preprocessor {
+      # assume fixed size of input images if cropper is not used
+      raw_width: 64
+      raw_height: 64
+
+      normalizer {
+        disable: false
+        scale: false
+        subtract_mean: false
+        unit_variance: false
+        z_score: true
+      }
+
+      subtractor {
+        disable: true
+      }
+
+      cropper {
+        disable: true
+      }
+
+      colorizer {
+        disable: true
+      }
+
+      augmenter {
+        disable: true
+      }
+    }
+  }
+
+  reader {
+    name: "jag_conduit"
+    role: "test"
+    shuffle: true
+    data_filedir: "/p/lscratchh/brainusr/datasets/jag/bundle_100_10/"
+    data_filename: "samples200-300.bundle"
+    validation_percent: 1.0
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+
+    # 0: JAG_Image,  1: JAG_Scalar,  2: JAG_Input
+    independent: [0, 1]
+    dependent: 2
+
+    num_labels: 111
+
+    image_preprocessor {
+      # assume fixed size of input images if cropper is not used
+      raw_width: 64
+      raw_height: 64
+
+      normalizer {
+        disable: false
+        scale: false
+        subtract_mean: false
+        unit_variance: false
+        z_score: true
+      }
+
+      subtractor {
+        disable: true
+      }
+
+      cropper {
+        disable: true
+      }
+
+      colorizer {
+        disable: true
+      }
+
+      augmenter {
+        disable: true
+      }
+    }
+  }
+}

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -296,9 +296,14 @@ const std::vector<int> data_reader_jag::get_data_dims() const {
 
 
 void data_reader_jag::load() {
-  if(m_gan_labelling) m_num_labels=2;
-  std::cout << "JAG load GAN m_gan_labelling : label_value "
-            << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
+  if (m_gan_labelling) {
+    m_num_labels=2;
+  }
+  if (is_master()) {
+    std::cout << "JAG load GAN m_gan_labelling : label_value "
+              << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
+  }
+
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string namestr = get_data_filename();
   std::vector<std::string> file_names = get_tokens(namestr);

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -582,9 +582,9 @@ std::vector<DataType> data_reader_jag::get_input(const size_t i) const {
 }
 
 
-std::vector<::Mat>
-data_reader_jag::create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
-  std::vector<::Mat> X_v(sizes.size());
+std::vector<CPUMat>
+data_reader_jag::create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
+  std::vector<CPUMat> X_v(sizes.size());
   El::Int h = 0;
   for(size_t i=0u; i < sizes.size(); ++i) {
     const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
@@ -623,7 +623,7 @@ bool data_reader_jag::fetch(CPUMat& X, int data_id, int mb_idx, int tid,
 
 bool data_reader_jag::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
   std::vector<size_t> sizes = get_linearized_data_sizes();
-  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
   bool ok = true;
   for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
     ok = fetch(X_v[i], data_id, mb_idx, tid, m_independent[i], "datum");
@@ -633,7 +633,7 @@ bool data_reader_jag::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
 
 bool data_reader_jag::fetch_response(CPUMat& X, int data_id, int mb_idx, int tid) {
   std::vector<size_t> sizes = get_linearized_response_sizes();
-  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
   bool ok = true;
   for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
     ok = fetch(X_v[i], data_id, mb_idx, tid, m_dependent[i], "response");

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -297,7 +297,7 @@ const std::vector<int> data_reader_jag::get_data_dims() const {
 
 void data_reader_jag::load() {
   if(m_gan_labelling) m_num_labels=2;
-  std::cout << "JAG load GAN m_gan_labelling : label_value " 
+  std::cout << "JAG load GAN m_gan_labelling : label_value "
             << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string namestr = get_data_filename();

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -39,7 +39,7 @@ namespace lbann {
 
 data_reader_jag::data_reader_jag(bool shuffle)
   : generic_data_reader(shuffle),
-    m_independent(Undefined), m_dependent(Undefined),
+    m_independent({Undefined}), m_dependent({Undefined}),
     m_image_loaded(false), m_scalar_loaded(false),
     m_input_loaded(false), m_num_samples(0u),
     m_linearized_image_size(0u),
@@ -55,32 +55,72 @@ data_reader_jag::data_reader_jag(bool shuffle)
 data_reader_jag::~data_reader_jag() {
 }
 
+
 void data_reader_jag::set_independent_variable_type(
+  const std::vector<data_reader_jag::variable_t> independent) {
+  if (!independent.empty() && !m_independent.empty() && (m_independent[0] == Undefined)) {
+    m_independent.clear();
+  }
+  for (const auto t: independent) {
+    add_independent_variable_type(t);
+  }
+}
+
+void data_reader_jag::add_independent_variable_type(
   const data_reader_jag::variable_t independent) {
   if (!(independent == JAG_Image || independent == JAG_Scalar ||
         independent == JAG_Input || independent == Undefined)) {
     throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
       " :: unrecognized variable type " + std::to_string(static_cast<int>(independent)));
   }
-  m_independent = independent;
+  m_independent.push_back(independent);
 }
 
 void data_reader_jag::set_dependent_variable_type(
+  const std::vector<data_reader_jag::variable_t> dependent) {
+  if (!dependent.empty() && !m_dependent.empty() && (m_dependent[0] == Undefined)) {
+    m_dependent.clear();
+  }
+  for (const auto t: dependent) {
+    add_dependent_variable_type(t);
+  }
+}
+
+void data_reader_jag::add_dependent_variable_type(
   const data_reader_jag::variable_t dependent) {
   if (!(dependent == JAG_Image || dependent == JAG_Scalar ||
         dependent == JAG_Input || dependent == Undefined)) {
     throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
       " :: unrecognized variable type " + std::to_string(static_cast<int>(dependent)));
   }
-  m_dependent = dependent;
+  m_dependent.push_back(dependent);
 }
 
-data_reader_jag::variable_t data_reader_jag::get_independent_variable_type() const {
+
+std::vector<data_reader_jag::variable_t> data_reader_jag::get_independent_variable_type() const {
   return m_independent;
 }
 
-data_reader_jag::variable_t data_reader_jag::get_dependent_variable_type() const {
+std::vector<data_reader_jag::variable_t> data_reader_jag::get_dependent_variable_type() const {
   return m_dependent;
+}
+
+bool data_reader_jag::is_independent(const variable_t t) const {
+  for(const auto i: m_independent) {
+    if (i == t) return true;
+  }
+  return false;
+}
+
+bool data_reader_jag::is_dependent(const variable_t t) const {
+  for(const auto d: m_dependent) {
+    if (d == t) return true;
+  }
+  return false;
+}
+
+bool data_reader_jag::is_used(const variable_t t) const {
+  return is_independent(t) || is_dependent(t);
 }
 
 void data_reader_jag::set_normalization_mode(int mode) {
@@ -162,40 +202,71 @@ void data_reader_jag::set_linearized_input_size() {
   }
 }
 
-int data_reader_jag::get_linearized_data_size() const {
-  switch (m_independent) {
+size_t data_reader_jag::get_linearized_size(const data_reader_jag::variable_t t) const {
+  switch (t) {
     case JAG_Image:
-      return static_cast<int>(m_linearized_image_size);
+      return m_linearized_image_size;
     case JAG_Scalar:
-      return static_cast<int>(m_linearized_scalar_size);
+      return m_linearized_scalar_size;
     case JAG_Input:
-      return static_cast<int>(m_linearized_input_size);
+      return m_linearized_input_size;
     default: { // includes Undefined case
-      throw lbann_exception(std::string("data_reader_jag::get_linearized_data_size() : ") +
+      throw lbann_exception(std::string("data_reader_jag::get_linearized_size() : ") +
                                         "unknown or undefined variable type");
     }
   }
-  return 0;
+  return 0u;
+}
+
+int data_reader_jag::get_linearized_data_size() const {
+  size_t sz = 0u;
+  for (const auto t: m_independent) {
+    if (t == Undefined) {
+      continue;
+    }
+    sz += get_linearized_size(t);
+  }
+  return static_cast<int>(sz);
 }
 
 int data_reader_jag::get_linearized_response_size() const {
-  switch (m_dependent) {
-    case JAG_Image:
-      return static_cast<int>(m_linearized_image_size);
-    case JAG_Scalar:
-      return static_cast<int>(m_linearized_scalar_size);
-    case JAG_Input:
-      return static_cast<int>(m_linearized_input_size);
-    default: { // includes Undefined case
-      throw lbann_exception(std::string("data_reader_jag::get_linearized_response_size() : ") +
-                                        "unknown or undefined variable type");
+  size_t sz = 0u;
+  for (const auto t: m_dependent) {
+    if (t == Undefined) {
+      continue;
     }
+    sz += get_linearized_size(t);
   }
-  return 0;
+  return static_cast<int>(sz);
 }
 
-const std::vector<int> data_reader_jag::get_data_dims() const {
-  switch (m_independent) {
+std::vector<size_t> data_reader_jag::get_linearized_data_sizes() const {
+  std::vector<size_t> all_dim;
+  all_dim.reserve(m_independent.size());
+  for (const auto t: m_independent) {
+    if (t == Undefined) {
+      continue;
+    }
+    all_dim.push_back(get_linearized_size(t));
+  }
+  return all_dim;
+}
+
+std::vector<size_t> data_reader_jag::get_linearized_response_sizes() const {
+  std::vector<size_t> all_dim;
+  all_dim.reserve(m_dependent.size());
+  for (const auto t: m_dependent) {
+    if (t == Undefined) {
+      continue;
+    }
+    all_dim.push_back(get_linearized_size(t));
+  }
+  return all_dim;
+}
+
+
+const std::vector<int> data_reader_jag::get_dims(const data_reader_jag::variable_t t) const {
+  switch (t) {
     case JAG_Image:
       return {1, m_image_height, m_image_width};
       //return {static_cast<int>(m_linearized_image_size)};
@@ -204,11 +275,23 @@ const std::vector<int> data_reader_jag::get_data_dims() const {
     case JAG_Input:
       return {static_cast<int>(m_linearized_input_size)};
     default: {
-      throw lbann_exception(std::string("data_reader_jag::get_data_dims() : ") +
+      throw lbann_exception(std::string("data_reader_jag::get_dims() : ") +
                                         "unknown or undefined variable type");
     }
   }
   return {};
+}
+
+const std::vector<int> data_reader_jag::get_data_dims() const {
+  std::vector<int> all_dim;
+  for (const auto t: m_independent) {
+    if (t == Undefined) {
+      continue;
+    }
+    const std::vector<int> ld = get_dims(t);
+    all_dim.insert(all_dim.end(), ld.begin(), ld.end());
+  }
+  return all_dim;
 }
 
 
@@ -255,27 +338,24 @@ void data_reader_jag::load(const std::string image_file,
             const std::string scalar_file,
             const std::string input_file,
             const size_t first_n) {
-  if ((m_independent == Undefined) && (m_dependent == Undefined)) {
+  if ((m_independent.empty() || (m_independent[0] == Undefined)) &&
+      !m_dependent.empty() && (m_dependent[0] == Undefined)) {
     throw lbann_exception("data_reader_jag: no type of variables to load is defined.");
   }
-  if ((m_independent == JAG_Image || m_dependent == JAG_Image) &&
-      !image_file.empty() && !check_if_file_exists(image_file)) {
+  if (is_used(JAG_Image) && !image_file.empty() && !check_if_file_exists(image_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + image_file);
   }
-  if ((m_independent == JAG_Scalar || m_dependent == JAG_Scalar) &&
-      !scalar_file.empty() && !check_if_file_exists(scalar_file)) {
+  if (is_used(JAG_Scalar) && !scalar_file.empty() && !check_if_file_exists(scalar_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + scalar_file);
   }
-  if ((m_independent == JAG_Input || m_dependent == JAG_Input) &&
-      !input_file.empty() && !check_if_file_exists(input_file)) {
+  if (is_used(JAG_Input) && !input_file.empty() && !check_if_file_exists(input_file)) {
     throw lbann_exception("data_reader_jag: failed to load " + input_file);
   }
 
   m_num_samples = 0u;
 
   // read in only those that will be used
-  if ((m_independent == JAG_Image || m_dependent == JAG_Image) &&
-      !image_file.empty()) {
+  if (is_used(JAG_Image) && !image_file.empty()) {
     m_images  = cnpy::npy_load(image_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_images, first_n);
@@ -283,8 +363,7 @@ void data_reader_jag::load(const std::string image_file,
     m_image_loaded = true;
     set_linearized_image_size();
   }
-  if ((m_independent == JAG_Scalar || m_dependent == JAG_Scalar) &&
-      !scalar_file.empty()) {
+  if (is_used(JAG_Scalar) && !scalar_file.empty()) {
     m_scalars = cnpy::npy_load(scalar_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_scalars, first_n);
@@ -292,8 +371,7 @@ void data_reader_jag::load(const std::string image_file,
     m_scalar_loaded = true;
     set_linearized_scalar_size();
   }
-  if ((m_independent == JAG_Input || m_dependent == JAG_Input) &&
-      !input_file.empty()) {
+  if (is_used(JAG_Input) && !input_file.empty()) {
     m_inputs  = cnpy::npy_load(input_file);
     if (first_n > 0u) { // to use only first_n samples
       cnpy_utils::shrink_to_fit(m_inputs, first_n);
@@ -368,13 +446,13 @@ bool data_reader_jag::check_data(size_t& num_samples) const {
   if (!ok) {
     num_samples = 0u;
   } else {
-    if (m_independent == JAG_Image || m_dependent == JAG_Image) {
+    if (is_used(JAG_Image)) {
       ok = ok && m_image_loaded;
     }
-    if (m_independent == JAG_Scalar || m_dependent == JAG_Scalar) {
+    if (is_used(JAG_Scalar)) {
       ok = ok && m_scalar_loaded;
     }
-    if (m_independent == JAG_Input || m_dependent == JAG_Input) {
+    if (is_used(JAG_Input)) {
       ok = ok && m_input_loaded;
     }
   }
@@ -387,8 +465,6 @@ std::string data_reader_jag::get_description() const {
   using std::string;
   using std::to_string;
   string ret = string("data_reader_jag:\n")
-    + " - independent: " + to_string(static_cast<int>(m_independent)) + "\n"
-    + " - dependent: " + to_string(static_cast<int>(m_dependent)) + "\n"
     + " - images: "   + cnpy_utils::show_shape(m_images) + "\n"
     + " - scalars: "  + cnpy_utils::show_shape(m_scalars) + "\n"
     + " - inputs: "   + cnpy_utils::show_shape(m_inputs) + "\n";
@@ -506,8 +582,21 @@ std::vector<DataType> data_reader_jag::get_input(const size_t i) const {
 }
 
 
-bool data_reader_jag::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
-  switch (m_independent) {
+std::vector<::Mat>
+data_reader_jag::create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
+  std::vector<::Mat> X_v(sizes.size());
+  El::Int h = 0;
+  for(size_t i=0u; i < sizes.size(); ++i) {
+    const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
+    El::View(X_v[i], X, El::IR(h, h_end), El::IR(mb_idx, mb_idx + 1));
+    h = h_end;
+  }
+  return X_v;
+}
+
+bool data_reader_jag::fetch(CPUMat& X, int data_id, int mb_idx, int tid,
+  const data_reader_jag::variable_t vt, const std::string tag) {
+  switch (vt) {
     case JAG_Image: {
       const data_t* ptr = get_image_ptr(data_id);
       set_minibatch_item<data_t>(X, mb_idx, ptr, m_linearized_image_size);
@@ -524,36 +613,32 @@ bool data_reader_jag::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
       break;
     }
     default: { // includes Undefined case
-      throw lbann_exception(std::string("data_reader_jag::fetch_datum() : ") + \
-                                        "unknown or undefined variable type");
+      throw lbann_exception(std::string("data_reader_jag::fetch_") + tag +
+                            "() : unknown or undefined variable type (" +
+                            std::to_string(static_cast<int>(vt)) + ')');
     }
   }
   return true;
 }
 
-bool data_reader_jag::fetch_response(CPUMat& Y, int data_id, int mb_idx, int tid) {
-  switch (m_dependent) {
-    case JAG_Image: {
-      const data_t* ptr = get_image_ptr(data_id);
-      set_minibatch_item<data_t>(Y, mb_idx, ptr, m_linearized_image_size);
-      break;
-    }
-    case JAG_Scalar: {
-      const scalar_t* ptr = get_scalar_ptr(data_id);
-      set_minibatch_item<scalar_t>(Y, mb_idx, ptr, m_linearized_scalar_size);
-      break;
-    }
-    case JAG_Input: {
-      const input_t* ptr = get_input_ptr(data_id);
-      set_minibatch_item<input_t>(Y, mb_idx, ptr, m_linearized_input_size);
-      break;
-    }
-    default: { // includes Undefined case
-      throw lbann_exception(std::string("data_reader_jag::fetch_response() : ") +
-                                        "unknown or undefined variable type");
-    }
+bool data_reader_jag::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
+  std::vector<size_t> sizes = get_linearized_data_sizes();
+  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  bool ok = true;
+  for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
+    ok = fetch(X_v[i], data_id, mb_idx, tid, m_independent[i], "datum");
   }
-  return true;
+  return ok;
+}
+
+bool data_reader_jag::fetch_response(CPUMat& X, int data_id, int mb_idx, int tid) {
+  std::vector<size_t> sizes = get_linearized_response_sizes();
+  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  bool ok = true;
+  for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
+    ok = fetch(X_v[i], data_id, mb_idx, tid, m_dependent[i], "response");
+  }
+  return ok;
 }
 
 bool data_reader_jag::fetch_label(CPUMat& Y, int data_id, int mb_idx, int tid) {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -429,9 +429,14 @@ void data_reader_jag_conduit::check_input_keys() {
 
 #ifndef _JAG_OFFLINE_TOOL_MODE_
 void data_reader_jag_conduit::load() {
-  if(m_gan_labelling) m_num_labels=2;
-  std::cout << "JAG load GAN m_gan_labelling : label_value "
-            << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
+  if(m_gan_labelling) {
+    m_num_labels=2;
+  }
+
+  if (is_master()) {
+    std::cout << "JAG load GAN m_gan_labelling : label_value "
+              << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
+  }
 
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string conduit_file_name = get_data_filename();

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -765,9 +765,9 @@ int data_reader_jag_conduit::check_exp_success(const size_t sample_id) const {
 }
 
 
-std::vector<::Mat>
-data_reader_jag_conduit::create_datum_views(::Mat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
-  std::vector<::Mat> X_v(sizes.size());
+std::vector<CPUMat>
+data_reader_jag_conduit::create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
+  std::vector<CPUMat> X_v(sizes.size());
   El::Int h = 0;
   for(size_t i=0u; i < sizes.size(); ++i) {
     const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
@@ -777,12 +777,12 @@ data_reader_jag_conduit::create_datum_views(::Mat& X, const std::vector<size_t>&
   return X_v;
 }
 
-bool data_reader_jag_conduit::fetch(Mat& X, int data_id, int mb_idx, int tid,
+bool data_reader_jag_conduit::fetch(CPUMat& X, int data_id, int mb_idx, int tid,
   const data_reader_jag_conduit::variable_t vt, const std::string tag) {
   switch (vt) {
     case JAG_Image: {
       const std::vector<size_t> sizes(get_num_img_srcs(), get_linearized_image_size());
-      std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+      std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
       std::vector<cv::Mat> images = get_cv_images(data_id);
 
       if (images.size() != get_num_img_srcs()) {
@@ -813,9 +813,9 @@ bool data_reader_jag_conduit::fetch(Mat& X, int data_id, int mb_idx, int tid,
   return true;
 }
 
-bool data_reader_jag_conduit::fetch_datum(Mat& X, int data_id, int mb_idx, int tid) {
+bool data_reader_jag_conduit::fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) {
   std::vector<size_t> sizes = get_linearized_data_sizes();
-  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
   bool ok = true;
   for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
     ok = fetch(X_v[i], data_id, mb_idx, tid, m_independent[i], "datum");
@@ -823,9 +823,9 @@ bool data_reader_jag_conduit::fetch_datum(Mat& X, int data_id, int mb_idx, int t
   return ok;
 }
 
-bool data_reader_jag_conduit::fetch_response(Mat& X, int data_id, int mb_idx, int tid) {
+bool data_reader_jag_conduit::fetch_response(CPUMat& X, int data_id, int mb_idx, int tid) {
   std::vector<size_t> sizes = get_linearized_response_sizes();
-  std::vector<::Mat> X_v = create_datum_views(X, sizes, mb_idx);
+  std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
   bool ok = true;
   for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
     ok = fetch(X_v[i], data_id, mb_idx, tid, m_dependent[i], "response");
@@ -833,7 +833,7 @@ bool data_reader_jag_conduit::fetch_response(Mat& X, int data_id, int mb_idx, in
   return ok;
 }
 
-bool data_reader_jag_conduit::fetch_label(Mat& Y, int data_id, int mb_idx, int tid) {
+bool data_reader_jag_conduit::fetch_label(CPUMat& Y, int data_id, int mb_idx, int tid) {
   if(m_gan_label_value) Y.Set(m_gan_label_value,mb_idx,1); //fake sample is set to 1; adversarial model
   else { //fake sample (second half of minibatch is set to 0;discriminator model
     //mb_idx < (m_mb_size/2) ? Y.Set(1,mb_idx,1) : Y.Set(m_gan_label_value,mb_idx,1);

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -310,14 +310,22 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
 
     reader_jag->set_image_dims(width, height);
 
-    // TODO: parse the list
-    const data_reader_jag_conduit::variable_t independent_type
-           = static_cast<data_reader_jag_conduit::variable_t>(pb_readme.independent());
-    reader_jag->set_independent_variable_type({independent_type});
+    using var_t = data_reader_jag_conduit::variable_t;
+    std::vector<var_t> independent_type(pb_readme.independent_size());
 
-    const data_reader_jag_conduit::variable_t dependent_type
-           = static_cast<data_reader_jag_conduit::variable_t>(pb_readme.dependent());
-    reader_jag->set_dependent_variable_type({dependent_type});
+    for (int i=0; i < pb_readme.independent_size(); ++i) {
+      independent_type[i] = static_cast<var_t>(pb_readme.independent(i));
+    }
+
+    reader_jag->set_independent_variable_type(independent_type);
+
+    std::vector<var_t> dependent_type(pb_readme.dependent_size());
+
+    for (int i=0; i < pb_readme.dependent_size(); ++i) {
+      dependent_type[i] = static_cast<var_t>(pb_readme.dependent(i));
+    }
+
+    reader_jag->set_dependent_variable_type(dependent_type);
 
     reader = reader_jag;
     if (master) std::cout << reader->get_type() << " is set" << std::endl;

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -311,6 +311,7 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
     reader_jag->set_image_dims(width, height);
 
     using var_t = data_reader_jag_conduit::variable_t;
+    // composite independent variable
     std::vector<var_t> independent_type(pb_readme.independent_size());
 
     for (int i=0; i < pb_readme.independent_size(); ++i) {
@@ -319,6 +320,7 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
 
     reader_jag->set_independent_variable_type(independent_type);
 
+    // composite dependent variable
     std::vector<var_t> dependent_type(pb_readme.dependent_size());
 
     for (int i=0; i < pb_readme.dependent_size(); ++i) {
@@ -326,6 +328,28 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
     }
 
     reader_jag->set_dependent_variable_type(dependent_type);
+
+    // keys of chosen scalar values in jag simulation output
+    std::vector<std::string> scalar_keys(pb_readme.jag_scalar_keys_size());
+
+    for (int i=0; i < pb_readme.jag_scalar_keys_size(); ++i) {
+      scalar_keys[i] = pb_readme.jag_scalar_keys(i);
+    }
+
+    if (scalar_keys.size() > 0u) {
+      reader_jag->set_scalar_choices(scalar_keys);
+    }
+
+    // keys of chosen values in jag simulation parameters
+    std::vector<std::string> input_keys(pb_readme.jag_input_keys_size());
+
+    for (int i=0; i < pb_readme.jag_input_keys_size(); ++i) {
+      input_keys[i] = pb_readme.jag_input_keys(i);
+    }
+
+    if (input_keys.size() > 0u) {
+      reader_jag->set_input_choices(input_keys);
+    }
 
     reader = reader_jag;
     if (master) std::cout << reader->get_type() << " is set" << std::endl;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -33,6 +33,8 @@ message Reader {
   bool gan_labelling = 201;
   int32 gan_label_value = 202;
   ImagePreprocessor image_preprocessor = 13;
+  repeated string jag_scalar_keys = 95; // only for jag
+  repeated string jag_input_keys = 96; // only for jag
   repeated int32 independent = 97; // only for jag
   repeated int32 dependent = 98; // only for jag
   int32 num_labels = 99; //for imagenet

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -33,8 +33,8 @@ message Reader {
   bool gan_labelling = 201;
   int32 gan_label_value = 202;
   ImagePreprocessor image_preprocessor = 13;
-  int32 independent = 97; // only for jag
-  int32 dependent = 98; // only for jag
+  repeated int32 independent = 97; // only for jag
+  repeated int32 dependent = 98; // only for jag
   int32 num_labels = 99; //for imagenet
   int64 num_samples = 100; //only for synthetic
   int64 num_features = 101; //only for synthetic

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -70,12 +70,24 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       set_up_generic_preprocessor = false;
     } else if (name == "jag") {
       auto* reader_jag = new data_reader_jag(shuffle);
-      const data_reader_jag::variable_t independent_type
-             = static_cast<data_reader_jag::variable_t>(readme.independent());
+
+      using var_t = data_reader_jag::variable_t;
+      std::vector<var_t> independent_type(readme.independent_size());
+
+      for (int i=0; i < readme.independent_size(); ++i) {
+        independent_type[i] = static_cast<var_t>(readme.independent(i));
+      }
+
       reader_jag->set_independent_variable_type(independent_type);
-      const data_reader_jag::variable_t dependent_type
-             = static_cast<data_reader_jag::variable_t>(readme.dependent());
+
+      std::vector<var_t> dependent_type(readme.dependent_size());
+
+      for (int i=0; i < readme.dependent_size(); ++i) {
+        dependent_type[i] = static_cast<var_t>(readme.dependent(i));
+      }
+
       reader_jag->set_dependent_variable_type(dependent_type);
+
       const lbann_data::ImagePreprocessor& pb_preproc = readme.image_preprocessor();
       reader_jag->set_image_dims(pb_preproc.raw_width(), pb_preproc.raw_height());
       reader_jag->set_normalization_mode(pb_preproc.early_normalization());


### PR DESCRIPTION
Continued improvements of jag_conduit reader for cycle_gan support.
- Implemented the create_datum_views() to support mixing multiple data sources for a variable.  A view of El::Mat is constructed using the linearized size of each data source and its order in the mix. Then, the data from each is copied to the corresponding view.
- Similar changes are applied to the original jag reader to allow interim testings with the current Sam's setup before deprecating it and moving on to the new conduit-based reader.
- Allow users to specify an array of data sources for the independent/dependent variable via the prototex interface.