### PR TITLE
initial implementation of jag_io class 

### DIFF
--- a/include/lbann/data_store/jag_io.hpp
+++ b/include/lbann/data_store/jag_io.hpp
@@ -1,0 +1,193 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef __JAG_IO_HPP__
+#define __JAG_IO_HPP__
+
+#include "lbann_config.hpp"
+
+#ifdef LBANN_HAS_CONDUIT
+#include "conduit/conduit.hpp"
+#include "conduit/conduit_relay.hpp"
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace lbann {
+
+class jag_io {
+ public:
+
+ /**
+  * NOTE: some methods below take variables "string node_name" while others
+  *       take "string key." My convention is that "node_name" indicated
+  *       a fully qualified name, i.e, it begins with the sample id:
+  *          0/field_1/field_2
+  *       on the other hand, "key" does not contain the sample id:
+  *          field_1/field_2
+  */
+
+/// WARNING! CAUTION! BE ADVISED!
+/// cut-n-paste from data_reader_jag_conduit; this is
+/// fragile -- probably best to but these in a small
+/// file that both reader and store can then include
+/// @todo
+using ch_t = double; ///< jag output image channel type
+using scalar_t = double; ///< jag scalar output type
+using input_t = double; ///< jag input parameter type
+
+  //! ctor
+  jag_io();
+
+  //! copy ctor
+  jag_io(const jag_io&) = default;
+
+  //! operator=
+  jag_io& operator=(const jag_io&) = default;
+
+  //@todo: this causes a compile error ... why?
+  //jag_io * copy() const { return new jag_io(*this); }
+
+  //! dtor
+  ~jag_io();
+
+  /// converts conduit data to our format and saves to disk
+  void convert(std::string conduit_pathname, std::string base_dir);
+
+  /// load our format from disk
+  void load(std::string base_dir);
+
+  /// returns the set of the child nodes of the parent node
+  /// @todo not currently used; may not be needed
+  const std::unordered_set<std::string> &get_children(std::string parent) const;
+
+  //const std::vector<jag_io::scalar_t> & get_scalars(size_t sample_id) const; 
+
+  /// Returns size and data type information for the requested node. 
+  /// 'total_bytes_out' is num_elts_out * bytes_per_elt_out; 
+  void get_metadata(std::string node_name, size_t &num_elts_out, size_t &bytes_per_elt_out, size_t &total_bytes_out, std::string &type_out);
+
+  /// Reads the requested data from file and returns it in 'data_out.'
+  /// The caller is responsible for allocating sufficient memory,
+  /// i.e, they should previously have called get_metadata(...), then
+  /// allocated memory, i.e, std::vector<char> d(total_bytes_out);
+  void get_data(std::string node_name, int tid, char * data_out, size_t num_bytes);
+
+  /// returns true if the key exists in the metadata map
+  bool has_key(std::string key) const;
+
+  const std::vector<std::string>& get_scalar_choices() const;
+
+  const std::vector<std::string>& get_input_choices() const;
+
+  size_t get_num_samples() const {
+    return m_num_samples;
+  }
+
+  /// this method is provided for testing and debugging
+  size_t get_offset(std::string node_name);
+
+  /// this method is provided for testing and debugging
+  const std::vector<std::string> &get_keys() const {
+    return m_keys;
+  }
+
+  /// this method is provided for testing and debugging
+  void print_metadata();
+
+protected :
+
+  struct MetaData {
+    MetaData() {}
+    MetaData(std::string tp, int elts, int bytes, size_t _offset = 0)
+      : dType(tp), num_elts(elts), num_bytes(bytes), offset(_offset) {}
+
+    std::string dType; //float64, int64, etc.
+    int         num_elts;  //number of elements in this field
+    int         num_bytes; //number of bytes for a single element
+    size_t      offset;  //offset wrt m_data: where this resides on disk
+  };
+
+  size_t m_num_samples;
+
+  /// used when reading converted data from file; 
+  /// each thread gets a separate stream
+  std::vector<std::ifstream> m_data_streams;
+
+  /// recursive function invoked by convert();
+  /// fills in m_keys and m_parent_to_children
+  void get_hierarchy(
+      conduit::Node &head,
+      std::string parent_name);
+
+  /// maps parent node_named to child node_names
+  std::unordered_map<std::string, std::unordered_set<std::string>> m_parent_to_children;
+
+  /// contains the same keys that appear in m_metadata; saving them 
+  /// separately so we can iterate through in the order they appeared
+  std::vector<std::string> m_keys;
+
+  
+  ///@todo this may go away ...
+  //std::unordered_map<std::string, std::string> m_data_reader;
+
+  std::unordered_map<std::string, MetaData> m_metadata;
+
+  /// number of bytes required to store each sample on disk in our format
+  size_t m_sample_offset;
+
+  //std::vector<std::string> m_scalar_keys;
+
+  std::vector<std::string> m_input_keys;
+
+  /// some conduit keys contain white space, which is annoying to parse,
+  /// so internally we convert them to underscores
+  void white_space_to_underscore(std::string &s) {
+    for (size_t j=0; j<s.size(); j++) {
+      if (s[j] == ' ') {
+        s[j] = '_';
+      }
+    }
+  }
+
+  /// returns the node_name with the sample_id removed;
+  /// also checks that the key exists in m_metadata
+  std::string get_metadata_key(std::string node_name) const;
+
+  /// checks that 'key' is a valid key in the m_metadata map;
+  /// if not, throws an exception
+  void key_exists(std::string key) const;
+
+  /// returns the sample ID
+  size_t get_sample_id(std::string node_name) const;
+};
+
+}  // namespace lbann
+
+#endif //ifndef LBANN_HAS_CONDUIT ... else
+
+#endif  // __JAG_IO_HPP__

--- a/src/data_store/jag_converter.cpp
+++ b/src/data_store/jag_converter.cpp
@@ -1,0 +1,227 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/lbann.hpp"
+#include "lbann/data_store/jag_io.hpp"
+#include "lbann/utils/options.hpp"
+#include <cstdint>
+
+std::string usage("\n\nusage: jag_converter --mode=<convert|test|both>  --bundle=<filename> --dir=<directory for converted *.bundle>");
+
+using namespace lbann;
+
+void convert(std::string bundle_fn, std::string dir);
+void test(std::string bundle_fn, std::string dir);
+
+int main(int argc, char *argv[]) {
+
+#ifndef LBANN_HAS_CONDUIT
+  std::cerr << "ERROR: lbann was not compiled with conduit support\n"
+               "(LBANN_HAS_CONDUIT was not defined at compile time)\n";
+  exit(9);
+#else
+
+  lbann_comm *comm = initialize(argc, argv, 42);
+
+  try {
+    options *opts = options::get();
+    opts->init(argc, argv);
+  
+    std::stringstream err;
+
+    std::string bundle_fn;
+    std::string convert_dir;
+    std::string mode;
+
+    if (!opts->has_string("mode")) {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "you must pass the option: --mode=<string>,\n"
+             "where <string> is \"convert\" or \"test\" or \"both\""
+             << usage;
+      throw lbann_exception(err.str());
+    }
+    mode = opts->get_string("mode");
+    
+    if (!opts->has_string("bundle")) {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "you must pass the option: --bundle=<pathname>,\n"
+             "which is the input filename"
+          << usage;
+      throw lbann_exception(err.str());
+    }
+    bundle_fn= opts->get_string("bundle");
+
+    if (!opts->has_string("dir")) {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "you must pass the option: --dir=<string>,\n"
+             "which is the directory for the converted file"
+          << usage;
+      throw lbann_exception(err.str());
+    }
+    convert_dir = opts->get_string("dir");
+
+    if (mode == "convert") {
+      convert(bundle_fn, convert_dir);
+    } else if (mode == "test") {
+      test(bundle_fn, convert_dir);
+    } else if (mode == "both") {
+      convert(bundle_fn, convert_dir);
+      test(bundle_fn, convert_dir);
+    } else {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "bad value for option: --mode=<string>;\n"
+             "must be 'convert' or 'test' or 'both'"
+          << usage;
+      throw lbann_exception(err.str());
+    }
+
+  } catch (lbann_exception& e) {
+    lbann_report_exception(e, comm);
+  }  
+
+#endif //ifdef LBANN_HAS_CONDUIT
+
+  return 0;
+}
+
+#ifdef LBANN_HAS_CONDUIT
+void convert(std::string bundle_fn, std::string dir) {
+  jag_io io;
+  io.convert(bundle_fn, dir);
+}
+
+void test(std::string bundle_fn, std::string dir) {
+  std::cerr << "\nstarting test ...\n";
+  std::cerr << "loading conduit node...\n";
+  conduit::Node head;
+  conduit::relay::io::load(bundle_fn, "hdf5", head);
+
+  std::cerr << "calling jag.load("<<dir<<")\n";
+  jag_io jag;
+  jag.load(dir);
+  size_t num_samples = jag.get_num_samples();
+  size_t sample_id = num_samples > 1 ? 1 : 0;
+  const std::vector<std::string> &keys = jag.get_keys();
+
+  std::cerr << "using sample " << sample_id << " of " << num_samples << "\n";
+  std::cerr << "num keys: " << keys.size() << "\n";
+
+  size_t num_elts;
+  size_t bytes_per_elt;
+  size_t total_bytes;
+  std::string type;
+  size_t tid = 0;
+  std::vector<char> data;
+  size_t pass = 0;
+  size_t skipped = 0;
+  size_t warnings = 0;
+  size_t total = 0;
+
+  //=========================================================================\n;
+  // test #1: 
+  //   loop over all keys; test that what we get from the jag_io is identical
+  //   to what we get directly from the conduit node
+  //
+  //=========================================================================\n;
+  for (auto key : keys) {
+    ++total;
+
+    // get data from jag_io
+    jag.get_metadata(key, num_elts, bytes_per_elt, total_bytes, type);
+    if (total_bytes == 0) {
+      ++skipped;
+      continue;
+    }
+    data.resize(total_bytes);
+    std::string key2 = std::to_string(sample_id) + '/' + key;
+    jag.get_data(key2, tid, data.data(), total_bytes);
+
+    // get data directly from conduit
+    conduit::Node truth = head[key2];
+
+    char *f2 = 0;
+    if (type == "int64") {
+      long *f = truth.as_int64_ptr();
+      f2 = (char*)f;
+    } else if (type == "float64") {
+      double *f = truth.as_float64_ptr();
+      f2 = (char*)f;
+    } else if (type == "uint64") {
+      uint64 *f = truth.as_uint64_ptr();
+      f2 = (char*)f;
+    } else if (type == "char8_str") {
+      char *f = truth.as_char8_str();
+      f2 = (char*)f;
+    } else {
+      std::cerr << "WARNING: unhandled type: " << type << "\n";
+      ++warnings;
+    }
+    if (f2) {
+      for (size_t i=0; i<total_bytes; i++) {
+        if (data[i] != f2[i]) {
+          std::cerr << "ERROR: data from jag_io doesn't match data from conuit Node\n"
+                    << "key: " << key2 << "\n";
+          exit(9);
+        }
+      }
+      ++pass;
+    }
+  }
+  size_t sanity = skipped + warnings + pass;
+  std::cerr << "\n\n"
+            << "total keys tested:  " << total << "\n"
+            << "total keys skipped: " << skipped << " (due to zero length data)\n"
+            << "total warnings:     " << warnings << " (handling a data type that's not yet supported)\n"
+            << "number that passed: " << pass << "\n"
+            << "sanity:             " << sanity << " (should be same as total keys tested)\n";
+
+  //=========================================================================\n;
+  // test #2: 
+  //   test, for each key, that type, num elts, num_bytes identical
+  //=========================================================================\n;
+  for (auto key : keys) {
+    jag.get_metadata(key, num_elts, bytes_per_elt, total_bytes, type);
+    for (size_t j=0; j<num_samples; j++) {
+      std::string key2 = std::to_string(sample_id) + '/' + key;
+      conduit::Node truth = head[key2];
+      conduit::DataType dType = truth.dtype();
+      if (num_elts != (size_t)dType.number_of_elements()) {
+        std::cerr << "ERROR 1!\n";
+        exit(9);
+      }
+      if (bytes_per_elt != (size_t)dType.element_bytes()) {
+        std::cerr << "ERROR 2!\n";
+        exit(9);
+      }
+      if (type != dType.name()) {
+        std::cerr << "ERROR 3!\n";
+        exit(9);
+      }
+    }
+  }
+}
+#endif //LBANN_HAS_CONDUIT

--- a/src/data_store/jag_io.cpp
+++ b/src/data_store/jag_io.cpp
@@ -1,0 +1,386 @@
+#include "lbann_config.hpp" // may define LBANN_HAS_CONDUIT
+
+#ifdef LBANN_HAS_CONDUIT
+
+#include "lbann/data_store/jag_io.hpp"
+#include "lbann/data_readers/data_reader_jag_conduit.hpp"
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/file_utils.hpp"
+#include "lbann_config.hpp" 
+#include <unordered_map>
+#include <unordered_set>
+#include <fstream>
+#include <cstdlib>
+#include <algorithm>
+
+namespace lbann {
+
+jag_io::~jag_io() {
+  for (size_t i=0; i<m_data_streams.size(); i++) {
+    if (m_data_streams[i].is_open()) {
+      m_data_streams[i].close();
+    }  
+  }
+}
+
+jag_io::jag_io() {}
+
+void jag_io::get_hierarchy(conduit::Node &nd, std::string parent) {
+  std::string parent_2 = parent;
+  if (parent.find('/') != std::string::npos) {
+    // hack to discard keys that vary between samples;
+    // will fix later, when we have the samples we're going
+    // to actually use, and guidance as to which outputs
+    // we should use.
+    if (parent.find("outputs/scalars") == std::string::npos) {
+      m_keys.push_back( parent.substr(2));
+    }  
+  } 
+  conduit::Node nd2 = nd[parent.c_str()];
+  const std::vector<std::string> &children_names = nd2.child_names();
+  for (auto t : children_names) {
+    m_parent_to_children[parent_2].insert(t);
+    std::string p = parent + '/' + t;
+    get_hierarchy(nd, p);
+  }
+}
+
+void jag_io::convert(std::string conduit_pathname, std::string base_dir) {
+  std::stringstream err;
+
+  //create the output directory (if it doesn't already exist)
+  create_dir(base_dir);
+
+  // load the conduit bundle
+  std::cerr << "Loading conduit file ...\n";
+  conduit::Node head;
+  conduit::relay::io::load(conduit_pathname, "hdf5", head);
+  m_num_samples = head.number_of_children();
+  std::cerr << "\nconversion in progress for " << m_num_samples << " samples\n";
+
+  // get the hierarchy (get all keys in the hierarchy); this fills in m_keys 
+  // and m_parent_to_children
+  get_hierarchy(head, "6");
+
+  // fill in m_metadata
+  m_sample_offset = 0;
+  for (auto t : m_keys) {
+    conduit::Node nd = head["0/" + t];
+    conduit::DataType m = nd.dtype();
+    m_metadata[t] = MetaData(m.name(), m.number_of_elements(), m.element_bytes(), m_sample_offset);
+    m_sample_offset += (m.number_of_elements() * m.element_bytes());
+  }
+
+  // write metadata to file
+  std::string fn = base_dir + "/metadata.txt";
+  std::ofstream metadata_writer(fn.c_str());
+  if (!metadata_writer.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for writing";
+    throw lbann_exception(err.str());
+  }
+
+  metadata_writer << m_num_samples << "\n";
+  metadata_writer << m_sample_offset << "\n";
+  for (auto t : m_keys) {
+    metadata_writer << m_metadata[t].dType << " " << m_metadata[t].num_elts
+           << " " << m_metadata[t].num_bytes << " " << m_metadata[t].offset 
+           << " " << t << "\n";
+  }
+  metadata_writer.close();
+  std::cerr << "wrote file: " << fn << "\n";
+
+
+  // open output file for binary data
+  fn = base_dir + "/data.bin";
+  std::ofstream bin_writer(fn.c_str(), std::ios::binary);
+  if (!bin_writer.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for writing";
+    throw lbann_exception(err.str());
+  }
+
+  // write binary data
+  for (size_t j=0; j<m_num_samples; j++) {
+    for (auto t2 : m_keys) {
+      conduit::Node d = head[std::to_string(j) + '/' + t2];
+      conduit::DataType t = d.dtype();
+      if (m_metadata.find(t2) == m_metadata.end()) {
+        err << __FILE__ << " " << __LINE__ << " :: "
+            << "key is missing from metadata map: " << t2;
+        throw lbann_exception(err.str());
+      }
+      size_t total_bytes = m_metadata[t2].num_elts * m_metadata[t2].num_bytes;
+
+      if (total_bytes) {
+        //as of now I'm only coding for the dataTypes that are in our
+        //current *.bundle files; we may need to add additional later,
+        //if the schema changes
+        if (t.name() == "char8_str") {
+           bin_writer.write((char*)d.as_char8_str(), total_bytes);
+        } else if (t.name() == "float64") {
+           bin_writer.write((char*)d.as_float64_ptr(), total_bytes);
+        } else if (t.name() == "uint64") {
+           bin_writer.write((char*)d.as_uint64_ptr(), total_bytes);
+        } else if (t.name() == "int64") {
+           bin_writer.write((char*)d.as_int64_ptr(), total_bytes);
+        } else {
+          std::cerr << t2 << " " << m_metadata[t2].num_elts * m_metadata[t2].num_bytes << "\n";
+          err << __FILE__ << " " << __LINE__ << " :: "
+              << "get_value() failed; dType: " << t.name()
+              << " " << (std::to_string(j) + '/' + t2);
+          throw lbann_exception(err.str());
+        }
+      }
+    }
+  }
+  bin_writer.close();
+  std::cerr << "wrote " << fn << "\n";
+
+  #if 0
+  //write scalar keys
+  fn = base_dir + "/scalar_keys.txt";
+  std::ofstream out_scalars(fn.c_str());
+  if (!out_scalars.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for writing";
+    throw lbann_exception(err.str());
+  }
+  const conduit::Node & n_scalar = head["0/outputs/scalars"];
+  conduit::NodeConstIterator itr5 = n_scalar.children();
+  while (itr5.has_next()) {
+    itr5.next();
+    out_scalars << itr5.name() << "\n";
+  }
+  out_scalars.close();
+  std::cerr << "wrote " << fn << "\n";
+  #endif
+
+  //write input keys
+  fn = base_dir + "/input_keys.txt";
+  std::ofstream out_inputs(fn.c_str());
+  if (!out_inputs.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for writing";
+    throw lbann_exception(err.str());
+  }
+  const conduit::Node & n_input = head["0/inputs"];
+  conduit::NodeConstIterator itr6 = n_input.children();
+  while (itr6.has_next()) {
+    itr6.next();
+    out_inputs << itr6.name() << "\n";
+  }
+  out_inputs.close();
+  std::cerr << "wrote " << fn << "\n";
+
+  //write the parent_to_child mapping
+  fn = base_dir + "/parent_to_child.txt";
+  std::ofstream out(fn.c_str());
+  if (!out.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for writing";
+    throw lbann_exception(err.str());
+  }
+  for (auto t : m_parent_to_children) {
+    out << t.first << " ";
+    for (auto t2 : t.second) {
+      out << t2 << " ";
+    }
+    out << "\n";
+  }
+  out.close();
+  std::cerr << "wrote " << fn << "\n";
+
+  std::cerr << "finished conversion!\n";
+}
+
+void jag_io::load(std::string base_dir) {
+
+  std::stringstream err;
+  std::string fn;
+  std::ifstream in;
+  std::string key;
+
+  // open the binary data file
+  m_data_streams.resize(omp_get_max_threads());
+  fn = base_dir + "/data.bin";
+  for (size_t i=0; i<m_data_streams.size(); i++) {
+    m_data_streams[i].open(fn.c_str());
+    if (!m_data_streams[i].good()) {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "failed to open " << fn << " for reading";
+      throw lbann_exception(err.str());
+    }  
+  }
+
+  // fill in parent_to_child map
+  fn = base_dir + "/parent_to_child.txt";
+  in.open(fn.c_str());
+  if (!in.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for reading";
+    throw lbann_exception(err.str());
+  }
+  std::string parent;
+  std::string child;
+  while (in >> parent >> child) {
+    m_parent_to_children[parent].insert(child);
+  }
+  in.close();
+
+  // open metadata file
+  fn = base_dir + "/metadata.txt";
+  in.open(fn.c_str(), std::ios::in | std::ios::binary);
+  if (!in.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for reading";
+    throw lbann_exception(err.str());
+  }
+
+  // get num_samples, etc.
+  in >> m_num_samples;
+  in >> m_sample_offset;
+
+  // fill in the metadata map
+  std::string dType;
+  int num_elts;
+  int bytes_per_elt;
+  size_t offset;
+  while (in >> dType >> num_elts >> bytes_per_elt >> offset >> key) {
+    m_metadata[key] = MetaData(dType, num_elts, bytes_per_elt, offset);
+    m_keys.push_back(key);
+  }
+  in.close();
+
+  #if 0
+  // fill in m_scalar_keys
+  fn = base_dir + "/scalar_keys.txt";
+  in.open(fn.c_str());
+  if (!in.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for reading";
+    throw lbann_exception(err.str());
+  }
+  while (in >> key) {
+    m_scalar_keys.push_back(key);
+  }
+  in.close();
+  #endif
+
+  // fill in m_input_keys
+  fn = base_dir + "/input_keys.txt";
+  in.open(fn.c_str());
+  if (!in.good()) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to open " << fn << " for reading";
+    throw lbann_exception(err.str());
+  }
+  while (in >> key) {
+    m_input_keys.push_back(key);
+  }
+  in.close();
+}
+
+const std::unordered_set<std::string> & jag_io::get_children(std::string parent) const {
+  std::unordered_map<std::string, std::unordered_set<std::string>>::const_iterator t;
+  t = m_parent_to_children.find(parent);
+  if (t == m_parent_to_children.end()) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to find " << parent << " in m_parent_to_children map\n"
+        << "m_parent_to_children.size(): " << m_parent_to_children.size();
+    throw lbann_exception(err.str());
+  }
+  return (*t).second;
+}
+
+size_t jag_io::get_sample_id(std::string node_name) const {
+  std::stringstream err;
+  size_t j = node_name.find('/');
+  if (j == std::string::npos) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to find '/' in node_name: " << node_name;
+    throw lbann_exception(err.str());
+  }
+  for (size_t i=0; i<j; i++) {
+    if (! isdigit(node_name[i])) {
+      err << __FILE__ << " " << __LINE__ << " :: "
+          << "isdigit(" << node_name << "[" << i << "] failed";
+      throw lbann_exception(err.str());
+    }
+  }
+  return atoi(node_name.data());
+}
+
+std::string jag_io::get_metadata_key(std::string node_name) const {
+  std::stringstream err;
+  size_t j = node_name.find('/');
+  if (j == std::string::npos) {
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "failed to find '/' in node_name: " << node_name;
+    throw lbann_exception(err.str());
+  }
+  std::string key = node_name.substr(j+1);
+  key_exists(key);
+  return key;
+}
+
+void jag_io::key_exists(std::string key) const {
+  if (m_metadata.find(key) == m_metadata.end()) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << "the key: " << key << " is not valid for the metadata map";
+    throw lbann_exception(err.str());
+  }
+}
+
+void jag_io::get_data(std::string node_name, int tid, char * data_out, size_t num_bytes) {
+  std::string key = get_metadata_key(node_name);
+  size_t sample_id = get_sample_id(node_name);
+  size_t offset = m_sample_offset * sample_id + m_metadata[key].offset;
+  m_data_streams[tid].seekg(offset);
+  m_data_streams[tid].read(data_out, num_bytes);
+}
+
+const std::vector<std::string>& jag_io::get_input_choices() const {
+  return m_input_keys;
+}
+
+/*
+const std::vector<std::string>& jag_io::get_scalar_choices() const {
+  return m_scalar_keys;
+}
+*/
+
+
+void jag_io::get_metadata(std::string key, size_t &num_elts_out, size_t &bytes_per_elt_out, size_t &total_bytes_out, std::string &type_out) {
+  num_elts_out = m_metadata[key].num_elts;
+  bytes_per_elt_out = m_metadata[key].num_bytes;
+  total_bytes_out = num_elts_out*bytes_per_elt_out;
+  type_out = m_metadata[key].dType;
+}
+
+bool jag_io::has_key(std::string key) const {
+  if (m_metadata.find(key) == m_metadata.end()) {
+    return false;
+  }  
+  return true;
+}
+
+size_t jag_io::get_offset(std::string node_name) {
+  std::string key = get_metadata_key(node_name);
+  size_t sample_id = get_sample_id(node_name);
+  return sample_id*m_sample_offset + m_metadata[key].offset;
+}
+
+void jag_io::print_metadata() {
+  for (auto key : m_keys) {
+    std::cerr << "type/num_elts/bytes_per_elt: " << m_metadata[key].dType
+              << " " << m_metadata[key].num_elts << " " << m_metadata[key].num_bytes << " offset: " << m_metadata[key].offset << " :: " << key << "\n";
+  }
+}
+
+}  // namespace lbann
+
+#endif //#ifdef LBANN_HAS_CONDUIT
+


### PR DESCRIPTION
Initial commit for jag_io class. This class provides functionality  to convert the *.bundle (aka, hdf5) data into our (my) proprietary format. It also provides functionality to read in data from our format, and pass the data to data_store_jag_conduit (note: data_store_jag_conduit doesn't yet exist). 

You should think of this class as : data_on_disk -> jag_io -> data_store_fag_io -> data_reader_jag_conduit.