### PR TITLE
Updated the input layer to support reconstruction target layers

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -122,6 +122,8 @@ enum class pool_mode {invalid, max, average, average_no_pad};
 /** returns a string representation of the pool_mode */
 std::string get_pool_mode_name(pool_mode m);
 
+enum class data_reader_target_mode {CLASSIFICATION, REGRESSION, RECONSTRUCTION};
+
 namespace lbann {
 
 // Forward-declaration.

--- a/include/lbann/io/data_buffers/generic_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/generic_io_buffer.hpp
@@ -35,15 +35,22 @@ namespace lbann
 {
 class fetch_data_functor {
  public:
-  fetch_data_functor (bool is_input_layer, bool is_for_regression) :
-    _is_input_layer(is_input_layer), _is_for_regression(is_for_regression) {}
-  int operator() (CPUMat& samples, CPUMat& response, generic_data_reader* data_reader) const {
+  fetch_data_functor (data_reader_target_mode target_mode) :
+    _target_mode(target_mode) {}
+  int operator() (CPUMat& samples, CPUMat& responses, generic_data_reader* data_reader) const {
     int num_samples_fetched = data_reader->fetch_data(samples);
     int num_responses_fetched;
-    if (_is_for_regression) {
-      num_responses_fetched = data_reader->fetch_responses(response);
-    } else {
-      num_responses_fetched = data_reader->fetch_labels(response);
+    switch(_target_mode) {
+    case data_reader_target_mode::REGRESSION:
+      num_responses_fetched = data_reader->fetch_responses(responses);
+      break;
+    case data_reader_target_mode::RECONSTRUCTION:
+      El::Copy(samples, responses);
+      num_responses_fetched = num_samples_fetched;
+      break;
+    case data_reader_target_mode::CLASSIFICATION:
+    default:
+      num_responses_fetched = data_reader->fetch_labels(responses);
     }
     if(num_samples_fetched != num_responses_fetched) {
       throw lbann_exception("Number of samples does not match the number of responses");
@@ -51,23 +58,15 @@ class fetch_data_functor {
     return num_samples_fetched;
   }
  private:
-  const bool _is_input_layer;
-  const bool _is_for_regression;
+  const data_reader_target_mode _target_mode;
 };
 
 class update_data_reader_functor {
  public:
-  update_data_reader_functor (bool is_input_layer) :
-    _is_input_layer(is_input_layer) {}
+  update_data_reader_functor () {}
   int operator() (bool is_active_reader, generic_data_reader* data_reader) const {
-    if (_is_input_layer) {
-      return data_reader->update(is_active_reader);
-    } else {
-      return (data_reader->is_data_reader_done(is_active_reader));
-    }
+    return data_reader->update(is_active_reader);
   }
- private:
-  const bool _is_input_layer;
 };
 
 class generic_io_buffer {

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -45,8 +45,9 @@ class generic_input_layer : public io_layer {
   generic_input_layer(lbann_comm *comm,
               int num_parallel_readers,
               std::map<execution_mode, generic_data_reader *> data_readers,
-              bool data_set_spans_models = true, bool for_regression = false)
-    : io_layer(comm, data_set_spans_models, for_regression),
+              bool data_set_spans_models = true,
+              data_reader_target_mode dr_mode = data_reader_target_mode::CLASSIFICATION)
+    : io_layer(comm, data_set_spans_models, dr_mode),
       io_buffer(nullptr),
       m_training_dataset(),
       m_testing_dataset(),
@@ -519,9 +520,13 @@ class generic_input_layer : public io_layer {
       if(child_index == 0) {
         return dr->get_data_dims();
       }else if(child_index == 1) {
-        if(is_for_regression()) {
+        switch(m_data_reader_mode) {
+        case data_reader_target_mode::REGRESSION:
           return std::vector<int>(1, dr->get_num_responses());
-        }else {
+        case data_reader_target_mode::RECONSTRUCTION:
+          return dr->get_data_dims();
+        case data_reader_target_mode::CLASSIFICATION:
+        default:
           return std::vector<int>(1, dr->get_num_labels());
         }
         //        the correct value based on initialization

--- a/include/lbann/layers/io/input/input_layer.hpp
+++ b/include/lbann/layers/io/input/input_layer.hpp
@@ -43,12 +43,13 @@ class input_layer : public generic_input_layer {
 
   /// @todo make the map and vector references
   input_layer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode,
-    generic_data_reader *> data_readers, bool data_set_spans_models = true, bool for_regression = false)
-    : generic_input_layer(comm, num_parallel_readers, data_readers, data_set_spans_models, for_regression) {
+    generic_data_reader *> data_readers, bool data_set_spans_models = true,
+    data_reader_target_mode target_mode = data_reader_target_mode::CLASSIFICATION)
+    : generic_input_layer(comm, num_parallel_readers, data_readers, data_set_spans_models, target_mode) {
     validate_data_layout();
     initialize_io_buffer(comm, std::min(num_parallel_readers, Layer::m_comm->get_procs_per_model()), data_readers);
-    io_buffer->fetch_data_fn = new fetch_data_functor(true, false);
-    io_buffer->update_data_reader_fn = new update_data_reader_functor(true);
+    io_buffer->fetch_data_fn = new fetch_data_functor(target_mode);
+    io_buffer->update_data_reader_fn = new update_data_reader_functor();
   }
   input_layer(const input_layer&) = default;
   input_layer& operator=(const input_layer&) = default;

--- a/include/lbann/layers/io/input/repeated_input_layer.hpp
+++ b/include/lbann/layers/io/input/repeated_input_layer.hpp
@@ -49,19 +49,19 @@ class repeated_input_layer : public input_layer<partitioned_io_buffer, data_layo
                        std::map<execution_mode, generic_data_reader *> data_readers,
                        int num_steps,
                        bool data_set_spans_models = true,
-                       bool for_regression = false)
+                       data_reader_target_mode target_mode = data_reader_target_mode::CLASSIFICATION)
     : input_layer<partitioned_io_buffer, data_layout::DATA_PARALLEL>(comm,
                                                                      num_parallel_readers,
                                                                      data_readers,
                                                                      data_set_spans_models,
-                                                                     for_regression),
+                                                                     target_mode),
       m_num_steps(num_steps) {
 
     m_label_io_buffer = new partitioned_io_buffer(comm,
                                                   num_parallel_readers,
                                                   data_readers);
-    m_label_io_buffer->fetch_data_fn = new fetch_data_functor(false, false);
-    m_label_io_buffer->update_data_reader_fn = new update_data_reader_functor(false);
+    m_label_io_buffer->fetch_data_fn = new fetch_data_functor(target_mode);
+    m_label_io_buffer->update_data_reader_fn = new update_data_reader_functor();
 
   }
 

--- a/include/lbann/layers/io/io_layer.hpp
+++ b/include/lbann/layers/io/io_layer.hpp
@@ -44,17 +44,15 @@ namespace lbann {
 class io_layer : public Layer {
  protected:
   bool m_data_set_spans_models;
-
- private:
-  bool m_for_regression;
+  data_reader_target_mode m_data_reader_mode;
 
  public:
   io_layer(lbann_comm *comm,
            bool data_set_spans_models = true,
-           bool for_regression = false)
+           data_reader_target_mode data_reader_mode = data_reader_target_mode::CLASSIFICATION)
     : Layer(comm),
       m_data_set_spans_models(data_set_spans_models),
-      m_for_regression(for_regression) {
+      m_data_reader_mode(data_reader_mode) {
   }
 
   /**
@@ -178,7 +176,7 @@ class io_layer : public Layer {
   }
 #endif
   bool is_for_regression() const {
-    return m_for_regression;
+    return (m_data_reader_mode == data_reader_target_mode::REGRESSION);
   }
 };
 

--- a/include/lbann/layers/io/target/reconstruction.hpp
+++ b/include/lbann/layers/io/target/reconstruction.hpp
@@ -38,16 +38,9 @@ template <data_layout T_layout, El::Device Dev>
 class reconstruction_layer : public generic_target_layer {
  private:
 
-  /** Original layer to reconstruct. */
-  Layer *m_original_layer;
-
  public:
-  reconstruction_layer(lbann_comm *comm,
-                       Layer *original_layer)
-    :  generic_target_layer(comm),
-       m_original_layer(original_layer) {
-    // Override the target layer's expected number of parents.
-    m_expected_num_parent_layers = 1;
+  reconstruction_layer(lbann_comm *comm)
+    :  generic_target_layer(comm) {
   }
 
   reconstruction_layer* copy() const override {
@@ -59,7 +52,6 @@ class reconstruction_layer : public generic_target_layer {
 
   std::string get_description() const override {
     return std::string{} + " reconstruction_layer " +
-                           " original: " + m_original_layer->get_name() +
                            " dataLayout: " + this->get_data_layout_string(get_data_layout());
   }
 
@@ -67,33 +59,14 @@ class reconstruction_layer : public generic_target_layer {
 
   El::Device get_device_allocation() const override { return Dev; }
 
-  /** Set original layer. */
-  void set_original_layer(Layer *original_layer) {
-    m_original_layer = original_layer;
-  }
-
-  void setup_dims() override {
-    generic_target_layer::setup_dims();
-    this->m_neuron_dims = m_original_layer->get_neuron_dims();
-    this->m_num_neuron_dims = m_original_layer->get_num_neuron_dims();
-    this->m_num_neurons = m_original_layer->get_num_neurons();
-    if(this->m_num_neurons != this->m_num_prev_neurons) {
-      throw lbann_exception("reconstruction_layer: original layer ("
-                            + std::to_string(this->m_num_neurons)
-                            + ") and reconstruction layer ("
-                            + std::to_string(this->m_num_prev_neurons)
-                            +") do not have the same number of neurons");
-    }
-  }
-
  protected:
 
   void fp_compute() override {}
 
   void bp_compute() override {}
 
-  virtual AbsDistMat& get_ground_truth() { return m_original_layer->get_activations(); }
-  virtual const AbsDistMat& get_ground_truth() const { return m_original_layer->get_activations(); }
+  virtual AbsDistMat& get_ground_truth() { return get_prev_activations(1); }
+  virtual const AbsDistMat& get_ground_truth() const { return get_prev_activations(1); }
 
 public:
 
@@ -104,19 +77,6 @@ public:
     // Skip target layer (for now).
     //    io_layer::summarize_stats(summarizer, step);
   }
-
-  std::vector<Layer*> get_layer_pointers() override {
-    std::vector<Layer*> layers = generic_target_layer::get_layer_pointers();
-    layers.push_back(m_original_layer);
-    return layers;
-  }
-
-  void set_layer_pointers(std::vector<Layer*> layers) override {
-    m_original_layer = layers.back();
-    layers.pop_back();
-    generic_target_layer::set_layer_pointers(layers);
-  }
-
 };
 
 }

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -60,9 +60,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -303,10 +305,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "relu10 data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
@@ -1,7 +1,7 @@
 model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
-  ### This network description is anologous to AutoEncoder_Chem_ECFP 
+  ### This network description is anologous to AutoEncoder_Chem_ECFP
   name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 1024
@@ -60,9 +60,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -119,7 +121,7 @@ model {
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons: 100 
+      num_neurons: 100
       weight_initialization: "glorot_uniform"
       has_bias: true
     }
@@ -297,16 +299,15 @@ model {
     }
   }
 
-  
+
   #################
   # RECONSTRUCTION
   #################
   layer {
     name: "reconstruction"
+    parents: "relu10 data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
@@ -52,9 +52,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -204,10 +206,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid6 data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
@@ -47,9 +47,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -123,10 +125,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "dropout2 data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
@@ -56,9 +56,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "conv1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -338,10 +340,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid data"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
+++ b/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
@@ -46,9 +46,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "conv1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
+      target_mode: "reconstruction"
     }
   }
 
@@ -142,10 +144,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid data"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
@@ -43,9 +43,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -217,10 +219,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
@@ -46,9 +46,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "conv1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -327,10 +329,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid data"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -3,7 +3,7 @@
 model {
   name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
-  mini_batch_size: 100 
+  mini_batch_size: 100
   block_size: 256
   num_epochs: 50
   num_parallel_readers: 0
@@ -61,9 +61,11 @@ model {
   ######################
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
+      target_mode: "reconstruction"
     }
   }
 
@@ -188,17 +190,17 @@ model {
     data_layout: "data_parallel"
     reduction {
       mode: "sum"
-    }    
+    }
   }
   layer {
     parents: "kldiv"
     name: "klloss"
     data_layout: "data_parallel"
-    evaluation {}    
+    evaluation {}
   }
 
   ######################
-  # Generate sample  
+  # Generate sample
   ######################
 
   layer {
@@ -294,11 +296,10 @@ model {
   }
   layer {
     parents: "loss_sigmoid"
+    parents: "decode1 data"
     name: "reconstruction"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
+++ b/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
@@ -1,7 +1,7 @@
 model {
   name: "sequential_model"
   data_layout: "model_parallel"
-  mini_batch_size: 50 
+  mini_batch_size: 50
   block_size: 256
   num_epochs: 20
   num_parallel_readers: 0
@@ -31,7 +31,7 @@ model {
       interval: 1
     }
   }
- 
+
   #callback {
   #  dump_weights {
   #    basename: "."
@@ -47,9 +47,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -93,7 +95,7 @@ model {
     num_neurons_from_data_reader: true
     fully_connected {
       has_bias: true
-      transpose: true      
+      transpose: true
     }
   }
 
@@ -111,10 +113,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "sigmoid2 data"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/candle/pilot1/combo.prototext
+++ b/model_zoo/models/candle/pilot1/combo.prototext
@@ -49,7 +49,7 @@ model {
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
-      for_regression: true
+      target_mode: "regression"
     }
   }
 

--- a/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
+++ b/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
@@ -47,14 +47,17 @@ model {
   # data
   layer {
     name: "data"
+    children: "fc1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
   # encode1
   layer {
+    name: "fc1:
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
@@ -101,12 +104,15 @@ model {
     }
   }
   layer {
+    name: "sigmoid"
     data_layout: "model_parallel"
     sigmoid {}
   }
 
   # reconstruction
   layer {
+    name: "reconstruction"
+    parents: "sigmoid data"
     data_layout: "model_parallel"
     reconstruction {
       original_layer: "data"

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -1,11 +1,11 @@
-#Example taken from: https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/vae_fcn.py and 
+#Example taken from: https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/vae_fcn.py and
 #https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/run_vae.py
 #Timestamp 02/26/2018 8:45AM
 model {
   name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
-  #mini_batch_size: 128 
-  mini_batch_size: 100 #more last minibatch images to save 
+  #mini_batch_size: 128
+  mini_batch_size: 100 #more last minibatch images to save
   block_size: 256
   num_epochs: 40
   num_parallel_readers: 0
@@ -64,9 +64,11 @@ model {
   ######################
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
+      target_mode: "reconstruction"
     }
   }
 
@@ -161,7 +163,7 @@ model {
     name: "z_mean"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons:5 
+      num_neurons:5
       weight_initialization: "glorot_normal"
       has_bias: true
     }
@@ -171,7 +173,7 @@ model {
     name: "z_log_sigma"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons:5 
+      num_neurons:5
       weight_initialization: "glorot_normal"
       has_bias: true
     }
@@ -195,7 +197,7 @@ model {
     data_layout: "model_parallel"
     power {
       exponent: 2.0
-    }    
+    }
   }
   layer {
     parents: "z_log_sigma"
@@ -236,7 +238,7 @@ model {
     data_layout: "model_parallel"
     sum {
       scaling_factors: "0.5"
-    }    
+    }
   }
   layer {
     parents: "sample_half"
@@ -372,12 +374,10 @@ model {
   ######################
 
   layer {
-    parents: "sigmoid"
+    parents: "sigmoid data"
     name: "reconstruction"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
@@ -46,9 +46,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "reshape1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
+      target_mode: "reconstruction"
     }
   }
 
@@ -305,10 +307,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "elu20 data"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
@@ -45,9 +45,11 @@ model {
   #######
   layer {
     name: "data"
+    children: "encode1 reconstruction"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
+      target_mode: "reconstruction"
     }
   }
 
@@ -102,10 +104,9 @@ model {
   #################
   layer {
     name: "reconstruction"
+    parents: "decode_relu10 data"
     data_layout: "data_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    reconstruction {}
   }
 
   ###################################################

--- a/src/models/greedy_layerwise_autoencoder.cpp
+++ b/src/models/greedy_layerwise_autoencoder.cpp
@@ -179,16 +179,15 @@ void greedy_layerwise_autoencoder::set_phase(int phase) {
 
   // Initialize reconstruction layer
   if (m_reconstruction != nullptr) delete m_reconstruction;
-  Layer* original_layer = m_layers[encoder_start-1];
   switch (encoder_parents[0]->get_data_layout()) {
   case data_layout::MODEL_PARALLEL:
     switch(encoder_parents[0]->get_device_allocation()) {
     case El::Device::CPU:
-      m_reconstruction = new reconstruction_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>(m_comm, original_layer);
+      m_reconstruction = new reconstruction_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>(m_comm);
       break;
 #ifdef LBANN_HAS_GPU
     case El::Device::GPU:
-      m_reconstruction = new reconstruction_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>(m_comm, original_layer);
+      m_reconstruction = new reconstruction_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>(m_comm);
       break;
 #endif // LBANN_HAS_GPU
     default:
@@ -201,11 +200,11 @@ void greedy_layerwise_autoencoder::set_phase(int phase) {
   case data_layout::DATA_PARALLEL:
     switch(encoder_parents[0]->get_device_allocation()) {
     case El::Device::CPU:
-      m_reconstruction = new reconstruction_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(m_comm, original_layer);
+      m_reconstruction = new reconstruction_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(m_comm);
       break;
 #ifdef LBANN_HAS_GPU
     case El::Device::GPU:
-      m_reconstruction = new reconstruction_layer<data_layout::DATA_PARALLEL, El::Device::GPU>(m_comm, original_layer);
+      m_reconstruction = new reconstruction_layer<data_layout::DATA_PARALLEL, El::Device::GPU>(m_comm);
       break;
 #endif // LBANN_HAS_GPU
     default:
@@ -225,9 +224,12 @@ void greedy_layerwise_autoencoder::set_phase(int phase) {
 
   // Setup layer pointers to train encoder and decoder
   encoder_children[0] = m_layers[decoder_start];
+  /// @todo FIXME this model needs to put a split layer in here so that we can duplicate the original data
+  /// @todo then it should have something like: encoder_children[1] = m_reconstruction;
   decoder_parents[0] = m_layers[encoder_end-1];
   decoder_children[0] = m_reconstruction;
   m_reconstruction->add_parent_layer(m_layers[decoder_end-1]);
+  m_reconstruction->add_parent_layer(m_layers[encoder_start-1]);
 
   // Set objective function to reconstruction layer
   for (auto term : m_objective_function->get_terms()) {

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -41,30 +41,40 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_input()) {
     const auto& params = proto_layer.input();
     const auto& io_buffer = params.io_buffer();
+    const auto& mode_str = params.target_mode();
+    data_reader_target_mode target_mode = data_reader_target_mode::CLASSIFICATION;
+    if (mode_str.empty() || mode_str == "classification") { target_mode = data_reader_target_mode::CLASSIFICATION; }
+    if (mode_str == "regression")                         { target_mode = data_reader_target_mode::REGRESSION; }
+    if (mode_str == "reconstruction")                     { target_mode = data_reader_target_mode::RECONSTRUCTION; }
     if (io_buffer == "distributed") {
       return new input_layer<distributed_io_buffer, layout, Dev>(comm,
                                                                  num_parallel_readers,
                                                                  data_readers,
                                                                  !params.data_set_per_model(),
-                                                                 params.for_regression());
+                                                                 target_mode);
     }
     if (io_buffer == "partitioned") {
       return new input_layer<partitioned_io_buffer, layout, Dev>(comm,
                                                                  num_parallel_readers,
                                                                  data_readers,
                                                                  !params.data_set_per_model(),
-                                                                 params.for_regression());
+                                                                 target_mode);
     }
   }
   if (proto_layer.has_repeated_input()) {
     /// @todo Remove when possible
     const auto& params = proto_layer.repeated_input();
+    const auto& mode_str = params.target_mode();
+    data_reader_target_mode target_mode = data_reader_target_mode::CLASSIFICATION;
+    if (mode_str.empty() || mode_str == "classification") { target_mode = data_reader_target_mode::CLASSIFICATION; }
+    if (mode_str == "regression")                         { target_mode = data_reader_target_mode::REGRESSION; }
+    if (mode_str == "reconstruction")                     { target_mode = data_reader_target_mode::RECONSTRUCTION; }
     return new repeated_input_layer(comm,
                                     num_parallel_readers,
                                     data_readers,
                                     params.num_steps(),
                                     !params.data_set_per_model(),
-                                    params.for_regression());
+                                    target_mode);
   }
 
   // Target layers
@@ -72,7 +82,7 @@ Layer* construct_layer(lbann_comm* comm,
     return new target_layer<layout, Dev>(comm);
   }
   if (proto_layer.has_reconstruction()) {
-    return new reconstruction_layer<layout, Dev>(comm, nullptr);
+    return new reconstruction_layer<layout, Dev>(comm);
   }
 
   // Fully connected layer

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -194,7 +194,7 @@ message Model {
 
   int64 mini_batch_size = 12;
   int64 num_epochs = 4;
-  int64 super_steps = 121; //multiple steps/epochs currently use in GAN 
+  int64 super_steps = 121; //multiple steps/epochs currently use in GAN
   int64 num_batches = 122; //multiple batches/sub epoch
   int64 block_size = 50;
   int64 procs_per_model = 51;
@@ -729,7 +729,7 @@ message Layer {
    Unpooling unpooling = 304;
    Hadamard hadamard = 308;
    Constant constant = 309;
-   Zero zero = 315; 
+   Zero zero = 315;
    Reduction reduction = 310;
    Evaluation evaluation = 311;
    Gaussian gaussian = 312;
@@ -888,14 +888,14 @@ message Dropout {
 message Input {
   bool data_set_per_model = 1;  //default: false
   string io_buffer = 2;
-  bool for_regression = 3; //default: false
+  string target_mode = 3;
 }
 
 /// @todo Remove when possible
 message RepeatedInput {
   bool data_set_per_model = 1;  //default: false
-  bool for_regression = 2; //default: false
-  int64 num_steps = 3;
+  int64 num_steps = 2;
+  string target_mode = 3;
 }
 
 //////////////////////
@@ -1079,5 +1079,4 @@ message Target {
 }
 
 message TargetReconstruction {
-  string original_layer = 1;
 }


### PR DESCRIPTION
Updated the input layer to have a data reader target mode that can be
set to classification, regression, or reconstruction mode.  Based on
the mode, the second output of the input layer will get the correct
data.  This allows the reconstruction layer to have two inputs, and
avoid having the original_layer pointer.  Note that the greedy
layerwise model is temporarily broken and needs to deal with adding a
split layer into the iterative model.