### PR TITLE
updates per Sam and Tim's comments and requests.

### DIFF
--- a/viz/layer.py
+++ b/viz/layer.py
@@ -15,6 +15,9 @@ class Layer :
       if line.find('{') != -1 :
         t = line.split()
         self._type = t[0]
+        j = self._type.find('{')
+        if j != -1 :
+          self._type = self._type[:j]
     for line in self._layer :
       if line.find('parents:') != -1 :
         t = line.replace('"', '')

--- a/viz/properties.py
+++ b/viz/properties.py
@@ -19,7 +19,7 @@ class properties :
     for j in range(len(a)) :
       if a[j].find('layer_names_and_overrides') != -1 :
         k = j+1
-        while len(a[k]) > 3 :
+        while k < len(a) and len(a[k]) > 3 :
           t = a[k].split()
           layer_type = t[0]
           layer_name = t[1]
@@ -35,24 +35,33 @@ class properties :
 
   def shape(self, name) :
     if not self._layers.has_key(name) :
-      print 'Nothing known about this layer:', name
+      return 'rect'
+      '''
+      print 'shape(): Nothing known about this layer:', name
       print 'Please check your properties file'
       print
       exit(0)
+      '''
     return self._layers[name][0]
 
   def color(self, name) :
     if not self._layers.has_key(name) :
-      print 'Nothing known about this layer:', name
+      return 'grey'
+      '''
+      print 'color(): Nothing known about this layer:', name
       print 'Please check your properties file'
       print
       exit(0)
+      '''
     return self._layers[name][1]
 
   def arrow(self, name) :
     if not self._layers.has_key(name) :
-      print 'Nothing known about this layer:', name
+      return 'grey'
+      '''
+      print 'arrow(): Nothing known about this layer:', name
       print 'Please check your properties file'
       print
       exit(0)
+      '''
     return self._layers[name][2]

--- a/viz/properties.txt
+++ b/viz/properties.txt
@@ -1,5 +1,5 @@
 #
-# shapes: http://www.graphviz.org/content/node-shapes
+# shapes: https://graphviz.gitlab.io/_pages/doc/info/shapes.html
 # color names: http://www.graphviz.org/doc/info/colors.html
 #
 # I found this tutorial useful: http://tonyballantyne.com/graphs.html
@@ -65,4 +65,3 @@ transform    discrete_random
 transform    stop_gradient
 transform    max
 transform    min
-

--- a/viz/viz.py
+++ b/viz/viz.py
@@ -43,7 +43,7 @@ def parsePrototext(fn) :
   a = open(fn).readlines()
   r = []
   for j in range(len(a)) :
-    if a[j].find('layer {') != -1 and a[j].find('#') == -1 :
+    if (a[j].find('layer {') != -1 or a[j].find('layer{') != -1) and a[j].find('#') == -1 :
       r.append(Layer(a[j:]))
   return r
 


### PR DESCRIPTION
This PR attempts to update viz.py to deal with evolving changes in our prototext
format (lbann.proto). Nikoli pointed out that we perhaps should use the python bindings 
for viz, instead of my rather hacky hand-parsing. The problem with
Nikoli's suggestion is that viz.py would then need to be updated whenever
layers and their attributes in lbann.proto were added or modified. If lbann
ever becomes relatively stable, then yes, we should do so.

Specific changes:

Add support to display all attributes of layers. Note: due to evolving
changes in lbann.proto, some attributes failed to be printed when the
cmd option full=1 was given

viz.py would crash unless there was a blank line at the end of properties.txt;
this has been fixed

viz.py would crash if there was a space missing before '{', eg, "layer{'
or "elu{". This has been fixed (... but its sort of a hack).

If a layer type did not appear in properties.txt viz.py would crash.
Now the layer is printed as a grey rectangle. (Hence, if you see a grey rectangle,
take it as a reminder that you should update properties.txt)
