### PR TITLE
updates to build_lbann_lc.sh to support Aluminum build

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -67,6 +67,8 @@ WITH_CUDA=
 WITH_TOPO_AWARE=ON
 INSTRUMENT=
 WITH_ALUMINUM=OFF
+ALUMINUM_WITH_MPI_CUDA=OFF
+ALUMINUM_WITH_NCCL=OFF
 WITH_CONDUIT=OFF
 WITH_TBINF=OFF
 RECONFIGURE=0
@@ -120,10 +122,11 @@ Options:
   ${C}--build${N}                 Specify alternative build directory; default is <lbann_home>/build.
   ${C}--suffix${N}                Specify suffix for build directory. If you are, e.g, building on surface, your build will be <someplace>/surface.llnl.gov, regardless of your choice of compiler or other flags. This option enables you to specify, e.g: --suffix gnu_debug, in which case your build will be in the directory <someplace>/surface.llnl.gov.gnu_debug
   ${C}--instrument${N}            Use -finstrument-functions flag, for profiling stack traces
-  ${C}--use-nccl${N}              Use NCCL library
   ${C}--disable-cuda${N}          Disable CUDA
   ${C}--disable-topo-aware${N}    Disable topological-aware configuration (no HWLOC)
   ${C}--with-aluminum${N}              Use Aluminum allreduce library
+  ${C}--aluminum-with-mpi-cuda         Enable MPI-CUDA backend in Aluminum
+  ${C}--aluminum-with-nccl             Enable NCCL backend in Aluminum
 EOF
 }
 
@@ -232,14 +235,17 @@ while :; do
         --disable-cuda)
             WITH_CUDA=OFF
             ;;
-        --use-nccl)
-            WITH_NCCL=ON
-            ;;
         --disable-topo-aware)
             WITH_TOPO_AWARE=OFF
             ;;
         --with-aluminum)
             WITH_ALUMINUM=ON
+            ;;
+        --aluminum-with-mpi-cda)
+            ALUMINUM_WITH_MPI_CUDA=ON
+            ;;
+        --aluminum-with-nccl)
+            ALUMINUM_WITH_NCCL=ON
             ;;
         --with-conduit)
             WITH_CONDUIT=ON
@@ -269,7 +275,7 @@ done
 # Determine whether system uses modules
 USE_MODULES=0
 case $TOSS in
-	3.10.0|4.11.0) 
+	3.10.0|4.11.0)
 		USE_MODULES=1
 		;;
 	2.6.32)
@@ -633,7 +639,7 @@ if [ "${CLUSTER}" == "sierra" ]; then
 else
 	OPENBLAS_ARCH=
 fi
-	
+
 ################################################################
 # Display parameters
 ################################################################
@@ -739,7 +745,10 @@ ${CMAKE_PATH}/cmake \
 -D LBANN_SB_BUILD_OPENCV=ON \
 -D LBANN_SB_BUILD_JPEG_TURBO=ON \
 -D LBANN_SB_BUILD_PROTOBUF=ON \
--D LBANN_SB_BUILD_CUB=${WITH_CUB}
+-D LBANN_SB_BUILD_CUB=${WITH_CUB} \
+-D LBANN_SB_BUILD_ALUMINUM=${WITH_ALUMINUM} \
+-D ALUMINUM_ENABLE_MPI_CUDA=${ALUMINUM_WITH_MPI_CUDA} \
+-D ALUMINUM_ENABLE_NCCL=${ALUMINUM_WITH_NCCL} \
 -D LBANN_SB_BUILD_LBANN=ON \
 -D CMAKE_CXX_FLAGS="${CXX_FLAGS}" \
 -D CMAKE_C_FLAGS="${C_FLAGS}" \
@@ -754,7 +763,6 @@ ${CMAKE_PATH}/cmake \
 -D LBANN_WITH_TOPO_AWARE=${WITH_TOPO_AWARE} \
 -D LBANN_SEQUENTIAL_INITIALIZATION=${SEQ_INIT} \
 -D LBANN_WITH_ALUMINUM=${WITH_ALUMINUM} \
--D LBANN_ALUMINUM_DIR=${ALUMINUM_DIR} \
 -D LBANN_WITH_CONDUIT=${WITH_CONDUIT} \
 -D LBANN_CONDUIT_DIR=${CONDUIT_DIR} \
 -D LBANN_BUILT_WITH_SPECTRUM=${WITH_SPECTRUM} \

--- a/superbuild/hydrogen/CMakeLists.txt
+++ b/superbuild/hydrogen/CMakeLists.txt
@@ -44,7 +44,7 @@ if (FALSE AND TARGET Aluminum)
     set(_hydrogen_depends_tag DEPENDS)
     list(APPEND _HYDROGEN_DEPENDS Aluminum)
   endif (Hydrogen_USE_Aluminum)
-endif (TARGET Aluminum)
+endif (FALSE AND TARGET Aluminum)
 
 # Get the list of HYDROGEN variables
 get_property(HYDROGEN_VARIABLES DIRECTORY PROPERTY VARIABLES)


### PR DESCRIPTION
This adds Aluminum to the superbuild invocation and eliminates the `--with-nccl` flag. The aluminum build is controlled by flags `--with-aluminum` to enable the build, `--aluminum-with-mpi-cuda` to build the MPI-CUDA backend for Aluminum, and `--aluminum-with-nccl` to build the NCCL backend for Aluminum.

I encountered a problem where git needed my github credentials to pull Aluminum, which was not great in the context of the fast-moving superbuild, so I manually set `Aluminum_URL` to use the SSH protocol, and that was fine (I have a key setup). This will go away when Aluminum is officially released.