### PR TITLE
Detect GPU matrices in allreduces

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -548,8 +548,7 @@ class lbann_comm {
   /** Matrix allreduce. */
   void allreduce(AbsDistMat& m,
                  const El::mpi::Comm c,
-                 El::mpi::Op op = El::mpi::SUM,
-                 std::type_index t = std::type_index(typeid(Al::mpi_backend)));
+                 El::mpi::Op op = El::mpi::SUM);
   /** Non-blocking matrix allreduce.
    *  If LBANN has not been built with Aluminum, then this calls a
    *  blocking matrix allreduce.
@@ -557,8 +556,7 @@ class lbann_comm {
   void nb_allreduce(AbsDistMat& m,
                     const El::mpi::Comm c,
                     Al::request& req,
-                    El::mpi::Op op = El::mpi::SUM,
-                    std::type_index t = std::type_index(typeid(Al::mpi_backend)));
+                    El::mpi::Op op = El::mpi::SUM);
   /** Non-blocking in-place scalar-array allreduce.
    *  If LBANN has not been built with Aluminum, then this calls a blocking
    *  allreduce.

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -141,17 +141,10 @@ void optimizer::start_gradient_staging_allreduce() {
   }
 
   m_gradient_allreduce_started = true;
-  std::type_index t = std::type_index(typeid(Al::mpi_backend));
-#ifdef LBANN_HAS_GPU
-  if (m_gradient_staging->GetLocalDevice() == El::Device::GPU) {
-    t = std::type_index(typeid(Al::nccl_backend));
-  }
-#endif
   m_comm->nb_allreduce(*m_gradient_staging,
                        m_gradient_staging->RedundantComm(),
                        m_gradient_allreduce_req,
-                       El::mpi::SUM,
-                       t);
+                       El::mpi::SUM);
   m_gradient_allreduce_finished = false;
 }
 


### PR DESCRIPTION
Now that Hydrogen supports GPU matrices, `lbann_comm::allreduce`/`nb_allreduce`, when using Aluminum, can detect whether data is on GPU, and select an appropriate backend. This forces the NCCL backend or throws an error if it's not present.