### PR TITLE
Weighted sum layer

### DIFF
--- a/include/lbann/layers/transform/CMakeLists.txt
+++ b/include/lbann/layers/transform/CMakeLists.txt
@@ -7,6 +7,7 @@ set_full_path(THIS_DIR_HEADERS
   slice.hpp
   split.hpp
   sum.hpp
+  weighted_sum.hpp
   transform.hpp
   unpooling.hpp
   constant.hpp

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -73,6 +73,7 @@
 #include "lbann/layers/transform/unpooling.hpp"
 #include "lbann/layers/transform/split.hpp"
 #include "lbann/layers/transform/sum.hpp"
+#include "lbann/layers/transform/weighted_sum.hpp"
 #include "lbann/layers/transform/slice.hpp"
 #include "lbann/layers/transform/concatenation.hpp"
 #include "lbann/layers/transform/constant.hpp"

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -172,7 +172,7 @@ model {
     parents: "meansq var logsd"
     name: "kldiv_plus_half"
     data_layout: "data_parallel"
-    sum {
+    weighted_sum {
       scaling_factors: "0.5 0.5 -1"
     }
   }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
@@ -330,7 +330,7 @@ model {
     name: "cycy_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_2 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -417,7 +417,7 @@ model {
     name: "cycx_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_gsample param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -439,7 +439,7 @@ model {
     name: "gsample_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_1 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
@@ -322,7 +322,7 @@ model {
     name: "cycy_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_2 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -478,7 +478,7 @@ model {
     name: "cycx_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_gsample param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -500,7 +500,7 @@ model {
     name: "gsample2_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_y param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }

--- a/model_zoo/models/gan/jags/cycle_gan/generate_cycgan_m2.py
+++ b/model_zoo/models/gan/jags/cycle_gan/generate_cycgan_m2.py
@@ -188,8 +188,8 @@ def configure_model(model):
     #Dont add weights, share weights with _1
     G_cyc_y = add_generator(model,g_sample2,'gen1',2500,False,True,False,'_2')
     #G_cyc_y - y
-    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_y - y = cycy_minus_y
     l = new_layer(model,'L_cyc_y', 'cycy_minus_y', 'abs')
     l = new_layer(model, 'L_cyc_y_eval','L_cyc_y', 'evaluation')
@@ -197,16 +197,16 @@ def configure_model(model):
     #G_cyc_x = generator2(G_sample) //freeze, shared weights with previous but not name
     G_cyc_x = add_generator(model,g_sample,'gen2', 11, True,False,False,'_gsample')
     #G_cyc_x - x
-    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_x - x = cycx_minus_x
     l = new_layer(model,'L_cyc_x', 'cycx_minus_x', 'abs')
     l = new_layer(model, 'L_cyc_x_eval','L_cyc_x', 'evaluation')
 
     #******************************************************
     #l2_norm(gsample - y)
-    l = new_layer(model, 'gsample_minus_y', g_sample+' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model, 'gsample_minus_y', g_sample+' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
 
     l = new_layer(model, 'l_l2_y', 'gsample_minus_y', 'l2_loss')
     l = new_layer(model, 'l_l2_y_eval','l_l2_y', 'evaluation')

--- a/model_zoo/models/gan/jags/cycle_gan/generate_cycgan_m3.py
+++ b/model_zoo/models/gan/jags/cycle_gan/generate_cycgan_m3.py
@@ -187,8 +187,8 @@ def configure_model(model):
     #Dont add weights, share weights with _1
     G_cyc_y = add_generator(model,g_sample2,'gen1',2500,True,True,False,'_2')
     #G_cyc_y - y
-    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_y - y = cycy_minus_y
     l = new_layer(model,'L_cyc_y', 'cycy_minus_y', 'abs')
     l = new_layer(model, 'L_cyc_y_eval','L_cyc_y', 'evaluation')
@@ -198,16 +198,16 @@ def configure_model(model):
     #G_cyc_x = generator2(G_sample) //freeze, shared weights with previous but not name
     G_cyc_x = add_generator(model,g_sample,'gen2', 11, False,False,False,'_gsample')
     #G_cyc_x - x
-    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_x - x = cycx_minus_x
     l = new_layer(model,'L_cyc_x', 'cycx_minus_x', 'abs')
     l = new_layer(model, 'L_cyc_x_eval','L_cyc_x', 'evaluation')
 
     #******************************************************
     #l2_norm(gsample2 - x)
-    l = new_layer(model, 'gsample2_minus_x', g_sample2+' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model, 'gsample2_minus_x', g_sample2+' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
 
     l = new_layer(model, 'l_l2_x', 'gsample2_minus_x', 'l2_loss')
     l = new_layer(model, 'l_l2_x_eval','l_l2_x', 'evaluation')

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
@@ -323,7 +323,7 @@ model {
     name: "cycy_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_2 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -410,7 +410,7 @@ model {
     name: "cycx_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_gsample param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -432,7 +432,7 @@ model {
     name: "gsample_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_1 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
@@ -315,7 +315,7 @@ model {
     name: "cycy_minus_y"
     data_layout: "data_parallel"
     parents: "gen1fc4_2 image_data_dummy"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -471,7 +471,7 @@ model {
     name: "cycx_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_gsample param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }
@@ -493,7 +493,7 @@ model {
     name: "gsample2_minus_x"
     data_layout: "data_parallel"
     parents: "gen2fc4_y param_data_id"
-    sum {
+    weighted_sum {
       scaling_factors: "1 -1"
     }
   }

--- a/model_zoo/models/jag/cycle_gan/generate_cycgan_m2.py
+++ b/model_zoo/models/jag/cycle_gan/generate_cycgan_m2.py
@@ -191,8 +191,8 @@ def configure_model(model):
     #Dont add weights, share weights with _1
     G_cyc_y = add_generator(model,g_sample2,'gen1',2500,False,True,False,'_2')
     #G_cyc_y - y
-    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_y - y = cycy_minus_y
     l = new_layer(model,'L_cyc_y', 'cycy_minus_y', 'abs')
     l = new_layer(model, 'L_cyc_y_eval','L_cyc_y', 'evaluation')
@@ -200,22 +200,22 @@ def configure_model(model):
     #G_cyc_x = generator2(G_sample) //freeze, shared weights with previous but not name
     G_cyc_x = add_generator(model,g_sample,'gen2', 11, True,False,False,'_gsample')
     #G_cyc_x - x
-    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_x - x = cycx_minus_x
     l = new_layer(model,'L_cyc_x', 'cycx_minus_x', 'abs')
     l = new_layer(model, 'L_cyc_x_eval','L_cyc_x', 'evaluation')
 
     #******************************************************
     #L_cyc = L_cyc_y + L_cyc_x
-    #l = new_layer(model, 'L_cyc', 'L_cyc_y L_cyc_x', 'sum')
-    #l.sum.scaling_factors = '1 1'
+    #l = new_layer(model, 'L_cyc', 'L_cyc_y L_cyc_x', 'weighted_sum')
+    #l.weighted_sum.scaling_factors = '1 1'
     #l = new_layer(model, 'L_cyc_eval','L_cyc', 'evaluation')
     #******************************************************
     #******************************************************
     #l2_norm(gsample - y)
-    l = new_layer(model, 'gsample_minus_y', g_sample+' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model, 'gsample_minus_y', g_sample+' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
 
     l = new_layer(model, 'l_l2_y', 'gsample_minus_y', 'l2_loss')
     l = new_layer(model, 'l_l2_y_eval','l_l2_y', 'evaluation')

--- a/model_zoo/models/jag/cycle_gan/generate_cycgan_m3.py
+++ b/model_zoo/models/jag/cycle_gan/generate_cycgan_m3.py
@@ -191,8 +191,8 @@ def configure_model(model):
     #Dont add weights, share weights with _1
     G_cyc_y = add_generator(model,g_sample2,'gen1',2500,True,True,False,'_2')
     #G_cyc_y - y
-    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycy_minus_y',G_cyc_y + ' image_data_dummy','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_y - y = cycy_minus_y
     l = new_layer(model,'L_cyc_y', 'cycy_minus_y', 'abs')
     l = new_layer(model, 'L_cyc_y_eval','L_cyc_y', 'evaluation')
@@ -202,22 +202,22 @@ def configure_model(model):
     #G_cyc_x = generator2(G_sample) //freeze, shared weights with previous but not name
     G_cyc_x = add_generator(model,g_sample,'gen2', 11, False,False,False,'_gsample')
     #G_cyc_x - x
-    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model,'cycx_minus_x',G_cyc_x + ' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
     #abs(x) x= G_cyc_x - x = cycx_minus_x
     l = new_layer(model,'L_cyc_x', 'cycx_minus_x', 'abs')
     l = new_layer(model, 'L_cyc_x_eval','L_cyc_x', 'evaluation')
 
     #******************************************************
     #L_cyc = L_cyc_y + L_cyc_x
-    #l = new_layer(model, 'L_cyc', 'L_cyc_y L_cyc_x', 'sum')
-    #l.sum.scaling_factors = '1 1'
+    #l = new_layer(model, 'L_cyc', 'L_cyc_y L_cyc_x', 'weighted_sum')
+    #l.weighted_sum.scaling_factors = '1 1'
     #l = new_layer(model, 'L_cyc_eval','L_cyc', 'evaluation')
     #******************************************************
     #******************************************************
     #l2_norm(gsample2 - x)
-    l = new_layer(model, 'gsample2_minus_x', g_sample2+' param_data_id','sum')
-    l.sum.scaling_factors = '1 -1'
+    l = new_layer(model, 'gsample2_minus_x', g_sample2+' param_data_id','weighted_sum')
+    l.weighted_sum.scaling_factors = '1 -1'
 
     l = new_layer(model, 'l_l2_x', 'gsample2_minus_x', 'l2_loss')
     l = new_layer(model, 'l_l2_x_eval','l_l2_x', 'evaluation')

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -209,7 +209,7 @@ model {
     parents: "kl_one z_log_sigma kl_z_mean2 kl_exp"
     name: "kl_full"
     data_layout: "model_parallel"
-    sum {
+    weighted_sum {
       scaling_factors: "-0.5 -0.5 0.5 0.5"
     }
   }
@@ -236,7 +236,7 @@ model {
     parents: "z_log_sigma"
     name: "sample_half"
     data_layout: "model_parallel"
-    sum {
+    weighted_sum {
       scaling_factors: "0.5"
     }
   }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -172,8 +172,12 @@ Layer* construct_layer(lbann_comm* comm,
     return new reshape_layer<layout, Dev>(comm, dims.size(), dims.data());
   }
   if (proto_layer.has_sum()) {
-    const auto& scaling_factors = parse_list<DataType>(proto_layer.sum().scaling_factors());
-    return new sum_layer<layout, Dev>(comm, scaling_factors);
+    return new sum_layer<layout, Dev>(comm);
+  }
+  if (proto_layer.has_weighted_sum()) {
+    const auto& params = proto_layer.weighted_sum();
+    const auto& scaling_factors = parse_list<DataType>(params.scaling_factors());
+    return new weighted_sum_layer<layout, Dev>(comm, scaling_factors);
   }
   if (proto_layer.has_split()) {
     return new split_layer<layout, Dev>(comm);

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -707,6 +707,7 @@ message Layer {
    Slice slice = 301;
    Split split = 302;
    Sum sum = 303;
+   WeightedSum weighted_sum = 323;
    Unpooling unpooling = 304;
    Hadamard hadamard = 308;
    Constant constant = 309;
@@ -929,6 +930,9 @@ message Split {
 }
 
 message Sum {
+}
+
+message WeightedSum {
   string scaling_factors = 1; //should be a space-separated list of doubles, e.g. "1.0 2.0 -1.0"
 }
 


### PR DESCRIPTION
The weighted sum functionality in the sum layer was mistakenly removed in 50b68b03255fdb1079435084fcbb2569d6e3547c. However, the incorrect implementation is nice for basic sums since it uses matrix views to eliminate an unnecessary memory copy during backprop. I think the best solution is to move the weighted sum functionality into its own layer and leave the optimized implementation for basic sums.