### PR TITLE
Small patch to workaround bamboo error

### DIFF
--- a/scripts/spack_recipes/build_lbann.sh
+++ b/scripts/spack_recipes/build_lbann.sh
@@ -253,4 +253,10 @@ fi
 # Deal with the fact that spack should not install a package when doing setup"
 FIX="spack uninstall --all -y lbann %${COMPILER} build_type=${BUILD_TYPE}"
 echo $FIX
-eval $FIX
+if [ ! -z "$bamboo_SPACK_ROOT" ]; then
+    eval $FIX &> /dev/null
+else
+    eval $FIX
+fi
+
+


### PR DESCRIPTION
This PR is a workaround for an edge case we run into when using one spack root across multiple build plans. Our compiler tests fail incorrectly occasionally when attempting to uninstall local lbann installs from the shared spack root, causing the entire build to fail. This PR catches this error when executing in bamboo so that we do not incorrectly fail and skip associated tests