### PR TITLE
Summarize certain runtimes from every rank

### DIFF
--- a/include/lbann/utils/summary.hpp
+++ b/include/lbann/utils/summary.hpp
@@ -81,6 +81,8 @@ class lbann_summary {
   void reduce_scalar(const std::string tag, DataType s, int step);
   /** Do a model_reduce (sum) on a scalar, then report that sum. */
   void sum_reduce_scalar(const std::string tag, DataType s, int step);
+  /** Report a scalar from every rank. */
+  void reduce_scalar_all(const std::string tag, DataType s, int step);
   /** Report a histogram of the values in mat. */
   void reduce_histogram(const std::string tag, const AbsDistMat& mat, int step);
   /** Report the (squared) 2-norm of mat. */
@@ -151,6 +153,8 @@ class lbann_summary {
   std::vector<pending_op> m_pending_scalars;
   /** Currently-pending sum_reduce_scalars. */
   std::vector<pending_op> m_pending_sum_scalars;
+  /** Currently-pending reduce_scalar_alls. */
+  std::vector<pending_op> m_pending_scalar_alls;
   /** Buckets for histograms. */
   std::vector<double> m_histogram_buckets;
   /** Currently-pending reduce_histograms. */
@@ -168,6 +172,8 @@ class lbann_summary {
   void flush_scalars();
   /** Execute all pending sum-scalar operations. */
   void flush_sum_scalars();
+  /** Execute all pending scalar-all operations. */
+  void flush_scalar_alls();
   /** Execute all pending histogram operations. */
   void flush_histograms();
 
@@ -203,6 +209,7 @@ class lbann_summary {
   void reduce_stdev(const std::string tag, const AbsDistMat& mat, int step) {}
   void reduce_scalar(const std::string tag, DataType s, int step) {}
   void sum_reduce_scalar(const std::string tag, DataType s, int step) {}
+  void reduce_scalar_all(const std::string tag, DataType s, int step) {}
   void reduce_histogram(const std::string tag, const AbsDistMat& mat, int step) {}
   void reduce_2norm(const std::string tag, const AbsDistMat& mat, int step) {}
   void flush() {}

--- a/src/callbacks/callback_timer.cpp
+++ b/src/callbacks/callback_timer.cpp
@@ -41,6 +41,7 @@ void lbann_callback_timer::batch_timing_end(model *m) {
   m_batch_times.push_back(mb_time);
   if (m_summarizer != nullptr) {
     m_summarizer->reduce_scalar("minibatch_time", mb_time, m->get_cur_step()-1);
+    m_summarizer->reduce_scalar_all("minibatch_time", mb_time, m->get_cur_step()-1);
   }
 }
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -307,6 +307,9 @@ void Layer::summarize_stats(lbann_summary& summarizer, int step) {
   summarizer.reduce_scalar(prefix + "fp_time", m_fp_time, step);
   summarizer.reduce_scalar(prefix + "bp_time", m_bp_time, step);
   summarizer.reduce_scalar(prefix + "update_time", m_update_time, step);
+  summarizer.reduce_scalar_all(prefix + "fp_time", m_fp_time, step);
+  summarizer.reduce_scalar_all(prefix + "bp_time", m_bp_time, step);
+  summarizer.reduce_scalar_all(prefix + "update_time", m_update_time, step);
   reset_counters();
   // Combine the optimizer step time from all the weights.
   double step_time = 0.0;
@@ -318,6 +321,7 @@ void Layer::summarize_stats(lbann_summary& summarizer, int step) {
     }
   }
   summarizer.reduce_scalar(prefix + "opt_time", step_time, step);
+  summarizer.reduce_scalar_all(prefix + "opt_time", step_time, step);
 }
 
 void Layer::summarize_matrices(lbann_summary& summarizer, int step) {


### PR DESCRIPTION
This adds support to the summarizer to log scalars from every rank instead of just the model masters. This is now used to log mini-batch, forward, backward, update, and optimization time from every rank.

The old approach of only logging from the model masters is kept as well, for backwards compatibility with plotting scripts. The overhead of this is minimal since communication is only done at the end of an epoch and each rank just pushes a few values into a vector.