### PR TITLE
siamse minor updates

### DIFF
--- a/model_zoo/models/siamese/finetune-cub/model_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub.prototext
@@ -545,7 +545,7 @@ model {
     fully_connected {
       # The number of outputs specific to the dataset used.
       # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons: 200
+      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
@@ -340,7 +340,7 @@ model {
 
   layer {
     name: "data_new"
-    children: "conv1_head0 target"
+    children: "conv1_head0 target_new"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
@@ -688,7 +688,7 @@ model {
     fully_connected {
       # The number of outputs specific to the dataset used.
       # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons: 200
+      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet.prototext
@@ -6,7 +6,7 @@ model {
   data_layout: "data_parallel"
   mini_batch_size: 128
   block_size: 256
-  num_epochs: 20
+  num_epochs: 1
   num_parallel_readers: 0
   procs_per_model: 0
 
@@ -655,7 +655,7 @@ model {
     children: "prob"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons: 20
+      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc9_linearity fc9_bias"

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm.prototext
@@ -6,7 +6,7 @@ model {
   data_layout: "data_parallel"
   mini_batch_size: 128
   block_size: 256
-  num_epochs: 20
+  num_epochs: 1
   num_parallel_readers: 0
   procs_per_model: 0
 
@@ -720,7 +720,7 @@ model {
     children: "prob"
     data_layout: "data_parallel"
     fully_connected {
-      num_neurons: 20
+      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc9_linearity fc9_bias"

--- a/src/data_readers/cv_process.cpp
+++ b/src/data_readers/cv_process.cpp
@@ -220,11 +220,10 @@ bool cv_process::preprocess(cv::Mat& image, unsigned int tr_start, unsigned int 
   // differently from other transforms. However, if a subtractor is used as a
   // normalizer, it is treated as an ordinary transform.
 
-  const bool lazy_normalization = to_fuse_normalizer_with_copy();
+  const unsigned int num_trs = static_cast<unsigned int>(m_transforms.size());
+  const bool lazy_normalization = (tr_end == num_trs) && to_fuse_normalizer_with_copy();
   const unsigned int n_immediate_transforms 
-      = std::min((lazy_normalization?
-                  m_normalizer_idx : static_cast<unsigned int>(m_transforms.size())),
-                 tr_end);
+      = std::min((lazy_normalization?  m_normalizer_idx : num_trs), tr_end);
 
   for (size_t i = tr_start; i < n_immediate_transforms; ++i) {
     if (m_transforms[i]->determine_transform(image)) {


### PR DESCRIPTION
- Fix the typo in a layer name in a prototext file, introduced during the io_layer refactor: target -> target_new
- Take advantage of 'num_neurons_is_num_labels'. In this way, the model prototext for cub data can be reused for compcars data without any modification.
- Avoid redundant normalization parameter computation. This only affects the performance of the Siamese runs with on-line patch generation.