### PR TITLE
Updated the I/O layers so that they can take a N/A (not applicable)

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -122,7 +122,8 @@ enum class pool_mode {invalid, max, average, average_no_pad};
 /** returns a string representation of the pool_mode */
 std::string get_pool_mode_name(pool_mode m);
 
-enum class data_reader_target_mode {CLASSIFICATION, REGRESSION, RECONSTRUCTION};
+// NA - Not applicable, used for input layers that don't produce a second output
+enum class data_reader_target_mode {CLASSIFICATION, REGRESSION, RECONSTRUCTION, NA};
 
 namespace lbann {
 

--- a/include/lbann/io/data_buffers/generic_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/generic_io_buffer.hpp
@@ -48,12 +48,27 @@ class fetch_data_functor {
       El::Copy(samples, responses);
       num_responses_fetched = num_samples_fetched;
       break;
+    case data_reader_target_mode::NA:
+       throw lbann_exception("Invalid data reader target mode");
     case data_reader_target_mode::CLASSIFICATION:
     default:
       num_responses_fetched = data_reader->fetch_labels(responses);
     }
     if(num_samples_fetched != num_responses_fetched) {
       throw lbann_exception("Number of samples does not match the number of responses");
+    }
+    return num_samples_fetched;
+  }
+  int operator() (CPUMat& samples, generic_data_reader* data_reader) const {
+    int num_samples_fetched = data_reader->fetch_data(samples);
+    switch(_target_mode) {
+    case data_reader_target_mode::NA:
+      break;
+    case data_reader_target_mode::REGRESSION:
+    case data_reader_target_mode::RECONSTRUCTION:
+    case data_reader_target_mode::CLASSIFICATION:
+    default:
+      throw lbann_exception("Invalid data reader target mode");
     }
     return num_samples_fetched;
   }

--- a/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
@@ -36,7 +36,7 @@ namespace lbann {
  */
 class partitioned_io_buffer : public generic_io_buffer {
  public:
-  partitioned_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers);
+  partitioned_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers, int num_child_layers);
   partitioned_io_buffer(
     const partitioned_io_buffer&) = default;
   partitioned_io_buffer& operator=(

--- a/include/lbann/layers/io/input/repeated_input_layer.hpp
+++ b/include/lbann/layers/io/input/repeated_input_layer.hpp
@@ -59,7 +59,8 @@ class repeated_input_layer : public input_layer<partitioned_io_buffer, data_layo
 
     m_label_io_buffer = new partitioned_io_buffer(comm,
                                                   num_parallel_readers,
-                                                  data_readers);
+                                                  data_readers,
+                                                  m_expected_num_child_layers);
     m_label_io_buffer->fetch_data_fn = new fetch_data_functor(target_mode);
     m_label_io_buffer->update_data_reader_fn = new update_data_reader_functor();
 

--- a/model_zoo/models/jag/cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m1.prototext
@@ -26,6 +26,7 @@ model {
   layer {
     input {
       io_buffer: "partitioned"
+      target_mode: "N/A"
     }
     name: "data"
     data_layout: "data_parallel"

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
@@ -18,6 +18,7 @@ model {
   layer {
     input {
       io_buffer: "partitioned"
+      target_mode: "N/A"
     }
     name: "data"
     data_layout: "data_parallel"

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
@@ -18,6 +18,7 @@ model {
   layer {
     input {
       io_buffer: "partitioned"
+      target_mode: "N/A"
     }
     name: "data"
     data_layout: "data_parallel"

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -46,6 +46,7 @@ Layer* construct_layer(lbann_comm* comm,
     if (mode_str.empty() || mode_str == "classification") { target_mode = data_reader_target_mode::CLASSIFICATION; }
     if (mode_str == "regression")                         { target_mode = data_reader_target_mode::REGRESSION; }
     if (mode_str == "reconstruction")                     { target_mode = data_reader_target_mode::RECONSTRUCTION; }
+    if (mode_str == "na" || mode_str == "NA" || mode_str == "N/A") { target_mode = data_reader_target_mode::NA; }
     if (io_buffer == "distributed") {
       return new input_layer<distributed_io_buffer, layout, Dev>(comm,
                                                                  num_parallel_readers,


### PR DESCRIPTION
mode for the data reader target mode.  This allows the input layers to
have a single output and not call the data reader
get_linearized_[label|response]_size function.  The CycleGAN networks
use this mode.