### PR TITLE
Precomputed scaling

### DIFF
--- a/include/lbann/data_readers/cv_subtractor.hpp
+++ b/include/lbann/data_readers/cv_subtractor.hpp
@@ -56,19 +56,30 @@ class cv_subtractor : public cv_transform {
  protected:
   // --- configuration variables ---
   /**
-   * The image to subtract from an input image.
+   * The image to subtract from an input image in the pixel-wise fashion.
    * It has channel values of a floating point type, in the scale from 0 to 1.
    * An input image will be mapped into the scale before subtraction by linearly
    * mapping the smallest representative value to 0 and the largest representative
    * value to 1.
    */
   cv::Mat m_img_to_sub;
+
   /**
-   * The image to divide an input image.
+   * The image to divide an input image in the pixel-wise fashion.
    * It has channel values of a floating point type, in the scale from 0 to 1.
    * An input image will be mapped into the scale before division.
    */
   cv::Mat m_img_to_div;
+
+  /** uniform mean per channel used for channel-wise mean-subtraction.
+   *  This is used to construct the m_img_to_sub when the size of the image is known.
+   */
+  std::vector<lbann::DataType> m_channel_mean;
+
+  /** uniform standard deviation per channel used for channel-wise z-score (division).
+   *  This is used to construct the m_img_to_div when the size of the image is known.
+   */
+  std::vector<lbann::DataType> m_channel_stddev;
 
   // --- state variables ---
   bool m_applied; ///< has been subtracted
@@ -83,6 +94,16 @@ class cv_subtractor : public cv_transform {
 
   static cv::Mat read_binary_image_file(const std::string filename);
 
+  /// Load and set the image to subtract from every input image.
+  void set_mean(const std::string name_of_img, const int depth_code = cv_image_type<lbann::DataType>::T());
+
+  /**
+   * Set the mean fixed per channel for mean-subtracting each input image.
+   * This supports an alternative method for mean subtraction given that the
+   * mean per channel is uniform.
+   */
+  void set_mean(const std::vector<lbann::DataType> channel_mean);
+
   /**
    * Set the dataset-wise mean image to subtract from each input image.
    * The image represents the pre-computed pixel-wise mean of the dataset.
@@ -91,22 +112,8 @@ class cv_subtractor : public cv_transform {
    */
   void set_mean(const cv::Mat& img, const int depth_code = cv_image_type<lbann::DataType>::T());
 
-  /**
-   * Set the mean fixed per channel for mean-subtracting each input image.
-   * This supports an alternative method for mean subtraction given that the
-   * mean per channel is uniform.
-   */
-  void set_mean(int width, int height, const std::vector<lbann::DataType> channel_mean);
-
-  /// Load and set the image to subtract from every input image.
-  void set_mean(const std::string name_of_img, const int depth_code = cv_image_type<lbann::DataType>::T());
-
-  /**
-   * Set the dataset-wise standard deviation to normalize each input image.
-   * In case that this image is not in a floating point type, it is converted to
-   * one with the depth specified by depth_code.
-   */
-  void set_stddev(const cv::Mat& img, const int depth_code = cv_image_type<lbann::DataType>::T());
+  /// Load and set the image to normalize the pixels of every input image.
+  void set_stddev(const std::string name_of_img, const int depth_code = cv_image_type<lbann::DataType>::T());
 
   /**
    * Set the dataset-wise standard deviation fixed per channel for normalizing
@@ -114,10 +121,14 @@ class cv_subtractor : public cv_transform {
    * This supports an alternative method for normalizing with stddev given that
    * it is uniform per channel.
    */
-  void set_stddev(int width, int height, const std::vector<lbann::DataType> channel_stddev);
+  void set_stddev(const std::vector<lbann::DataType> channel_stddev);
 
-  /// Load and set the image to normalize the pixels of every input image.
-  void set_stddev(const std::string name_of_img, const int depth_code = cv_image_type<lbann::DataType>::T());
+  /**
+   * Set the dataset-wise standard deviation to normalize each input image.
+   * In case that this image is not in a floating point type, it is converted to
+   * one with the depth specified by depth_code.
+   */
+  void set_stddev(const cv::Mat& img, const int depth_code = cv_image_type<lbann::DataType>::T());
 
   void reset() override {
     m_enabled = false;
@@ -140,9 +151,18 @@ class cv_subtractor : public cv_transform {
    */
   bool apply(cv::Mat& image) override;
 
+  /// true if both sub and div are channel-wise
+  bool check_if_channel_wise() const;
+
   std::string get_type() const override { return "subtractor"; }
   std::string get_description() const override;
   std::ostream& print(std::ostream& os) const override;
+
+ protected:
+  /// Construct an image of the unform channel values using the channel-wise mean.
+  bool create_img_to_sub(int width, int height, int n_channels);
+  /// Construct an image of the unform channel values using the channel-wise stddev.
+  bool create_img_to_div(int width, int height, int n_channels);
 };
 
 } // end of namespace lbann

--- a/model_zoo/models/siamese/finetune-cub/data_reader_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/data_reader_cub.prototext
@@ -15,12 +15,6 @@ data_reader {
       raw_width: 256
       raw_height: 256
 
-      subtractor {
-        disable: false
-#        image_to_sub: "../../../../tools/compute_mean/sample/imagenet-trainset/mean-256x256x3-6.bin"
-        image_to_sub: "mean-256x256x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 224
@@ -36,6 +30,11 @@ data_reader {
 
       augmenter {
         disable: true
+      }
+
+      subtractor {
+        disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
       }
 
       normalizer {
@@ -60,12 +59,6 @@ data_reader {
       raw_width: 256
       raw_height: 256
 
-      subtractor {
-        disable: false
-#        image_to_sub: "../../../../tools/compute_mean/sample/imagenet-trainset/mean-256x256x3-6.bin"
-        image_to_sub: "mean-256x256x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 224
@@ -81,6 +74,11 @@ data_reader {
 
       augmenter {
         disable: true
+      }
+
+      subtractor {
+        disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
       }
 
       normalizer {

--- a/model_zoo/models/siamese/siamese_alexnet/data_reader_imagenet_patches.prototext
+++ b/model_zoo/models/siamese/siamese_alexnet/data_reader_imagenet_patches.prototext
@@ -13,8 +13,8 @@ data_reader {
 
     image_preprocessor {
       # assume fixed size of input images if cropper is not used
-      raw_width: 512
-      raw_height: 512
+      raw_width: 440
+      raw_height: 440
 
       # crop_size must be at least 3*patch_size+2*patch_gap+2*patch_jitter
       # In addition, it might be better to leave some margin such that patches are
@@ -22,21 +22,21 @@ data_reader {
 
       cropper {
         disable: false
-        crop_width: 512
-        crop_height: 512
+        crop_width: 440
+        crop_height: 440
         crop_randomly: false
-        resized_width: 512
-        resized_height: 512
+        resized_width: 440
+        resized_height: 440
       }
 
-#      decolorizer {
-#        disable: false
-#        pick_1ch: true
-#      }
-
-      colorizer {
+      decolorizer {
         disable: false
+        pick_1ch: true
       }
+
+#      colorizer {
+#        disable: false
+#      }
 
       augmenter {
         disable: true
@@ -80,26 +80,26 @@ data_reader {
 
     image_preprocessor {
       # assume fixed size of input images if cropper is not used
-      raw_width: 512
-      raw_height: 512
+      raw_width: 440
+      raw_height: 440
 
       cropper {
         disable: false
-        crop_width: 512
-        crop_height: 512
+        crop_width: 440
+        crop_height: 440
         crop_randomly: false
-        resized_width: 512
-        resized_height: 512
+        resized_width: 440
+        resized_height: 440
       }
 
-#      decolorizer {
-#        disable: false
-#        pick_1ch: true
-#      }
-
-      colorizer {
+      decolorizer {
         disable: false
+        pick_1ch: true
       }
+
+#      colorizer {
+#        disable: false
+#      }
 
       augmenter {
         disable: true

--- a/model_zoo/models/siamese/siamese_alexnet/model_siamese_alexnet.prototext
+++ b/model_zoo/models/siamese/siamese_alexnet/model_siamese_alexnet.prototext
@@ -71,8 +71,8 @@ model {
     data_layout: "data_parallel"
     slice {
       slice_axis: 0
-      slice_points: "0 3 6"
-#      slice_points: "0 1 2"
+#      slice_points: "0 3 6"
+      slice_points: "0 1 2"
     }
   }
 

--- a/model_zoo/models/siamese/triplet/data_reader_multi_images.prototext
+++ b/model_zoo/models/siamese/triplet/data_reader_multi_images.prototext
@@ -16,11 +16,6 @@ data_reader {
       raw_width: 110
       raw_height: 110
 
-      subtractor {
-        disable: true
-        image_to_sub: "mean_uniform-110x110x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 96
@@ -38,8 +33,13 @@ data_reader {
         disable: true
       }
 
-      normalizer {
+      subtractor {
         disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
+      }
+
+      normalizer {
+        disable: true
         scale: true
         subtract_mean: true
         unit_variance: true
@@ -65,11 +65,6 @@ data_reader {
       raw_width: 110
       raw_height: 110
 
-      subtractor {
-        disable: true
-        image_to_sub: "mean_uniform-110x110x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 96
@@ -87,8 +82,13 @@ data_reader {
         disable: true
       }
 
-      normalizer {
+      subtractor {
         disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
+      }
+
+      normalizer {
+        disable: true
         scale: true
         subtract_mean: true
         unit_variance: true

--- a/model_zoo/models/siamese/triplet/data_reader_triplet.prototext
+++ b/model_zoo/models/siamese/triplet/data_reader_triplet.prototext
@@ -15,11 +15,6 @@ data_reader {
       raw_width: 110
       raw_height: 110
 
-      subtractor {
-        disable: true
-        image_to_sub: "mean_uniform-110x110x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 96
@@ -37,8 +32,13 @@ data_reader {
         disable: true
       }
 
-      normalizer {
+      subtractor {
         disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
+      }
+
+      normalizer {
+        disable: true
         scale: true
         subtract_mean: true
         unit_variance: true
@@ -63,11 +63,6 @@ data_reader {
       raw_width: 110
       raw_height: 110
 
-      subtractor {
-        disable: true
-        image_to_sub: "mean_uniform-110x110x3-6.bin"
-      }
-
       cropper {
         disable: false
         crop_width: 96
@@ -85,8 +80,13 @@ data_reader {
         disable: true
       }
 
-      normalizer {
+      subtractor {
         disable: false
+        channel_mean: [0.40625, 0.45703, 0.48047]
+      }
+
+      normalizer {
+        disable: true
         scale: true
         subtract_mean: true
         unit_variance: true

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
@@ -52,8 +52,8 @@ model {
 #  callback {
 #    checkpoint {
 #      checkpoint_dir: "pretrain"
-#      checkpoint_epochs: 1
-##      checkpoint_steps: 50000
+##      checkpoint_epochs: 1
+#      checkpoint_steps: 5000
 #    }
 #  }
 

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm.prototext
@@ -52,8 +52,8 @@ model {
 #  callback {
 #    checkpoint {
 #      checkpoint_dir: "pretrain"
-#      checkpoint_epochs: 1
-##      checkpoint_steps: 5000
+##      checkpoint_epochs: 1
+#      checkpoint_steps: 5000
 #    }
 #  }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -111,8 +111,6 @@ message ImagePreprocessor {
     string image_to_div = 4;
     repeated float channel_mean = 5 [packed = true];
     repeated float channel_stddev = 6 [packed = true];
-    int32 width = 7;
-    int32 height = 8;
   }
 
   message PatchExtractor {

--- a/tests/test_img_pipeline/CMakeLists.txt
+++ b/tests/test_img_pipeline/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.8)
 cmake_policy(SET CMP0015 NEW)
 
 set(COMPILER "gnu")
-set(CLUSTER "surface")
+#set(CLUSTER "surface") # only usable with non-custom built MPI that is detected by SetupMPI.cmake below
+set(CLUSTER "catalyst")
 set(LBANN_DIR ../..)
 set(LBANN_BUILD_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
 include(${LBANN_DIR}/cmake/modules/SetupMPI.cmake)

--- a/tests/test_img_pipeline/lbann_config.hpp
+++ b/tests/test_img_pipeline/lbann_config.hpp
@@ -1,9 +1,1 @@
-#ifndef LBANN_CONFIG_HPP__
-#define LBANN_CONFIG_HPP__
-
-namespace lbann
-{
-  using DataType = float;
-}// namespace lbann
-
-#endif /* LBANN_CONFIG_H__ */
+../../tools/compute_mean/lbann_config.hpp

--- a/tests/test_img_pipeline/main.cpp
+++ b/tests/test_img_pipeline/main.cpp
@@ -229,19 +229,19 @@ bool test_image_io(const std::string filename,
         pp.add_normalizer(std::move(normalizer));
       } else {
         std::unique_ptr<lbann::cv_subtractor> normalizer(new(lbann::cv_subtractor));
-#if 1
+#if 0
         cv::Mat img_to_sub = cv::imread(mp.m_mean_image_name);
         if (img_to_sub.empty()) {
           std::cout << mp.m_mean_image_name << " does not exist" << std::endl;
           return false;
         }
-#else
-        cv::Scalar px = {0.40625, 0.45703, 0.48047};
-        cv::Mat img_to_sub(rp.m_crop_sz.second, rp.m_crop_sz.first,
-                           lbann::cv_image_type<lbann::DataType>::T(3), px);
-        normalizer->set_stddev(img_to_sub.cols, img_to_sub.rows, {0.3, 0.5, 0.3});
-#endif
         normalizer->set_mean(img_to_sub);
+#else
+        std::vector<lbann::DataType> mean = {0.40625, 0.45703, 0.48047};
+        normalizer->set_mean(mean);
+        std::vector<lbann::DataType> stddev = {0.3, 0.5, 0.3};
+        normalizer->set_stddev(stddev);
+#endif
         pp.add_normalizer(std::move(normalizer));
       }
       transform_idx ++;
@@ -276,9 +276,9 @@ bool test_image_io(const std::string filename,
     if (num_bytes == 0) {
       ok = lbann::image_utils::import_image(inbuf, width, height, type, pp, Images);
       num_bytes = Images.Height();
-      El::View(Image_v, Images, 0, 0, num_bytes, 1);
+      El::View(Image_v, Images, El::IR(0, num_bytes), El::IR(0, 1));
     } else {
-      El::View(Image_v, Images, 0, 0, num_bytes, 1);
+      El::View(Image_v, Images, El::IR(0, num_bytes), El::IR(0, 1));
       //ok = lbann::image_utils::import_image(buf, width, height, type, pp, Image_v);
       ok = lbann::image_utils::import_image(inbuf, width, height, type, pp, Image_v);
     }


### PR DESCRIPTION
This PR is to finish addressing the Luke's requirements with dataset-wide image normalization as well as to improve the normalization interface for the Siamese model.
- make channel-wise subtractor more flexible such that the mean/stddev image to subtract/divide is created on demand. This is possible only for channel-wise operation with which the pixel value is uniform per channel. 
- position the subtractor in the image preprocessing pipeline based on whether it does channel-wise operation or pixel-wise operation. In case of the former, it comes at the same place as the sample-wise normalizer as it does not require the size of image known in advance. In case of the latter, it comes as it was used to be, which is at the beginning.
- previous requirement to specify width and height for channel-wise subtractor is now removed, as the image to subtract/divide can be created on-the-fly.
- update the data reader prototexts of Siamse model to use the channel-wise subtractor.
- miscellaneous updates to model prototexts as well.
- update image preprocessing test