### PR TITLE
correct value type handling in jag_conduit data reader

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -167,7 +167,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// A utility function to convert a JAG variable type to name string
   static std::string to_string(const variable_t t);
 
+  /// print the schema of the all the samples
   void print_schema() const;
+  /// print the schema of the specific sample identified by a given id
   void print_schema(const size_t i) const;
 
  protected:

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -167,6 +167,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// A utility function to convert a JAG variable type to name string
   static std::string to_string(const variable_t t);
 
+  void print_schema() const;
+  void print_schema(const size_t i) const;
+
  protected:
   virtual void set_defaults();
   virtual bool replicate_processor(const cv_process& pp);

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -267,7 +267,7 @@ class data_reader_jag_conduit : public generic_data_reader {
 
 
 template<typename S>
-size_t data_reader_jag_conduit::add_val(const std::string key, const conduit::Node& n, std::vector<S>& vals) {
+inline size_t data_reader_jag_conduit::add_val(const std::string key, const conduit::Node& n, std::vector<S>& vals) {
   size_t cnt = 0u;
 
   switch (n.dtype().id()) {

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -272,7 +272,7 @@ inline size_t data_reader_jag_conduit::add_val(const std::string key, const cond
 
   switch (n.dtype().id()) {
     case TypeID::OBJECT_ID: {
-        std::cout << "O " << n.path() << std::endl;
+        //std::cout << "O " << n.path() << std::endl;
         if (check_non_numeric(key)) {
           return 0u;
         }
@@ -284,7 +284,7 @@ inline size_t data_reader_jag_conduit::add_val(const std::string key, const cond
       }
       break;
     case TypeID::LIST_ID: {
-        std::cout << "L " << n.path() << std::endl;
+        //std::cout << "L " << n.path() << std::endl;
         if (check_non_numeric(key)) {
           return 0u;
         }
@@ -306,7 +306,7 @@ inline size_t data_reader_jag_conduit::add_val(const std::string key, const cond
     case TypeID::FLOAT32_ID:
     case TypeID::FLOAT64_ID:
       cnt = 1u;
-      std::cout << "N " << n.path() << ": " << static_cast<S>(n.to_value()) << std::endl;
+      //std::cout << "N " << n.path() << ": " << static_cast<S>(n.to_value()) << std::endl;
       vals.push_back(static_cast<S>(n.to_value()));
       break;
     case TypeID::CHAR8_STR_ID: {
@@ -322,15 +322,15 @@ inline size_t data_reader_jag_conduit::add_val(const std::string key, const cond
         cnt = 1u;
         const S v = static_cast<S>(atof(str.c_str()));
         vals.push_back(v);
-      std::cout << "S " << n.path() << ": " << str << " => " << vals.back() << std::endl;
+        //std::cout << "S " << n.path() << ": " << str << " => " << vals.back() << std::endl;
       }
       break;
     case TypeID::EMPTY_ID:
     default:
       std::string err = std::string("data_reader_jag_conduit::add_val() : invalid dtype (")
-                      + n.dtype().name() + ") for " + n.path();
+                      + n.dtype().name() + ") for " + n.path() + '.';
      #if 1
-      std::cerr << err << std::endl;
+      std::cerr << err << " Skipping for now." << std::endl;
      #else
       throw lbann_exception(err);
      #endif

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -313,16 +313,18 @@ inline size_t data_reader_jag_conduit::add_val(const std::string key, const cond
         // In case of a charater string, the method to convert it to a float number is specific to each key
         if (check_non_numeric(key)) {
           return 0u;
-        }
-        const char* c_str = n.as_char8_str();
-        // make sure that the std::string does not contain null character
-        const std::string str
-          = ((c_str == nullptr)? std::string() : std::string(c_str, n.dtype().number_of_elements())).c_str();
+        //} else if (key == "some_key_with_non_numeric_values_that_can_be_converted_to_numerics_in_a_specific_way") {
+        } else {
+          const char* c_str = n.as_char8_str();
+          // make sure that the std::string does not contain null character
+          const std::string str
+            = ((c_str == nullptr)? std::string() : std::string(c_str, n.dtype().number_of_elements())).c_str();
 
-        cnt = 1u;
-        const S v = static_cast<S>(atof(str.c_str()));
-        vals.push_back(v);
-        //std::cout << "S " << n.path() << ": " << str << " => " << vals.back() << std::endl;
+          cnt = 1u;
+          const S v = static_cast<S>(atof(str.c_str()));
+          vals.push_back(v);
+          //std::cout << "S " << n.path() << ": " << str << " => " << vals.back() << std::endl;
+        }
       }
       break;
     case TypeID::EMPTY_ID:

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -910,6 +910,15 @@ void data_reader_jag_conduit::save_image(Mat& pixels, const std::string filename
 #endif // _JAG_OFFLINE_TOOL_MODE_
 }
 
+void data_reader_jag_conduit::print_schema() const {
+  m_data.schema().print();
+}
+
+void data_reader_jag_conduit::print_schema(const size_t sample_id) const {
+  const conduit::Node & n = get_conduit_node(std::to_string(sample_id));
+  n.schema().print();
+}
+
 } // end of namespace lbann
 
 #undef _CN_


### PR DESCRIPTION
Handle various numeric types that is not float64 in conduit data, and
avoid blindly treating non-numeric values as a numeric.