### PR TITLE
Simple image resize

### DIFF
--- a/include/lbann/data_readers/cv_process.hpp
+++ b/include/lbann/data_readers/cv_process.hpp
@@ -37,6 +37,7 @@
 #include "cv_colorizer.hpp"
 #include "cv_decolorizer.hpp"
 #include "cv_cropper.hpp"
+#include "cv_resizer.hpp"
 #include "cv_mean_extractor.hpp"
 #include <memory>
 #include <limits> // std::numeric_limits

--- a/include/lbann/data_readers/cv_resizer.hpp
+++ b/include/lbann/data_readers/cv_resizer.hpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// cv_resizer .cpp .hpp - Functions to resize images
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CV_RESIZER_HPP
+#define LBANN_CV_RESIZER_HPP
+
+#include "lbann/data_readers/cv_transform.hpp"
+#include <utility>
+#include <ostream>
+
+#ifdef LBANN_HAS_OPENCV
+namespace lbann {
+
+/**
+ * Simple image resizing without maintaining the aspect ratio.
+ */
+class cv_resizer : public cv_transform {
+ protected:
+  // --- configuration variables ---
+  unsigned int m_width; ///< desired width of an image
+  unsigned int m_height; ///< desired height of an image
+
+  // --- state variables ---
+  /** Three modes of pixel interpolation: INTER_LINEAR, INTER_AREA, and INTER_LINEAR
+   *  The first choice is the default when not adaptive. The other two are used when
+   *  interpolatng  adaptively. The second is when shrinking, and the third is when enlarging
+   */
+  static const int m_interpolation_choices[3];
+  int m_interpolation; ///< id of the channel value interpolation method used
+  bool m_adaptive_interpolation; ///< whether to use adaptive interpolation
+
+ public:
+  cv_resizer();
+  cv_resizer(const cv_resizer& rhs) = default;
+  cv_resizer& operator=(const cv_resizer& rhs) = default;
+  cv_resizer *clone() const override;
+  ~cv_resizer() override {}
+
+  /**
+   * Set the parameters all at once
+   * @param width  desired width
+   * @param height desired height
+   * @param adaptive_interpolation whether to apply a different interpolation method depending on how an image is resized
+   */
+  void set(const unsigned int width, const unsigned int height,
+           const bool adaptive_interpolation = false);
+
+  unsigned int get_width() const { return m_width; }
+  unsigned int get_height() const { return m_height; }
+
+  /// Clear the states of the previous transform applied
+  void reset() override;
+
+  /**
+   * Determine whether to enable transformation.
+   * @return false if not enabled.
+   */
+  bool determine_transform(const cv::Mat& image) override;
+
+  /// Determine whether to enable inverse transformation.
+  bool determine_inverse_transform() override { return false; }
+
+  /**
+   * Apply the transformation.
+   * As this method is executed, the transform becomes deactivated.
+   * @return false if not successful.
+   */
+  bool apply(cv::Mat& image) override;
+
+  std::string get_type() const override { return "resizer"; }
+  std::string get_description() const override;
+  std::ostream& print(std::ostream& os) const override;
+};
+
+} // end of namespace lbann
+#endif // LBANN_HAS_OPENCV
+
+#endif // LBANN_CV_RESIZER_HPP

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -8,6 +8,7 @@ set_full_path(THIS_DIR_SOURCES
   cv_normalizer.cpp
   cv_process.cpp
   cv_process_patches.cpp
+  cv_resizer.cpp
   cv_subtractor.cpp
   cv_transform.cpp
   cv_utils.cpp

--- a/src/data_readers/cv_resizer.cpp
+++ b/src/data_readers/cv_resizer.cpp
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// cv_resizer .cpp .hpp - Functions to resize images
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/data_readers/cv_resizer.hpp"
+#include "lbann/utils/exception.hpp"
+#include <algorithm>
+#include <ostream>
+
+#ifdef LBANN_HAS_OPENCV
+namespace lbann {
+
+const int cv_resizer::m_interpolation_choices[3] = {cv::INTER_LINEAR, cv::INTER_AREA, cv::INTER_LINEAR};
+
+cv_resizer::cv_resizer()
+  : cv_transform(), m_width(0u), m_height(0u),
+    m_interpolation(m_interpolation_choices[0]),
+    m_adaptive_interpolation(false) {}
+
+
+cv_resizer *cv_resizer::clone() const {
+  return new cv_resizer(*this);
+}
+
+void cv_resizer::set(const unsigned int width, const unsigned int height,
+                     const bool adaptive_interpolation) {
+  reset();
+  m_width = width;
+  m_height = height;
+  m_adaptive_interpolation = adaptive_interpolation;
+
+  if ((m_width == 0u) || (m_height == 0u)) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: cv_resizer: invalid size of the resized image";
+    throw lbann_exception(err.str());
+  }
+}
+
+void cv_resizer::reset() {
+  m_enabled = false; 
+  m_interpolation = m_interpolation_choices[0];
+}
+
+bool cv_resizer::determine_transform(const cv::Mat& image) {
+  m_enabled = false; //sufficient for now in place of reset();
+
+  if (image.empty()) {
+    throw lbann_exception("cv_resizer::determine_transform : empty image.");
+  }
+
+  const double zoom = image.cols * image.rows / static_cast<double>(m_width * m_height);
+
+  if (zoom <= 1.0) { // shirinking
+    m_interpolation =  m_interpolation_choices[static_cast<int>(m_adaptive_interpolation)];
+  } else { // enlarging
+    m_interpolation =  m_interpolation_choices[static_cast<int>(m_adaptive_interpolation) << 1];
+  }
+
+  return (m_enabled = true);
+}
+
+bool cv_resizer::apply(cv::Mat& image) {
+  m_enabled = false; // turn off as it is applied
+
+  cv::Mat image_new;
+  cv::resize(image, image_new, cv::Size(m_width, m_height), 0, 0, m_interpolation);
+  image = image_new;
+
+  return true;
+}
+
+std::string cv_resizer::get_description() const {
+  std::stringstream os;
+  os << get_type() + ":" << std::endl
+     << " - desired size: " << m_width  << "x" << m_height << std::endl
+     << " - adaptive interpolation: " << m_adaptive_interpolation << std::endl;
+  return os.str();
+}
+
+std::ostream& cv_resizer::print(std::ostream& os) const {
+  os << get_description()
+     << " - interpolation: ";
+  switch(m_interpolation) {
+    case cv::INTER_LINEAR: os << "INTER_LINEAR" << std::endl; break;
+    case cv::INTER_CUBIC:  os << "INTER_CUBIC" << std::endl; break;
+    case cv::INTER_AREA:   os << "INTER_AREA" << std::endl; break;
+    default: os << "unrecognized" << std::endl; break;
+  }
+  return os;
+}
+
+} // end of namespace lbann
+#endif // LBANN_HAS_OPENCV
+

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -73,6 +73,14 @@ message ImagePreprocessor {
     bool adaptive_interpolation = 8;
   }
 
+  message Resizer {
+    string name = 1;
+    bool disable = 2;
+    int32 resized_width = 3;
+    int32 resized_height = 4;
+    bool adaptive_interpolation = 5;
+  }
+
   message Augmenter {
     string name = 1;
     bool disable = 2;
@@ -131,6 +139,7 @@ message ImagePreprocessor {
   }
 
   Cropper cropper = 5;
+  Resizer resizer = 34;
   Augmenter augmenter = 6;
   Decolorizer decolorizer = 7;
   Colorizer colorizer = 8;

--- a/tests/test_img_pipeline/CMakeLists.txt
+++ b/tests/test_img_pipeline/CMakeLists.txt
@@ -66,6 +66,7 @@ file(GLOB IMGPIPE_DEPEND_SRCS
      ${LBANN_DIR}/src/data_readers/cv_normalizer.cpp
      ${LBANN_DIR}/src/data_readers/cv_process.cpp
      ${LBANN_DIR}/src/data_readers/cv_process_patches.cpp
+     ${LBANN_DIR}/src/data_readers/cv_resizer.cpp
      ${LBANN_DIR}/src/data_readers/cv_subtractor.cpp
      ${LBANN_DIR}/src/data_readers/cv_transform.cpp
      ${LBANN_DIR}/src/data_readers/cv_utils.cpp

--- a/tests/test_patchworks/CMakeLists.txt
+++ b/tests/test_patchworks/CMakeLists.txt
@@ -66,6 +66,7 @@ file(GLOB PATCHWORKS_DEPEND_SRCS
      ${LBANN_DIR}/src/data_readers/cv_normalizer.cpp
      ${LBANN_DIR}/src/data_readers/cv_process.cpp
      ${LBANN_DIR}/src/data_readers/cv_process_patches.cpp
+     ${LBANN_DIR}/src/data_readers/cv_resizer.cpp
      ${LBANN_DIR}/src/data_readers/cv_subtractor.cpp
      ${LBANN_DIR}/src/data_readers/cv_transform.cpp
      ${LBANN_DIR}/src/data_readers/cv_utils.cpp


### PR DESCRIPTION
This PR implements the feature referred in issue #407.
It allows simple image resizing while preserving the context from the original image even if distorting the aspect ratio. My initial plan was to keep it in my private branch, but I decided to create a PR as merging will make Luke's work easier. The decision is up to the reviewer.