### PR TITLE
Trying to fix performance regression.

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -293,8 +293,8 @@ class base_convolution_layer : public learning_layer {
                                                 cudnn::get_data_type()));
 
     // Set bias tensor descriptor
-    std::vector<int> bias_dims(get_num_neuron_dims(), 1);
-    bias_dims[0] = get_neuron_dims()[0];
+    std::vector<int> bias_dims(get_num_neuron_dims() + 1, 1);
+    bias_dims[1] = get_neuron_dims()[0];
     cudnn::set_tensor_desc(m_bias_cudnn_desc, bias_dims);
 
   #endif // LBANN_HAS_CUDNN

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ set_full_path(THIS_DIR_HEADERS
   glob.hpp
   im2col.hpp
   mild_exception.hpp
+  number_theory.hpp
   omp_diagnostics.hpp
   options.hpp
   prototext.hpp

--- a/include/lbann/utils/number_theory.hpp
+++ b/include/lbann/utils/number_theory.hpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_NUMBER_THEORY_HPP
+#define LBANN_UTILS_NUMBER_THEORY_HPP
+
+#include <vector>
+
+namespace lbann {
+namespace number_theory {
+
+/** Get prime number.
+ *  Indices are zero-indexed, so prime(0) is 2, prime(1) is 3, and so
+ *  on. Results are cached for future function calls.
+ */
+int prime(int n);
+
+/** Get prime factorization of n.
+ *  Prime factors are sorted in ascending order.
+ */
+std::vector<int> prime_factors(int n);
+
+/** Get balanced factorization of n.
+ *  Factors are sorted in ascending order. The factors should be as
+ *  close as possible.
+ */
+std::vector<int> balanced_factors(int n, int num_factors);
+
+} // namespace number_theory
+} // lbann
+
+#endif // LBANN_UTILS_NUMBER_THEORY_HPP

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
   file_utils.cpp
   graph.cpp
   im2col.cpp
+  number_theory.cpp
   omp_diagnostics.cpp
   options.cpp
   protobuf_utils.cpp

--- a/src/utils/cudnn_wrapper.cpp
+++ b/src/utils/cudnn_wrapper.cpp
@@ -27,6 +27,7 @@
 #include "lbann/utils/cudnn_wrapper.hpp"
 #include "lbann/utils/cublas_wrapper.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/number_theory.hpp"
 
 #include <iostream>
 #include <unordered_map>
@@ -454,41 +455,6 @@ entrywise_layer_tensor_manager
 
 namespace {
 
-/** Factor integer into three factors.
- *  The three factors should be as close as possible. This
- *  implementation is very crude.
- */
-std::tuple<int,int,int> cube_factorize(int n) {
-  static std::unordered_map<int,std::tuple<int,int,int>> past_factors;
-  
-  // Return trivial or known factorizations
-  if (n <= 1) { return std::tuple<int,int,int>(1, 1, 1); }
-  if (past_factors.count(n) > 0) { return past_factors[n]; }
-
-  // Compute prime factorization
-  std::vector<int> prime_factors;
-  for (int i = 2; n > 1; ++i) {
-    while (n % i == 0) {
-      prime_factors.push_back(i);
-      n /= i;
-    }
-  }
-  
-  // Construct three factors from primes
-  int a = 1, b = 1, c = 1;
-  const int num_prime_factors = prime_factors.size();
-  for (int i = num_prime_factors - 1; i >= 0; --i) {
-    a *= prime_factors[i];
-    if (b < a) { std::swap(a, b); }
-    if (c < b) { std::swap(b, c); }
-  }
-
-  // Record factorization and return result
-  past_factors[n] = std::tuple<int,int,int>(a, b, c);
-  return std::tuple<int,int,int>(a, b, c);
-
-}
-
 /** Set a cuDNN tensor descriptor for an entrywise tensor operation.
  *  Given local data in a (height x width) matrix, the tensor is
  *  initialized with dimensions (width, a, b, c), where
@@ -506,11 +472,20 @@ void set_entrywise_tensor_desc(cudnnTensorDescriptor_t& desc,
   const int width = local_data.Width();
   const int ldim = local_data.LDim();
   if (height > 0 && width > 0) {
-    const auto& factors = cube_factorize(height);
-    const auto& a = std::get<0>(factors);
-    const auto& b = std::get<1>(factors);
-    const auto& c = std::get<2>(factors);
-    set_tensor_desc(desc, {width, c, b, a}, {ldim, a*b, a, 1});
+
+    // Factorize height into three factors
+    // Note: factorization is memoized
+    static std::unordered_map<int,std::vector<int>> cache;
+    auto& factors = cache[height];
+    if (factors.empty()) {
+      factors = number_theory::balanced_factors(height, 3);
+    }
+
+    // Set cuDNN tensor descriptor with 4D tensor
+    set_tensor_desc(desc,
+                    {width, factors[2], factors[1], factors[0]},
+                    {ldim, factors[1]*factors[0], factors[0], 1});
+
   }
 }
 

--- a/src/utils/number_theory.cpp
+++ b/src/utils/number_theory.cpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/number_theory.hpp"
+#include "lbann/utils/exception.hpp"
+#include <algorithm>
+#include <unordered_map>
+
+namespace lbann {
+namespace number_theory {
+
+int prime(int n) {
+  if (n < 0) { 
+    std::stringstream err;
+    err << "invalid index (" << n << ")";
+    LBANN_ERROR(err.str());
+  }
+  if (n == 0) { return 2; }
+
+  // Expand list of odd primes if needed
+  // Note: Odd primes are cached for future function calls. We iterate
+  // through odd numbers and check whether they have any prime
+  // divisors. The smallest prime divisor of a composite number q must
+  // be less than or equal to sqrt(q).
+  static std::vector<int> cache = {3};
+  for (int q = cache.back() + 2;
+       n-1 >= (int) cache.size();
+       q += 2) {
+    for (const auto& p : cache) {
+      if (q % p == 0) { break; }
+      if (p * p > q) {
+        cache.push_back(q);
+        break;
+      }
+    }
+  }
+
+  // Return cached prime
+  return cache[n-1];
+
+}
+
+std::vector<int> prime_factors(int n) {
+  if (n < 2) { 
+    std::stringstream err;
+    err << "invalid number to factorize (" << n << ")";
+    LBANN_ERROR(err.str());
+  }
+  std::vector<int> factors;
+  for (int i = 0; n > 1; ++i) {
+    const auto& p = prime(i);
+    while (n % p == 0) {
+      factors.push_back(p);
+      n /= p;
+    }
+  }
+  return factors;
+}
+
+std::vector<int> balanced_factors(int n, int num_factors) {
+  std::stringstream err;
+  if (n < 1) {
+    err << "invalid number to factorize (" << n << ")";
+    LBANN_ERROR(err.str());
+  }
+  if (num_factors < 1) {
+    err << "invalid number of factors (" << num_factors << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Get prime factorization
+  const auto& primes = prime_factors(n);
+
+  // Compute balanced factors
+  /// @todo Non-greedy algorithm
+  std::vector<int> factors(num_factors, 1);
+  for (int i = primes.size() - 1; i >= 0; --i) {
+    factors.front() *= primes[i];
+    std::inplace_merge(factors.begin(),
+                       factors.begin()+1,
+                       factors.end());
+  }
+  return factors;
+
+}
+
+} // namespace number_theory
+} // lbann


### PR DESCRIPTION
@ndryden has traced a performance regression in Resnet50 to #405. @samadejacobs has also observed a performance regression on Catalyst.

Changes:
- Initialize cuDNN tensors as 4D tensors whenever possible. My profiling shows that cuDNN ReLU gets poor performance on 1D and 2D tensors, often taking longer than convolution. `cudnn::entrywise_layer_tensor_manager` constructs a 4D tensor by factoring the local matrix height into three factors.