### PR TITLE
fix clang compilation errors

### DIFF
--- a/include/lbann/io/data_buffers/generic_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/generic_io_buffer.hpp
@@ -38,6 +38,7 @@ class fetch_data_functor {
   fetch_data_functor (bool is_input_layer, bool is_for_regression) :
     _is_input_layer(is_input_layer), _is_for_regression(is_for_regression) {}
   int operator() (CPUMat& samples, CPUMat& response, generic_data_reader* data_reader) const {
+    (void) _is_input_layer;
     int num_samples_fetched = data_reader->fetch_data(samples);
     int num_responses_fetched;
     if (_is_for_regression) {
@@ -60,6 +61,7 @@ class update_data_reader_functor {
   update_data_reader_functor (bool is_input_layer) :
     _is_input_layer(is_input_layer) {}
   int operator() (bool is_active_reader, generic_data_reader* data_reader) const {
+    (void) _is_input_layer;
     if (_is_input_layer) {
       return data_reader->update(is_active_reader);
     } else {

--- a/include/lbann/layers/io/target/reconstruction.hpp
+++ b/include/lbann/layers/io/target/reconstruction.hpp
@@ -92,8 +92,8 @@ class reconstruction_layer : public generic_target_layer {
 
   void bp_compute() override {}
 
-  virtual AbsDistMat& get_ground_truth() { return m_original_layer->get_activations(); }
-  virtual const AbsDistMat& get_ground_truth() const { return m_original_layer->get_activations(); }
+  AbsDistMat& get_ground_truth() override { return m_original_layer->get_activations(); }
+  const AbsDistMat& get_ground_truth() const override { return m_original_layer->get_activations(); }
 
 public:
 


### PR DESCRIPTION
- unused variable: _is_input_layer -> this is removed in the latest update, and the conflict has been resolved.
- 'override'