### PR TITLE
Fix cuDNN workspace size

### DIFF
--- a/include/lbann/utils/cudnn_wrapper.hpp
+++ b/include/lbann/utils/cudnn_wrapper.hpp
@@ -113,7 +113,7 @@ class cudnn_manager {
 #ifdef LBANN_HAS_CUDNN
 
  public:
-  cudnn_manager(size_t workspace_size = 1 << 9);
+  cudnn_manager(size_t workspace_size = 1 << 30);
   ~cudnn_manager();
 
   /** Get cuDNN handle.

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
     // Check for cudnn, with user feedback
     cudnn::cudnn_manager *cudnn = nullptr;
 #ifdef LBANN_HAS_CUDNN
-    const size_t workspace_size = 1 << 9; // 1 GB
+    const size_t workspace_size = 1 << 30; // 1 GB
     if (! pb_model->disable_cuda()) {
       if (master) {
         std::cerr << "code was compiled with LBANN_HAS_CUDNN, and we are using cudnn\n";


### PR DESCRIPTION
We were allocating 512 bytes (`1<<9`) instead of 1 GiB (`1 << 30`) for our cuDNN workspace. This results in slower algorithms being chosen for forward and backward prop.

For example, for `res2a_branch2b` in ResNet-50, it would select the implicit GEMM algorithm for forward prop. The Winograd algorithm is faster, and requires only 256 KiB of workspace.

We now allocate 1 GiB, and cuDNN choses more appropriate algorithms.