### PR TITLE
Restoring prototext field 'num_gpus'.

### DIFF
--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -198,6 +198,7 @@ message Model {
   int64 num_batches = 122; //multiple batches/sub epoch
   int64 block_size = 50;
   int64 procs_per_model = 51;
+  int64 num_gpus = 53; //has no effect
   int64 evaluation_frequency = 54;
   int64 num_parallel_readers = 100;
 


### PR DESCRIPTION
'num_gpus' is deprecated and doesn't do anything. However, changing it might break many model prototexts. We should probably have a discussion when we make big changes to the prototext interface.