### PR TITLE
use cv::imdecode() instead of cv::imread()

### DIFF
--- a/include/lbann/data_readers/cv_utils.hpp
+++ b/include/lbann/data_readers/cv_utils.hpp
@@ -111,12 +111,7 @@ class cv_utils {
    *  return type. Avoiding the extra access to the underlying filesystem may
    *  result in a better performance.
    */
-  static cv::Mat load_decode(const std::string& img_file_path, int flags);
-  /**
-   * Additionally, this measures the time to load the image data from a file to
-   * memory, and the time to decode it.
-   */
-  static cv::Mat load_decode(const std::string& img_file_path, int flags, double& t_load, double& t_decode);
+  static cv::Mat lbann_imread(const std::string& img_file_path, int flags);
 };
 
 

--- a/include/lbann/data_readers/cv_utils.hpp
+++ b/include/lbann/data_readers/cv_utils.hpp
@@ -102,6 +102,21 @@ class cv_utils {
    *  otherwise.
    */
   static cv::Mat copy_buf_to_cvMat(const ::Mat& buf, const int Width, const int Height, const int Type, const cv_process& pp);
+
+  /**
+   *  Use cv::imdecode() to load an image data instead of relying on cv::imread().
+   *  This avoids reading the image header to determine the decoder directly from
+   *  the file but allow doing so from the memory.
+   *  The arguments are the same as the ones with cv::imread() as well as the
+   *  return type. Avoiding the extra access to the underlying filesystem may
+   *  result in a better performance.
+   */
+  static cv::Mat load_decode(const std::string& img_file_path, int flags);
+  /**
+   * Additionally, this measures the time to load the image data from a file to
+   * memory, and the time to decode it.
+   */
+  static cv::Mat load_decode(const std::string& img_file_path, int flags, double& t_load, double& t_decode);
 };
 
 

--- a/src/data_readers/cv_utils.cpp
+++ b/src/data_readers/cv_utils.cpp
@@ -28,6 +28,8 @@
 
 #include "lbann/data_readers/cv_utils.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/timer.hpp"
+#include "lbann/utils/file_utils.hpp"
 //#include <iostream>
 
 #ifdef LBANN_HAS_OPENCV
@@ -86,6 +88,51 @@ cv::Mat cv_utils::copy_buf_to_cvMat(const ::Mat& buf,
 std::ostream& operator<<(std::ostream& os, const cv_transform& tr) {
   tr.print(os);
   return os;
+}
+
+
+cv::Mat cv_utils::load_decode(const std::string& img_file_path, int flags, double& t_load, double& t_decode) {
+  const double t1 = get_time();
+
+  std::vector<unsigned char> buf;
+  // Load an image bytestream into memory
+  bool ok = lbann::load_file(img_file_path, buf);
+  if (!ok) {
+    throw lbann_exception("load_decode() : failed to load " + img_file_path);
+  }
+
+  const double t2 = get_time();
+
+  // create a zero-copying view on a block of bytes
+  using InputBuf_T = lbann::cv_image_type<uint8_t>;
+  const cv::Mat inbuf(1, buf.size(), InputBuf_T::T(1), &(buf[0]));
+
+  // decode the image data in the memory buffer
+  cv::Mat image = cv::imdecode(inbuf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+
+  t_load += t2 - t1;
+  t_decode += get_time() - t2;
+
+  return image;
+}
+
+
+cv::Mat cv_utils::load_decode(const std::string& img_file_path, int flags) {
+  std::vector<unsigned char> buf;
+  // Load an image bytestream into memory
+  bool ok = lbann::load_file(img_file_path, buf);
+  if (!ok) {
+    throw lbann_exception("load_decode() : failed to load " + img_file_path);
+  }
+
+  // create a zero-copying view on a block of bytes
+  using InputBuf_T = lbann::cv_image_type<uint8_t>;
+  const cv::Mat inbuf(1, buf.size(), InputBuf_T::T(1), &(buf[0]));
+
+  // decode the image data in the memory buffer
+  cv::Mat image = cv::imdecode(inbuf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+
+  return image;
 }
 
 

--- a/src/data_readers/cv_utils.cpp
+++ b/src/data_readers/cv_utils.cpp
@@ -91,38 +91,12 @@ std::ostream& operator<<(std::ostream& os, const cv_transform& tr) {
 }
 
 
-cv::Mat cv_utils::load_decode(const std::string& img_file_path, int flags, double& t_load, double& t_decode) {
-  const double t1 = get_time();
-
+cv::Mat cv_utils::lbann_imread(const std::string& img_file_path, int flags) {
   std::vector<unsigned char> buf;
   // Load an image bytestream into memory
   bool ok = lbann::load_file(img_file_path, buf);
   if (!ok) {
-    throw lbann_exception("load_decode() : failed to load " + img_file_path);
-  }
-
-  const double t2 = get_time();
-
-  // create a zero-copying view on a block of bytes
-  using InputBuf_T = lbann::cv_image_type<uint8_t>;
-  const cv::Mat inbuf(1, buf.size(), InputBuf_T::T(1), &(buf[0]));
-
-  // decode the image data in the memory buffer
-  cv::Mat image = cv::imdecode(inbuf, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
-
-  t_load += t2 - t1;
-  t_decode += get_time() - t2;
-
-  return image;
-}
-
-
-cv::Mat cv_utils::load_decode(const std::string& img_file_path, int flags) {
-  std::vector<unsigned char> buf;
-  // Load an image bytestream into memory
-  bool ok = lbann::load_file(img_file_path, buf);
-  if (!ok) {
-    throw lbann_exception("load_decode() : failed to load " + img_file_path);
+    throw lbann_exception("lbann_imread() : failed to load " + img_file_path);
   }
 
   // create a zero-copying view on a block of bytes

--- a/src/data_readers/image_utils.cpp
+++ b/src/data_readers/image_utils.cpp
@@ -36,49 +36,12 @@
   throw lbann_exception(err.str()); \
 }
 
-#define _LBANN_REPLACE_IMREAD_WITH_IMDECODE_
-//------------------------------------------------------------------------------------------------
-#if defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
-/**
- * _IMGFILE_ is the same as the first argument of cv::imread(), which is the
- * path to the image file in std::string type.
- * _FLAG_ is the sane as the second argument of cv::imread().
- * The return type is cv::Mat same as that of cv::imread().
- */
-#define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
-        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_))
-
-/** Same as LBANN_IMREAD but with timing instrumentation
- *  _T1_ and _T2_ should be openmp thread private double type variables.
- *  _T1_ is the accumulated time to load the image file from the filesystem to the memory
- *  _T2_ is the accumulated time to execute cv::imdcode()
- */
-#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) \
-        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_), (_T1_), (_T2_))
-#else // -----------------------------------------------------------------------------------------
-#include "lbann/utils/timer.hpp"
-#define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
-        cv::imread((_IMGFILE_), (_FLAG_))
-
-/** Same as LBANN_IMREAD but with timing instrumentation
- *  _T1_ should be a openmp thread private double type variable
- *  _T1_ is the accumulated time to load the image file from the filesystem to the memory and decode it.
- *  _T2_ is not really used other than to make the interface consistent. Thus can be anything.
- */
-#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) ({\
-        const double t1 = lbann::get_time(); \
-        cv::Mat imgret = cv::imread((_IMGFILE_), (_FLAG_)); \
-        _T1_ += lbann::get_time() - t1; \
-        imgret; })
-#endif // defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
-//------------------------------------------------------------------------------------------------
-
 
 namespace lbann {
 
 bool image_utils::loadIMG(const std::string& Imagefile, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = LBANN_IMREAD(Imagefile, _LBANN_CV_COLOR_);
+  cv::Mat image = cv_utils::lbann_imread(Imagefile, _LBANN_CV_COLOR_);
   if (image.empty()) {
     return false;
   }
@@ -230,7 +193,7 @@ bool image_utils::process_image(cv::Mat& image, int& Width, int& Height, int& Ty
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& buf) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = cv_utils::lbann_imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, buf);
 #else
@@ -266,7 +229,7 @@ bool image_utils::save_image(const std::string& filename,
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process& pp, ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = cv_utils::lbann_imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, data);
 #else
@@ -286,7 +249,7 @@ bool image_utils::load_image(const std::string& filename,
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& data) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = cv_utils::lbann_imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, data);
 #else

--- a/src/data_readers/image_utils.cpp
+++ b/src/data_readers/image_utils.cpp
@@ -39,20 +39,37 @@
 #define _LBANN_REPLACE_IMREAD_WITH_IMDECODE_
 //------------------------------------------------------------------------------------------------
 #if defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
-#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) \
-        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_), (_T1_), (_T2_))
-
+/**
+ * _IMGFILE_ is the same as the first argument of cv::imread(), which is the
+ * path to the image file in std::string type.
+ * _FLAG_ is the sane as the second argument of cv::imread().
+ * The return type is cv::Mat same as that of cv::imread().
+ */
 #define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
         lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_))
-#else // -----------------------------------------------------------------------------------------
-#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) (\
-        const double t1 = get_time(); \
-        cv::Mat imgret = cv::imread((_IMGFILE_), (_FLAG_)); \
-        _T1_ += get_time() - t1; \
-        img_ret)
 
+/** Same as LBANN_IMREAD but with timing instrumentation
+ *  _T1_ and _T2_ should be openmp thread private double type variables.
+ *  _T1_ is the accumulated time to load the image file from the filesystem to the memory
+ *  _T2_ is the accumulated time to execute cv::imdcode()
+ */
+#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) \
+        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_), (_T1_), (_T2_))
+#else // -----------------------------------------------------------------------------------------
+#include "lbann/utils/timer.hpp"
 #define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
         cv::imread((_IMGFILE_), (_FLAG_))
+
+/** Same as LBANN_IMREAD but with timing instrumentation
+ *  _T1_ should be a openmp thread private double type variable
+ *  _T1_ is the accumulated time to load the image file from the filesystem to the memory and decode it.
+ *  _T2_ is not really used other than to make the interface consistent. Thus can be anything.
+ */
+#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) ({\
+        const double t1 = lbann::get_time(); \
+        cv::Mat imgret = cv::imread((_IMGFILE_), (_FLAG_)); \
+        _T1_ += lbann::get_time() - t1; \
+        imgret; })
 #endif // defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
 //------------------------------------------------------------------------------------------------
 

--- a/src/data_readers/image_utils.cpp
+++ b/src/data_readers/image_utils.cpp
@@ -36,11 +36,32 @@
   throw lbann_exception(err.str()); \
 }
 
+#define _LBANN_REPLACE_IMREAD_WITH_IMDECODE_
+//------------------------------------------------------------------------------------------------
+#if defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
+#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) \
+        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_), (_T1_), (_T2_))
+
+#define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
+        lbann::cv_utils::load_decode((_IMGFILE_), (_FLAG_))
+#else // -----------------------------------------------------------------------------------------
+#define LBANN_IMREAD_T(_IMGFILE_, _FLAG_, _T1_, _T2_) (\
+        const double t1 = get_time(); \
+        cv::Mat imgret = cv::imread((_IMGFILE_), (_FLAG_)); \
+        _T1_ += get_time() - t1; \
+        img_ret)
+
+#define LBANN_IMREAD(_IMGFILE_, _FLAG_) \
+        cv::imread((_IMGFILE_), (_FLAG_))
+#endif // defined(_LBANN_REPLACE_IMREAD_WITH_IMDECODE_)
+//------------------------------------------------------------------------------------------------
+
+
 namespace lbann {
 
 bool image_utils::loadIMG(const std::string& Imagefile, int& Width, int& Height, bool Flip, unsigned char *&Pixels) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imread(Imagefile, _LBANN_CV_COLOR_);
+  cv::Mat image = LBANN_IMREAD(Imagefile, _LBANN_CV_COLOR_);
   if (image.empty()) {
     return false;
   }
@@ -192,7 +213,7 @@ bool image_utils::process_image(cv::Mat& image, int& Width, int& Height, int& Ty
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process& pp, std::vector<uint8_t>& buf) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, buf);
 #else
@@ -228,7 +249,7 @@ bool image_utils::save_image(const std::string& filename,
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process& pp, ::Mat& data) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, data);
 #else
@@ -248,7 +269,7 @@ bool image_utils::load_image(const std::string& filename,
 bool image_utils::load_image(const std::string& filename,
                                     int& Width, int& Height, int& Type, cv_process_patches& pp, std::vector<::Mat>& data) {
 #ifdef LBANN_HAS_OPENCV
-  cv::Mat image = cv::imread(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
+  cv::Mat image = LBANN_IMREAD(filename, cv::IMREAD_ANYCOLOR | cv::IMREAD_ANYDEPTH);
 
   return process_image(image, Width, Height, Type, pp, data);
 #else


### PR DESCRIPTION
Add an interface, load_decode(), using cv::imdecode() to load image data instead of using cv::imread().
It basically reads the entire file from
This is to avoid reading the image header in determining the decoder directly from the file but to allow doing so from the memory.
This would help mitigating the issue #213 in case of sub-optimal filesystem cache operations.