### PR TITLE
Finer-grained NCCL streams

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -63,6 +63,13 @@ lbann_comm::lbann_comm(int ppm, const El::mpi::Comm world) :
   int argc_dummy = 0;
   char** argv_dummy = nullptr;
   ::Al::Initialize(argc_dummy, argv_dummy);
+#ifdef AL_HAS_NCCL
+  for (int i = 0; i < m_num_al_nccl_streams; ++i) {
+    CHECK_CUDA(cudaStreamCreate(&m_al_nccl_streams[i]));
+  }
+  CHECK_CUDA(cudaEventCreateWithFlags(&m_al_nccl_sync_event,
+                                      cudaEventDisableTiming));
+#endif
 #endif
   // Set up the initial model split
   split_models(procs_per_model);
@@ -88,6 +95,15 @@ lbann_comm::~lbann_comm() {
   }
 #ifdef LBANN_HAS_ALUMINUM
   m_al_comms.clear();
+#ifdef AL_HAS_NCCL
+  for (int i = 0; i < m_num_al_nccl_streams; ++i) {
+    CHECK_CUDA(cudaStreamDestroy(m_al_nccl_streams[i]));
+  }
+  CHECK_CUDA(cudaEventDestroy(m_al_nccl_sync_event));
+  for (auto&& e : m_al_nccl_req_events) {
+    CHECK_CUDA(cudaEventDestroy(e));
+  }
+#endif
   ::Al::Finalize();
 #endif
 }
@@ -228,13 +244,33 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
   /// @todo MPI-CUDA backend
 #ifdef AL_HAS_NCCL
   if (t == std::type_index(typeid(::Al::NCCLBackend))) {
-    El::GPUManager::SynchronizeStream();
+    cudaStream_t stream = m_al_nccl_streams[m_al_cur_nccl_req % m_num_al_nccl_streams];
+    ++m_al_cur_nccl_req;
+    // Use an event to synchronize the selected NCCL stream and LBANN's stream.
+    // Note that cudaStreamWaitEvent uses the event state when it is called, so
+    // the event can be overwritten safely.
+    CHECK_CUDA(cudaEventRecord(m_al_nccl_sync_event, El::GPUManager::Stream()));
+    CHECK_CUDA(cudaStreamWaitEvent(stream, m_al_nccl_sync_event, 0));
+    // Enqueue the allreduce in the NCCL stream.
     ::Al::NonblockingAllreduce<::Al::NCCLBackend>(
       m.Buffer(),
       local_size,
       mpi_op_to_al_op(op),
       *static_cast<::Al::NCCLCommunicator*>(comm),
-      req.nccl_req);
+      stream);
+    // Use a separate event as the request object to synchronize on.
+    // This avoids having to wait for all work in the stream to complete.
+    // Grab a spare event if one is available, otherwise create one.
+    cudaEvent_t req_event;
+    if (m_al_nccl_req_events.empty()) {
+      CHECK_CUDA(cudaEventCreateWithFlags(&req_event,
+                                          cudaEventDisableTiming));
+    } else {
+      req_event = m_al_nccl_req_events.back();
+      m_al_nccl_req_events.pop_back();
+    }
+    CHECK_CUDA(cudaEventRecord(req_event, stream));
+    req.nccl_req = req_event;
   }
 #endif // AL_HAS_NCCL
   bytes_received += sizeof(DataType) * local_size * (El::mpi::Size(c) - 1);
@@ -245,13 +281,15 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
 
 void lbann_comm::wait(Al::request& req) {
 #ifdef LBANN_HAS_ALUMINUM
-  if (req.mpi_req != Al::mpi_backend::null_req) {
+  if (req.mpi_req != Al::mpi_null_req) {
     ::Al::Wait<::Al::MPIBackend>(req.mpi_req);
   }
   /// @todo MPI-CUDA backend
 #ifdef AL_HAS_NCCL
-  if (req.nccl_req != Al::nccl_backend::null_req) {
-    ::Al::Wait<::Al::NCCLBackend>(req.nccl_req);
+  if (req.nccl_req != Al::nccl_null_req) {
+    CHECK_CUDA(cudaEventSynchronize(req.nccl_req));
+    // Reuse the event.
+    m_al_nccl_req_events.push_back(req.nccl_req);
   }
 #endif // AL_HAS_NCCL
 #endif // LBANN_HAS_ALUMINUM
@@ -260,13 +298,16 @@ void lbann_comm::wait(Al::request& req) {
 bool lbann_comm::test(Al::request& req) {
   bool req_test = true;
 #ifdef LBANN_HAS_ALUMINUM
-  if (req.mpi_req != Al::mpi_backend::null_req) {
+  if (req.mpi_req != Al::mpi_null_req) {
     req_test = req_test && ::Al::Test<::Al::MPIBackend>(req.mpi_req);
   }
   /// @todo MPI-CUDA backend
 #ifdef AL_HAS_NCCL
-  if (req.nccl_req != Al::nccl_backend::null_req) {
-    req_test = req_test && ::Al::Test<::Al::NCCLBackend>(req.nccl_req);
+  if (req.nccl_req != Al::nccl_null_req) {
+    req_test = req_test && (cudaEventQuery(req.nccl_req) == cudaSuccess);
+    if (req_test) {
+      m_al_nccl_req_events.push_back(req.nccl_req);
+    }
   }
 #endif // AL_HAS_NCCL
 #endif // LBANN_HAS_ALUMINUM

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -871,7 +871,8 @@ void model::backward_prop() {
 
 void model::update_weights() {
   do_model_optimize_begin_cbs();
-  for (const auto& w : m_weights) {
+  for (int i = m_weights.size() - 1; i >= 0; --i) {
+    auto& w = m_weights[i];
     optimizer* opt = w->get_optimizer();
     if (opt != nullptr) {
       do_weight_optimize_begin_cbs(w);


### PR DESCRIPTION
This does better synchronization between LBANN and Al/NCCL to avoid unnecessary stream synchronizations and improve overlap.

Specifically:
* `lbann_comm` keeps a small set of streams (currently five, arbitrarily-chosen number) to round-robin between for allreduces.
* When a GPU `nb_allreduce` is called, an event is used to synchronize between a NCCL stream and the LBANN stream. The allreduce is enqueued to run after the sync finishes. This avoids having to synchronize the LBANN stream to ensure data is ready.
* A separate event is enqueued after the allreduce, and is used to check for its completion. This avoids having to synchronize the entire stream (which would require waiting for other allreduces).
* Optimization steps are now done from end to start of the network. This should be roughly analogous to the order backprop is done in (assuming weights are added in the same order as layers). This better overlaps optimization with communication by waiting in the same order allreduces were started.