### PR TITLE
callback to synchronize selected layers

### DIFF
--- a/include/lbann/callbacks/callback_sync_layers.hpp
+++ b/include/lbann/callbacks/callback_sync_layers.hpp
@@ -64,7 +64,7 @@ class lbann_callback_sync_layers : public lbann_callback {
   void on_forward_prop_end(model *m, Layer *l) override;
   void on_backward_prop_end(model *m, Layer *l) override;
     
- private:
+ protected:
   /** Whether to synchronize GPUs. */
   bool m_sync_gpus;
   /** Whether to do a global synchronization. */
@@ -72,7 +72,7 @@ class lbann_callback_sync_layers : public lbann_callback {
   /** Whether to only synchronize after the input layer. */
   bool m_only_input;
 
-  void do_sync(Layer *l);
+  virtual void do_sync(Layer *l);
 };
 
 }  // namespace lbann

--- a/include/lbann/callbacks/callback_sync_selected.hpp
+++ b/include/lbann/callbacks/callback_sync_selected.hpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// callback_sync_selected.hpp - Callback to synchronize selected layers
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_SYNC_SELECTED_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_SYNC_SELECTED_HPP_INCLUDED
+
+#include "lbann/callbacks/callback_sync_layers.hpp"
+#include <unordered_map>
+#include <unordered_set>
+
+namespace lbann {
+
+/**
+ * Synchronize at the beginning and the end of the propagation operation(s) of
+ * a selected layer, which can be both/either of the forward prop and/or the
+ * backward prop of the layer. Additionally updates layer timing information to
+ * account for the synchronization at the end of propagation(s).
+ * When nvprof is enabled, cudaProfilerStart() follows the synchronization
+ * inserted at the beginning of the selected prop step(s), and cudaProfilerEnd()
+ * comes after the local GPU sychronization and before the global MPI barrier
+ * inserted at the end of the selected prop step(s).
+ * Note that this callback should come before the summarizer callback
+ * as the base callback lbann_callback_sync_layers requires.
+ */
+class lbann_callback_sync_selected : public lbann_callback_sync_layers {
+ public:
+  ///type of propagation toch synchronize
+  enum prop_t {Both = 0, Forward = 1, Backward = 2};
+  static const std::map<prop_t, std::string> m_prop_str;
+
+  using layers_t = std::unordered_map<std::string, prop_t>;
+  using layer_ptrs_t = std::unordered_set<Layer*>;
+
+  /**
+   * @param layers specifies the layers to synchronize
+   * @param async_gpus sets not to synchronize gpus. The default is false.
+   * @param async_mpi sets not to synchronize mpi. The default is false.
+   */
+  lbann_callback_sync_selected(const layers_t& layers,
+                               bool async_gpus = false, bool async_mpi = false);
+
+  lbann_callback_sync_selected(const lbann_callback_sync_selected&) = default;
+
+  lbann_callback_sync_selected& operator=(
+    const lbann_callback_sync_selected&) = default;
+
+  lbann_callback_sync_selected* copy() const override {
+    return new lbann_callback_sync_selected(*this);
+  }
+
+  ~lbann_callback_sync_selected() override;
+
+  std::string name() const override { return "sync_selected"; }
+
+  /// To protect in case that cudaProfilerInitialized() has already been called
+  static void turn_off_init_cuda_profiler();
+
+  /// Tells if cuda_profiler has been initialized
+  static bool check_if_cuda_profiler_initialized();
+
+  void init_cuda_profiler(const std::string cfg_file, const std::string out_dir,
+                          int out_mode, lbann_comm* comm) const;
+
+  using lbann_callback::on_forward_prop_begin;
+  using lbann_callback::on_backward_prop_begin;
+  using lbann_callback_sync_layers::on_forward_prop_end;
+  using lbann_callback_sync_layers::on_backward_prop_end;
+
+  /// Synchronize at the beginning of the forward prop of layer l
+  void on_forward_prop_begin(model* m, Layer* l) override;
+  /// Synchronize at the end of the forward prop of layer l
+  void on_forward_prop_end(model* m, Layer* l) override;
+  /// Synchronize at the beginning of the backward prop of layer l
+  void on_backward_prop_begin(model* m, Layer* l) override;
+  /// Synchronize at the end of the backward prop of layer l
+  void on_backward_prop_end(model* m, Layer* l) override;
+
+ protected:
+  bool check_if_all_accounted_for() const;
+
+  layer_ptrs_t::iterator populate_layer_ptrs(Layer* l, const prop_t current_prop);
+
+  /// Synchronize and enable cuda profiler
+  void do_pre_sync(Layer* l);
+  /// Synchronize and disble cuda profiler
+  void do_sync(Layer* l) override;
+
+  /// The layers to synchronize.
+  layers_t m_layers;
+
+  /** The pointers of layers to synchronize for forward prop.
+   *  This set includes those of layers to synchronize for both props. */
+  layer_ptrs_t m_fwd_ptrs;
+  /** The pointers of layers to synchronize for backward prop.
+   *  This set includes those of layers to synchronize for both props. */
+  layer_ptrs_t m_bwd_ptrs;
+  /// The pointers of layers to synchronize for both props.
+  layer_ptrs_t m_both_ptrs;
+
+  bool m_all_set; ///< whether all the layer pointers are collected
+
+  /// Tells if cudaProfilerInitialized() has already been called.
+  static bool m_cuda_profiler_initialized;
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_CALLBACKS_CALLBACK_SYNC_SELECTED_HPP_INCLUDED

--- a/include/lbann/callbacks/callback_sync_selected.hpp
+++ b/include/lbann/callbacks/callback_sync_selected.hpp
@@ -76,6 +76,7 @@ class lbann_callback_sync_selected : public lbann_callback_sync_layers {
   ~lbann_callback_sync_selected() override;
 
   std::string name() const override { return "sync_selected"; }
+  std::string get_description() const;
 
   /// To protect in case that cudaProfilerInitialized() has already been called
   static void turn_off_init_cuda_profiler();
@@ -85,6 +86,10 @@ class lbann_callback_sync_selected : public lbann_callback_sync_layers {
 
   void init_cuda_profiler(const std::string cfg_file, const std::string out_dir,
                           int out_mode, lbann_comm* comm) const;
+
+  /** Called once to set up the callback (after all layers are set up).
+   * Then, populate the layer pointers */
+  void setup(model *m) override;
 
   using lbann_callback::on_forward_prop_begin;
   using lbann_callback::on_backward_prop_begin;

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -62,6 +62,7 @@ class lbann_callback_sync_layers;
  */
 class Layer {
   friend class lbann_callback_sync_layers;
+  friend class lbann_callback_sync_selected;
 
  public:
   Layer(lbann_comm *comm);

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -162,6 +162,7 @@
 #include "lbann/callbacks/callback_save_model.hpp"
 #include "lbann/callbacks/callback_gpu_memory_usage.hpp"
 #include "lbann/callbacks/callback_sync_layers.hpp"
+#include "lbann/callbacks/callback_sync_selected.hpp"
 
 /// Weights and weight initializers
 #include "lbann/weights/weights.hpp"

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -23,6 +23,7 @@ set_full_path(THIS_DIR_SOURCES
   callback_save_model.cpp
   callback_summary.cpp
   callback_sync_layers.cpp
+  callback_sync_selected.cpp
   callback_timeline.cpp
   callback_timer.cpp
   callback_variable_minibatch.cpp

--- a/src/callbacks/callback_sync_selected.cpp
+++ b/src/callbacks/callback_sync_selected.cpp
@@ -1,0 +1,262 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// callback_sync_selected.cpp - Callback to synchronize selected layers
+///////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_sync_selected.hpp"
+#include "lbann/utils/timer.hpp"
+#ifdef LBANN_NVPROF
+#include <cuda_profiler_api.h>
+#include "lbann/utils/file_utils.hpp"
+#include <sstream>
+#endif // LBANN_NVPROF
+
+namespace lbann {
+
+bool lbann_callback_sync_selected::m_cuda_profiler_initialized = false;
+const std::map<lbann_callback_sync_selected::prop_t, std::string>
+  lbann_callback_sync_selected::m_prop_str
+    = {std::make_pair(lbann_callback_sync_selected::prop_t::Both, "Both"),
+       std::make_pair(lbann_callback_sync_selected::prop_t::Forward, "Forward"),
+       std::make_pair(lbann_callback_sync_selected::prop_t::Backward, "Backward")};
+
+lbann_callback_sync_selected::lbann_callback_sync_selected(
+  const lbann_callback_sync_selected::layers_t& layers, bool async_gpus, bool async_mpi)
+  : lbann_callback_sync_layers(!async_gpus, !async_mpi, false),
+    m_layers(layers), m_all_set(false) {
+  #ifdef LBANN_NVPROF
+  cudaProfilerStop(); // make sure to flush out profile data
+  #endif
+
+  size_t cnt_fwd = 0u;
+  size_t cnt_bwd = 0u;
+  for(const auto& l: m_layers) {
+    switch (l.second) {
+      case Forward: cnt_fwd ++; break;
+      case Backward: cnt_bwd ++; break;
+      case Both: cnt_fwd ++; cnt_bwd ++; break;
+    }
+  }
+  m_fwd_ptrs.reserve(cnt_fwd);
+  m_bwd_ptrs.reserve(cnt_bwd);
+}
+
+lbann_callback_sync_selected::~lbann_callback_sync_selected() {
+  #ifdef LBANN_NVPROF
+  cudaProfilerStop(); // make sure to flush out profile data
+  #endif
+}
+
+void lbann_callback_sync_selected::turn_off_init_cuda_profiler() {
+  m_cuda_profiler_initialized = true;
+}
+
+bool lbann_callback_sync_selected::check_if_cuda_profiler_initialized() {
+  return m_cuda_profiler_initialized;
+}
+
+/**
+ * Allow users to pass parameters to cudaProfilerInitialize() via prototext.
+ * @param cfg_file configuration file for cuda profiler.
+ *        (cuda_profiler_setup::config_file in the prototext)
+ * @param out_dir output mode for cuda profiler.
+ *        (cuda_profiler_setup::output_dir in the prototext)
+ * @param out_mode output mode for cuda profiler.
+ *        (cuda_profiler_setup::output_mode in the prototext)
+ * @param comm global world communicator.
+ * The profile output will be wrttien to out_dir/layer_name.prop.rank
+ */
+void lbann_callback_sync_selected::init_cuda_profiler(
+  const std::string cfg_file, const std::string out_dir, int out_mode, lbann_comm* comm) const {
+#ifdef LBANN_NVPROF
+  if (check_if_cuda_profiler_initialized()) {
+    return;
+  }
+  turn_off_init_cuda_profiler();
+
+  std::string o_dir = out_dir;
+  if (comm->am_world_master()) {
+    if (!lbann::create_dir(o_dir)) {
+      throw lbann_exception("sync_selected failed to create output directory: " + out_dir);
+    }
+  }
+  o_dir = add_delimiter(o_dir);
+
+  El::GPUManager::SynchronizeDevice();
+  comm->global_barrier();
+
+  std::string selection;
+  for (const auto& l: m_layers) {
+    std::map<prop_t, std::string>::const_iterator it = m_prop_str.find(l.second);
+    selection += l.first + '.' + it->second + '.';
+  }
+  const std::string o_prefix = o_dir + selection;
+  const int my_rank = comm->get_rank_in_world();
+  const std::string o_file = o_prefix + std::to_string(my_rank);
+  const cudaOutputMode_t o_mode = (out_mode == 0)? cudaKeyValuePair : cudaCSV;
+
+  const auto ret = cudaProfilerInitialize(cfg_file.c_str(), o_file.c_str(), o_mode);
+
+  if (ret == cudaErrorInvalidValue) {
+    throw lbann_exception("sync_selected is unabled to initialze cuda profiler: invalid inputs.");
+  } else if (ret == cudaErrorProfilerDisabled) {
+    std::stringstream err;
+    err << "sync_selected is unable to initialize cuda profiler: " << std::endl
+        << "  An external profiling tool (nvprof/nvvp) may already be running." << std::endl
+        << "  To use this callback with such a tool, set 'cuda_profiler::no_init'." << std::endl;
+    throw lbann_exception(err.str());
+  } else {
+    cudaProfilerStop(); // suppress profiling until reaching the region of interest
+
+    if (comm->am_world_master()) {
+      std::string msg = "Preparing callback sync_selected";
+      if (!o_prefix.empty()) {
+        msg += " with cudaProfiler writing to " + o_prefix + ".rank";
+      }
+      std::cout << msg << std::endl;
+    }
+  }
+#endif
+}
+
+
+void lbann_callback_sync_selected::on_forward_prop_begin(model *m, Layer *l) {
+  const layer_ptrs_t::const_iterator it
+    = (!m_all_set)? populate_layer_ptrs(l, Forward) : m_fwd_ptrs.find(l);
+
+  if (it == m_fwd_ptrs.cend()) {
+    return;
+  }
+  // We do not measure the time to synchronize here and thus not contribute it
+  // back to the cost of the preceding layer as we are only interested in the
+  // selected layer.
+  do_pre_sync(l);
+}
+
+void lbann_callback_sync_selected::on_forward_prop_end(model *m, Layer *l) {
+  const layer_ptrs_t::const_iterator it = m_fwd_ptrs.find(l);
+  if (it == m_fwd_ptrs.cend()) {
+    return;
+  }
+  const double start = get_time();
+  do_sync(l);
+  l->m_fp_time += get_time() - start;
+}
+
+void lbann_callback_sync_selected::on_backward_prop_begin(model *m, Layer *l) {
+  const layer_ptrs_t::const_iterator it
+    = (!m_all_set)? populate_layer_ptrs(l, Backward) : m_bwd_ptrs.find(l);
+
+  if (it == m_bwd_ptrs.cend()) {
+    return;
+  }
+  do_pre_sync(l);
+}
+
+void lbann_callback_sync_selected::on_backward_prop_end(model *m, Layer *l) {
+  const layer_ptrs_t::const_iterator it = m_bwd_ptrs.find(l);
+  if (it == m_bwd_ptrs.cend()) {
+    return;
+  }
+  const double start = get_time();
+  do_sync(l);
+  l->m_bp_time += get_time() - start;
+}
+
+bool lbann_callback_sync_selected::check_if_all_accounted_for() const {
+  return (m_fwd_ptrs.size() + m_bwd_ptrs.size()
+         == m_layers.size() + m_both_ptrs.size());
+}
+
+/**
+ * When the pointer of a selected layer is not known, rely on the layer name
+ * to match. When the first time the match is found, save the pointer of the
+ * selected layer and use it for the subsequent matching instead of name.
+ */
+lbann_callback_sync_selected::layer_ptrs_t::iterator
+lbann_callback_sync_selected::populate_layer_ptrs(
+  Layer* l, const lbann_callback_sync_selected::prop_t current_prop) {
+
+  std::pair<layer_ptrs_t::iterator, bool> ret
+    = std::make_pair(((current_prop == Forward)? m_fwd_ptrs.end() : m_bwd_ptrs.end()), false);
+
+  const layers_t::const_iterator it = m_layers.find(l->get_name());
+
+  if (it != m_layers.cend()) { // A matching layer is found
+    const prop_t selected_prop = it->second;
+
+    if ((selected_prop != Both) && (selected_prop != current_prop)) {
+      return ret.first; // Prop direction does not match
+    }
+
+    if (selected_prop == Forward) {
+      ret = m_fwd_ptrs.emplace(l);
+    } else if (selected_prop == Backward) {
+      ret = m_bwd_ptrs.emplace(l);
+    } else { // Both
+      m_both_ptrs.emplace(l);
+
+      if (current_prop == Forward) {
+        ret = m_fwd_ptrs.emplace(l);
+        m_bwd_ptrs.emplace(l);
+      } else {
+        m_fwd_ptrs.emplace(l);
+        ret = m_bwd_ptrs.emplace(l);
+      }
+    }
+    if (check_if_all_accounted_for()) {
+      m_all_set = true;
+    }
+  }
+  return ret.first;
+}
+
+
+void lbann_callback_sync_selected::do_pre_sync(Layer *l) {
+  lbann_callback_sync_layers::do_sync(l);
+  #ifdef LBANN_NVPROF
+  cudaProfilerStart();
+  #endif
+}
+
+void lbann_callback_sync_selected::do_sync(Layer *l) {
+#ifdef LBANN_NVPROF //(also deinfed LBANN_HAS_GPU)
+  if (m_sync_gpus) {
+    El::GPUManager::SynchronizeDevice();
+    cudaProfilerStop();
+  }
+  if (m_sync_mpi) {
+    l->get_comm()->global_barrier();
+  }
+  if (!m_sync_gpus) {
+    cudaProfilerStop();
+  }
+#else
+  lbann_callback_sync_layers::do_sync(l);
+#endif
+}
+
+}  // namespace lbann

--- a/src/callbacks/callback_sync_selected.cpp
+++ b/src/callbacks/callback_sync_selected.cpp
@@ -96,7 +96,7 @@ bool lbann_callback_sync_selected::check_if_cuda_profiler_initialized() {
  * @param out_mode output mode for cuda profiler.
  *        (cuda_profiler_setup::output_mode in the prototext)
  * @param comm global world communicator.
- * The profile output will be wrttien to out_dir/layer_name.prop.rank
+ * The profile output will be wrttien to out_dir/layer_name.prop.rank.prof
  */
 void lbann_callback_sync_selected::init_cuda_profiler(
   const std::string cfg_file, const std::string out_dir, int out_mode, lbann_comm* comm) const {
@@ -124,7 +124,7 @@ void lbann_callback_sync_selected::init_cuda_profiler(
   }
   const std::string o_prefix = o_dir + selection;
   const int my_rank = comm->get_rank_in_world();
-  const std::string o_file = o_prefix + std::to_string(my_rank);
+  const std::string o_file = o_prefix + std::to_string(my_rank) + ".prof";
   const cudaOutputMode_t o_mode = (out_mode == 0)? cudaKeyValuePair : cudaCSV;
 
   const auto ret = cudaProfilerInitialize(cfg_file.c_str(), o_file.c_str(), o_mode);
@@ -143,7 +143,7 @@ void lbann_callback_sync_selected::init_cuda_profiler(
     if (comm->am_world_master()) {
       std::string msg = "Preparing callback sync_selected";
       if (!o_prefix.empty()) {
-        msg += " with cudaProfiler writing to " + o_prefix + ".rank";
+        msg += " with cudaProfiler writing to " + o_prefix + ".rank.prof";
       }
       std::cout << msg << std::endl;
     }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -232,6 +232,43 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                           params.sync_mpi(),
                                           params.only_input());
   }
+  if (proto_cb.has_sync_selected()) {
+    const auto& params = proto_cb.sync_selected();
+    const int num_layers = params.layer_to_sync_size();
+    if (num_layers == 0) {
+      throw lbann_exception("sync_selected requires at least a layer to synchronize.");
+    }
+
+    using layers_t = lbann_callback_sync_selected::layers_t;
+    using prop_t = lbann_callback_sync_selected::prop_t;
+
+    layers_t selected_layers;
+    selected_layers.reserve(num_layers);
+
+    for (int i = 0; i < num_layers; ++i) {
+      const auto& layer_to_sync = params.layer_to_sync(i);
+      selected_layers.emplace(layer_to_sync.name(),
+                              static_cast<prop_t>(layer_to_sync.prop()));
+    }
+
+    lbann_callback_sync_selected* cb_ptr
+      = new lbann_callback_sync_selected(selected_layers,
+                                        params.async_gpus(),
+                                        params.async_mpi());
+
+    #ifdef LBANN_NVPROF
+    const auto& cp_setup = params.cuda_profiler_setup();
+    if (cp_setup.no_init()) {
+      lbann_callback_sync_selected::turn_off_init_cuda_profiler();
+    } else {
+      cb_ptr->init_cuda_profiler(cp_setup.config_file(),
+                                 cp_setup.output_dir(),
+                                 cp_setup.output_mode(),
+                                 comm);
+    }
+    #endif // LBANN_NVPROF
+    return cb_ptr;
+  }
 
   //////////////////////////////////////////////////////////////////
   // Debugging

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -612,10 +612,14 @@ message CallbackSyncSelected {
   }
 
   message CudaProfilerSetup {
+    enum OutputMode {
+      KeyValuePair = 0;
+      CSV = 1;
+    }
     bool no_init = 1;
     string config_file = 2;
     string output_dir = 3;
-    int32 output_mode = 4;
+    OutputMode output_mode = 4;
   }
 
   bool async_gpus = 1;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -428,6 +428,7 @@ message Callback {
    CallbackPolyLearningRate poly_learning_rate = 30;
    CallbackGPUMemoryUsage gpu_memory_usage = 31;
    CallbackSyncLayers sync_layers = 32;
+   CallbackSyncSelected sync_selected = 33;
 }
 
 message CallbackLTFB {
@@ -597,6 +598,30 @@ message CallbackSyncLayers {
   bool sync_gpus = 1;
   bool sync_mpi = 2;
   bool only_input = 3;
+}
+
+message CallbackSyncSelected {
+  message LayerToSync {
+    enum PropDirection {
+      Both = 0;
+      Forward = 1;
+      Backward = 2;
+    }
+    string name = 1; // name of the layer to synchronize
+    PropDirection prop = 2; // propagation setep to synchronize
+  }
+
+  message CudaProfilerSetup {
+    bool no_init = 1;
+    string config_file = 2;
+    string output_dir = 3;
+    int32 output_mode = 4;
+  }
+
+  bool async_gpus = 1;
+  bool async_mpi = 2;
+  repeated LayerToSync layer_to_sync = 3;
+  CudaProfilerSetup cuda_profiler_setup = 4;
 }
 
 //========================================================================


### PR DESCRIPTION
A callback to synchronize selected layers in particular prop steps.
It helps get a closer look at the performance of particular layers, especially marking the selected layers especially by `cudaProfilerStart()` and `cudaProfilerStop()` to profile GPU activities of those.
This inherits sync_layers callback.

The prototext interface is as below:
```
  callback {
    sync_selected {
      layer_to_sync {
        name: "conv1_head0"
        prop: Forward  # Forward, Backward or Both
      }
      layer_to_sync {
        name: "fc7"
        prop: Backward
      }

      async_gpus: false
      async_mpi: false

      cuda_profiler_setup {
        # set no_init to true to skip calling cudaProfilerInitialize(), which will avoid conflict with
        # an external profiler such as nvprof while still profiling selectively using the cudaProfilerStart()
        # and cudaProfilerStop() instrumented
        no_init: true  
        config_file: ""
        output_dir: "nvprof"
        output_mode: KeyValuePair # KeyValuePair or CSV
      }
    }
  }
```