### PR TITLE
handle nullptr of the data reader undefined for an execution mode

### DIFF
--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -212,5 +212,6 @@
 #include "lbann/io/persist.hpp"
 #include "lbann/utils/compiler_control.hpp"
 #include "lbann/utils/omp_diagnostics.hpp"
+#include "lbann/utils/peek_map.hpp"
 
 #endif // LBANN_HPP_INCLUDED

--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -34,19 +34,19 @@ namespace proto {
 
 /** Construct a model specified with a prototext. */
 model* construct_model(lbann_comm* comm,
-                       std::map<execution_mode, generic_data_reader*>& data_readers,
+                       const std::map<execution_mode, generic_data_reader*>& data_readers,
                        const lbann_data::Optimizer& proto_opt,
                        const lbann_data::Model& proto_model);
 
 /** Construct a layer graph specified with a prototext. */
 std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
-                                          std::map<execution_mode, generic_data_reader *>& data_readers,
+                                          const std::map<execution_mode, generic_data_reader *>& data_readers,
                                           const lbann_data::Model& proto_model);
 
 /** Construct a layer specified with prototext. */
 template <data_layout layout, El::Device Dev>
 Layer* construct_layer(lbann_comm* comm,
-                       std::map<execution_mode, generic_data_reader*>& data_readers,
+                       const std::map<execution_mode, generic_data_reader*>& data_readers,
                        int num_parallel_readers,
                        const lbann_data::Layer& proto_layer);
 
@@ -58,7 +58,7 @@ weights* construct_weights(lbann_comm* comm,
 /** Construct a callback specified with prototext. */
 lbann_callback* construct_callback(lbann_comm* comm,
                                    const lbann_data::Callback& proto_cb,
-                                   std::map<execution_mode, generic_data_reader*>& data_readers,
+                                   const std::map<execution_mode, generic_data_reader*>& data_readers,
                                    std::vector<Layer*> layer_list,
                                    std::vector<weights*> weights_list,
                                    lbann_summary* summarizer);

--- a/include/lbann/utils/peek_map.hpp
+++ b/include/lbann/utils/peek_map.hpp
@@ -37,23 +37,21 @@ namespace lbann {
 /**
  * A utility function to peek into a std::map without the side effect of adding
  * the default value when a key is not found.
- * It has the the template parameter list as std::map does.
+ * It has the the template parameter list as std::map does except the allocator.
  * Searches 'idx' in std::map 'map_to_peek', and returns the matching value if
  * found or the default otherwise. 'found' is set to true when the key 'idx' is
  * found, or false when not.
  */
 template < class KEY_T,                    // map::key_type
            class VAL_T,                    // map::mapped_type
-           class CMP_T = std::less<KEY_T>, // map::key_compare
-           class ALC_T = std::allocator<std::pair<const KEY_T, VAL_T> > // map::allocator_type
+           class CMP_T = std::less<KEY_T>  // map::key_compare
          >
-VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T, ALC_T>& map_to_peek, KEY_T idx, bool& found) {
-  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T, ALC_T>;
+VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T>& map_to_peek, KEY_T idx, bool& found) {
+  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T>;
   typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
   if (it == map_to_peek.cend()) {
-    map_to_peek_t tmp;
     found = false;
-    return tmp[idx];
+    return VAL_T();
   }
   found = true;
   return it->second;
@@ -65,15 +63,55 @@ VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T, ALC_T>& map_to_peek, KEY_T id
  */
 template < class KEY_T,                    // map::key_type
            class VAL_T,                    // map::mapped_type
-           class CMP_T = std::less<KEY_T>, // map::key_compare
-           class ALC_T = std::allocator<std::pair<const KEY_T, VAL_T> > // map::allocator_type
+           class CMP_T = std::less<KEY_T>  // map::key_compare
          >
-VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T, ALC_T>& map_to_peek, KEY_T idx) {
-  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T, ALC_T>;
+VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T>& map_to_peek, KEY_T idx) {
+  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T>;
   typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
   if (it == map_to_peek.cend()) {
-    map_to_peek_t tmp;
-    return tmp[idx];
+    return VAL_T();
+  }
+  return it->second;
+}
+
+/**
+ * A utility function to peek into a std::unordered_map without the side effect of adding
+ * the default value when a key is not found.
+ * It has the the template parameter list as std::unordered_map does except the allocator.
+ * Searches 'idx' in std::unordered_map 'map_to_peek', and returns the matching value if
+ * found or the default otherwise. 'found' is set to true when the key 'idx' is
+ * found, or false when not.
+ */
+template < class KEY_T,                         // unordered_map::key_type
+	   class VAL_T,                         // unordered_map::mapped_type
+           class HASH_T = std::hash<KEY_T>,     // unordered_map::hasher
+           class KEYeq_T = std::equal_to<KEY_T> // unordered_map::key_equal
+	 >
+VAL_T peek_map(const std::unordered_map<KEY_T, VAL_T, HASH_T, KEYeq_T>& map_to_peek, KEY_T idx, bool& found) {
+  using map_to_peek_t = std::unordered_map<KEY_T, VAL_T, HASH_T, KEYeq_T>;
+  typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
+  if (it == map_to_peek.cend()) {
+    found = false;
+    return VAL_T();
+  }
+  found = true;
+  return it->second;
+}
+
+/**
+ * Same as the other peek_map interface but does not require the third argument
+ * that indicates the success of searching.
+ */
+template < class KEY_T,                         // unordered_map::key_type
+	   class VAL_T,                         // unordered_map::mapped_type
+           class HASH_T = std::hash<KEY_T>,     // unordered_map::hasher
+           class KEYeq_T = std::equal_to<KEY_T> // unordered_map::key_equal
+	 >
+VAL_T peek_map(const std::unordered_map<KEY_T, VAL_T, HASH_T, KEYeq_T>& map_to_peek, KEY_T idx) {
+  using map_to_peek_t = std::unordered_map<KEY_T, VAL_T, HASH_T, KEYeq_T>;
+  typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
+  if (it == map_to_peek.cend()) {
+    return VAL_T();
   }
   return it->second;
 }

--- a/include/lbann/utils/peek_map.hpp
+++ b/include/lbann/utils/peek_map.hpp
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// peek_map .hpp .cpp - Utility to peek into a map without the side effect
+//                      of adding the default value when a key is not found
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_PEEK_MAP_HPP_INCLUDED
+#define LBANN_PEEK_MAP_HPP_INCLUDED
+
+#include <map>
+
+namespace lbann {
+
+/**
+ * A utility function to peek into a std::map without the side effect of adding
+ * the default value when a key is not found.
+ * It has the the template parameter list as std::map does.
+ * Searches 'idx' in std::map 'map_to_peek', and returns the matching value if
+ * found or the default otherwise. 'found' is set to true when the key 'idx' is
+ * found, or false when not.
+ */
+template < class KEY_T,                    // map::key_type
+           class VAL_T,                    // map::mapped_type
+           class CMP_T = std::less<KEY_T>, // map::key_compare
+           class ALC_T = std::allocator<std::pair<const KEY_T, VAL_T> > // map::allocator_type
+         >
+VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T, ALC_T>& map_to_peek, KEY_T idx, bool& found) {
+  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T, ALC_T>;
+  typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
+  if (it == map_to_peek.cend()) {
+    map_to_peek_t tmp;
+    found = false;
+    return tmp[idx];
+  }
+  found = true;
+  return it->second;
+}
+
+/**
+ * Same as the other peek_map interface but does not require the third argument
+ * that indicates the success of searching.
+ */
+template < class KEY_T,                    // map::key_type
+           class VAL_T,                    // map::mapped_type
+           class CMP_T = std::less<KEY_T>, // map::key_compare
+           class ALC_T = std::allocator<std::pair<const KEY_T, VAL_T> > // map::allocator_type
+         >
+VAL_T peek_map(const std::map<KEY_T, VAL_T, CMP_T, ALC_T>& map_to_peek, KEY_T idx) {
+  using map_to_peek_t = std::map<KEY_T, VAL_T, CMP_T, ALC_T>;
+  typename map_to_peek_t::const_iterator it = map_to_peek.find(idx);
+  if (it == map_to_peek.cend()) {
+    map_to_peek_t tmp;
+    return tmp[idx];
+  }
+  return it->second;
+}
+
+} // end of namespace
+
+#endif // LBANN_PEEK_MAP_HPP_INCLUDED

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -230,6 +230,7 @@ int main(int argc, char *argv[]) {
         std::cerr << "\nUSING DATA STORE!\n\n";
       }
       for (auto r : data_readers) {
+        if (!r.second) continue;
         r.second->setup_data_store(model);
       }
     }

--- a/src/data_store/generic_data_store.cpp
+++ b/src/data_store/generic_data_store.cpp
@@ -39,28 +39,43 @@ namespace lbann {
 
 generic_data_store::generic_data_store(generic_data_reader *reader, model *m) :
     m_reader(reader), 
-    m_comm(m->get_comm()),
     m_my_minibatch_indices(nullptr),
     m_epoch(0),
     m_in_memory(true),
     m_model(m),
-    m_dir(m_reader->get_file_dir()),
     m_extended_testing(false),
     m_is_subsidiary_store(false),
     m_cur_minibatch(1000000),
     m_is_setup(false),
     m_verbose(false)
 {
+  if (m_reader == nullptr) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << " m_reader is nullptr";
+        throw lbann_exception(err.str());
+  }
+
+  if (m_model == nullptr) {
+    std::stringstream err;
+    err << __FILE__ << " " << __LINE__ << " :: "
+        << " m_model is nullptr";
+        throw lbann_exception(err.str());
+  }
+
+  m_comm = m_model->get_comm();
   if (m_comm == nullptr) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
-        << " m_reader->get_comm is nullptr";
+        << " m_comm is nullptr";
         throw lbann_exception(err.str());
   }
   m_master = m_comm->am_world_master();
   m_rank = m_comm->get_rank_in_model();
   m_np = m_comm->get_procs_per_model();
   m_mpi_comm = m_comm->get_model_comm().comm;
+
+  m_dir = m_reader->get_file_dir();
 
   set_name("generic_data_store");
   options *opts = options::get();

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/proto/factories.hpp"
+#include "lbann/utils/peek_map.hpp"
 
 namespace lbann {
 namespace proto {
@@ -53,7 +54,7 @@ std::unordered_set<T*> select_from_list(std::string names,
 
 lbann_callback* construct_callback(lbann_comm* comm,
                                    const lbann_data::Callback& proto_cb,
-                                   std::map<execution_mode, generic_data_reader*>& data_readers,
+                                   const std::map<execution_mode, generic_data_reader*>& data_readers,
                                    std::vector<Layer*> layer_list,
                                    std::vector<weights*> weights_list,
                                    lbann_summary* summarizer) {
@@ -77,7 +78,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
   }
   if (proto_cb.has_save_images()) {
     const auto& params = proto_cb.save_images();
-    auto&& reader = data_readers[execution_mode::training] ;
+    auto&& reader = lbann::peek_map(data_readers, execution_mode::training);
     const auto& layer_names = parse_list<>(params.layer_names());
     return new lbann_callback_save_images(reader,
                                           params.image_dir(),

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -25,13 +25,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/proto/factories.hpp"
+#include "lbann/utils/peek_map.hpp"
 
 namespace lbann {
 namespace proto {
 
 template <data_layout layout, El::Device Dev>
 Layer* construct_layer(lbann_comm* comm,
-                       std::map<execution_mode, generic_data_reader*>& data_readers,
+                       const std::map<execution_mode, generic_data_reader*>& data_readers,
                        int num_parallel_readers,
                        const lbann_data::Layer& proto_layer) {
   std::stringstream err;
@@ -90,7 +91,11 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& params = proto_layer.fully_connected();
     int num_neurons = params.num_neurons();
     if (proto_layer.num_neurons_from_data_reader()) {
-      num_neurons = data_readers[execution_mode::training]->get_linearized_data_size();
+      const auto dr  = lbann::peek_map(data_readers, execution_mode::training);
+      if (!dr) {
+        LBANN_ERROR("training data reader does not exist!");
+      }
+      num_neurons = dr->get_linearized_data_size();
     }
     return new fully_connected_layer<layout, Dev>(comm,
                                                   num_neurons,
@@ -132,7 +137,11 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& bias = params.has_bias();
     int num_output_channels = params.num_output_channels();
     if (proto_layer.num_neurons_from_data_reader()) {
-      num_output_channels = data_readers[execution_mode::training]->get_linearized_data_size();
+      const auto dr  = lbann::peek_map(data_readers, execution_mode::training);
+      if (!dr) {
+        LBANN_ERROR("Training data reader does not exist!");
+      }
+      num_output_channels = dr->get_linearized_data_size();
     }
     if (params.has_vectors()) {
       const auto& dims = parse_list<int>(params.conv_dims());
@@ -167,7 +176,11 @@ Layer* construct_layer(lbann_comm* comm,
       if (params.reshape_to_flattened_conv_format()) {
         dims.push_back(1);
       }
-      dims.push_back(data_readers[execution_mode::training]->get_linearized_data_size());
+      const auto dr  = lbann::peek_map(data_readers, execution_mode::training);
+      if (!dr) {
+        LBANN_ERROR("Training data reader does not exist!");
+      }
+      dims.push_back(dr->get_linearized_data_size());
     }
     return new reshape_layer<layout, Dev>(comm, dims.size(), dims.data());
   }
@@ -439,26 +452,26 @@ Layer* construct_layer(lbann_comm* comm,
 // Template instantiation
 template Layer* construct_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(
   lbann_comm* comm,
-  std::map<execution_mode, generic_data_reader*>& data_readers,
+  const std::map<execution_mode, generic_data_reader*>& data_readers,
   int num_parallel_readers,
   const lbann_data::Layer& proto_layer
 );
 template Layer* construct_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>(
   lbann_comm* comm,
-  std::map<execution_mode, generic_data_reader*>& data_readers,
+  const std::map<execution_mode, generic_data_reader*>& data_readers,
   int num_parallel_readers,
   const lbann_data::Layer& proto_layer
 );
 #ifdef LBANN_HAS_GPU
 template Layer* construct_layer<data_layout::DATA_PARALLEL, El::Device::GPU>(
   lbann_comm* comm,
-  std::map<execution_mode, generic_data_reader*>& data_readers,
+  const std::map<execution_mode, generic_data_reader*>& data_readers,
   int num_parallel_readers,
   const lbann_data::Layer& proto_layer
 );
 template Layer* construct_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>(
   lbann_comm* comm,
-  std::map<execution_mode, generic_data_reader*>& data_readers,
+  const std::map<execution_mode, generic_data_reader*>& data_readers,
   int num_parallel_readers,
   const lbann_data::Layer& proto_layer
 );

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -62,7 +62,7 @@ void setup_parents_and_children(lbann_comm* comm,
 
 void setup_fc_num_neurons(
   std::vector<Layer*>& layers,
-  std::map<execution_mode, generic_data_reader *>& data_readers,
+  const std::map<execution_mode, generic_data_reader *>& data_readers,
   const lbann_data::Model& proto_model) {
   std::stringstream err;
   for (int i=0; i<proto_model.layer_size(); ++i) {
@@ -73,6 +73,7 @@ void setup_fc_num_neurons(
       if (set_num_neurons) {
         int num_neurons = 0;
         for (auto t : data_readers) {
+          if (!t.second) continue;
           if (t.second->get_role() == "train") {
             num_neurons = t.second->get_num_labels();
             auto&& fc_dp_cpu = dynamic_cast<fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::CPU>*>(l);
@@ -167,7 +168,7 @@ void setup_unpooling_pointers(lbann_comm* comm,
 } // namespace
 
 std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
-                                          std::map<execution_mode, generic_data_reader *>& data_readers,
+                                          const std::map<execution_mode, generic_data_reader *>& data_readers,
                                           const lbann_data::Model& proto_model) {
   std::stringstream err;
 

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -172,7 +172,7 @@ void assign_weights_to_layers(std::vector<Layer*>& layer_list,
 } // namespace
 
 model* construct_model(lbann_comm* comm,
-                       std::map<execution_mode, generic_data_reader*>& data_readers,
+                       const std::map<execution_mode, generic_data_reader*>& data_readers,
                        const lbann_data::Optimizer& proto_opt,
                        const lbann_data::Model& proto_model) {
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -353,16 +353,24 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
 
   if (master) {
     if (separate_validation) {
-      const generic_data_reader* r_train = data_readers[execution_mode::training];
-      const generic_data_reader* r_validate = data_readers[execution_mode::validation];
+      const generic_data_reader* r_train = peek_map(data_readers, execution_mode::training);
+      const generic_data_reader* r_validate = peek_map(data_readers, execution_mode::validation);
       const size_t num_train = (r_train == nullptr)? 0u : r_train->get_num_data();
       const size_t num_validate = (r_validate == nullptr)? 0u : r_validate->get_num_data();
       std::cout << "Training using " << num_train << " samples." << std::endl
                 << "Validating using " << num_validate << " samples." << std::endl;
     }
-    const generic_data_reader* r_test = data_readers[execution_mode::testing];
+    const generic_data_reader* r_test = peek_map(data_readers, execution_mode::testing);
     const size_t num_test = (r_test == nullptr)? 0u : r_test->get_num_data();
     std::cout << "Testing using " << num_test << " samples." << std::endl;
+  }
+  // remove null data_reader pointers if there is any
+  for (auto it = data_readers.cbegin(); it != data_readers.cend() ; ) {
+    if (!it->second) {
+      data_readers.erase(it++);
+    } else {
+      ++it;
+    }
   }
 }
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -367,7 +367,7 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
   // remove null data_reader pointers if there is any
   for (auto it = data_readers.cbegin(); it != data_readers.cend() ; ) {
     if (!it->second) {
-      data_readers.erase(it++);
+      it = data_readers.erase(it);
     } else {
       ++it;
     }


### PR DESCRIPTION
Avoid the error when test data reader is not used, and add gaurd against similar issues.
The error was introduced by the side effect of accessing std::map via the operator '[]' in my earlier PR #443. `const generic_data_reader* r_test = data_readers[execution_mode::testing];`
If there was no reader given for the testing mode, accessing the map by '[key]' would automatically add a nullptr value for the key. It seems that non-nullptr is expected thoughout the code.
- I added a method to avoid this side effect, peek_map().
- fixed the error
- added guards against null pointers in the map data_readers, which is populated by init_data_readers() during setup and then passed around to construct models, layers, and callbacks.
- added guards against null pointers in initializing data_store

This not only prevents similar mistakes but also is likely to be necessary to support the inference mode where there is no training reader is given.

Ideally, it would be better to apply the similar change to input_layer and generic_input_layer constructors, but it would create merge conflict. So, it is left alone in this PR.