### PR TITLE
Update checkpoint tests 

### DIFF
--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -2,7 +2,7 @@ import sys
 sys.path.insert(0, '../common_python')
 import tools
 import pytest
-import os, sys
+import os
 
 def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name, compiler_name):
     if compiler_name not in executables:
@@ -107,28 +107,22 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
      assert diff_test == 0
 
 def test_unit_checkpoint_lenet_clang4(cluster, exes, dirname):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 256 == 0
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'clang4')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang4')
 
 def test_unit_checkpoint_lenet_gcc4(cluster, exes, dirname):
-    if cluster in ['catalyst', 'quartz', 'surface']:
+    if cluster in ['quartz', 'surface']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 256 == 0
         # Surface Errors:
         # assert 256 == 0
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc4')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc4')
 
 def test_unit_checkpoint_lenet_gcc7(cluster, exes, dirname):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 256 == 0
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc7')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc7')
 

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -107,22 +107,14 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
      assert diff_test == 0
 
 def test_unit_checkpoint_lenet_clang4(cluster, exes, dirname):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'clang4')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang4')
 
 def test_unit_checkpoint_lenet_gcc4(cluster, exes, dirname):
-    if cluster in ['quartz', 'surface']:
-        pytest.skip('FIXME')
-        # Surface Errors:
-        # assert 256 == 0
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc4')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc4')
 
 def test_unit_checkpoint_lenet_gcc7(cluster, exes, dirname):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc7')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc7')
 

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -66,7 +66,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd',
+         model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_nockpt = os.system(command)
      if return_code_nockpt != 0:
@@ -81,7 +81,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=1, optimizer_name='sgd',
+         model_name='lenet_mnist_dist_ckpt', num_epochs=1, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_1 = os.system(command)
      if return_code_ckpt_1 != 0:
@@ -95,7 +95,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
          dir_name=dir_name,
          data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
          data_reader_name='mnist', model_folder='tests',
-         model_name='lenet_mnist_ckpt_dist', num_epochs=2, optimizer_name='sgd',
+         model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_2 = os.system(command)
      if return_code_ckpt_2 != 0:
@@ -109,7 +109,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name, compil
 def test_unit_checkpoint_lenet_clang4(cluster, exes, dirname):
     if cluster in ['catalyst', 'quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:                                                                                                                                          
+        # Catalyst Errors:
         # assert 256 == 0
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'clang4')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang4')
@@ -136,7 +136,7 @@ def test_unit_checkpoint_lenet_intel18(cluster, exes, dirname):
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'intel18')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel18')
 
-# Run with python -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_exe' --exe=<executable>                                                  
+# Run with python -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_exe' --exe=<executable>
 def test_unit_checkpoint_lenet_exe(cluster, dirname, exe):
     if exe == None:
         pytest.skip('Non-local testing')

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -7,37 +7,39 @@ import os, sys
 def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
     if compiler_name not in executables:
       pytest.skip('default_exes[%s] does not exist' % compiler_name)
+
     lbann2  = executables[compiler_name] + '2'
     model_path = '{../../model_zoo/models/lenet_mnist/model_lenet_mnist.prototext,../../model_zoo/tests/model_lenet_mnist_lbann2ckpt.prototext}'
     output_file_name = '%s/bamboo/unit_tests/output/lbann2_no_checkpoint_%s_output.txt' % (dir_name, compiler_name)
     error_file_name  = '%s/bamboo/unit_tests/error/lbann2_no_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
-        cluster=cluster, executable=lbann2, data_reader_name='mnist',
+        cluster=cluster, executable=lbann2, num_nodes=1, num_processes=2,
+        data_reader_name='mnist',
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
-        dir_name=dir_name, 
+        dir_name=dir_name,
         model_path=model_path,
         optimizer_name='sgd',
         num_epochs=2,
         output_file_name=output_file_name,
         error_file_name=error_file_name)
+    os.mkdir('lbann2_ckpt')
     return_code = os.system(command)
     if return_code != 0:
         sys.stderr.write('LBANN2 LeNet execution failed, exiting with error')
         sys.exit(1)
 
-    
     os.system('mv lbann2_ckpt lbann2_nockpt')
 
     output_file_name = '%s/bamboo/unit_tests/output/lbann2_checkpoint_%s_output.txt' % (dir_name, compiler_name)
     error_file_name  = '%s/bamboo/unit_tests/error/lbann2_checkpoint_%s_error.txt' % (dir_name, compiler_name)
     command = tools.get_command(
-        cluster=cluster, executable=lbann2, num_nodes=1, num_processes=1,
+        cluster=cluster, executable=lbann2, num_nodes=1, num_processes=2,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist', model_folder='tests',
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name,
-        error_file_name=error_file_name)   
+        error_file_name=error_file_name)
     return_code_ckpt_1 = os.system(command)
     if return_code_ckpt_1 != 0:
         sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
@@ -45,8 +47,9 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
 
     output_file_name = '%s/bamboo/unit_tests/output/lbann2_restart_%s_output.txt' % (dir_name, compiler_name)
     error_file_name  = '%s/bamboo/unit_tests/error/lbann2_restart_%s_error.txt' % (dir_name, compiler_name)
+    os.mkdir('lbann2_ckpt')
     command = tools.get_command(
-        cluster=cluster, executable=lbann2, num_nodes=1, num_processes=1,
+        cluster=cluster, executable=lbann2, num_nodes=1, num_processes=2,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchf/brainusr/datasets/MNIST',
         data_reader_name='mnist',
@@ -66,12 +69,10 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
     assert diff_test == 0
 
 def test_unit_lbann2_reload_clang4(cluster, exes, dirname):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:
-        # assert 512 == 0 
     skeleton_lbann2_reload(cluster, exes, dirname, 'clang4')
-    
+
 def test_unit_lbann2_reload_gcc4(cluster, exes, dirname):
   if cluster in ['surface']:
     pytest.skip('FIXME')
@@ -82,13 +83,13 @@ def test_unit_lbann2_reload_gcc4(cluster, exes, dirname):
   skeleton_lbann2_reload(cluster, exes, dirname, 'gcc4')
 
 def test_unit_lbann2_reload_gcc7(cluster, exes, dirname):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['quartz']:
         pytest.skip('FIXME')
-        # Catalyst Errors:                                                                                                                                    
-        # assert 512 == 0
     skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7')
 
 def test_unit_lbann2_reload_intel18(cluster, exes, dirname):
+    if cluster in ['quartz']:
+        pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'intel18')
 
 # Run with python -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -69,27 +69,15 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
     assert diff_test == 0
 
 def test_unit_lbann2_reload_clang4(cluster, exes, dirname):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'clang4')
 
 def test_unit_lbann2_reload_gcc4(cluster, exes, dirname):
-  if cluster in ['surface']:
-    pytest.skip('FIXME')
-    # Surface Errors:
-    # SystemExit: 1
-    # [surface64:mpi_rank_0][error_sighandler] Caught error: Segmentation fault (signal 11)
-    # srun: error: surface64: task 0: Segmentation fault (core dumped)
   skeleton_lbann2_reload(cluster, exes, dirname, 'gcc4')
 
 def test_unit_lbann2_reload_gcc7(cluster, exes, dirname):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7')
 
 def test_unit_lbann2_reload_intel18(cluster, exes, dirname):
-    if cluster in ['quartz']:
-        pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'intel18')
 
 # Run with python -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -77,7 +77,7 @@ int main(int argc, char *argv[]) {
 
     // When using checkpoint states, skip training as those could be the result
     // of checkpointing by steps.
-    if (!opts->has_string("ckpt_dir")){
+    if (!opts->has_string("no_model1_train")){
       model_1->train( pb_model.num_epochs() );
     }
     // Evaluate model 1 unless it is set to skip
@@ -298,13 +298,16 @@ bool load_model_weights(std::string ckpt_dir, model * m){
   sprintf(latest, "%s/last.shared.checkpoint", ckpt_dir.c_str());
   // get last epoch and step saved.
   int fd = openread(latest);
+  lbann_comm *temp_comm = m->get_comm();
   if (fd != -1) {
     char field[256];
     read_string(fd, "shared.last", field, sizeof(field));
     int ret = sscanf(field, "epoch=%d step=%d\n", &epochLast, &stepLast);
     if(ret != 2) { return false; }
     closeread(fd, latest);
-    sprintf(latest, "%s/shared.epoch.%d.step.%d/", ckpt_dir.c_str() ,epochLast, stepLast);
+    if(temp_comm->am_model_master())
+      sprintf(latest, "%s/shared.model.%d.epoch.%d.step.%d/", ckpt_dir.c_str(), temp_comm->get_model_rank(), epochLast, stepLast);
+    temp_comm->model_broadcast(0, &(latest[0]), sizeof(latest));
   }
 
   DIR *weight_dir;


### PR DESCRIPTION
`test_unit_checkpoint` was only really broken (and subsequently skipped in bamboo) because a hydrogen fix had not yet merged. This is now resolved, and a minor path issue for distributed ckpt test is fixed by this PR. 

`lbann2_reload` was broken in a couple ways: 

- dump weights callback failure due to the specified directory not existing before attempting the weight write. 

- it appears that by default lbann2 does not go through model training when weights are loaded from saved ckpt files. This causes the test  to fail, as the initial training weights are never dumped by the callback, and we check these weights against what would be loaded in during a standard lbann2 execution. I have resolved this by having the 'skip training' option as a command line option rather than default behavior. 