### PR TITLE
Skip single-GPU allreduces

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -143,6 +143,9 @@ void lbann_comm::intermodel_sum_matrix(AbsDistMat& mat) {
 void lbann_comm::allreduce(AbsDistMat& m,
                            const El::mpi::Comm c,
                            El::mpi::Op op) {
+  if (El::mpi::Size(c) == 1) {
+    return;  // Can skip allreduce on one rank.
+  }
   const int local_size = m.LocalHeight() * m.LocalWidth();
   bytes_sent += sizeof(DataType) * local_size;
 #ifdef LBANN_HAS_ALUMINUM
@@ -191,6 +194,9 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
                               const El::mpi::Comm c,
                               Al::request& req,
                               El::mpi::Op op) {
+  if (El::mpi::Size(c) == 1) {
+    return;  // Can skip allreduce on one rank.
+  }
 #ifdef LBANN_HAS_ALUMINUM
   const int local_size = m.LocalHeight() * m.LocalWidth();
   bytes_sent += sizeof(DataType) * local_size;


### PR DESCRIPTION
The allreduces should internally be skipping communication, but this also avoids unneeded stream syncs.