### PR TITLE
Fix all the compiler errors with intel/18.0.0

### DIFF
--- a/include/lbann/callbacks/callback_checkpoint.hpp
+++ b/include/lbann/callbacks/callback_checkpoint.hpp
@@ -108,6 +108,14 @@ class lbann_callback_checkpoint : public lbann_callback {
   persist p;
   bool m_checkpoint_dist;
   bool m_checkpoint_shared;
+
+  template<size_t _max_dir_len>
+  struct header_t {
+    int epoch;
+    int step;
+    int shared;
+    char dirname[_max_dir_len];
+  };
 };
 
 }  // namespace lbann

--- a/include/lbann/callbacks/callback_debug.hpp
+++ b/include/lbann/callbacks/callback_debug.hpp
@@ -58,6 +58,15 @@ class lbann_callback_debug : public lbann_callback {
   /** Print that a layer's forward prop is ending. */
   void on_batch_evaluate_end(model *m) override;
 
+  using lbann_callback::on_forward_prop_begin;
+  using lbann_callback::on_forward_prop_end;
+  using lbann_callback::on_backward_prop_begin;
+  using lbann_callback::on_backward_prop_end;
+  using lbann_callback::on_evaluate_forward_prop_begin;
+  using lbann_callback::on_evaluate_forward_prop_end;
+  using lbann_callback::on_optimize_begin;
+  using lbann_callback::on_optimize_end;
+
   /** Print that a layer's forward prop is beginning. */
   void on_forward_prop_begin(model *m, Layer *l) override;
   /** Print that a layer's forward prop is ending. */

--- a/include/lbann/callbacks/callback_sync_layers.hpp
+++ b/include/lbann/callbacks/callback_sync_layers.hpp
@@ -58,6 +58,9 @@ class lbann_callback_sync_layers : public lbann_callback {
   }
   std::string name() const override { return "sync_layers"; }
 
+  using lbann_callback::on_forward_prop_end;
+  using lbann_callback::on_backward_prop_end;
+
   void on_forward_prop_end(model *m, Layer *l) override;
   void on_backward_prop_end(model *m, Layer *l) override;
     

--- a/include/lbann/data_store/data_store_image.hpp
+++ b/include/lbann/data_store/data_store_image.hpp
@@ -58,6 +58,8 @@ class data_store_image : public generic_data_store {
 
   void setup() override;
 
+  using generic_data_store::get_data_buf;
+
   /// data readers call this method
   void get_data_buf(int data_id, std::vector<unsigned char> *&buf, int multi_idx = 0) override;
 

--- a/include/lbann/data_store/data_store_merge_samples.hpp
+++ b/include/lbann/data_store/data_store_merge_samples.hpp
@@ -56,6 +56,7 @@ class data_store_merge_samples : public generic_data_store {
   //! dtor
   ~data_store_merge_samples() override;
 
+  using generic_data_store::get_data_buf;
   void get_data_buf(int data_id, std::vector<unsigned char> *&buf, int multi_idx = 0) override {}
 
   void setup() override;

--- a/include/lbann/data_store/data_store_pilot2_molecular.hpp
+++ b/include/lbann/data_store/data_store_pilot2_molecular.hpp
@@ -57,6 +57,7 @@ class data_store_pilot2_molecular : public generic_data_store {
   //! dtor
   ~data_store_pilot2_molecular() override;
 
+  using generic_data_store::get_data_buf;
   void get_data_buf(int data_id, int tid, std::vector<double> *&buf) override; 
 
   void setup() override;

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -243,8 +243,9 @@ bool lbann_callback_checkpoint::restart(model *m) {
   if (m_checkpoint_dir.length() == 0 &&  m_per_rank_dir.length() == 0) {
     return false;
   }
+  constexpr unsigned int max_len_dirname = 1024;
   // get top level directory
-  char dir[1024];
+  char dir[max_len_dirname];
   int epoch = -1;
   int step = -1;
   int epoch_dist = -1;
@@ -281,13 +282,7 @@ bool lbann_callback_checkpoint::restart(model *m) {
   // TODO: we would want to prepend dir with the model name and model rank:
   // m->get_name() + '.' + std::to_string(comm->get_model_rank()) + '.'
 #if 1
-  struct header_t {
-    int epoch;
-    int step;
-    int shared;
-    char dirname[sizeof(dir)];
-  };
-  header_t header;
+  header_t<max_len_dirname> header;
 
   header.epoch = epoch;
   header.step = step;

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -168,7 +168,7 @@ static void set_subtractor(const lbann_data::ImagePreprocessor& pb_preprocessor,
       }
       else if (pb_subtractor.channel_mean_size() > 0) {
         const size_t n = pb_subtractor.channel_mean_size();
-        if (n != static_cast<const size_t>(channels)) {
+        if (n != static_cast<size_t>(channels)) {
           throw lbann_exception("Failed to setup subtractor due to inconsistent number of channels.");
         }
         std::vector<lbann::DataType> ch_mean(n);
@@ -192,7 +192,7 @@ static void set_subtractor(const lbann_data::ImagePreprocessor& pb_preprocessor,
       }
       else if (pb_subtractor.channel_stddev_size() > 0) {
         const size_t n = pb_subtractor.channel_stddev_size();
-        if (n != static_cast<const size_t>(channels)) {
+        if (n != static_cast<size_t>(channels)) {
           throw lbann_exception("Failed to setup subtractor due to inconsistent number of channels.");
         }
         std::vector<lbann::DataType> ch_stddev(n);


### PR DESCRIPTION
To address issue #425 
- partially overriden virtual functions
- ckpt message packing buffer size definition issue
- type casting