### PR TITLE
Update model setup test 

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -200,7 +200,7 @@ def get_command(cluster,
         option_model = ' --model=%s' % model_path
     if data_reader_path != None:
         # If data_reader_name is set, an exception will be raised later.
-        option_data_reader_name = ' --reader=%s' % data_reader_path
+        option_data_reader = ' --reader=%s' % data_reader_path
     if optimizer_path != None:
         # If optimizer_name is set, an exception will be raised later.
         option_optimizer_name = ' --optimizer=%s' % optimizer_path
@@ -261,7 +261,7 @@ def get_command(cluster,
             option_data_filedir_train  = ' --data_filedir_train=%s'  % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filedir_train_default)
             option_data_filename_train = ' --data_filename_train=%s' % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filename_train_default)
             option_data_filedir_test   = ' --data_filedir_test=%s'   % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filedir_test_default)
-            option_data_filename_train = ' --data_filename_test=%s'  % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filename_test_default)
+            option_data_filename_test = ' --data_filename_test=%s'  % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filename_test_default)
     if (data_reader_name != None) or (data_reader_path != None):
         if data_filedir_default != None:
             if data_file_parameters != [None, None, None, None]: # If any are not None

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
         default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'ray':
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-2018.04.27_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_cuda-9.2.64_cudnn-7.0_spectrum-mpi-2018.04.27_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'surface':
         default_exes['gcc4'] = default_exes['default']

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -30,10 +30,10 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                     data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
                     data_reader_name = 'mnist'
                 elif 'adversarial' in file_name:
-		    data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
+                    data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
                     data_reader_path = '%s/model_zoo/models/gan/mnist/adversarial_data.prototext' % (dir_name)
-		    data_reader_name = None
-		elif 'discriminator' in file_name:
+                    data_reader_name = None
+                elif 'discriminator' in file_name:
                     data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
                     data_reader_path = '%s/model_zoo/models/gan/mnist/discriminator_data.prototext' % (dir_name)
                     data_reader_name = None
@@ -105,15 +105,11 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
 def test_unit_models_clang4(cluster, dirname, exes):
     if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 5 == 0
     skeleton_models(cluster, dirname, exes, 'clang4')
 
 def test_unit_models_gcc4(cluster, dirname, exes):
     if cluster in ['quartz', 'surface']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 4 == 0
         # Surface Errors:
         # assert 8 == 0
     skeleton_models(cluster, dirname, exes, 'gcc4')

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -26,7 +26,10 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                 data_filedir_test_default=None
                 data_filename_test_default=None
                 data_reader_path=None
-                if 'mnist' in file_name:
+                if 'motif' in file_name:
+                    print('Skipping %s because motifs are deprecated' % model_path)
+                    continue
+                elif 'mnist' in file_name:
                     data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
                     data_reader_name = 'mnist'
                 elif 'adversarial' in file_name:

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -7,14 +7,15 @@ import os, re, subprocess, sys
 def skeleton_models(cluster, dir_name, executables, compiler_name):
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
-    opt = 'adagrad'
+    opt = 'sgd'
+    node_count = 1
+    time_limit = 1
     defective_models = []
     working_models = []
-    tell_Dylan = []
     for subdir, dirs, files in os.walk(dir_name + '/model_zoo/models/'):
         if 'greedy' in subdir:
             print('Skipping greedy_layerwise_autoencoder_mnist, kills bamboo agent')
-            continue            
+            continue
         for file_name in files:
             if file_name.endswith('.prototext') and "model" in file_name:
                 model_path = subdir + '/' + file_name
@@ -24,15 +25,41 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                 data_filename_train_default=None
                 data_filedir_test_default=None
                 data_filename_test_default=None
+                data_reader_path=None
                 if 'mnist' in file_name:
                     data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
                     data_reader_name = 'mnist'
+                elif 'adversarial' in file_name:
+		    data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
+                    data_reader_path = '%s/model_zoo/models/gan/mnist/adversarial_data.prototext' % (dir_name)
+		    data_reader_name = None
+		elif 'discriminator' in file_name:
+                    data_filedir_default = '/p/lscratchf/brainusr/datasets/MNIST'
+                    data_reader_path = '%s/model_zoo/models/gan/mnist/discriminator_data.prototext' % (dir_name)
+                    data_reader_name = None
+                elif 'triplet' in file_name:
+                    data_filedir_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/patches_84h_110x110_13x13-blur-ab_compact/'
+                    data_filename_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/patches_84h_110x110_13x13-blur-ab_compact/train/train_list_8h.nfl.npz'
+                    data_filedir_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/patches_84h_110x110_13x13-blur-ab_compact/'
+                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/patches_84h_110x110_13x13-blur-ab_compact/val/val_list_8h.nfl.npz'
+                    data_reader_path = '%s/model_zoo/models/siamese/triplet/data_reader_triplet.prototext' % (dir_name)
+                    data_reader_name = None
+                elif 'siamese_alexnet' in file_name:
+                    data_filedir_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/train/'
+                    data_filename_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/train.txt'
+                    data_filedir_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/val/'
+                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/labels/val.txt'
+                    data_reader_path = '%s/model_zoo/models/siamese/siamese_alexnet/data_reader_imagenet_patches.prototext' % (dir_name)
+                    data_reader_name = None
                 elif 'net' in file_name:
                     data_filedir_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/train/'
                     data_filename_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/train.txt'
                     data_filedir_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/val/'
                     data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/labels/val.txt'
                     data_reader_name = 'imagenet'
+                    node_count = 2
+                    if(cluster == 'ray'):
+                        time_limit=3
                 elif 'cifar' in file_name:
                     data_filename_train_default = '/p/lscratchf/brainusr/datasets/cifar10-bin/data_all.bin'
                     data_filename_test_default = '/p/lscratchf/brainusr/datasets/cifar10-bin/test_batch.bin'
@@ -41,24 +68,25 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                     data_filedir_default = '/p/lscratche/brainusr/datasets/tinyshakespeare/'
                     data_reader_name = 'ascii'
                 else:
-                    print("Tell Dylan which data reader this model needs")
-                    tell_Dylan.append(file_name)
+                    print("Shared lbannusr account doesn't have access to dataset this model requires")
                     continue
                 if (cluster == 'ray') and (data_reader_name in ['cifar10', 'ascii']):
                     print('Skipping %s because data is not available on ray' % model_path)
+                elif (cluster == 'ray') and ('conv_autoencoder_imagenet' in file_name):
+                    print('Skipping %s because unpooling is not implemented on gpu' % model_path)
                 else:
                     output_file_name = '%s/bamboo/unit_tests/output/check_proto_models_%s_%s_output.txt' % (dir_name, file_name, compiler_name)
                     error_file_name = '%s/bamboo/unit_tests/error/check_proto_models_%s_%s_error.txt' % (dir_name, file_name, compiler_name)
                     cmd = tools.get_command(
-                        cluster=cluster, executable=executables[compiler_name], num_nodes=1,
-                        partition='pdebug', time_limit=1, dir_name=dir_name,
+                        cluster=cluster, executable=executables[compiler_name], num_nodes=node_count,
+                        partition='pbatch', time_limit=time_limit, dir_name=dir_name,
                         data_filedir_default=data_filedir_default,
                         data_filedir_train_default=data_filedir_train_default,
                         data_filename_train_default=data_filename_train_default,
                         data_filedir_test_default=data_filedir_test_default,
                         data_filename_test_default=data_filename_test_default,
-                        data_reader_name=data_reader_name, exit_after_setup=True,
-                        model_path=model_path, optimizer_name=opt,
+                        data_reader_name=data_reader_name, data_reader_path=data_reader_path,
+                        exit_after_setup=True, model_path=model_path, optimizer_name=opt,
                         output_file_name=output_file_name, error_file_name=error_file_name)
                     if os.system(cmd) != 0:
                         print("Error detected in " + model_path)
@@ -72,20 +100,17 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
         print('Errors for: The following models exited with errors %s' % compiler_name)
         for model in defective_models:
             print(model)
-        print('Errors for: tell Dylan: the following models have unknown data readers: %s' % compiler_name)
-        for model in tell_Dylan :
-            print(model)
     assert num_defective == 0
 
 def test_unit_models_clang4(cluster, dirname, exes):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:                                                                                                                                          
+        # Catalyst Errors:
         # assert 5 == 0
     skeleton_models(cluster, dirname, exes, 'clang4')
 
 def test_unit_models_gcc4(cluster, dirname, exes):
-    if cluster in ['catalyst', 'quartz', 'surface']:
+    if cluster in ['quartz', 'surface']:
         pytest.skip('FIXME')
         # Catalyst Errors:
         # assert 4 == 0

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -51,18 +51,20 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                     data_filedir_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/train/'
                     data_filename_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/train.txt'
                     data_filedir_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/val/'
-                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/labels/val.txt'
+                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/val.txt'
                     data_reader_path = '%s/model_zoo/models/siamese/siamese_alexnet/data_reader_imagenet_patches.prototext' % (dir_name)
                     data_reader_name = None
                 elif 'net' in file_name:
                     data_filedir_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/train/'
                     data_filename_train_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/train.txt'
                     data_filedir_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/val/'
-                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/original/labels/val.txt'
+                    data_filename_test_default = '/p/lscratche/brainusr/datasets/ILSVRC2012/labels/val.txt'
                     data_reader_name = 'imagenet'
                     node_count = 2
                     if(cluster == 'ray'):
-                        time_limit=3
+                        time_limit = 3
+                    if 'resnet50' in file_name:
+                        node_count = 8
                 elif 'cifar' in file_name:
                     data_filename_train_default = '/p/lscratchf/brainusr/datasets/cifar10-bin/data_all.bin'
                     data_filename_test_default = '/p/lscratchf/brainusr/datasets/cifar10-bin/test_batch.bin'
@@ -75,8 +77,8 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                     continue
                 if (cluster == 'ray') and (data_reader_name in ['cifar10', 'ascii']):
                     print('Skipping %s because data is not available on ray' % model_path)
-                elif (cluster == 'ray') and ('conv_autoencoder_imagenet' in file_name):
-                    print('Skipping %s because unpooling is not implemented on gpu' % model_path)
+                elif (cluster == 'ray') or (cluster == 'pascal')  and ('conv_autoencoder' in file_name) or ('gan' in subdir):
+                    print('Skipping %s because unpooling/noise is not implemented on gpu' % model_path)
                 else:
                     output_file_name = '%s/bamboo/unit_tests/output/check_proto_models_%s_%s_output.txt' % (dir_name, file_name, compiler_name)
                     error_file_name = '%s/bamboo/unit_tests/error/check_proto_models_%s_%s_error.txt' % (dir_name, file_name, compiler_name)
@@ -106,12 +108,10 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
     assert num_defective == 0
 
 def test_unit_models_clang4(cluster, dirname, exes):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_models(cluster, dirname, exes, 'clang4')
 
 def test_unit_models_gcc4(cluster, dirname, exes):
-    if cluster in ['quartz', 'surface']:
+    if cluster in ['surface']:
         pytest.skip('FIXME')
         # Surface Errors:
         # assert 8 == 0

--- a/model_zoo/models/imagenet/model_imagenet.prototext
+++ b/model_zoo/models/imagenet/model_imagenet.prototext
@@ -32,7 +32,6 @@ model {
     name: "1"
     parents: "1"
     children: "2 7"
-    children: ""
     data_layout: "data_parallel"
   }
   #############################################


### PR DESCRIPTION
Fixes a couple of bugs:
-  Resnet models failing incorrectly due to lack of memory
-  Adds correct reader for the alexnet variations that were failing incorrectly (Siamese, triplet)

Also adds GAN models to this test. A number of models are still skipped because the shared account does not have access to the datasets. 

This PR will remove this test from quarantine. Before merging I am going to tag a few folks about models which are still failing to see how to fix that/if we should not include these models in this test. 