### PR TITLE
Layers for visual attention.

### DIFF
--- a/include/lbann/layers/transform/CMakeLists.txt
+++ b/include/lbann/layers/transform/CMakeLists.txt
@@ -21,6 +21,8 @@ set_full_path(THIS_DIR_HEADERS
   categorical_random.hpp
   discrete_random.hpp
   stop_gradient.hpp
+  max.hpp
+  min.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/transform/CMakeLists.txt
+++ b/include/lbann/layers/transform/CMakeLists.txt
@@ -20,6 +20,7 @@ set_full_path(THIS_DIR_HEADERS
   crop.hpp
   categorical_random.hpp
   discrete_random.hpp
+  stop_gradient.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/transform/max.hpp
+++ b/include/lbann/layers/transform/max.hpp
@@ -1,0 +1,196 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_MAX_HPP_INCLUDED
+#define LBANN_LAYER_MAX_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+
+namespace lbann {
+
+/** Max layer.
+ *  This layer outputs the entrywise maximum of its input tensors.
+ */
+template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
+class max_layer : public transform_layer {
+
+ public:
+  max_layer(lbann_comm *comm,
+            cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm) {
+
+    /// @todo Implement
+    static_assert(Dev == El::Device::CPU,
+                  "max layer currently only supports CPU");
+
+    // Max layer has no limit on parents
+    m_expected_num_parent_layers = -1;
+
+  #ifdef LBANN_HAS_CUDNN
+    // Initialize GPU if available
+    this->m_cudnn = cudnn;
+  #endif // LBANN_HAS_CUDNN
+
+  }
+
+  max_layer* copy() const override { return new max_layer(*this); }
+  std::string get_type() const override { return "max"; }
+  data_layout get_data_layout() const override { return T_layout; }
+  El::Device get_device_allocation() const override { return Dev; }
+
+ protected:
+
+  void setup_dims() override {
+    transform_layer::setup_dims();
+    for (const auto& parent : this->m_parent_layers) {
+      const auto& parent_dims = parent->fp_output_dims(this);
+      if (m_neuron_dims != parent_dims) {
+        std::stringstream err;
+        err << "layer " << get_name() << " expects inputs with "
+            << "dimensions ";
+        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
+          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+        }
+        err << ", but layer " << parent->get_name() << " outputs with "
+            << "dimensions ";
+        for (size_t i = 0; i < parent_dims.size(); ++i) {
+          err << (i > 0 ? "x" : "") << parent_dims[i];
+        }
+        LBANN_ERROR(err.str());
+      }
+    }
+  }
+
+  void fp_compute() override {
+    const int num_parents = get_num_parents();
+    auto& output = get_activations();
+    switch (num_parents) {
+    case 0: El::Zero(output); break;
+    case 1: El::LockedView(output, get_prev_activations()); break;
+    default:
+
+      // Local matrices
+      const auto& local_input0 = get_local_prev_activations(0);
+      const auto& local_input1 = get_local_prev_activations(1);
+      auto& local_output = output.Matrix();
+      const int local_height = local_output.Height();
+      const int local_width = local_output.Width();
+
+      // Maximum of first two inputs
+      #pragma omp parallel for collapse(2)
+      for (int col = 0; col < local_width; ++col) {
+        for (int row = 0; row < local_height; ++row) {
+          local_output(row, col) = std::max(local_input0(row, col),
+                                            local_input1(row, col));
+        }
+      }
+
+      // Case with more than 2 parents
+      for (int i = 2; i < num_parents; ++i) {
+        const auto& local_input = get_local_prev_activations(i);
+        #pragma omp parallel for collapse(2)
+        for (int col = 0; col < local_width; ++col) {
+          for (int row = 0; row < local_height; ++row) {
+            const auto& x = local_input(row, col);
+            auto& y = local_output(row, col);
+            if (x > y) { y = x; }
+          }
+        }
+      }
+
+    }
+  }
+
+  void bp_compute() override {
+
+    const int num_parents = get_num_parents();
+
+    const auto& gradient_wrt_output = get_prev_error_signals();
+    const auto& local_gradient_wrt_output = gradient_wrt_output.LockedMatrix();
+    const int local_height = local_gradient_wrt_output.Height();
+    const int local_width = local_gradient_wrt_output.Width();
+
+    switch (num_parents) {
+    case 0: break;
+    case 1:
+      El::LockedView(get_error_signals(), gradient_wrt_output);
+      break;
+    case 2:
+      {
+        const auto& local_input0 = get_local_prev_activations(0);
+        const auto& local_input1 = get_local_prev_activations(1);
+        auto& local_gradient_wrt_input0 = get_local_error_signals(0);
+        auto& local_gradient_wrt_input1 = get_local_error_signals(1);
+        #pragma omp parallel for collapse(2)
+        for (int col = 0; col < local_width; ++col) {
+          for (int row = 0; row < local_height; ++row) {
+            const auto& dy = local_gradient_wrt_output(row, col);
+            if (local_input0(row, col) >= local_input1(row, col)) {
+              local_gradient_wrt_input0(row, col) += dy;
+              local_gradient_wrt_input1(row, col) += DataType(0);
+            } else {
+              local_gradient_wrt_input0(row, col) += DataType(0);
+              local_gradient_wrt_input1(row, col) += dy;
+            }
+          }
+        }
+      }
+      break;
+    default:
+      #pragma omp parallel for collapse(2)
+      for (int col = 0; col < local_width; ++col) {
+        for (int row = 0; row < local_height; ++row) {
+
+          // Find maximum input
+          int max_index = 0;
+          int max_value = get_local_activations(0)(row, col);
+          for (int i = 1; i < num_parents; ++i) {
+            const auto& current_value = get_local_activations(i)(row, col);
+            if (current_value > max_value) {
+              max_index = i;
+              max_value = current_value;
+            }
+          }
+
+          // Output error signal to maximum input
+          for (int i = 0; i < num_parents; ++i) {
+            get_local_error_signals(i)(row, col)
+              += (i == max_index ?
+                  local_gradient_wrt_output(row, col) :
+                  DataType(0));
+          }
+
+        }
+      }
+    }
+
+  }
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_MAX_HPP_INCLUDED

--- a/include/lbann/layers/transform/max.hpp
+++ b/include/lbann/layers/transform/max.hpp
@@ -63,6 +63,16 @@ class max_layer : public transform_layer {
 
  protected:
 
+  void setup_pointers() override {
+    transform_layer::setup_pointers();
+    if (get_num_parents() < 1) {
+      std::stringstream err;
+      err << "layer \"" << get_name() << "\" has no parents, "
+          << "but max layers expect at least one parent";
+      LBANN_ERROR(err.str());
+    }
+  }
+
   void setup_dims() override {
     transform_layer::setup_dims();
     for (const auto& parent : this->m_parent_layers) {
@@ -85,58 +95,63 @@ class max_layer : public transform_layer {
   }
 
   void fp_compute() override {
+
+    // Handle case with one parent
+    // Note: Case with no parents is handled in setup_pointers
     const int num_parents = get_num_parents();
-    auto& output = get_activations();
-    switch (num_parents) {
-    case 0: El::Zero(output); break;
-    case 1: El::LockedView(output, get_prev_activations()); break;
-    default:
+    if (num_parents == 1) {
+      El::LockedView(get_activations(), get_prev_activations());
+      return;
+    }
+    
+    // Local matrices
+    const auto& local_input0 = get_local_prev_activations(0);
+    const auto& local_input1 = get_local_prev_activations(1);
+    auto& local_output = get_local_activations();
+    const int local_height = local_output.Height();
+    const int local_width = local_output.Width();
 
-      // Local matrices
-      const auto& local_input0 = get_local_prev_activations(0);
-      const auto& local_input1 = get_local_prev_activations(1);
-      auto& local_output = output.Matrix();
-      const int local_height = local_output.Height();
-      const int local_width = local_output.Width();
+    // Maximum of first two inputs
+    #pragma omp parallel for collapse(2)
+    for (int col = 0; col < local_width; ++col) {
+      for (int row = 0; row < local_height; ++row) {
+        local_output(row, col) = std::max(local_input0(row, col),
+                                          local_input1(row, col));
+      }
+    }
 
-      // Maximum of first two inputs
+    // Handle case with more than two parents
+    for (int i = 2; i < num_parents; ++i) {
+      const auto& local_input = get_local_prev_activations(i);
       #pragma omp parallel for collapse(2)
       for (int col = 0; col < local_width; ++col) {
         for (int row = 0; row < local_height; ++row) {
-          local_output(row, col) = std::max(local_input0(row, col),
-                                            local_input1(row, col));
+          const auto& x = local_input(row, col);
+          auto& y = local_output(row, col);
+          if (x > y) { y = x; }
         }
       }
-
-      // Case with more than 2 parents
-      for (int i = 2; i < num_parents; ++i) {
-        const auto& local_input = get_local_prev_activations(i);
-        #pragma omp parallel for collapse(2)
-        for (int col = 0; col < local_width; ++col) {
-          for (int row = 0; row < local_height; ++row) {
-            const auto& x = local_input(row, col);
-            auto& y = local_output(row, col);
-            if (x > y) { y = x; }
-          }
-        }
-      }
-
     }
+
   }
 
   void bp_compute() override {
 
-    const int num_parents = get_num_parents();
+    // Useful constants
+    const DataType zero = DataType(0);
 
-    const auto& gradient_wrt_output = get_prev_error_signals();
-    const auto& local_gradient_wrt_output = gradient_wrt_output.LockedMatrix();
+    // Local matrices
+    const auto& local_gradient_wrt_output = get_local_prev_error_signals();
     const int local_height = local_gradient_wrt_output.Height();
     const int local_width = local_gradient_wrt_output.Width();
 
+    // Handle cases for different number of parents
+    // Note: Case with no parents is handled in setup_pointers
+    const int num_parents = get_num_parents();
     switch (num_parents) {
-    case 0: break;
     case 1:
-      El::LockedView(get_error_signals(), gradient_wrt_output);
+      // El::LockedView(get_error_signals(), get_prev_error_signals());
+      El::Axpy(DataType(1), get_prev_error_signals(), get_error_signals());
       break;
     case 2:
       {
@@ -147,13 +162,20 @@ class max_layer : public transform_layer {
         #pragma omp parallel for collapse(2)
         for (int col = 0; col < local_width; ++col) {
           for (int row = 0; row < local_height; ++row) {
+            const auto& x0 = local_input0(row, col);
+            const auto& x1 = local_input1(row, col);
             const auto& dy = local_gradient_wrt_output(row, col);
-            if (local_input0(row, col) >= local_input1(row, col)) {
-              local_gradient_wrt_input0(row, col) += dy;
-              local_gradient_wrt_input1(row, col) += DataType(0);
+            auto& dx0 = local_gradient_wrt_input0(row, col);
+            auto& dx1 = local_gradient_wrt_input1(row, col);
+            if (x0 > x1) {
+              dx0 += dy;
+              dx1 += zero;
+            } else if (x0 < x1) {
+              dx0 += zero;
+              dx1 += dy;
             } else {
-              local_gradient_wrt_input0(row, col) += DataType(0);
-              local_gradient_wrt_input1(row, col) += dy;
+              dx0 += dy / 2;
+              dx1 += dy / 2;
             }
           }
         }
@@ -163,6 +185,7 @@ class max_layer : public transform_layer {
       #pragma omp parallel for collapse(2)
       for (int col = 0; col < local_width; ++col) {
         for (int row = 0; row < local_height; ++row) {
+          const auto& dy = local_gradient_wrt_output(row, col);
 
           // Find maximum input
           int max_index = 0;
@@ -177,10 +200,8 @@ class max_layer : public transform_layer {
 
           // Output error signal to maximum input
           for (int i = 0; i < num_parents; ++i) {
-            get_local_error_signals(i)(row, col)
-              += (i == max_index ?
-                  local_gradient_wrt_output(row, col) :
-                  DataType(0));
+            auto& dx = get_local_error_signals(i)(row, col);
+            dx += (i == max_index) ? dy : zero;
           }
 
         }

--- a/include/lbann/layers/transform/min.hpp
+++ b/include/lbann/layers/transform/min.hpp
@@ -1,0 +1,196 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_MIN_HPP_INCLUDED
+#define LBANN_LAYER_MIN_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+
+namespace lbann {
+
+/** Min layer.
+ *  This layer outputs the entrywise minimum of its input tensors.
+ */
+template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
+class min_layer : public transform_layer {
+
+ public:
+  min_layer(lbann_comm *comm,
+            cudnn::cudnn_manager *cudnn = nullptr)
+    : transform_layer(comm) {
+
+    /// @todo Implement
+    static_assert(Dev == El::Device::CPU,
+                  "min layer currently only supports CPU");
+
+    // Min layer has no limit on parents
+    m_expected_num_parent_layers = -1;
+
+  #ifdef LBANN_HAS_CUDNN
+    // Initialize GPU if available
+    this->m_cudnn = cudnn;
+  #endif // LBANN_HAS_CUDNN
+
+  }
+
+  min_layer* copy() const override { return new min_layer(*this); }
+  std::string get_type() const override { return "min"; }
+  data_layout get_data_layout() const override { return T_layout; }
+  El::Device get_device_allocation() const override { return Dev; }
+
+ protected:
+
+  void setup_dims() override {
+    transform_layer::setup_dims();
+    for (const auto& parent : this->m_parent_layers) {
+      const auto& parent_dims = parent->fp_output_dims(this);
+      if (m_neuron_dims != parent_dims) {
+        std::stringstream err;
+        err << "layer " << get_name() << " expects inputs with "
+            << "dimensions ";
+        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
+          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+        }
+        err << ", but layer " << parent->get_name() << " outputs with "
+            << "dimensions ";
+        for (size_t i = 0; i < parent_dims.size(); ++i) {
+          err << (i > 0 ? "x" : "") << parent_dims[i];
+        }
+        LBANN_ERROR(err.str());
+      }
+    }
+  }
+
+  void fp_compute() override {
+    const int num_parents = get_num_parents();
+    auto& output = get_activations();
+    switch (num_parents) {
+    case 0: El::Zero(output); break;
+    case 1: El::LockedView(output, get_prev_activations()); break;
+    default:
+
+      // Local matrices
+      const auto& local_input0 = get_local_prev_activations(0);
+      const auto& local_input1 = get_local_prev_activations(1);
+      auto& local_output = output.Matrix();
+      const int local_height = local_output.Height();
+      const int local_width = local_output.Width();
+
+      // Minimum of first two inputs
+      #pragma omp parallel for collapse(2)
+      for (int col = 0; col < local_width; ++col) {
+        for (int row = 0; row < local_height; ++row) {
+          local_output(row, col) = std::min(local_input0(row, col),
+                                            local_input1(row, col));
+        }
+      }
+
+      // Case with more than 2 parents
+      for (int i = 2; i < num_parents; ++i) {
+        const auto& local_input = get_local_prev_activations(i);
+        #pragma omp parallel for collapse(2)
+        for (int col = 0; col < local_width; ++col) {
+          for (int row = 0; row < local_height; ++row) {
+            const auto& x = local_input(row, col);
+            auto& y = local_output(row, col);
+            if (x < y) { y = x; }
+          }
+        }
+      }
+
+    }
+  }
+
+  void bp_compute() override {
+
+    const int num_parents = get_num_parents();
+
+    const auto& gradient_wrt_output = get_prev_error_signals();
+    const auto& local_gradient_wrt_output = gradient_wrt_output.LockedMatrix();
+    const int local_height = local_gradient_wrt_output.Height();
+    const int local_width = local_gradient_wrt_output.Width();
+
+    switch (num_parents) {
+    case 0: break;
+    case 1:
+      El::LockedView(get_error_signals(), gradient_wrt_output);
+      break;
+    case 2:
+      {
+        const auto& local_input0 = get_local_prev_activations(0);
+        const auto& local_input1 = get_local_prev_activations(1);
+        auto& local_gradient_wrt_input0 = get_local_error_signals(0);
+        auto& local_gradient_wrt_input1 = get_local_error_signals(1);
+        #pragma omp parallel for collapse(2)
+        for (int col = 0; col < local_width; ++col) {
+          for (int row = 0; row < local_height; ++row) {
+            const auto& dy = local_gradient_wrt_output(row, col);
+            if (local_input0(row, col) <= local_input1(row, col)) {
+              local_gradient_wrt_input0(row, col) += dy;
+              local_gradient_wrt_input1(row, col) += DataType(0);
+            } else {
+              local_gradient_wrt_input0(row, col) += DataType(0);
+              local_gradient_wrt_input1(row, col) += dy;
+            }
+          }
+        }
+      }
+      break;
+    default:
+      #pragma omp parallel for collapse(2)
+      for (int col = 0; col < local_width; ++col) {
+        for (int row = 0; row < local_height; ++row) {
+
+          // Find minimum input
+          int min_index = 0;
+          int min_value = get_local_activations(0)(row, col);
+          for (int i = 1; i < num_parents; ++i) {
+            const auto& current_value = get_local_activations(i)(row, col);
+            if (current_value < min_value) {
+              min_index = i;
+              min_value = current_value;
+            }
+          }
+
+          // Output error signal to minimum input
+          for (int i = 0; i < num_parents; ++i) {
+            get_local_error_signals(i)(row, col)
+              += (i == min_index ?
+                  local_gradient_wrt_output(row, col) :
+                  DataType(0));
+          }
+
+        }
+      }
+    }
+
+  }
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_MAX_HPP_INCLUDED

--- a/include/lbann/layers/transform/stop_gradient.hpp
+++ b/include/lbann/layers/transform/stop_gradient.hpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef STOP_GRADIENT_HPP_INCLUDED
+#define STOP_GRADIENT_HPP_INCLUDED
+
+#include "lbann/layers/transform/transform.hpp"
+
+namespace lbann {
+
+/** Layer that blocks back propagation.
+ *  This layer's output is identical to its input, but its back
+ *  propagation output (i.e. its error signal) is always zero. Compare
+ *  with the stop_gradient operation in TensorFlow and Keras. Note
+ *  that this means that computed gradients in preceeding layers are
+ *  not exact gradients of the objective function.
+ */
+template <data_layout T_layout, El::Device Dev>
+class stop_gradient_layer : public transform_layer {
+ public:
+  stop_gradient_layer(lbann_comm *comm,
+                      cudnn::cudnn_manager* cudnn = nullptr)
+    : transform_layer(comm) {
+    this->m_cudnn = cudnn;
+  }
+  stop_gradient_layer* copy() const override { return new stop_gradient_layer(*this); }
+  std::string get_type() const override { return "stop_gradient"; }
+  data_layout get_data_layout() const override { return T_layout; }
+  El::Device get_device_allocation() const override { return Dev; }
+
+  void setup_gpu() override {
+    transform_layer::setup_gpu();
+#ifdef HYDROGEN_HAVE_CUB
+    // Set output matrix to use CUB GPU memory pool
+    // Note: During each forward prop, the output matrix is resized to
+    // the mini-batch size and cleared to obtain a matrix view. To
+    // avoid expensive GPU memory allocation and deallocation, we use
+    // CUB's GPU memory pool.
+    if (Dev == El::Device::GPU) {
+      get_local_activations().SetMemoryMode(1);
+    }
+#endif
+  }
+
+  void fp_compute() override {
+    El::LockedView(get_activations(), get_prev_activations());
+  }
+
+  void bp_compute() override {
+    // El::Zero(get_error_signals());
+  }
+
+};
+
+} // namespace lbann
+
+#endif // STOP_GRADIENT_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -88,6 +88,7 @@
 #include "lbann/layers/transform/crop.hpp"
 #include "lbann/layers/transform/categorical_random.hpp"
 #include "lbann/layers/transform/discrete_random.hpp"
+#include "lbann/layers/transform/stop_gradient.hpp"
 
 /// Regularization layers.
 #include "lbann/layers/regularizers/local_response_normalization.hpp"

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -89,6 +89,8 @@
 #include "lbann/layers/transform/categorical_random.hpp"
 #include "lbann/layers/transform/discrete_random.hpp"
 #include "lbann/layers/transform/stop_gradient.hpp"
+#include "lbann/layers/transform/max.hpp"
+#include "lbann/layers/transform/min.hpp"
 
 /// Regularization layers.
 #include "lbann/layers/regularizers/local_response_normalization.hpp"

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -309,6 +309,16 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_stop_gradient()) {
     return new stop_gradient_layer<layout, Dev>(comm, cudnn);
   }
+  if (proto_layer.has_max()) {
+    if (Dev == El::Device::CPU) {
+      return new max_layer<layout, El::Device::CPU>(comm, cudnn);
+    }
+  }
+  if (proto_layer.has_min()) {
+    if (Dev == El::Device::CPU) {
+      return new min_layer<layout, El::Device::CPU>(comm, cudnn);
+    }
+  }
 
   // Regularizer layers
   if (proto_layer.has_batch_normalization()) {

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -306,6 +306,9 @@ Layer* construct_layer(lbann_comm* comm,
                    comm, values, dims, cudnn);
     }
   }
+  if (proto_layer.has_stop_gradient()) {
+    return new stop_gradient_layer<layout, Dev>(comm, cudnn);
+  }
 
   // Regularizer layers
   if (proto_layer.has_batch_normalization()) {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -732,6 +732,7 @@ message Layer {
    Crop crop = 316;
    CategoricalRandom categorical_random = 317;
    DiscreteRandom discrete_random = 318;
+   StopGradient stop_gradient = 319;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -990,6 +991,9 @@ message CategoricalRandom {
 message DiscreteRandom {
   string values = 1;
   string dims = 2;
+}
+
+message StopGradient {
 }
 
 /////////////////////

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -733,6 +733,8 @@ message Layer {
    CategoricalRandom categorical_random = 317;
    DiscreteRandom discrete_random = 318;
    StopGradient stop_gradient = 319;
+   Max max = 320;
+   Min min = 321;
 
    // learning Layers
    FullyConnected fully_connected = 11;
@@ -994,6 +996,12 @@ message DiscreteRandom {
 }
 
 message StopGradient {
+}
+
+message Max {
+}
+
+message Min {
 }
 
 /////////////////////

--- a/viz/properties.txt
+++ b/viz/properties.txt
@@ -62,4 +62,5 @@ transform    noise
 transform    crop
 transform    categorical_random
 transform    discrete_random
+transform    stop_gradient
 

--- a/viz/properties.txt
+++ b/viz/properties.txt
@@ -63,4 +63,6 @@ transform    crop
 transform    categorical_random
 transform    discrete_random
 transform    stop_gradient
+transform    max
+transform    min
 


### PR DESCRIPTION
A `stop_gradient_layer` blocks error signals from passing through during backprop (compare with https://www.tensorflow.org/api_docs/python/tf/stop_gradient). I've also implemented entry-wise min and max layers.

@samadejacobs TensorFlow includes GANs as an example use-case for `stop_gradient`.