### PR TITLE
Avoid TranslateBetweenGrids

### DIFF
--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -35,7 +35,10 @@ using namespace lbann;
 
 const int lbann_default_random_seed = 42;
 
-model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &pb);
+model * build_model_from_prototext(int argc, char **argv,
+                                   lbann_data::LbannPB &pb,
+                                   lbann_comm *comm,
+                                   bool first_model);
 bool load_model_weights(std::string ckpt_dir, model * m);
 
 int main(int argc, char *argv[]) {
@@ -62,10 +65,12 @@ int main(int argc, char *argv[]) {
     std::vector<lbann_data::LbannPB *> pbs;
     protobuf_utils::load_prototext(master, argc, argv, pbs);
 
-    model *model_1 = build_model_from_prototext(argc, argv, *(pbs[0]));
+    model *model_1 = build_model_from_prototext(argc, argv, *(pbs[0]),
+                                                comm, true);
     model *model_2 = nullptr;
     if (pbs.size() > 1) {
-      model_2 = build_model_from_prototext(argc, argv, *(pbs[1]));
+      model_2 = build_model_from_prototext(argc, argv, *(pbs[1]),
+                                           comm, false);
     }
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
@@ -123,9 +128,11 @@ int main(int argc, char *argv[]) {
   return 0;
 }
 
-model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &pb) {
+model * build_model_from_prototext(int argc, char **argv,
+                                   lbann_data::LbannPB &pb,
+                                   lbann_comm *comm,
+                                   bool first_model) {
   int random_seed = lbann_default_random_seed;
-  lbann_comm *comm = initialize(argc, argv, random_seed);
   bool master = comm->am_world_master();
   if (master) std::cerr << "starting build_model_from_prototext\n";
   model *model = nullptr; //d hysom bad namimg! should fix
@@ -173,14 +180,20 @@ model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &p
     }
 #endif
 
-    // Set up the communicator and get the grid.
+    // Set up the communicator and get the grid based on the first model's spec.
+    // We do not currently support splitting different models in different ways,
+    // as this implies different grids.
     int procs_per_model = pb_model->procs_per_model();
     if (procs_per_model == 0) {
       procs_per_model = comm->get_procs_in_world();
     }
-    comm->split_models(procs_per_model);
-    if (pb_model->num_parallel_readers() > procs_per_model) {
-      pb_model->set_num_parallel_readers(procs_per_model);
+    if (first_model) {
+      comm->split_models(procs_per_model);
+      if (pb_model->num_parallel_readers() > procs_per_model) {
+        pb_model->set_num_parallel_readers(procs_per_model);
+      }
+    } else if (procs_per_model != comm->get_procs_per_model()) {
+      LBANN_ERROR("Model prototexts requesting different procs per model is not supported");
     }
 
     // Save info to file; this includes the complete prototext (with any over-rides


### PR DESCRIPTION
This fixes lbann2 to use the same `lbann_comm` object for every model, instead of creating separate ones, which results in different grids being used. This should fix #432.

I tried the command line @DylanMcKinney posted in that issue, and I'm not seeing any segfaults.