### PR TITLE
Warning macro

### DIFF
--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -36,14 +36,25 @@
 #include <exception>
 
 // Macro to throw an LBANN exception
-#define LBANN_ERROR(message)                                            \
+#define LBANN_ERROR(message)                                    \
+  do {                                                          \
+    std::stringstream ss_LBANN_ERROR;                           \
+    ss_LBANN_ERROR << "LBANN error "                            \
+                   << "(" << __FILE__ << ":" << __LINE__ << ")" \
+                   << ": " << (message);                        \
+    throw lbann::lbann_exception(ss_LBANN_ERROR.str());         \
+  } while (0)
+
+// Macro to print a warning to standard error stream.
+#define LBANN_WARNING(message, comm)                                    \
   do {                                                                  \
-    std::stringstream ss_LBANN_ERROR;                                   \
-    ss_LBANN_ERROR << "LBANN error"                                     \
-                   << " (" << __FILE__ << ":" << __LINE__ << ")"        \
-                   << ": " << (message);                                \
-    throw lbann::lbann_exception(ss_LBANN_ERROR.str());                 \
-  } while(0)
+    std::stringstream ss_LBANN_WARNING;                                 \
+    ss_LBANN_WARNING << "LBANN warning "                                \
+                     << "on rank " << comm.get_rank_in_world() << " "   \
+                     << "(" << __FILE__ << ":" << __LINE__ << ")"       \
+                     << ": " << (message) << std::endl;                 \
+    std::cerr << ss_LBANN_WARNING.str();                                \
+  } while (0)
 
 namespace lbann {
 


### PR DESCRIPTION
I've added an `LBANN_WARNING` macro that is helpful for non-fatal warnings and printf debugging. It reports the MPI rank, file, line number, and a message to the standard output. For instance:
```
some_function();
LBANN_WARNING("debug1", *m_comm);
horrible_bug_on_rank_1();
LBANN_WARNING("debug2", *m_comm);
another_function();
```
will output something like:
```
LBANN warning on rank 1 (lbann/some/file.cpp:42): debug1
LBANN warning on rank 0 (lbann/some/file.cpp:42): debug1
LBANN warning on rank 0 (lbann/some/file.cpp:44): debug2
srun: error: surface176: task 1: Segmentation fault (core dumped)
```