### PR TITLE
Improvements to debug callback

### DIFF
--- a/include/lbann/callbacks/callback_debug.hpp
+++ b/include/lbann/callbacks/callback_debug.hpp
@@ -71,6 +71,11 @@ class lbann_callback_debug : public lbann_callback {
   /** Print that a layer's backward prop is ending. */
   void on_evaluate_forward_prop_end(model *m, Layer *l) override;
 
+  /** Print that a weights' optimization step is beginning. */
+  void on_optimize_begin(model *m, weights *w) override;
+  /** Print that a weights' optimization step is ending. */
+  void on_optimize_end(model *m, weights *w) override;
+
  private:
 
   /** Execution modes for which status updates will be printed.

--- a/include/lbann/callbacks/callback_debug.hpp
+++ b/include/lbann/callbacks/callback_debug.hpp
@@ -22,66 +22,64 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_debug .hpp .cpp - Callback hooks to debug LBANN
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_CALLBACKS_CALLBACK_DEBUG_HPP_INCLUDED
 #define LBANN_CALLBACKS_CALLBACK_DEBUG_HPP_INCLUDED
 
-#include <chrono>
-#include <vector>
 #include "lbann/callbacks/callback.hpp"
 
 namespace lbann {
 
-/**
- * Print status updates on where training is.
+/** Print verbose status updates to standard error stream.
+ *  This callback is useful for "printf debugging."
  */
 class lbann_callback_debug : public lbann_callback {
  public:
-  using lbann_callback::on_forward_prop_begin;
-  using lbann_callback::on_forward_prop_end;
-  using lbann_callback::on_backward_prop_begin;
-  using lbann_callback::on_backward_prop_end;
-  using lbann_callback::on_evaluate_forward_prop_begin;
-  using lbann_callback::on_evaluate_forward_prop_end;
 
-  /**
-   * Debug a particular phase; use invalid to debug every phase.
+  /** Constructor.
+   *  If modes is empty, status updates will be printed for all
+   *  execution modes.
    */
-  lbann_callback_debug(execution_mode phase = execution_mode::invalid,
+  lbann_callback_debug(const std::set<execution_mode>& modes,
                        lbann_summary *summarizer = nullptr) :
-    lbann_callback(1, summarizer), m_debug_phase(phase) {}
+    lbann_callback(1, summarizer), m_modes(modes) {}
   lbann_callback_debug(const lbann_callback_debug&) = default;
-  lbann_callback_debug& operator=(
-    const lbann_callback_debug&) = default;
+  lbann_callback_debug& operator=(const lbann_callback_debug&) = default;
   lbann_callback_debug* copy() const override { return new lbann_callback_debug(*this); }
-  /** Print that a batch is being started. */
-  void on_batch_begin(model *m) override;
-  /** Print that forward prop for a layer is beginning. */
-  void on_forward_prop_begin(model *m, Layer *l) override;
-  /** Print that forward prop for a layer has completed. */
-  void on_forward_prop_end(model *m, Layer *l) override;
-  /** Print that backward prop for a layer is beginning. */
-  void on_backward_prop_begin(model *m, Layer *l) override;
-  /** Print that backward prop for a layer has completed. */
-  void on_backward_prop_end(model *m, Layer *l) override;
-
-  /** Print that an evaluation batch is being started. */
-  void on_batch_evaluate_begin(model *m) override;
-  /** Print that an evaluation batch has completed. */
-  void on_batch_evaluate_end(model *m) override;
-  /** Print that an evaluation forward prop is beginning. */
-  void on_evaluate_forward_prop_begin(model *m, Layer *l) override;
-  /** Print that an evaluation forward prop has completed. */
-  void on_evaluate_forward_prop_end(model *m, Layer *l) override;
   std::string name() const override { return "debug"; }
+
+  /** Print that a batch is beginning. */
+  void on_batch_begin(model *m) override;
+  /** Print that a batch is ending. */
+  void on_batch_end(model *m) override;
+  /** Print that a layer's forward prop is beginning. */
+  void on_batch_evaluate_begin(model *m) override;
+  /** Print that a layer's forward prop is ending. */
+  void on_batch_evaluate_end(model *m) override;
+
+  /** Print that a layer's forward prop is beginning. */
+  void on_forward_prop_begin(model *m, Layer *l) override;
+  /** Print that a layer's forward prop is ending. */
+  void on_forward_prop_end(model *m, Layer *l) override;
+  /** Print that a layer's backward prop is beginning. */
+  void on_backward_prop_begin(model *m, Layer *l) override;
+  /** Print that a layer's backward prop is ending. */
+  void on_backward_prop_end(model *m, Layer *l) override;
+  /** Print that a layer's backward prop is beginning. */
+  void on_evaluate_forward_prop_begin(model *m, Layer *l) override;
+  /** Print that a layer's backward prop is ending. */
+  void on_evaluate_forward_prop_end(model *m, Layer *l) override;
+
  private:
-  /** The phase to debug. */
-  execution_mode m_debug_phase;
+
+  /** Execution modes for which status updates will be printed.
+   *  If empty, status updates are printed for all execution modes.
+   */
+  std::set<execution_mode> m_modes;
+
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_CALLBACKS_CALLBACK_DEBUG_HPP_INCLUDED
+#endif // LBANN_CALLBACKS_CALLBACK_DEBUG_HPP_INCLUDED

--- a/include/lbann/optimizers/adagrad.hpp
+++ b/include/lbann/optimizers/adagrad.hpp
@@ -50,7 +50,7 @@ class adagrad : public optimizer {
   adagrad* copy() const override { return new adagrad(*this); }
 
   /** Get the optimizer name. */
-  std::string get_type() const override { return "adagrad"; }
+  std::string get_type() const override { return "Adagrad"; }
   /** Get a human-readable description of the optimizer. */
   std::string get_description() const override;
 

--- a/include/lbann/optimizers/adam.hpp
+++ b/include/lbann/optimizers/adam.hpp
@@ -57,7 +57,7 @@ class adam : public optimizer {
   adam* copy() const override { return new adam(*this); }
 
   /** Returns the optimizer name. */
-  std::string get_type() const override { return "adam"; }
+  std::string get_type() const override { return "Adam"; }
   /** Get a human-readable description of the optimizer. */
   std::string get_description() const override;
 

--- a/include/lbann/optimizers/hypergradient_adam.hpp
+++ b/include/lbann/optimizers/hypergradient_adam.hpp
@@ -62,7 +62,7 @@ class hypergradient_adam : public optimizer {
   hypergradient_adam* copy() const override { return new hypergradient_adam(*this); }
   
   /** Returns the optimizer name. */
-  std::string get_type() const override { return "hypergradient_adam"; }
+  std::string get_type() const override { return "hypergradient Adam"; }
   /** Get a human-readable description of the optimizer. */
   std::string get_description() const override;
 

--- a/include/lbann/optimizers/rmsprop.hpp
+++ b/include/lbann/optimizers/rmsprop.hpp
@@ -52,7 +52,7 @@ class rmsprop : public optimizer {
   rmsprop* copy() const override { return new rmsprop(*this); }
   
   /** Get the optimizer name. */
-  std::string get_type() const override { return "rmsprop"; }
+  std::string get_type() const override { return "RMSprop"; }
   /** Get a human-readable description of the optimizer. */
   std::string get_description() const override;
 

--- a/include/lbann/optimizers/sgd.hpp
+++ b/include/lbann/optimizers/sgd.hpp
@@ -54,7 +54,7 @@ class sgd : public optimizer {
   sgd* copy() const override { return new sgd(*this); }
 
   /** Get the optimizer name. */
-  std::string get_type() const override { return "sgd"; }
+  std::string get_type() const override { return "SGD"; }
   /** Get a human-readable description of the optimizer. */
   std::string get_description() const override;
 

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -40,11 +40,7 @@ model {
   }
   callback { print {} }
   callback { timer {} }
-  # callback {
-  #   debug {
-  #     phase: "train"
-  #   }
-  # }
+  # callback { debug {} }
   callback {
     drop_fixed_learning_rate {
       drop_epoch: 20

--- a/src/callbacks/callback_debug.cpp
+++ b/src/callbacks/callback_debug.cpp
@@ -22,109 +22,117 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_debug .hpp .cpp - Callback hooks to debug LBANN
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/callback_debug.hpp"
+#include "lbann/comm.hpp"
 
-void lbann::lbann_callback_debug::on_batch_begin(model *m) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    std::cout << "Phase: " << _to_string(m->get_execution_mode()) << " starting batch" << std::endl;
+namespace lbann {
+
+namespace {
+
+/** Get human-readable string describing process rank. */
+std::string rank_string(const lbann_comm& comm) {
+  std::stringstream msg;
+  msg << "Rank " << comm.get_rank_in_world();
+  if (comm.get_num_models() > 1) {
+    msg << " (rank " << comm.get_rank_in_model()
+        << " of model " << comm.get_model_rank() << ")";
   }
+  return msg.str();
 }
 
-void lbann::lbann_callback_debug::on_forward_prop_begin(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << m->get_cur_epoch() << "." << m->get_cur_step() << " Phase: " << _to_string(m->get_execution_mode()) << " starting forward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
-  }
+/** Get human-readable string describing layer. */
+std::string layer_string(const Layer& l) {
+  return l.get_type() + " layer \"" + l.get_name() + "\"";
 }
 
-void lbann::lbann_callback_debug::on_forward_prop_end(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << m->get_cur_epoch() << "." << m->get_cur_step() << " Phase: " << _to_string(m->get_execution_mode()) << "   ending forward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
+/** Get human-readable string describing current batch step. */
+std::string batch_step_string(const model& m) {
+  std::stringstream msg;
+  const auto& mode = m.get_execution_mode();
+  msg << _to_string(mode) << " batch";
+  switch (mode) {
+  case execution_mode::training:
+    msg << " " << m.get_cur_step(); break;
+  case execution_mode::validation:
+    msg << " " << m.get_cur_validation_step(); break;
+  case execution_mode::testing:
+    msg << " " << m.get_cur_testing_step(); break;
+  default: break;
   }
+  msg << " (epoch " << m.get_cur_epoch() << ")";
+  return msg.str();
 }
 
-void lbann::lbann_callback_debug::on_backward_prop_begin(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << m->get_cur_epoch() << "." << m->get_cur_step() << " Phase: " << _to_string(m->get_execution_mode()) << " starting backward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
+} // namespace
+
+// Status updates for batch beginnings/endings
+void lbann_callback_debug::on_batch_begin(model *m) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) {
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": "
+        << "starting " << batch_step_string(*m) << std::endl;
+    std::cerr << msg.str();
   }
+}
+void lbann_callback_debug::on_batch_end(model *m) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) {
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": "
+        << "ending " << batch_step_string(*m) << std::endl;
+    std::cerr << msg.str();
+  }
+}
+void lbann_callback_debug::on_batch_evaluate_begin(model *m) {
+  on_batch_begin(m);
+}
+void lbann_callback_debug::on_batch_evaluate_end(model *m) {
+  on_batch_end(m);
 }
 
-void lbann::lbann_callback_debug::on_backward_prop_end(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << m->get_cur_epoch() << "." << m->get_cur_step() << " Phase: " << _to_string(m->get_execution_mode()) << "   ending backward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
+// Status updates for beginning/ending of layer forward/backward prop
+void lbann_callback_debug::on_forward_prop_begin(model *m, Layer *l) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) {
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": " << layer_string(*l)
+        << " is starting forward prop for " << batch_step_string(*m)
+        << std::endl;
+    std::cerr << msg.str();
   }
+}
+void lbann_callback_debug::on_forward_prop_end(model *m, Layer *l) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) {
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": " << layer_string(*l)
+        << " is   ending forward prop for " << batch_step_string(*m)
+        << std::endl;
+    std::cerr << msg.str();
+  }
+}
+void lbann_callback_debug::on_backward_prop_begin(model *m, Layer *l) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) {
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": " << layer_string(*l)
+        << " is starting backward prop for " << batch_step_string(*m)
+        << std::endl;
+    std::cerr << msg.str();
+  }
+}
+void lbann_callback_debug::on_backward_prop_end(model *m, Layer *l) {
+  if(m_modes.empty() || m_modes.count(m->get_execution_mode()) > 0) { 
+    std::stringstream msg;
+    msg << rank_string(*m->get_comm()) << ": " << layer_string(*l)
+        << " is   ending backward prop for " << batch_step_string(*m)
+        << std::endl;
+    std::cerr << msg.str();
+  }
+}
+void lbann_callback_debug::on_evaluate_forward_prop_begin(model *m, Layer *l) {
+  on_forward_prop_begin(m, l);
+}
+void lbann_callback_debug::on_evaluate_forward_prop_end(model *m, Layer *l) {
+  on_backward_prop_end(m, l);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Evaluation phase debugging
-////////////////////////////////////////////////////////////////////////////////
-void lbann::lbann_callback_debug::on_batch_evaluate_begin(model *m) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    int64_t step;
-    switch(m->get_execution_mode()) {
-    case execution_mode::validation:
-      step = m->get_cur_validation_step();
-      break;
-    case execution_mode::testing:
-      step = m->get_cur_testing_step();
-      break;
-    default:
-      throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-    }
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << 0 << "." << step << " Phase: " << _to_string(m->get_execution_mode()) << " starting batch" << std::endl;
-  }
-}
-
-void lbann::lbann_callback_debug::on_batch_evaluate_end(model *m) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    int64_t step;
-    switch(m->get_execution_mode()) {
-    case execution_mode::validation:
-      step = m->get_cur_validation_step();
-      break;
-    case execution_mode::testing:
-      step = m->get_cur_testing_step();
-      break;
-    default:
-      throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-    }
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << 0 << "." << step << " Phase: " << _to_string(m->get_execution_mode()) << " ending batch" << std::endl;
-  }
-}
-
-void lbann::lbann_callback_debug::on_evaluate_forward_prop_begin(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    int64_t step;
-    switch(m->get_execution_mode()) {
-    case execution_mode::validation:
-      step = m->get_cur_validation_step();
-      break;
-    case execution_mode::testing:
-      step = m->get_cur_testing_step();
-      break;
-    default:
-      throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-    }
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << 0 << "." << step << " Phase: " << _to_string(m->get_execution_mode()) << " starting forward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
-  }
-}
-
-void lbann::lbann_callback_debug::on_evaluate_forward_prop_end(model *m, Layer *l) {
-  if(m_debug_phase == execution_mode::invalid || m_debug_phase == m->get_execution_mode()) {
-    int64_t step;
-    switch(m->get_execution_mode()) {
-    case execution_mode::validation:
-      step = m->get_cur_validation_step();
-      break;
-    case execution_mode::testing:
-      step = m->get_cur_testing_step();
-      break;
-    default:
-      throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-    }
-    std::cout << "[" << m->get_comm()->get_model_rank() << "." << m->get_comm()->get_rank_in_model() << "] @" << 0 << "." << step << " Phase: " << _to_string(m->get_execution_mode()) << "   ending forward propagation for layer " << l->get_name() << " type: " << l->get_type() << std::endl;
-  }
-}
+} // namespace lbann

--- a/src/callbacks/callback_debug.cpp
+++ b/src/callbacks/callback_debug.cpp
@@ -34,7 +34,7 @@ namespace {
 /** Get human-readable string describing process rank. */
 std::string rank_string(const lbann_comm& comm) {
   std::stringstream msg;
-  msg << "Rank " << comm.get_rank_in_world();
+  msg << "rank " << comm.get_rank_in_world();
   if (comm.get_num_models() > 1) {
     msg << " (rank " << comm.get_rank_in_model()
         << " of model " << comm.get_model_rank() << ")";
@@ -45,6 +45,17 @@ std::string rank_string(const lbann_comm& comm) {
 /** Get human-readable string describing layer. */
 std::string layer_string(const Layer& l) {
   return l.get_type() + " layer \"" + l.get_name() + "\"";
+}
+
+/** Get human-readable string describing weights and optimizer. */
+std::string weights_string(const weights& w) {
+  std::stringstream msg;
+  msg << "weights \"" << w.get_name() << "\" (";
+  const auto* opt = w.get_optimizer();
+  if (opt == nullptr) { msg << "no"; }
+  else { msg << opt->get_type(); }
+  msg << " optimizer)";
+  return msg.str();
 }
 
 /** Get human-readable string describing current batch step. */
@@ -133,6 +144,22 @@ void lbann_callback_debug::on_evaluate_forward_prop_begin(model *m, Layer *l) {
 }
 void lbann_callback_debug::on_evaluate_forward_prop_end(model *m, Layer *l) {
   on_backward_prop_end(m, l);
+}
+
+// Status updates for optimization step
+void lbann_callback_debug::on_optimize_begin(model *m, weights *w) {
+  std::stringstream msg;
+  msg << rank_string(*m->get_comm()) << ": " << weights_string(*w)
+      << " is starting optimization step for " << batch_step_string(*m)
+      << std::endl;
+  std::cerr << msg.str();
+}
+void lbann_callback_debug::on_optimize_end(model *m, weights *w) {
+  std::stringstream msg;
+  msg << rank_string(*m->get_comm()) << ": " << weights_string(*w)
+      << " is   ending optimization step for " << batch_step_string(*m)
+      << std::endl;
+  std::cerr << msg.str();
 }
 
 } // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -231,16 +231,20 @@ lbann_callback* construct_callback(lbann_comm* comm,
   // Debugging
   //////////////////////////////////////////////////////////////////
   if (proto_cb.has_debug()) {
-    const auto& phase = proto_cb.debug().phase();
-    if (phase == "train" || phase == "training") {
-      return new lbann_callback_debug(execution_mode::training, summarizer);
-    } else if (phase == "validate" || phase == "validation") {
-      return new lbann_callback_debug(execution_mode::validation, summarizer);
-    } else if (phase == "test" || phase == "testing") {
-      return new lbann_callback_debug(execution_mode::testing, summarizer);
-    } else {
-      return new lbann_callback_debug();
+    const auto& params = proto_cb.debug();
+    std::set<execution_mode> modes;
+    for (const auto& mode : parse_list<>(params.phase())) {
+      if (mode == "train" || mode == "training") {
+        modes.insert(execution_mode::training);
+      } else if (mode == "validate" || mode == "validation") {
+        modes.insert(execution_mode::validation);
+      } else if (mode == "test" || mode == "testing") {
+        modes.insert(execution_mode::testing);
+      } else {
+        LBANN_ERROR("invalid execution mode (" + mode + ")");
+      }
     }
+    return new lbann_callback_debug(modes, summarizer);
   }
   if (proto_cb.has_debug_io()) {
     const auto& params = proto_cb.debug_io();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -513,7 +513,7 @@ message CallbackImComm {
 }
 
 message CallbackDebug {
-  string phase = 1;
+  string phase = 1; //should be called "modes"
 }
 
 message CallbackDebugIO {


### PR DESCRIPTION
This PR makes several changes to make the debug callback more effective for printf debugging:
- Messages are output to the standard error stream. The standard output stream is not always flushed when LBANN crashes.
- It is now possible to debug any combination of execution modes.
- Messages are output during the optimization step.