### PR TITLE
GPU evaluation layer

### DIFF
--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -60,7 +60,7 @@ private:
   /** Scaling factor to apply to evaluated value. */
   EvalType m_scale;
   /** Evaluated value. */
-  std::unique_ptr<El::AbstractDistMatrix<EvalType>> m_value;
+  std::unique_ptr<AbsDistMat> m_value;
   /** Non-blocking allreduce request. */
   Al::request m_allreduce_req;
   

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -31,24 +31,51 @@
 
 namespace lbann {
 
+/** Abstract evaluation layer.
+ *  Computes the average value across a mini-batch. If the input
+ *  tensor has multiple neurons, their values are added together.
+ */
+class abstract_evaluation_layer : public transform_layer {
+public:
+
+  /** Get scaling factor. */
+  EvalType get_scale() const { return m_scale; }
+  /** Set scaling factor. */
+  void set_scale(EvalType scale) { m_scale = scale; }
+  /** Get evaluated value. */
+  EvalType get_value(bool scaled = true);
+
+protected:
+
+  abstract_evaluation_layer(lbann_comm *comm);
+  abstract_evaluation_layer(const abstract_evaluation_layer& other);
+  abstract_evaluation_layer& operator=(const abstract_evaluation_layer& other);
+
+  void setup_matrices(const El::Grid& grid) override;
+  void fp_compute() override;
+  void bp_compute() override;
+
+private:
+
+  /** Scaling factor to apply to evaluated value. */
+  EvalType m_scale;
+  /** Evaluated value. */
+  std::unique_ptr<El::AbstractDistMatrix<EvalType>> m_value;
+  /** Non-blocking allreduce request. */
+  Al::request m_allreduce_req;
+  
+};
+
 /** Evaluation layer.
  *  Computes the average value across a mini-batch. If the input
  *  tensor has multiple neurons, their values are added together.
  */
 template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
-class evaluation_layer : public transform_layer {
+class evaluation_layer : public abstract_evaluation_layer {
 
  public:
 
-  evaluation_layer(lbann_comm *comm)
-    : transform_layer(comm), m_scale(0), m_value(0) {
-    static_assert(Dev == El::Device::CPU,
-                  "evaluation layer currently only supports CPU");
-
-    // Evaluation layer has no children
-    m_expected_num_child_layers = 0;
-
-  }
+  evaluation_layer(lbann_comm *comm) : abstract_evaluation_layer(comm) {}
 
   evaluation_layer* copy() const override { return new evaluation_layer(*this); }
   std::string get_type() const override { return "evaluation"; }
@@ -61,60 +88,6 @@ class evaluation_layer : public transform_layer {
      s << "evaluation_layer  dataLayout: " << this->get_data_layout_string(get_data_layout());
      return s.str();
   }
-
-  /** Get scaling factor. */
-  EvalType get_scale() const { return m_scale; }
-  /** Set scaling factor. */
-  void set_scale(EvalType scale) { m_scale = scale; }
-
-  /** Get evaluated value. */
-  EvalType get_value(bool unscaled = false) {
-    this->m_comm->wait(m_allreduce_req);
-    if (unscaled) {
-      return m_value;
-    } else {
-      return m_scale * m_value;
-    }
-  }
-
- protected:
-
-  virtual void fp_compute() override {
-    const auto& input = get_prev_activations();
-    const auto& local_input = input.LockedMatrix();
-    const El::Int local_height = local_input.Height();
-    const El::Int local_width = local_input.Width();
-    const auto& mini_batch_size = input.Width();
-
-    // Compute average value
-    EvalType sum = EvalType(0);
-    #pragma omp parallel for reduction(+:sum) collapse(2)
-    for (El::Int col = 0; col < local_width; ++col) {
-      for (El::Int row = 0; row < local_height; ++row) {
-        sum += local_input(row, col);
-      }
-    }
-    m_value = sum / mini_batch_size;
-    this->m_comm->nb_allreduce(&m_value, 1, input.DistComm(), m_allreduce_req);
-
-  }
-
-  virtual void bp_compute() override {
-    auto& error_signal = get_error_signals();
-    if (m_scale == EvalType(0)) {
-      El::Zero(error_signal);
-    } else {
-      El::Fill(error_signal, DataType(m_scale));
-    }
-  }
-
- private:
-  /** Scaling factor to apply to evaluated value. */
-  EvalType m_scale;
-  /** Evaluated value. */
-  EvalType m_value;
-  /** Non-blocking allreduce request. */
-  Al::request m_allreduce_req;
 
 };
 

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -48,10 +48,7 @@ public:
 protected:
 
   abstract_evaluation_layer(lbann_comm *comm);
-  abstract_evaluation_layer(const abstract_evaluation_layer& other);
-  abstract_evaluation_layer& operator=(const abstract_evaluation_layer& other);
 
-  void setup_matrices(const El::Grid& grid) override;
   void fp_compute() override;
   void bp_compute() override;
 
@@ -60,7 +57,7 @@ private:
   /** Scaling factor to apply to evaluated value. */
   EvalType m_scale;
   /** Evaluated value. */
-  std::unique_ptr<AbsDistMat> m_value;
+  DataType m_value;
   /** Non-blocking allreduce request. */
   Al::request m_allreduce_req;
   

--- a/include/lbann/metrics/layer_metric.hpp
+++ b/include/lbann/metrics/layer_metric.hpp
@@ -28,6 +28,7 @@
 #define LBANN_METRIC_LAYER_METRIC_HPP
 
 #include "lbann/metrics/metric.hpp"
+#include "lbann/layers/transform/evaluation.hpp"
 
 namespace lbann {
 
@@ -44,8 +45,8 @@ class layer_metric : public metric {
   std::string name() const override;
   std::string get_unit() const override { return m_unit; }
 
-  void set_evaluation_layer(Layer* l);
-  Layer* get_evaluation_layer() { return m_evaluation_layer; }
+  void set_evaluation_layer(abstract_evaluation_layer* l) { m_evaluation_layer = l; }
+  abstract_evaluation_layer* get_evaluation_layer() const { return m_evaluation_layer; }
 
  protected:
   
@@ -64,7 +65,7 @@ class layer_metric : public metric {
  private:
   
   std::string m_unit;
-  Layer* m_evaluation_layer;
+  abstract_evaluation_layer* m_evaluation_layer;
 
 };
 

--- a/include/lbann/objective_functions/layer_term.hpp
+++ b/include/lbann/objective_functions/layer_term.hpp
@@ -38,9 +38,9 @@ class layer_term : public objective_function_term {
   layer_term* copy() const override { return new layer_term(*this); } 
   std::string name() const override { return "evaluation layer term"; }
 
-  void set_evaluation_layer(Layer* l);
+  void set_evaluation_layer(abstract_evaluation_layer* l);
 
-  Layer* get_evaluation_layer();
+  abstract_evaluation_layer* get_evaluation_layer();
 
   void setup(model& m) override;
 

--- a/model_zoo/tests/model_mnist_conv_graph.prototext
+++ b/model_zoo/tests/model_mnist_conv_graph.prototext
@@ -222,13 +222,13 @@ model {
     name: "cross_entropy"
     parents: "prob labels"
     data_layout: "model_parallel"
-    cross_entropy {}    
+    cross_entropy {}
   }
   layer {
     name: "cross_entropy_eval"
     parents: "cross_entropy"
     data_layout: "model_parallel"
-    evaluation {}    
+    evaluation {}
   }
 
 }

--- a/src/layers/transform/CMakeLists.txt
+++ b/src/layers/transform/CMakeLists.txt
@@ -1,14 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
-  layer.cpp
+  evaluation.cpp
   )
-
-# Add the subdirectories
-add_subdirectory(activations)
-add_subdirectory(learning)
-add_subdirectory(loss)
-add_subdirectory(regularizers)
-add_subdirectory(transform)
 
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/transform/evaluation.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+namespace {
+
+/** Compute sum of entries in local matrix.
+ *  Result is recorded in 1x1 matrix 'sum'.
+ */
+void local_matrix_sum(const AbsMat& local_matrix,
+                      El::AbstractMatrix<EvalType>& local_sum) {
+  if (local_matrix.GetDevice() != local_sum.GetDevice()) {
+    LBANN_ERROR("input matrix and accumulation variable "
+                "must be on same device");
+  }
+  El::Zeros(local_sum, 1, 1);
+  switch (local_matrix.GetDevice()) {
+  case El::Device::CPU:
+    {
+      auto& sum = local_sum(0,0);
+#pragma omp parallel for reduction(+:sum) collapse(2)
+      for (El::Int col = 0; col < local_matrix.Height(); ++col) {
+        for (El::Int row = 0; row < local_matrix.Width(); ++row) {
+          sum += EvalType(local_matrix(row, col));
+        }
+      }
+    }
+    break;
+#ifdef LBANN_HAS_GPU
+  case El::Device::GPU:
+    {
+      LBANN_ERROR("not yet implemented");
+    }
+    break;
+#endif // LBANN_HAS_GPU
+  default: LBANN_ERROR("invalid device");
+  }
+}
+
+} // namespace
+
+EvalType abstract_evaluation_layer::get_value(bool scaled) {
+  get_comm()->wait(m_allreduce_req);
+  const auto& value = m_value->Get(0,0);
+  if (scaled) { return m_scale * value; }
+  else        { return value; }
+}
+
+abstract_evaluation_layer::abstract_evaluation_layer(lbann_comm *comm)
+  : transform_layer(comm), m_scale(0) {
+
+  // Evaluation layer has no children
+  m_expected_num_child_layers = 0;
+
+}
+
+abstract_evaluation_layer
+::abstract_evaluation_layer(const abstract_evaluation_layer& other)
+  : transform_layer(other),
+    m_scale(other.m_scale),
+    m_value(other.m_value ? other.m_value->Copy() : nullptr),
+    m_allreduce_req(other.m_allreduce_req) {}
+
+abstract_evaluation_layer&
+abstract_evaluation_layer::operator=(const abstract_evaluation_layer& other) {
+  transform_layer::operator=(other);
+  m_scale = other.m_scale;
+  m_value.reset(other.m_value ? other.m_value->Copy() : nullptr);
+  m_allreduce_req = other.m_allreduce_req;
+  return *this;
+}
+
+void abstract_evaluation_layer::setup_matrices(const El::Grid& grid) {
+  transform_layer::setup_matrices(grid);
+  switch (get_device_allocation()) {
+  case El::Device::CPU:
+    m_value.reset(new El::DistMatrix<EvalType, El::STAR, El::STAR, El::ELEMENT, El::Device::CPU>());
+    break;
+#ifdef LBANN_HAS_GPU
+  case El::Device::GPU:
+    m_value.reset(new El::DistMatrix<EvalType, El::STAR, El::STAR, El::ELEMENT, El::Device::GPU>());
+    break;
+#endif // LBANN_HAS_GPU
+  default: LBANN_ERROR("invalid device");
+  }
+  El::Zeros(*m_value, 1, 1);
+}
+
+void abstract_evaluation_layer::fp_compute() {
+  const auto& input = get_prev_activations();
+  const auto& mini_batch_size = input.Width();
+  local_matrix_sum(input.LockedMatrix(), m_value->Matrix());
+  *m_value *= EvalType(1) / mini_batch_size;
+  get_comm()->nb_allreduce(m_value->Buffer(), 1, input.DistComm(),
+                           m_allreduce_req);
+}
+
+void abstract_evaluation_layer::bp_compute() {
+  El::Fill(get_error_signals(), DataType(m_scale));
+}
+
+} // namespace lbann

--- a/src/metrics/layer_metric.cpp
+++ b/src/metrics/layer_metric.cpp
@@ -40,18 +40,6 @@ std::string layer_metric::name() const {
   }
 }
 
-void layer_metric::set_evaluation_layer(Layer* eval) {
-  auto&& eval_dp = dynamic_cast<evaluation_layer<data_layout::DATA_PARALLEL>*>(eval);
-  auto&& eval_mp = dynamic_cast<evaluation_layer<data_layout::MODEL_PARALLEL>*>(eval);
-  if (eval_dp == nullptr && eval_mp == nullptr) {
-    std::stringstream err;
-    err << "layer metric must point to an evaluation layer, "
-        << "but " << eval->get_name() << " is type " << eval->get_type();
-    LBANN_ERROR(err.str());
-  }
-  m_evaluation_layer = eval;
-}
-
 void layer_metric::setup(model& m) {
   if (m_evaluation_layer == nullptr) {
     LBANN_ERROR("attempted to setup layer metric without setting evaluation layer");
@@ -66,18 +54,15 @@ EvalType layer_metric::evaluate(execution_mode mode,
     LBANN_ERROR("attempted to evaluate metric without setting a target layer");
   }
 
+  // Get evaluation layer value
   const auto& start = get_time();
-  EvalType total_value = 0;
-  auto&& eval_dp = dynamic_cast<evaluation_layer<data_layout::DATA_PARALLEL>*>(m_evaluation_layer);
-  auto&& eval_mp = dynamic_cast<evaluation_layer<data_layout::MODEL_PARALLEL>*>(m_evaluation_layer);
-  if (eval_dp) { total_value = eval_dp->get_value(true) * mini_batch_size; }
-  if (eval_mp) { total_value = eval_mp->get_value(true) * mini_batch_size; }
-  if (m_unit == "%") { total_value *= 100; }
+  auto value = m_evaluation_layer->get_value(false);
+  if (m_unit == "%") { value *= 100; }
   get_evaluate_time() += get_time() - start;
 
   // Record result in statistics and return
-  get_statistics()[mode].add_value(total_value, mini_batch_size);
-  return total_value / mini_batch_size;
+  get_statistics()[mode].add_value(value * mini_batch_size, mini_batch_size);
+  return value;
 
 }
 

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -285,7 +285,7 @@ Layer* construct_layer(lbann_comm* comm,
     }
   }
   if (proto_layer.has_evaluation()) {
-    return new evaluation_layer<layout>(comm);
+    return new evaluation_layer<layout, Dev>(comm);
   }
   if (proto_layer.has_crop()) {
     const auto& params = proto_layer.crop();

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -93,7 +93,7 @@ void assign_layers_to_objective_function(std::vector<Layer*>& layer_list,
       if (num_layer_terms > proto_obj.layer_term_size()) { continue; }
       const auto& params = proto_obj.layer_term(num_layer_terms-1);
       auto&& eval = names_to_layers[params.layer()];
-      term->set_evaluation_layer(eval);
+      term->set_evaluation_layer(dynamic_cast<abstract_evaluation_layer*>(eval));
     }
   }
 
@@ -129,7 +129,7 @@ void assign_layers_to_metrics(std::vector<Layer*>& layer_list,
     if (m != nullptr) {
       const auto& params = proto_model.metric(i).layer_metric();
       auto&& eval = names_to_layers[params.layer()];
-      m->set_evaluation_layer(eval);
+      m->set_evaluation_layer(dynamic_cast<abstract_evaluation_layer*>(eval));
     }
   }
   


### PR DESCRIPTION
This PR adds a GPU implementation of the evaluation layer. To simplify interactions with the evaluation layer (e.g. in objective function layer terms and layer metrics), the templated evaluation layer class inherits from an abstract evaluation layer class.

Gradient checks come back clean.