### PR TITLE
Compiler test update -- Pascal

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -105,9 +105,9 @@ def get_command(cluster,
 
         # Create run command
         if command_allocate == '':
-            command_run = 'srun'
+            command_run = 'srun --mpibind=off'
         else:
-            command_run = ' srun'
+            command_run = ' srun --mpibind=off'
         option_num_processes = ''
         if num_processes != None:
             # --ntasks => Specify  the  number of tasks to run.

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -40,36 +40,38 @@ def test_compiler_intel18_debug(cluster, dirname):
     skeleton_intel18(cluster, dirname, True)
 
 def skeleton_clang4(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'pascal', 'quartz']:
+    if cluster in ['catalyst', 'quartz']:
         spack_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
-        build_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'clang@4.0.0', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'pascal', 'quartz', 'ray']:
-        if cluster in ['catalyst', 'pascal', 'quartz']:
+    if cluster in ['catalyst', 'quartz', 'ray']:
+        if cluster in ['catalyst','quartz']:
             mpi = 'mvapich2@2.2'
+        elif cluster in  ['pascal', 'surface']:
+            mpi = 'mvapich2@2.2+cuda'
         elif cluster == 'ray':
             mpi = 'spectrum-mpi@2018.04.27'
         else:
             raise Exception('Unsupported Cluster %s' % cluster)
         spack_skeleton(dir_name, 'gcc@4.9.3', mpi, debug, should_log)
-        build_skeleton(dir_name, 'gcc@4.9.3', mpi, debug, should_log)
+        build_skeleton(dir_name, 'gcc@4.9.3', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'pascal', 'quartz']:
+    if cluster in ['catalyst', 'quartz']:
         spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
-        build_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'gcc@7.1.0', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_intel18(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'pascal', 'quartz']:
+    if cluster in ['catalyst', 'quartz']:
         spack_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
-        build_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'intel@18.0.0', debug, should_log)
     else:
         pytest.skip('Unsupported Cluster %s' % cluster)
 
@@ -98,7 +100,7 @@ def spack_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
             print('%s: %s' % (error_file_name, line))
     assert return_code == 0
 
-def build_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
+def build_skeleton(dir_name, compiler, debug, should_log):
     compiler_underscored = re.sub('[@\.]', '_', compiler)
     if debug:
         build_type = 'debug'
@@ -107,7 +109,7 @@ def build_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
     output_file_name = '%s/bamboo/compiler_tests/output/%s_%s_build_output.txt' % (dir_name, compiler_underscored, build_type)
     error_file_name = '%s/bamboo/compiler_tests/error/%s_%s_build_error.txt' % (dir_name, compiler_underscored, build_type)
     compiler = compiler.replace('@', '-')
-    mpi_lib = mpi_lib.replace('@', '-')
+    #mpi_lib = mpi_lib.replace('@', '-')
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     # For reference:
     # x86_64 <=> catalyst, pascal, quartz, surface
@@ -115,9 +117,11 @@ def build_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
     architecture = subprocess.check_output('uname -m'.split()).strip()
     if cluster == 'ray':
         architecture += '_gpu_cuda-9.2.64_cudnn-7.0'
-    elif cluster in ['pascal', 'surface']:
-        architecture += "_gpu"
-    os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s_%s_openblas_%s/build' % (dir_name, cluster, compiler, architecture, mpi_lib, build_type))
+    elif cluster == 'pascal':
+        architecture += '_gpu_cuda-9.1.85_cudnn-7.1'
+    elif cluster == 'surface':
+        architecture += '_gpu'
+    os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s/build' % (dir_name, cluster, compiler, build_type))
     command = 'make -j all > %s 2> %s' % (output_file_name, error_file_name)
     return_code = os.system(command)
     os.chdir('../..')

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -112,15 +112,16 @@ def build_skeleton(dir_name, compiler, debug, should_log):
     #mpi_lib = mpi_lib.replace('@', '-')
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     # For reference:
+    # Commenting out for now. These additions to path name will likely return one day, so I am not removing them entirely
     # x86_64 <=> catalyst, pascal, quartz, surface
     # ppc64le <=> ray
-    architecture = subprocess.check_output('uname -m'.split()).strip()
-    if cluster == 'ray':
-        architecture += '_gpu_cuda-9.2.64_cudnn-7.0'
-    elif cluster == 'pascal':
-        architecture += '_gpu_cuda-9.1.85_cudnn-7.1'
-    elif cluster == 'surface':
-        architecture += '_gpu'
+    #architecture = subprocess.check_output('uname -m'.split()).strip()
+    #if cluster == 'ray':
+    #    architecture += '_gpu_cuda-9.2.64_cudnn-7.0'
+    #elif cluster == 'pascal':
+    #    architecture += '_gpu_cuda-9.1.85_cudnn-7.1'
+    #elif cluster == 'surface':
+    #    architecture += '_gpu'
     os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s/build' % (dir_name, cluster, compiler, build_type))
     command = 'make -j all > %s 2> %s' % (output_file_name, error_file_name)
     return_code = os.system(command)

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -16,15 +16,12 @@ def pytest_addoption(parser):
         default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
-    if cluster in ['ray']:
+    if cluster == 'ray':
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
-    if cluster == 'surface':
+    if cluster in ['surface', 'pascal']:
         default_exes['gcc4'] = default_exes['default']
-
-    if cluster == 'pascal':
-        default_exes['gcc7'] = default_exes['default']
 
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -4,36 +4,27 @@ def pytest_addoption(parser):
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
-    default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
+    default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if cluster in ['catalyst', 'quartz']:
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
-        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
-    if cluster == 'pascal':
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-
-        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-
-    if cluster == 'ray':
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-2018.04.27_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-
-        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_spectrum-mpi-2018.04.27_openblas_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+    if cluster in ['ray']:
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'surface':
         default_exes['gcc4'] = default_exes['default']
+
+    if cluster == 'pascal':
+        default_exes['gcc7'] = default_exes['default']
 
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
@@ -45,7 +36,7 @@ def pytest_addoption(parser):
                      help='--log=1 to keep trimmed accuracy files. Default (--log=0) removes files')
     parser.addoption('--weekly', action='store_true', default=False,
                      help='--weekly specifies that the test should ONLY be run weekly, not nightly')
-    # For local testing only                                                                                                                                            
+    # For local testing only
     parser.addoption('--exe', action='store', help='--exe=<hand-picked executable>')
 
 @pytest.fixture

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -16,10 +16,10 @@ def pytest_addoption(parser):
         #default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         default_exes['gcc7'] = default_exes['default'] #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
         #default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-    if cluster in ['ray']:
+    if cluster ==  'ray':
         default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
-    if cluster == 'surface':
+    if cluster in ['surface', 'pascal']:
         default_exes['gcc4'] = default_exes['default']
 
     parser.addoption('--cluster', action='store', default=cluster,

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -4,21 +4,20 @@ def pytest_addoption(parser):
     cluster = re.sub('[0-9]+', '', subprocess.check_output('hostname'.split()).strip())
     default_dirname = subprocess.check_output('git rev-parse --show-toplevel'.split()).strip()
     default_exes = {}
-    default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/lbann/build/model_zoo/lbann' % (default_dirname, cluster)
+    default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if cluster in ['catalyst', 'quartz']:
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'pascal':
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-
-    if cluster == 'ray':
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_ppc64le_gpu_cuda-9.2.64_cudnn-7.0_spectrum-mpi-2018.04.27_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = default_exes['default'] #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+    if cluster in ['ray']:
+        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'surface':
         default_exes['gcc4'] = default_exes['default']
@@ -31,7 +30,7 @@ def pytest_addoption(parser):
                      help='--exes={compiler_name: path}')
     # For local testing only
     parser.addoption('--exe', action='store', help='--exe=<hand-picked executable>')
-    
+
 @pytest.fixture
 def cluster(request):
     return request.config.getoption('--cluster')

--- a/scripts/spack_recipes/build_lbann.sh
+++ b/scripts/spack_recipes/build_lbann.sh
@@ -27,6 +27,8 @@ DTYPE=float
 EL_VER=develop
 if [ "${CLUSTER}" == "ray" -o "${CLUSTER}" == "sierra" ]; then
   MPI=spectrum-mpi
+elif [ "${CLUSTER}" == "pascal" -o "${CLUSTER}" == "surface" ]; then
+  MPI='mvapich2 +cuda'
 else
   MPI=mvapich2
 fi
@@ -109,6 +111,9 @@ if [ "${GPU}" == "1" -o "${CLUSTER}" == "surface" -o "${CLUSTER}" == "ray" -o "$
   elif [ "${CLUSTER}" == "sierra" -o "${CLUSTER}" == "ray" ]; then
     PLATFORM="+gpu ^cuda@9.2.64 ^cudnn@7.0"
     FEATURE="_gpu_cuda-9.2.64_cudnn-7.0"
+  elif [ "${CLUSTER}" == "pascal" ]; then
+    PLATFORM="+gpu ^cuda@9.1.85 ^cudnn@7.1"
+    FEATURE="_gpu_cuda-9.1.85_cudnn-7.1"
   else
     PLATFORM="+gpu"
     FEATURE="_gpu"
@@ -195,7 +200,7 @@ if [ "${CLUSTER}" == "ray" ]; then
   MPI="spectrum-mpi@2018.04.27"
 fi
 
-SPACK_OPTIONS="lbann@local build_type=${BUILD_TYPE} dtype=${DTYPE} ${PLATFORM} ${VARIANTS} %${COMPILER} ^hydrogen@${EL_VER} build_type=${BUILD_TYPE} blas=${BLAS} ^${MPI}"
+SPACK_OPTIONS="lbann@local %${COMPILER} build_type=${BUILD_TYPE} dtype=${DTYPE} ${PLATFORM} ${VARIANTS} ^hydrogen@${EL_VER} build_type=${BUILD_TYPE} blas=${BLAS} ^${MPI}"
 # Disable the extra compiler flags until spack supports propagating flags properly
 #SPACK_OPTIONS="lbann@local build_type=${BUILD_TYPE} dtype=${DTYPE} ${PLATFORM} ${VARIANTS} %${COMPILER} ${SPACK_CFLAGS} ${SPACK_CXXFLAGS} ${SPACK_FFLAGS} ^elemental@${EL_VER} blas=${BLAS} ^${MPI}"
 
@@ -208,10 +213,17 @@ SPEC="spack spec ${SPACK_OPTIONS}"
 CMD="spack setup ${SPACK_SETUP_FLAGS} ${SPACK_OPTIONS}"
 
 # Create a directory for the build
-DIR="${CLUSTER}_${COMPILER}_${ARCH}${FEATURE}_${MPI}_${BLAS}_${DIST}"
-DIR=${DIR//@/-}
-DIR=${DIR// /-}
-
+if [ ! -z "$bamboo_SPACK_ROOT" ]; then
+  DIR="${CLUSTER}_${COMPILER}_${DIST}"
+  DIR=${DIR//@/-}
+  DIR=${DIR// /-}
+  DIR=${DIR//+/-}
+else
+  DIR="${CLUSTER}_${COMPILER}_${ARCH}${FEATURE}_${MPI}_${BLAS}_${DIST}"
+  DIR=${DIR//@/-}
+  DIR=${DIR// /-}
+  DIR=${DIR//+/-}
+fi
 echo "Creating directory ${DIR}"
 mkdir -p ${DIR}/build
 cd ${DIR}


### PR DESCRIPTION
This PR updates the bamboo compiler tests, primarily making changes needed to add pascal builds to bamboo. It also simplifies the spack build script paths when operating in bamboo. This allows us to update the script without needing to propagate the new version numbers/anything else to our various pytest configuration files. 

This should not be merged until I have successfully used spack to build on pascal. I am making behind the scenes spack environment changes to try to make this happen, and will remove the in progress tag upon completion.

**Edit 8/7:** I am going to circumvent pascal spack usage for now, as that was in a lousy state last time I tried. This PR instead adds testing for pascal using the executable built by the build script. This will be a good work around until spack+pascal gets figured out.