### PR TITLE
Label readers in merge feature reader

### DIFF
--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -185,11 +185,13 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
           if (readme.format() == "numpy") {
              auto* label_numpy  = new numpy_reader(false);
              label_numpy->set_label_filename(readme.label_filename());
+             label_numpy->set_data_filename(readme.label_filename());
              label_reader = label_numpy;
            } else if (readme.format() == "csv") { //if format is csv and label_filename is not empty
              auto* label_csv = new csv_reader(shuffle);
              if(master) { std::cout << "Set label filename: " << readme.label_filename() << std::endl; }
              label_csv->set_label_filename(readme.label_filename());
+             label_csv->set_data_filename(readme.label_filename());
              label_csv->disable_labels(readme.disable_labels());
              label_csv->enable_responses(readme.disable_responses());
              label_csv->set_has_header(readme.has_header()); //use same as parent file


### PR DESCRIPTION
Set label filename as data filename in merge features data reader. The load function in underlying reader (e.g., csv)  called by merge_features requires that data_filename be set or exception is thrown. This fix a crash in loading pilot1 combo data (csv), the fix should be general but want to me sure it is correct and nothing else is broken (or might break in future).