### PR TITLE
Fixing runtime errors in check_nan callback.

### DIFF
--- a/include/lbann/callbacks/callback_checknan.hpp
+++ b/include/lbann/callbacks/callback_checknan.hpp
@@ -58,11 +58,7 @@ class lbann_callback_checknan : public lbann_callback {
   /** Check that weights are good. */
   void on_batch_end(model *m) override;
   std::string name() const override { return "checknan"; }
- private:
-  /** Return true if there are no problems with m. */
-  bool is_good(const AbsDistMat& m);
-  /** Dump the (local) network matrices for debugging. */
-  void dump_network(model *m);
+
 };
 
 }  // namespace lbann


### PR DESCRIPTION
Callback can now handle layers with multiple or no parents/children. Warning message better indicates position of nan or inf.

The changes to the check_nan callback are identical to those in 58a53dc063615ec3a11687bc58724e371a9b39a2 from #405.