### PR TITLE
add key filtering mechanisms to jag_conduit data reader

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -59,6 +59,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   enum variable_t {Undefined=0, JAG_Image, JAG_Scalar, JAG_Input};
   using TypeID = conduit::DataType::TypeID;
 
+  /// Type to define a prefix string and the minimum length requirement to filter out a key
+  using prefix_t = std::pair<std::string, size_t>;
+
   data_reader_jag_conduit(bool shuffle = true) = delete;
   data_reader_jag_conduit(const std::shared_ptr<cv_process>& pp, bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&);
@@ -82,6 +85,15 @@ class data_reader_jag_conduit : public generic_data_reader {
 
   /// Set the image dimension
   void set_image_dims(const int width, const int height, const int ch = 1);
+
+  /// Add a scalar key to filter out
+  void add_scalar_filter(const std::string& key);
+  /// Add a scalar key prefix to filter out
+  void add_scalar_prefix_filter(const prefix_t& p);
+  /// Add an input key to filter out
+  void add_input_filter(const std::string& key);
+  /// Add an input key prefix to filter out
+  void add_input_prefix_filter(const prefix_t& p);
 
   /// Select the set of scalar output variables to use
   void set_scalar_choices(const std::vector<std::string>& keys);
@@ -177,10 +189,15 @@ class data_reader_jag_conduit : public generic_data_reader {
   virtual bool replicate_processor(const cv_process& pp);
   virtual void copy_members(const data_reader_jag_conduit& rhs);
 
+
   /// add data type for independent variable
   void add_independent_variable_type(const variable_t independent);
   /// add data type for dependent variable
   void add_dependent_variable_type(const variable_t dependent);
+
+  /// Check if a key is in the black lists to filter out
+  bool filter(const std::set<std::string>& filter,
+              const std::vector<prefix_t>& prefix_filter, const std::string& name) const;
 
   /// Return the linearized size of a particular JAG variable type
   size_t get_linearized_size(const variable_t t) const;
@@ -274,6 +291,15 @@ class data_reader_jag_conduit : public generic_data_reader {
    * we can rely on a data extraction method with lower overhead.
    */
   bool m_uniform_input_type;
+
+  /// The set of scalar variables to filter out
+  std::set<std::string> m_scalar_filter;
+  /// The list of scalar key prefixes to filter out
+  std::vector<prefix_t> m_scalar_prefix_filter;
+  /// The set of input variables to filter out
+  std::set<std::string> m_input_filter;
+  /// The list of input key prefixes to filter out
+  std::vector<prefix_t> m_input_prefix_filter;
 };
 
 

--- a/model_zoo/models/jag/data_reader_jag_conduit.prototext
+++ b/model_zoo/models/jag/data_reader_jag_conduit.prototext
@@ -40,6 +40,16 @@ data_reader {
 #        "MINradius"
       ]
 
+    # When using all the keys without explicit selection, key filters can be used
+    # to explicitly exclude the particular variables with keys that matches a filter.
+    # 'jag_scalar_filters' and 'jag_input_filters' rely on exact key string matching.
+    # 'jag_scalar_prefix_filters' and 'jag_input_prefix_filters' define a filter as
+    # the pair of a prefix substring and the minimum key length.
+    # For example, with the example below, any key that has a length no shorter
+    # than 27 and starts with the substring "image_[" is excluded.
+
+    jag_scalar_prefix_filters: [ { key_prefix: "image_[" min_len: 27} ]
+
     # The parameter "shape_model_initial_velocities" is used in numpy-based format but empty in conduit-based format
     jag_input_keys: ["stopping_mult",
                      "radiation_mult",
@@ -48,6 +58,8 @@ data_reader {
                      "conduction_mult",
                      "shape_model_initial_velocity_amplitude"
                     ];
+
+    jag_input_filters: ["shape_model_initial_velocity"]
 
     num_labels: 6
 
@@ -122,6 +134,8 @@ data_reader {
 #        "MINradius"
       ]
 
+    jag_scalar_prefix_filters: [ { key_prefix: "image_[" min_len: 27} ]
+
     jag_input_keys: ["stopping_mult",
                      "radiation_mult",
                      "ablation_cv",
@@ -129,6 +143,8 @@ data_reader {
                      "conduction_mult",
                      "shape_model_initial_velocity_amplitude"
                     ];
+
+    jag_input_filters: ["shape_model_initial_velocity"]
 
     num_labels: 6
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -163,6 +163,10 @@ void data_reader_jag_conduit::set_defaults() {
   m_scalar_keys.clear();
   m_input_keys.clear();
   m_uniform_input_type = false;
+  m_scalar_filter.clear();
+  m_scalar_prefix_filter.clear();
+  m_input_filter.clear();
+  m_input_prefix_filter.clear();
 }
 
 /// Replicate image processor for each OpenMP thread
@@ -266,7 +270,7 @@ void data_reader_jag_conduit::add_scalar_filter(const std::string& key) {
 }
 
 void data_reader_jag_conduit::add_scalar_prefix_filter(const prefix_t& p) {
-  m_scalar_prefix_filter.push_back(p);
+  m_scalar_prefix_filter.push_back((p.first.length() > p.second)? prefix_t(p.first, p.first.length()) : p);
 }
 
 void data_reader_jag_conduit::add_input_filter(const std::string& key) {
@@ -274,7 +278,7 @@ void data_reader_jag_conduit::add_input_filter(const std::string& key) {
 }
 
 void data_reader_jag_conduit::add_input_prefix_filter(const prefix_t& p) {
-  m_input_prefix_filter.push_back(p);
+  m_input_prefix_filter.push_back((p.first.length() > p.second)? prefix_t(p.first, p.first.length()) : p);
 }
 
 /**
@@ -708,6 +712,34 @@ std::string data_reader_jag_conduit::get_description() const {
     + " - scalars: "  + std::to_string(get_linearized_scalar_size()) + "\n"
     + " - inputs: "   + std::to_string(get_linearized_input_size()) + "\n"
     + " - uniform_input_type: " + (m_uniform_input_type? "true" : "false") + '\n';
+  if (!m_scalar_filter.empty()) {
+    ret += " - scalar filter:";
+    for (const auto& f: m_scalar_filter) {
+      ret += " \"" + f + '"';
+    }
+    ret += '\n';
+  }
+  if (!m_scalar_prefix_filter.empty()) {
+    ret += " - scalar prefix filter:";
+    for (const auto& f: m_scalar_prefix_filter) {
+      ret += " [\"" + f.first + "\" " + std::to_string(f.second) + ']';
+    }
+    ret += '\n';
+  }
+  if (!m_input_filter.empty()) {
+    ret += " - input filter:";
+    for (const auto& f: m_input_filter) {
+      ret += " \"" + f + '"';
+    }
+    ret += '\n';
+  }
+  if (!m_input_prefix_filter.empty()) {
+    ret += " - input prefix filter:";
+    for (const auto& f: m_input_prefix_filter) {
+      ret += " [\"" + f.first + "\" " + std::to_string(f.second) + ']';
+    }
+    ret += '\n';
+  }
   return ret;
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -323,10 +323,8 @@ void data_reader_jag_conduit::set_all_scalar_choices() {
   }
   const conduit::Node & n_scalar = get_conduit_node("0/outputs/scalars");
   m_scalar_keys.reserve(n_scalar.number_of_children());
-  conduit::NodeConstIterator itr = n_scalar.children();
-  while (itr.has_next()) {
-    itr.next();
-    const std::string key = itr.name();
+  const std::vector<std::string>& child_names = n_scalar.child_names();
+  for (const auto& key: child_names) {
     if (filter(m_scalar_filter, m_scalar_prefix_filter, key)) {
       continue;
     }
@@ -360,10 +358,8 @@ void data_reader_jag_conduit::set_all_input_choices() {
   }
   const conduit::Node & n_input = get_conduit_node("0/inputs");
   m_input_keys.reserve(n_input.number_of_children());
-  conduit::NodeConstIterator itr = n_input.children();
-  while (itr.has_next()) {
-    itr.next();
-    const std::string key = itr.name();
+  const std::vector<std::string>& child_names = n_input.child_names();
+  for (const auto& key: child_names) {
     if (filter(m_input_filter, m_input_prefix_filter, key)) {
       continue;
     }
@@ -439,15 +435,14 @@ void data_reader_jag_conduit::check_scalar_keys() {
     return;
   }
 
-  const conduit::Node & n_scalar = get_conduit_node("0/outputs/scalars");
-  conduit::NodeConstIterator itr = n_scalar.children();
   size_t num_found = 0u;
   std::vector<bool> found(m_scalar_keys.size(), false);
   std::set<std::string> keys_conduit;
 
-  while (itr.has_next()) {
-    itr.next();
-    keys_conduit.insert(itr.name());
+  const conduit::Node & n_scalar = get_conduit_node("0/outputs/scalars");
+  const std::vector<std::string>& child_names = n_scalar.child_names();
+  for (const auto& key: child_names) {
+    keys_conduit.insert(key);
   }
 
   for (size_t i=0u; i < m_scalar_keys.size(); ++i) {
@@ -476,11 +471,12 @@ void data_reader_jag_conduit::check_input_keys() {
     return;
   }
 
-  const conduit::Node & n_input = get_conduit_node("0/inputs");
-  conduit::NodeConstIterator itr = n_input.children();
   size_t num_found = 0u;
   std::vector<bool> found(m_input_keys.size(), false);
   std::map<std::string, TypeID> keys_conduit;
+
+  const conduit::Node & n_input = get_conduit_node("0/inputs");
+  conduit::NodeConstIterator itr = n_input.children();
 
   while (itr.has_next()) {
     const conduit::Node & n = itr.next();

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -372,6 +372,36 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
       reader_jag->set_input_choices(input_keys);
     }
 
+    // add scalar output keys to filter out
+    const int num_scalar_filters = pb_readme.jag_scalar_filters_size();
+    for (int i=0; i < num_scalar_filters; ++i) {
+      reader_jag->add_scalar_filter(pb_readme.jag_scalar_filters(i));
+    }
+
+    // add scalar output key prefixes to filter out by
+    const int num_scalar_prefix_filters = pb_readme.jag_scalar_prefix_filters_size();
+    for (int i=0; i < num_scalar_prefix_filters; ++i) {
+      using prefix_t = lbann::data_reader_jag_conduit::prefix_t;
+      const prefix_t pf = std::make_pair(pb_readme.jag_scalar_prefix_filters(i).key_prefix(),
+                                         pb_readme.jag_scalar_prefix_filters(i).min_len());
+      reader_jag->add_scalar_prefix_filter(pf);
+    }
+
+    // add input parameter keys to filter out
+    const int num_input_filters = pb_readme.jag_input_filters_size();
+    for (int i=0; i < num_input_filters; ++i) {
+      reader_jag->add_input_filter(pb_readme.jag_input_filters(i));
+    }
+
+    // add scalar output key prefixes to filter out by
+    const int num_input_prefix_filters = pb_readme.jag_input_prefix_filters_size();
+    for (int i=0; i < num_input_prefix_filters; ++i) {
+      using prefix_t = lbann::data_reader_jag_conduit::prefix_t;
+      const prefix_t pf = std::make_pair(pb_readme.jag_scalar_prefix_filters(i).key_prefix(),
+                                         pb_readme.jag_scalar_prefix_filters(i).min_len());
+      reader_jag->add_input_prefix_filter(pf);
+    }
+
     reader = reader_jag;
     if (master) std::cout << reader->get_type() << " is set" << std::endl;
     return;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -19,7 +19,7 @@ message DataReader {
 
 message Reader {
   string name = 1; //mnist, nci, nci_regression, numpy, imagenet, synthetic, merge_samples
-  string role = 3; //train, test
+  string role = 3; //train, validation, test
   bool shuffle = 4;
   string data_filedir = 5;
   string data_local_filedir = 50; //to support data_store
@@ -33,10 +33,22 @@ message Reader {
   bool gan_labelling = 201;
   int32 gan_label_value = 202;
   ImagePreprocessor image_preprocessor = 13;
-  repeated string jag_scalar_keys = 95; // only for jag
-  repeated string jag_input_keys = 96; // only for jag
-  repeated int32 independent = 97; // only for jag
-  repeated int32 dependent = 98; // only for jag
+
+  //------------------ start of only for jag_conduit -----------------------
+  repeated string jag_scalar_keys = 91;
+  repeated string jag_input_keys = 92;
+  message JagKeyPrefixFilter {
+    string key_prefix = 1;
+    uint32 min_len = 2;
+  }
+  repeated string jag_scalar_filters = 93;
+  repeated JagKeyPrefixFilter jag_scalar_prefix_filters = 94;
+  repeated string jag_input_filters = 95;
+  repeated JagKeyPrefixFilter jag_input_prefix_filters = 96;
+  repeated int32 independent = 97;
+  repeated int32 dependent = 98;
+  //------------------  end of only for jag_conduit  -----------------------
+
   int32 num_labels = 99; //for imagenet
   int64 num_samples = 100; //only for synthetic
   int64 num_features = 101; //only for synthetic


### PR DESCRIPTION
Add two mechanisms to filter out certain keys with the default mode, which selects all the variables. One is by the exact string matching, and the other is by prefix substring matching. Users can express such a negative selection in the prototext of the jag_conduit data reader. Especially, "jag_scalar_filters" and "jag_input_filters" rely on the former. "jag_scalar_prefix_filters" and "jag_input_prefix_filters" rely on the latter.

For example, the line below will screen out the jag scalar variables with either of the "key1" or "key2".
jag_scalar_filters: ["key1", "key2"]

Given the line below, any variable of the key that has a length no shorter than 27 and starts with the substring "image_[" is excluded.

jag_scalar_prefix_filters: [ { key_prefix: "image_["  min_len: 27} ]
