### PR TITLE
Refactoring tensor dimension management in layers

### DIFF
--- a/include/lbann/layers/activations/sigmoid.hpp
+++ b/include/lbann/layers/activations/sigmoid.hpp
@@ -110,7 +110,7 @@ class sigmoid_layer : public entrywise_activation_layer {
 #ifndef LBANN_HAS_GPU
     LBANN_ERROR("CUDA not detected");
 #else
-    sigmoid_cuda::fp(get_num_neurons(),
+    sigmoid_cuda::fp(get_output_size(),
                      get_prev_activations().LocalWidth(),
                      get_prev_activations().LockedBuffer(),
                      get_prev_activations().LDim(),
@@ -124,7 +124,7 @@ class sigmoid_layer : public entrywise_activation_layer {
 #ifndef LBANN_HAS_GPU
     LBANN_ERROR("CUDA not detected");
 #else
-    sigmoid_cuda::bp(get_num_neurons(),
+    sigmoid_cuda::bp(get_output_size(),
                      get_prev_activations().LocalWidth(),
                      get_prev_activations().LockedBuffer(),
                      get_prev_activations().LDim(),

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -122,47 +122,11 @@ class generic_input_layer : public io_layer {
            + " (" + s + ")";
   }
 
-  std::vector<int> get_neuron_dims(int child_index = 0) const override {
-    return get_data_dims(child_index);
-  }
-
-  int get_num_neurons(int child_index = 0) const override {
-    auto&& neuron_dims = get_neuron_dims(child_index);
-    return std::accumulate(neuron_dims.begin(),
-                           neuron_dims.end(),
-                           1,
-                           std::multiplies<int>());
-  }
-
-  std::vector<int> fp_output_dims(const Layer* next_layer) const override {
-
-    // Return all neurons if input is null
-    if(next_layer == nullptr) {
-      return m_neuron_dims;
-    }
-
-    // Check if input is in the list of child layers
-    const int child_index = (std::find(this->m_child_layers.begin(),
-                                       this->m_child_layers.end(),
-                                       next_layer)
-                             - this->m_child_layers.begin());
-    if(child_index >= (int) this->m_child_layers.size()) {
-      return m_neuron_dims;
-    }
-
-    // Return slice dimensions
-    return get_neuron_dims(child_index);
-
-  }
-
   void setup_dims() override {
     io_layer::setup_dims();
-    this->m_neuron_dims = get_data_dims();
-    this->m_num_neuron_dims = this->m_neuron_dims.size();
-    this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                          this->m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
+    for (int i = 0; i < get_num_children(); ++i) {
+      set_output_dims(get_data_dims(i), i);
+    }
   }
 
   void setup_data() override {
@@ -205,7 +169,9 @@ class generic_input_layer : public io_layer {
     default:
       linearized_target_size = 0;
     }
-    io_buffer->setup_data(this->m_num_neurons, linearized_target_size, max_mb_size);
+    io_buffer->setup_data(get_output_size(0),
+                          linearized_target_size,
+                          max_mb_size);
   }
 
   /** Define the standard view of the matrix -- and set it for the model
@@ -560,7 +526,7 @@ class generic_input_layer : public io_layer {
     std::stringstream ss;
     const size_t num_children = get_num_children();
     for (size_t i = 0; i < num_children; ++i) {
-      const auto& dims = get_neuron_dims(i);
+      const auto& dims = get_output_dims(i);
       if (i > 0) { ss << ", "; }
       ss << "activations";
       if (num_children > 1) { ss << "[" << i << "]"; }

--- a/include/lbann/layers/io/input/repeated_input_layer.hpp
+++ b/include/lbann/layers/io/input/repeated_input_layer.hpp
@@ -84,12 +84,8 @@ class repeated_input_layer : public input_layer<partitioned_io_buffer, data_layo
     input_layer<partitioned_io_buffer, data_layout::DATA_PARALLEL>::setup_dims();
     const auto& data_size = get_linearized_data_size();
     const auto& label_size = get_linearized_label_size();
-    this->m_neuron_dims.assign(1, m_num_steps * (data_size + label_size));
-    this->m_num_neuron_dims = this->m_neuron_dims.size();
-    this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                          this->m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
+    std::vector<int> dims(1, m_num_steps * (data_size + label_size));
+    set_output_dims(dims);
   }
 
   void setup_data() override {

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -281,8 +281,8 @@ class Layer {
    */
   std::vector<int> get_output_dims(int output_index = 0) const;
   /** Get size of an output tensor.
-   *  E.g. get the size of a "previous activations tensor" or
-   *  the number of "previous neurons."
+   *  E.g. get the size of an "activations tensor" or the number of
+   *  "neurons."
    */
   int get_output_size(int output_index = 0) const;
 
@@ -404,10 +404,9 @@ class Layer {
    */
   virtual void setup_pointers();
   /** Setup tensor dimensions
-   *  Called by the setup function. Ihe base class sets all
-   *  uninitialized output tensor dimensions equal to the first input
-   *  tensor's dimensions (provided there is at least one input
-   *  tensor)
+   *  Called by the setup function. If there are any input tensors,
+   *  the base method sets all uninitialized output tensor dimensions
+   *  equal to the first input tensor dimensions.
    */
   virtual void setup_dims();
   /** Instantiate distributed matrices.
@@ -466,7 +465,7 @@ class Layer {
   /** Whether current layer is using a GPU implementation. */
   bool m_using_gpus;
 
-  /** Dimensions of each output tensor. */
+  /** Dimensions of output tensors. */
   std::vector<std::vector<int>> m_output_dims_list;
 
   /** Instantiate distributed matrices. */

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -295,6 +295,27 @@ class Layer {
   /** Replace weights with another Layer's weights*/
   void replace_weights(Layer* other_layer);
 
+  /** Get dimensions of an input tensor.
+   *  E.g. get the dimensions of a "previous activations tensor" or
+   *  the "previous neuron dimensions."
+   */
+  std::vector<int> get_input_dims(int input_index = 0) const;
+  /** Get size of an input tensor.
+   *  E.g. get the size of a "previous activations tensor" or
+   *  the number of "previous neurons."
+   */
+  int get_input_size(int input_index = 0) const;
+  /** Get dimensions of an output tensor.
+   *  E.g. get the dimensions of an "activations tensor" or the
+   *  "neuron dimensions."
+   */
+  std::vector<int> get_output_dims(int output_index = 0) const;
+  /** Get size of an output tensor.
+   *  E.g. get the size of a "previous activations tensor" or
+   *  the number of "previous neurons."
+   */
+  int get_output_size(int output_index = 0) const;
+
   /** Get previous activation tensor. */
   AbsDistMat& get_prev_activations(int parent_index = 0);
   /** Get activation tensor. */
@@ -408,6 +429,12 @@ class Layer {
   /** Reference to model managing this layer. */
   model *m_model = nullptr;
 
+  /** Set dimensions of an output tensor.
+   *  E.g. set the dimensions of an "activations tensor" or the
+   *  "neuron dimensions."
+   */
+  void set_output_dims(std::vector<int> dims, int output_index = 0);
+
   /** Setup data for forward propagation.
    *  Base method gets previous activations from parent layers and
    *  resizes activations for the current mini-batch size.
@@ -486,6 +513,9 @@ class Layer {
 
   /** Whether current layer is using a GPU implementation. */
   bool m_using_gpus;
+
+  /** Dimensions of each output tensor. */
+  std::vector<std::vector<int>> m_output_dims_list;
 
   /** Instantiate distributed matrices. */
   template <data_layout T, El::Device Dev>

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -163,31 +163,6 @@ class Layer {
   /** Get a short human-readable description of the device allocation */
   std::string get_device_allocation_string_short(El::Device dev) const;
 
-  /** Get the dimensions of a previous activations tensor. */
-  virtual std::vector<int> get_prev_neuron_dims(int parent_index = 0) const {
-    return m_prev_neuron_dims;
-  }
-  /** Get the size of a previous activations tensor. */
-  virtual int get_num_prev_neurons(int parent_index = 0) const {
-    return m_num_prev_neurons;
-  }
-  /** Get the number of dimensions of a previous activations tensor. */
-  virtual int get_num_prev_neuron_dims(int parent_index = 0) const {
-    return m_num_prev_neuron_dims;
-  }
-  /** Get the dimensions of an activations tensor. */
-  virtual std::vector<int> get_neuron_dims(int child_index = 0) const {
-    return m_neuron_dims;
-  }
-  /** Get the size of an activations tensor. */
-  virtual int get_num_neurons(int child_index = 0) const {
-    return m_num_neurons;
-  }
-  /** Get the number of dimensions of an activations tensor. */
-  virtual int get_num_neuron_dims(int child_index = 0) const {
-    return m_num_neuron_dims;
-  }
-
   /** Reset layer stat counters. */
   virtual void reset_counters();
 
@@ -229,11 +204,6 @@ class Layer {
    *  appropriate error signal tensor.
    */
   virtual void get_bp_output(AbsDistMat& bp_output, const Layer* parent) const;
-
-  /** Get dimensions of forward propagation output to a child layer.
-   *  Returns the dimensions of the appropriate activations tensor.
-   */
-  virtual std::vector<int> fp_output_dims(const Layer* child = nullptr) const { return m_neuron_dims; }
 
   /** Add to the layer's error signal. */
   virtual void add_to_error_signal(const AbsDistMat& error_signals,
@@ -361,25 +331,6 @@ class Layer {
   /** Reference to LBANN communicator. */
   lbann_comm *m_comm;
 
-  /** Dimensions of activation tensor.
-   *  If a derived class has more than one activation tensor, it is
-   *  responsible for its own interpretation.
-   */
-  std::vector<int> m_neuron_dims;
-  /** Size of activation tensor. */
-  int m_num_neurons;
-  /** Number of dimensions of activation tensor. */
-  int m_num_neuron_dims;
-  /** Dimensions of previous activation tensor.
-   *  If a derived class has more than one previous activation tensor,
-   *  it is responsible for its own interpretation.
-   */
-  std::vector<int> m_prev_neuron_dims;
-  /** Size of previous activation tensor. */
-  int m_num_prev_neurons;
-  /** Number of dimensions of previous activation tensor. */
-  int m_num_prev_neuron_dims;
-
   /** Previous activation matrices.
    *  Forward propagation inputs from each parent layer. These are
    *  typically matrix views where each column is a flattened tensor
@@ -453,9 +404,10 @@ class Layer {
    */
   virtual void setup_pointers();
   /** Setup tensor dimensions
-   *  Called by the setup function. The base method sets the
-   *  dimensions of the activation tensors equal to the dimensions of
-   *  the first previous activation tensor.
+   *  Called by the setup function. Ihe base class sets all
+   *  uninitialized output tensor dimensions equal to the first input
+   *  tensor's dimensions (provided there is at least one input
+   *  tensor)
    */
   virtual void setup_dims();
   /** Instantiate distributed matrices.

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -232,12 +232,12 @@ class base_convolution_layer : public learning_layer {
     auto* cast_initializer
       = dynamic_cast<fan_in_fan_out_initializer*>(&this->m_weights[0]->get_initializer());
     if (cast_initializer != nullptr) {
-      cast_initializer->set_fan_in(m_kernel_size / this->m_neuron_dims[0]);
-      cast_initializer->set_fan_out(m_kernel_size / this->m_prev_neuron_dims[0]);
+      cast_initializer->set_fan_in(m_kernel_size / get_output_dims()[0]);
+      cast_initializer->set_fan_out(m_kernel_size / get_input_dims()[0]);
     }
 
     // Initialize bias
-    this->m_weights[1]->setup(this->m_neuron_dims[0], Dev);
+    this->m_weights[1]->setup(get_output_dims()[0], Dev);
     El::Zeros(m_bias_gradient,
               this->m_weights[1]->get_matrix_height(),
               this->m_weights[1]->get_matrix_width());
@@ -268,6 +268,8 @@ class base_convolution_layer : public learning_layer {
     LBANN_ERROR("cuDNN not detected");
 #else
 
+    const auto& output_dims = get_output_dims();
+
     // Set kernel descriptor
     CHECK_CUDNN(cudnnCreateFilterDescriptor(&m_kernel_cudnn_desc));
     CHECK_CUDNN(cudnnSetFilterNdDescriptor(m_kernel_cudnn_desc,
@@ -279,7 +281,7 @@ class base_convolution_layer : public learning_layer {
     // Set convolution descriptor
     // Note: upscales are not supported as of cuDNN v5.1
     CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&m_convolution_cudnn_desc));
-    std::vector<int> upscales(this->m_num_neuron_dims-1, 1);
+    std::vector<int> upscales(output_dims.size() - 1, 1);
     CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(m_convolution_cudnn_desc,
                                                 m_pads.size(),
                                                 m_pads.data(),
@@ -289,8 +291,8 @@ class base_convolution_layer : public learning_layer {
                                                 cudnn::get_data_type()));
 
     // Set bias tensor descriptor
-    std::vector<int> bias_dims(get_num_neuron_dims() + 1, 1);
-    bias_dims[1] = get_neuron_dims()[0];
+    std::vector<int> bias_dims(output_dims.size() + 1, 1);
+    bias_dims[1] = output_dims[0];
     cudnn::set_tensor_desc(m_bias_cudnn_desc, bias_dims);
 
   #endif // LBANN_HAS_CUDNN
@@ -365,14 +367,14 @@ class base_convolution_layer : public learning_layer {
     std::vector<int> input_dims, output_dims;
     cudnnTensorDescriptor_t input_desc, output_desc;
     if (during_forward_prop) {
-      input_dims = get_prev_neuron_dims();
-      output_dims = get_neuron_dims();
+      input_dims = get_input_dims();
+      output_dims = get_output_dims();
       input_desc = m_tensors_cudnn_desc.get_prev_activations();
       output_desc = m_tensors_cudnn_desc.get_activations();
     }
     else {
-      input_dims = get_neuron_dims();
-      output_dims = get_prev_neuron_dims();
+      input_dims = get_output_dims();
+      output_dims = get_input_dims();
       input_desc = m_tensors_cudnn_desc.get_prev_error_signals();
       output_desc = m_tensors_cudnn_desc.get_error_signals();
     }
@@ -447,14 +449,14 @@ class base_convolution_layer : public learning_layer {
     std::vector<int> input_dims, output_dims;
     cudnnTensorDescriptor_t input_desc, output_desc;
     if (during_forward_prop) {
-      input_dims = get_prev_neuron_dims();
-      output_dims = get_neuron_dims();
+      input_dims = get_input_dims();
+      output_dims = get_output_dims();
       input_desc = m_tensors_cudnn_desc.get_prev_activations();
       output_desc = m_tensors_cudnn_desc.get_activations();
     }
     else {
-      input_dims = get_neuron_dims();
-      output_dims = get_prev_neuron_dims();
+      input_dims = get_output_dims();
+      output_dims = get_input_dims();
       input_desc = m_tensors_cudnn_desc.get_prev_error_signals();
       output_desc = m_tensors_cudnn_desc.get_error_signals();
     }
@@ -660,12 +662,12 @@ class base_convolution_layer : public learning_layer {
     const El::Int local_width = local_input.Width();
     std::vector<int> input_dims, output_dims;
     if (during_forward_prop) {
-      input_dims = this->m_prev_neuron_dims;
-      output_dims = this->m_neuron_dims;
+      input_dims = get_input_dims();
+      output_dims = get_output_dims();
     }
     else {
-      input_dims = this->m_neuron_dims;
-      output_dims = this->m_prev_neuron_dims;
+      input_dims = get_output_dims();
+      output_dims = get_input_dims();
     }
 
     // Initialize matrices
@@ -717,12 +719,12 @@ class base_convolution_layer : public learning_layer {
     const El::Int local_width = local_input.Width();
     std::vector<int> input_dims, output_dims;
     if (during_forward_prop) {
-      input_dims = this->m_prev_neuron_dims;
-      output_dims = this->m_neuron_dims;
+      input_dims = get_input_dims();
+      output_dims = get_output_dims();
     }
     else {
-      input_dims = this->m_neuron_dims;
-      output_dims = this->m_prev_neuron_dims;
+      input_dims = get_output_dims();
+      output_dims = get_input_dims();
     }
 
     // Initialize matrices
@@ -769,8 +771,8 @@ class base_convolution_layer : public learning_layer {
 
     // Matrix parameters
     const El::Int local_width = local_output.Width();
-    const El::Int num_output_channels = this->m_neuron_dims[0];
-    const El::Int num_per_output_channel = this->m_num_neurons / num_output_channels;
+    const El::Int num_output_channels = get_output_dims()[0];
+    const El::Int num_per_output_channel = get_output_size() / num_output_channels;
 
     // Apply bias to each output channel
     #pragma omp parallel for
@@ -797,9 +799,11 @@ class base_convolution_layer : public learning_layer {
 
     // Get convolution parameters
     const El::Int local_width = local_input.Width();
-    const int num_input_channels = this->m_prev_neuron_dims[0];
-    const int num_output_channels = this->m_neuron_dims[0];
-    const int num_per_output_channel = this->m_num_neurons / num_output_channels;
+    const auto& input_dims = get_input_dims();
+    const auto& output_dims = get_output_dims();
+    const int num_input_channels = input_dims[0];
+    const int num_output_channels = output_dims[0];
+    const int num_per_output_channel = get_output_size() / num_output_channels;
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
 
     // Compute bias gradient
@@ -840,8 +844,8 @@ class base_convolution_layer : public learning_layer {
                    num_input_channels :
                    num_output_channels);
     const int k = (using_transposed_convolution ?
-                   this->m_num_prev_neurons / num_input_channels :
-                   this->m_num_neurons / num_output_channels);
+                   get_input_size() / num_input_channels :
+                   get_output_size() / num_output_channels);
     DMat<Dev> im2col_matrix(m, k);
     DMat<Dev> kernel_gradient_matrix(m, n, local_kernel_gradient.Buffer(), m);
     El::Zero(kernel_gradient_matrix);
@@ -855,8 +859,8 @@ class base_convolution_layer : public learning_layer {
         im2col(gradient_wrt_output_col,
                im2col_matrix,
                num_output_channels,
-               this->m_num_neuron_dims - 1,
-               &this->m_neuron_dims[1],
+               output_dims.size() - 1,
+               &output_dims[1],
                m_pads.data(),
                &m_kernel_dims[2],
                m_strides.data());
@@ -871,8 +875,8 @@ class base_convolution_layer : public learning_layer {
         im2col(input_col,
                im2col_matrix,
                num_input_channels,
-               this->m_num_prev_neuron_dims - 1,
-               &this->m_prev_neuron_dims[1],
+               input_dims.size() - 1,
+               &input_dims[1],
                m_pads.data(),
                &m_kernel_dims[2],
                m_strides.data());

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -202,6 +202,8 @@ class base_convolution_layer : public learning_layer {
    *  deconvolution classes. */
   void setup_data() override {
     learning_layer::setup_data();
+    const auto& input_dims = get_input_dims();
+    const auto& output_dims = get_output_dims();
 
     // Initialize default weights if none are provided
     if (this->m_weights.size() > 2) {
@@ -232,12 +234,12 @@ class base_convolution_layer : public learning_layer {
     auto* cast_initializer
       = dynamic_cast<fan_in_fan_out_initializer*>(&this->m_weights[0]->get_initializer());
     if (cast_initializer != nullptr) {
-      cast_initializer->set_fan_in(m_kernel_size / get_output_dims()[0]);
-      cast_initializer->set_fan_out(m_kernel_size / get_input_dims()[0]);
+      cast_initializer->set_fan_in(m_kernel_size / output_dims[0]);
+      cast_initializer->set_fan_out(m_kernel_size / input_dims[0]);
     }
 
     // Initialize bias
-    this->m_weights[1]->setup(get_output_dims()[0], Dev);
+    this->m_weights[1]->setup(output_dims[0], Dev);
     El::Zeros(m_bias_gradient,
               this->m_weights[1]->get_matrix_height(),
               this->m_weights[1]->get_matrix_width());
@@ -771,7 +773,8 @@ class base_convolution_layer : public learning_layer {
 
     // Matrix parameters
     const El::Int local_width = local_output.Width();
-    const El::Int num_output_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const El::Int num_output_channels = output_dims[0];
     const El::Int num_per_output_channel = get_output_size() / num_output_channels;
 
     // Apply bias to each output channel

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -142,23 +142,25 @@ class convolution_layer : public base_convolution_layer<Dev> {
     // Get tensor dimensions
     auto& kernel_dims = this->m_kernel_dims;
     const auto& input_dims = this->get_input_dims();
-    std::vector<int> output_dims = input_dims;
+    auto output_dims = input_dims;
 
     // Initialize convolution kernel dimensions
     kernel_dims.insert(kernel_dims.begin() + 1, input_dims[0]);
+    this->m_kernel_size = std::accumulate(kernel_dims.begin(),
+                                          kernel_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
 
     // Check if input tensor dimensions are valid
-#ifdef LBANN_DEBUG
     if (input_dims.size() != kernel_dims.size() - 1) {
       std::stringstream err;
-      err << get_type() << " layer \"" << get_name() << "\ "
+      err << this->get_type() << " layer \"" << this->get_name() << "\" "
           << "has an input tensor with "
           << input_dims.size() << " dimensions "
           << "and a convolution kernel with "
           << kernel_dims.size() << " dimensions";
       LBANN_ERROR(err.str());
     }
-#endif
 
     // Initialize output tensor dimensions
     output_dims[0] = kernel_dims[0];
@@ -171,12 +173,6 @@ class convolution_layer : public base_convolution_layer<Dev> {
       output_dims[i+1] = (effective_dim + stride - 1) / stride;
     }
     this->set_output_dims(output_dims);
-
-    // Get size of convolutional kernel
-    this->m_kernel_size = std::accumulate(kernel_dims.begin(),
-                                          kernel_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
 
   }
 

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -94,7 +94,7 @@ class deconvolution_layer : public base_convolution_layer<Dev> {
     for (size_t h=0; h<this->m_strides.size(); h++) {
       s << this->m_strides[h] << " ";
     }
-    s << " num_output_channels: " << this->m_neuron_dims[0]
+    s << " num_output_channels: " << this->get_output_dims()[0]
       << " has_bias: " << this->m_bias_scaling_factor
       << " dataLayout: " << this->get_data_layout_string(get_data_layout())
       << " device alloc: " + this->get_device_allocation_string(get_device_allocation());
@@ -110,39 +110,45 @@ class deconvolution_layer : public base_convolution_layer<Dev> {
   El::Device get_device_allocation() const override { return Dev; }
 
   void setup_dims() override {
-
-    // Initialize previous neuron tensor dimensions
     base_convolution_layer<Dev>::setup_dims();
 
+    // Get tensor dimensions
+    auto& kernel_dims = this->m_kernel_dims;
+    const auto& input_dims = this->get_input_dims();
+    std::vector<int> output_dims = input_dims;
+
     // Initialize deconvolution kernel dimensions
-    // Note that unlike the convolutional kernel, the previous layer's
+    // Note: Unlike the convolutional kernel, the previous layer's
     // number of channels is now the leading position -- keep in mind
-    // that deconvolution is the transpose of a convolution
-    this->m_kernel_dims.insert(this->m_kernel_dims.begin(),
-                               this->m_prev_neuron_dims[0]);
+    // that deconvolution is the transpose of a convolution.
+    kernel_dims.insert(kernel_dims.begin(), input_dims[0]);
 
-    // Check if previous neuron tensor dimensions are valid
-  #ifdef LBANN_DEBUG
-    if(this->m_num_neuron_dims != (int) this->m_kernel_dims.size() - 1) {
-      throw lbann_exception("deconvolution_layer: previous neuron tensor dimensions are unexpected");
+    // Check if input tensor dimensions are valid
+#ifdef LBANN_DEBUG
+    if (input_dims.size() != kernel_dims.size() - 1) {
+      std::stringstream err;
+      err << get_type() << " layer \"" << get_name() << "\ "
+          << "has an input tensor with "
+          << input_dims.size() << " dimensions "
+          << "and a convolution kernel with "
+          << kernel_dims.size() << " dimensions";
+      LBANN_ERROR(err.str());
     }
-  #endif
+#endif
 
-    // Initialize neuron tensor dimensions
-    this->m_neuron_dims[0] = this->m_kernel_dims[1];
-    for(int i=0; i<this->m_num_neuron_dims-1; ++i) {
-      this->m_neuron_dims[i+1]
-        = ((this->m_prev_neuron_dims[i+1]-1) * this->m_strides[i]
-           + this->m_kernel_dims[i+2] - 2*this->m_pads[i]);
+    // Initialize output tensor dimensions
+    output_dims[0] = kernel_dims[1];
+    for (size_t i = 0; i < output_dims.size() - 1; ++i) {
+      const auto& stride = this->m_strides[i];
+      const auto& pad = this->m_pads[i];
+      output_dims[i+1] = ((input_dims[i+1] - 1) * stride
+                          + kernel_dims[i+2] - 2 * pad);
     }
-    this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                          this->m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
+    this->set_output_dims(output_dims);
 
     // Get size of convolutional kernel
-    this->m_kernel_size = std::accumulate(this->m_kernel_dims.begin(),
-                                          this->m_kernel_dims.end(),
+    this->m_kernel_size = std::accumulate(kernel_dims.begin(),
+                                          kernel_dims.end(),
                                           1,
                                           std::multiplies<int>());
 

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -115,26 +115,28 @@ class deconvolution_layer : public base_convolution_layer<Dev> {
     // Get tensor dimensions
     auto& kernel_dims = this->m_kernel_dims;
     const auto& input_dims = this->get_input_dims();
-    std::vector<int> output_dims = input_dims;
+    auto output_dims = input_dims;
 
     // Initialize deconvolution kernel dimensions
     // Note: Unlike the convolutional kernel, the previous layer's
     // number of channels is now the leading position -- keep in mind
     // that deconvolution is the transpose of a convolution.
     kernel_dims.insert(kernel_dims.begin(), input_dims[0]);
+    this->m_kernel_size = std::accumulate(kernel_dims.begin(),
+                                          kernel_dims.end(),
+                                          1,
+                                          std::multiplies<int>());
 
     // Check if input tensor dimensions are valid
-#ifdef LBANN_DEBUG
     if (input_dims.size() != kernel_dims.size() - 1) {
       std::stringstream err;
-      err << get_type() << " layer \"" << get_name() << "\ "
+      err << this->get_type() << " layer \"" << this->get_name() << "\" "
           << "has an input tensor with "
           << input_dims.size() << " dimensions "
           << "and a convolution kernel with "
           << kernel_dims.size() << " dimensions";
       LBANN_ERROR(err.str());
     }
-#endif
 
     // Initialize output tensor dimensions
     output_dims[0] = kernel_dims[1];
@@ -145,12 +147,6 @@ class deconvolution_layer : public base_convolution_layer<Dev> {
                           + kernel_dims[i+2] - 2 * pad);
     }
     this->set_output_dims(output_dims);
-
-    // Get size of convolutional kernel
-    this->m_kernel_size = std::accumulate(kernel_dims.begin(),
-                                          kernel_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
 
   }
 

--- a/include/lbann/layers/loss/cross_entropy.hpp
+++ b/include/lbann/layers/loss/cross_entropy.hpp
@@ -36,6 +36,8 @@ class cross_entropy_layer : public Layer {
 public:
 
   cross_entropy_layer(lbann_comm *comm) : Layer(comm) {
+    set_output_dims({1});
+
     // Expects inputs for prediction and ground truth
     m_expected_num_parent_layers = 2;
   }
@@ -59,13 +61,6 @@ public:
   std::string get_type() const override { return "cross entropy"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-
-  void setup_dims() override {
-    Layer::setup_dims();
-    this->m_num_neurons = 1;
-    this->m_num_neuron_dims = 1;
-    this->m_neuron_dims = {1};
-  }
 
   void setup_data() override {
     Layer::setup_data();

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -46,6 +46,8 @@ public:
 
   top_k_categorical_accuracy_layer(lbann_comm *comm, El::Int k)
     : Layer(comm), m_k(k) {
+    set_output_dims({1});
+
     // Expects inputs for prediction and ground truth
     m_expected_num_parent_layers = 2;
   }
@@ -56,13 +58,6 @@ public:
   std::string get_type() const override { return "top-k accuracy"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-
-  void setup_dims() override {
-    Layer::setup_dims();
-    this->m_num_neurons = 1;
-    this->m_num_neuron_dims = 1;
-    this->m_neuron_dims = {1};
-  }
 
   void fp_compute() override;
 

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -235,7 +235,8 @@ class batch_normalization : public regularizer_layer {
 
   void setup_data() override {
     regularizer_layer::setup_data();
-    const auto& num_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const auto& num_channels = output_dims[0];
 
     // Initialize default weights if none are provided
     if (this->m_weights.size() > 4) {
@@ -329,7 +330,8 @@ class batch_normalization : public regularizer_layer {
     // Compute statistics during training
     const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
     if (is_training) {
-      const int num_channels = get_output_dims()[0];
+      const auto& output_dims = get_output_dims();
+      const int num_channels = output_dims[0];
       const int channel_size = get_output_size() / num_channels;
       batch_normalization_cuda::channel_sums(num_channels,
                                              local_input,
@@ -452,7 +454,8 @@ class batch_normalization : public regularizer_layer {
     // Matrix parameters
     const int width = input.Width();
     const El::Int local_width = local_input.Width();
-    const int num_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
     const int channel_size = get_output_size() / num_channels;
 
     // Compute statistics
@@ -583,7 +586,8 @@ class batch_normalization : public regularizer_layer {
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
     const int width = input.Width();
     const El::Int local_width = local_input.Width();
-    const int num_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
     const int channel_size = get_output_size() / num_channels;
 
     // Compute local gradients

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -235,6 +235,7 @@ class batch_normalization : public regularizer_layer {
 
   void setup_data() override {
     regularizer_layer::setup_data();
+    const auto& num_channels = get_output_dims()[0];
 
     // Initialize default weights if none are provided
     if (this->m_weights.size() > 4) {
@@ -272,10 +273,10 @@ class batch_normalization : public regularizer_layer {
     }
 
     // Setup weights
-    this->m_weights[0]->setup(this->m_neuron_dims[0], Dev);
-    this->m_weights[1]->setup(this->m_neuron_dims[0], Dev);
-    this->m_weights[2]->setup(this->m_neuron_dims[0], Dev);
-    this->m_weights[3]->setup(this->m_neuron_dims[0], Dev);
+    this->m_weights[0]->setup(num_channels, Dev);
+    this->m_weights[1]->setup(num_channels, Dev);
+    this->m_weights[2]->setup(num_channels, Dev);
+    this->m_weights[3]->setup(num_channels, Dev);
 
     if (m_frozen) {
       this->m_weights[0]->freeze();
@@ -290,12 +291,12 @@ class batch_normalization : public regularizer_layer {
     }
 
     // Initialize matrices
-    El::Zeros(*m_mean, this->m_neuron_dims[0], 1);
-    El::Zeros(*m_var, this->m_neuron_dims[0], 1);
-    El::Zeros(*m_mean_gradient, this->m_neuron_dims[0], 1);
-    El::Zeros(*m_var_gradient, this->m_neuron_dims[0], 1);
-    El::Zeros(*m_scale_gradient, this->m_neuron_dims[0], 1);
-    El::Zeros(*m_bias_gradient, this->m_neuron_dims[0], 1);
+    El::Zeros(*m_mean,           num_channels, 1);
+    El::Zeros(*m_var,            num_channels, 1);
+    El::Zeros(*m_mean_gradient,  num_channels, 1);
+    El::Zeros(*m_var_gradient,   num_channels, 1);
+    El::Zeros(*m_scale_gradient, num_channels, 1);
+    El::Zeros(*m_bias_gradient,  num_channels, 1);
 
   }
 
@@ -328,8 +329,8 @@ class batch_normalization : public regularizer_layer {
     // Compute statistics during training
     const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
     if (is_training) {
-      const int num_channels = this->m_neuron_dims[0];
-      const int channel_size = this->m_num_neurons / num_channels;
+      const int num_channels = get_output_dims()[0];
+      const int channel_size = get_output_size() / num_channels;
       batch_normalization_cuda::channel_sums(num_channels,
                                              local_input,
                                              m_mean->Matrix(),
@@ -451,8 +452,8 @@ class batch_normalization : public regularizer_layer {
     // Matrix parameters
     const int width = input.Width();
     const El::Int local_width = local_input.Width();
-    const int num_channels = this->m_neuron_dims[0];
-    const int channel_size = this->m_num_neurons / num_channels;
+    const int num_channels = get_output_dims()[0];
+    const int channel_size = get_output_size() / num_channels;
 
     // Compute statistics
     if (is_training) {
@@ -582,8 +583,8 @@ class batch_normalization : public regularizer_layer {
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
     const int width = input.Width();
     const El::Int local_width = local_input.Width();
-    const int num_channels = this->m_neuron_dims[0];
-    const int channel_size = this->m_num_neurons / num_channels;
+    const int num_channels = get_output_dims()[0];
+    const int channel_size = get_output_size() / num_channels;
 
     // Compute local gradients
     #pragma omp parallel for

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -245,8 +245,8 @@ class local_response_normalization_layer : public regularizer_layer {
     const int output_ldim = local_output.LDim();
 
     // Get LRN parameters
-    const int num_channels = this->m_neuron_dims[0];
-    const int num_per_channel = this->m_num_neurons / num_channels;
+    const int num_channels = get_output_dims()[0];
+    const int num_per_channel = get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter
     const bool default_beta = (std::fabs((m_beta - 0.75) / 0.75)
@@ -333,8 +333,8 @@ class local_response_normalization_layer : public regularizer_layer {
     const int gradient_wrt_input_ldim = local_gradient_wrt_input.LDim();
 
     // Get LRN parameters
-    const int num_channels = this->m_neuron_dims[0];
-    const int num_per_channel = this->m_num_neurons / num_channels;
+    const int num_channels = get_output_dims()[0];
+    const int num_per_channel = get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter
     const bool default_beta = (std::fabs((m_beta - 0.75) / 0.75)

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -245,7 +245,8 @@ class local_response_normalization_layer : public regularizer_layer {
     const int output_ldim = local_output.LDim();
 
     // Get LRN parameters
-    const int num_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
     const int num_per_channel = get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter
@@ -333,7 +334,8 @@ class local_response_normalization_layer : public regularizer_layer {
     const int gradient_wrt_input_ldim = local_gradient_wrt_input.LDim();
 
     // Get LRN parameters
-    const int num_channels = get_output_dims()[0];
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
     const int num_per_channel = get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter

--- a/include/lbann/layers/transform/bernoulli.hpp
+++ b/include/lbann/layers/transform/bernoulli.hpp
@@ -43,21 +43,11 @@ class bernoulli_layer : public transform_layer {
 
  public:
   bernoulli_layer(lbann_comm *comm,
-                 const std::vector<int>& neuron_dims,
-                 DataType prob = DataType(0.5))
+                  std::vector<int> dims,
+                  DataType prob = DataType(0.5))
     : transform_layer(comm), m_prob(prob) {
-
-    // Record neuron dimensions
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
-    // Bernoulli layer has no parents
+    set_output_dims(dims);
     m_expected_num_parent_layers = 0;
-
   }
   bernoulli_layer* copy() const override { return new bernoulli_layer(*this); }
   std::string get_type() const override { return "Bernoulli"; }
@@ -74,17 +64,6 @@ class bernoulli_layer : public transform_layer {
   }
 
  protected:
-
-  void setup_dims() override {
-    const auto neuron_dims = this->m_neuron_dims;
-    transform_layer::setup_dims();
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-  }
 
   void fp_compute() override {
     auto& output = get_activations();

--- a/include/lbann/layers/transform/constant.hpp
+++ b/include/lbann/layers/transform/constant.hpp
@@ -39,20 +39,10 @@ class constant_layer : public transform_layer {
   /** Constructor. */
   constant_layer(lbann_comm *comm,
                  DataType value,
-                 const std::vector<int>& neuron_dims)
+                 std::vector<int> dims)
     : transform_layer(comm), m_value(value) {
-
-    // Record neuron dimensions
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
-    // Constant layer has no parents
+    set_output_dims(dims);
     m_expected_num_parent_layers = 0;
-
   }
 
   constant_layer* copy() const override { return new constant_layer(*this); }
@@ -69,17 +59,6 @@ class constant_layer : public transform_layer {
   }
 
  protected:
-
-  void setup_dims() override {
-    const auto neuron_dims = this->m_neuron_dims;
-    transform_layer::setup_dims();
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-  }
 
   void setup_data() override {
     transform_layer::setup_data();

--- a/include/lbann/layers/transform/crop.hpp
+++ b/include/lbann/layers/transform/crop.hpp
@@ -60,12 +60,7 @@ class crop_layer : public transform_layer {
                   "crop layer currently only supports DATA_PARALLEL");
 
     // Crop dimensions
-    this->m_neuron_dims = dims;
-    this->m_num_neuron_dims = m_neuron_dims.size();
-    this->m_num_neurons = std::accumulate(m_neuron_dims.begin(),
-                                          m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
+    set_output_dims(dims);
  
     // Parent layers for original tensor and crop position
     m_expected_num_parent_layers = 2;
@@ -119,19 +114,34 @@ class crop_layer : public transform_layer {
   }
 
   void setup_dims() override {
-    const auto crop_dims = this->m_neuron_dims;
     transform_layer::setup_dims();
-    this->m_neuron_dims = crop_dims;
-    this->m_num_neuron_dims = m_neuron_dims.size();
-    this->m_num_neurons = std::accumulate(m_neuron_dims.begin(),
-                                          m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
+    std::stringstream err;
 
-    // Make sure crop position has correct dimensions
-    if (this->m_parent_layers[1]->fp_output_dims(this)
-        != get_prev_neuron_dims(1)) {
-      LBANN_ERROR("crop position tensor input must match number of neuron dimensions");
+    // Make sure input tensors have valid dimensions
+    const auto& input_dims = get_input_dims(0);
+    const auto& loc_dims = get_input_dims(1);
+    const auto& output_dims = get_output_dims();
+    if (input_dims.size() != output_dims.size()) {
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "expects a crop input tensor with "
+          << output_dims.size() << " dimensions, "
+          << "but parent layer "
+          << "\"" << m_parent_layers[0]->get_name() << "\" "
+          << "outputs a tensor with "
+          << input_dims.size() << " dimensions";
+      LBANN_ERROR(err.str());
+    }
+    if (loc_dims.size() != 1 || loc_dims[0] != (int) input_dims.size()) {
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "expects a 1D crop position tensor with "
+          << output_dims.size() << " entries, "
+          << "but parent layer "
+          << "\"" << m_parent_layers[1]->get_name() << "\" "
+          << "outputs a tensor with dimensions ";
+      for (size_t i = 0; i < loc_dims.size(); ++i) {
+        err << (i > 0 ? " x " : "") << loc_dims[i];
+      }
+      LBANN_ERROR(err.str());
     }
 
   }
@@ -157,9 +167,9 @@ class crop_layer : public transform_layer {
   void fp_compute_cpu() {
 
     // Tensor dimensions
-    const El::Int num_dims = get_num_neuron_dims();
-    const auto& input_dims = get_prev_neuron_dims(0);
-    const auto& output_dims = get_neuron_dims();
+    const auto& input_dims = get_input_dims(0);
+    const auto& output_dims = get_output_dims();
+    const El::Int num_dims = output_dims.size();
 
     // Input and output tensors
     const auto& local_crop_pos = get_local_prev_activations(1);
@@ -216,9 +226,9 @@ class crop_layer : public transform_layer {
   void bp_compute_cpu() {
 
     // Tensor dimensions
-    const El::Int num_dims = get_num_neuron_dims();
-    const auto& input_dims = get_prev_neuron_dims(0);
-    const auto& output_dims = get_neuron_dims();
+    const auto& input_dims = get_input_dims(0);
+    const auto& output_dims = get_output_dims();
+    const El::Int num_dims = output_dims.size();
 
     // Input and output tensors
     const auto& local_crop_pos = get_local_prev_activations(1);
@@ -279,26 +289,6 @@ class crop_layer : public transform_layer {
   void bp_compute_gpu() {
     /// @todo Implement
     LBANN_ERROR("not yet implemented");
-  }
-
-  std::vector<int> get_prev_neuron_dims(int parent_index = 0) const override {
-    switch (parent_index) {
-    case 0: return transform_layer::get_prev_neuron_dims(parent_index);
-    case 1: return {get_num_neuron_dims()};
-    default: LBANN_ERROR("attempted to access invalid parent of crop layer");
-    }
-  }
-
-  int get_num_prev_neurons(int parent_index = 0) const override {
-    const auto& prev_neuron_dims = get_prev_neuron_dims(parent_index);
-    return std::accumulate(prev_neuron_dims.begin(),
-                           prev_neuron_dims.end(),
-                           1,
-                           std::multiplies<int>());
-  }
-
-  int get_num_prev_neuron_dims(int parent_index = 0) const override {
-    return get_prev_neuron_dims(parent_index).size();
   }
 
 };

--- a/include/lbann/layers/transform/discrete_random.hpp
+++ b/include/lbann/layers/transform/discrete_random.hpp
@@ -54,15 +54,7 @@ class discrete_random_layer : public transform_layer {
                   "discrete random layer currently only supports CPU");
     static_assert(T_layout == data_layout::DATA_PARALLEL,
                   "discrete random layer currently only supports DATA_PARALLEL");
-    
-    // Record neuron dimensions
-    this->m_neuron_dims = dims;
-    this->m_num_neuron_dims = this->m_neuron_dims.size();
-    this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                          this->m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
+    set_output_dims(dims);
   }
   discrete_random_layer* copy() const override { return new discrete_random_layer(*this); }
   std::string get_type() const override { return "discrete random"; }
@@ -72,20 +64,11 @@ class discrete_random_layer : public transform_layer {
  protected:
 
   void setup_dims() override {
-    const auto neuron_dims = this->m_neuron_dims;
     transform_layer::setup_dims();
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
-    // Check input dimensions
-    if (get_num_prev_neurons() != (int) m_values.size()) {
-      LBANN_ERROR("input dimensions don't match number of values in discrete distribution");
+    if (get_input_size() != (int) m_values.size()) {
+      LBANN_ERROR("input tensor dimensions don't match number of "
+                  "values in discrete distribution");
     }
-
   }
 
   void fp_compute() override {

--- a/include/lbann/layers/transform/gaussian.hpp
+++ b/include/lbann/layers/transform/gaussian.hpp
@@ -46,22 +46,12 @@ class gaussian_layer : public transform_layer {
 
  public:
   gaussian_layer(lbann_comm *comm,
-                 const std::vector<int>& neuron_dims,
+                 const std::vector<int>& dims,
                  DataType mean = DataType(0),
                  DataType stdev = DataType(1))
     : transform_layer(comm), m_mean(mean), m_stdev(stdev) {
-
-    // Record neuron dimensions
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
-    // Gaussian layer has no parents
+    set_output_dims(dims);
     m_expected_num_parent_layers = 0;
-
   }
   gaussian_layer* copy() const override { return new gaussian_layer(*this); }
   std::string get_type() const override { return "Gaussian"; }
@@ -79,17 +69,6 @@ class gaussian_layer : public transform_layer {
   }
 
  protected:
-
-  void setup_dims() override {
-    const auto neuron_dims = this->m_neuron_dims;
-    transform_layer::setup_dims();
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-  }
 
   void fp_compute() override {
     auto& output = get_activations();

--- a/include/lbann/layers/transform/hadamard.hpp
+++ b/include/lbann/layers/transform/hadamard.hpp
@@ -66,6 +66,29 @@ class hadamard_layer : public transform_layer {
 
   protected:
 
+  void setup_dims() override {
+    transform_layer::setup_dims();
+    const auto& output_dims = get_output_dims();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      const auto& input_dims = get_input_dims(i);
+      if (input_dims != output_dims) {
+        std::stringstream err;
+        err << get_type() << " layer \"" << get_name() << "\" "
+            << "expects input tensors with dimensions ";
+        for (size_t j = 0; j < output_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << output_dims[j];
+        }
+        err << ", but parent layer "
+            << "\"" << m_parent_layers[i]->get_name() << "\" "
+            << "outputs with dimensions ";
+        for (size_t j = 0; j < input_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << input_dims[j];
+        }
+        LBANN_ERROR(err.str());
+      }
+    }
+  }
+
   void fp_compute() override {
     auto& output = get_activations();
     switch (get_num_parents()) {

--- a/include/lbann/layers/transform/max.hpp
+++ b/include/lbann/layers/transform/max.hpp
@@ -69,19 +69,21 @@ class max_layer : public transform_layer {
 
   void setup_dims() override {
     transform_layer::setup_dims();
-    for (const auto& parent : this->m_parent_layers) {
-      const auto& parent_dims = parent->fp_output_dims(this);
-      if (m_neuron_dims != parent_dims) {
+    const auto& output_dims = get_output_dims();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      const auto& input_dims = get_input_dims(i);
+      if (input_dims != output_dims) {
         std::stringstream err;
-        err << "layer " << get_name() << " expects inputs with "
-            << "dimensions ";
-        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+        err << get_type() << " layer \"" << get_name() << "\" "
+            << "expects input tensors with dimensions ";
+        for (size_t j = 0; j < output_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << output_dims[j];
         }
-        err << ", but layer " << parent->get_name() << " outputs with "
-            << "dimensions ";
-        for (size_t i = 0; i < parent_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << parent_dims[i];
+        err << ", but parent layer "
+            << "\"" << m_parent_layers[i]->get_name() << "\" "
+            << "outputs with dimensions ";
+        for (size_t j = 0; j < input_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << input_dims[j];
         }
         LBANN_ERROR(err.str());
       }

--- a/include/lbann/layers/transform/min.hpp
+++ b/include/lbann/layers/transform/min.hpp
@@ -69,19 +69,21 @@ class min_layer : public transform_layer {
 
   void setup_dims() override {
     transform_layer::setup_dims();
-    for (const auto& parent : this->m_parent_layers) {
-      const auto& parent_dims = parent->fp_output_dims(this);
-      if (m_neuron_dims != parent_dims) {
+    const auto& output_dims = get_output_dims();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      const auto& input_dims = get_input_dims(i);
+      if (input_dims != output_dims) {
         std::stringstream err;
-        err << "layer " << get_name() << " expects inputs with "
-            << "dimensions ";
-        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+        err << get_type() << " layer \"" << get_name() << "\" "
+            << "expects input tensors with dimensions ";
+        for (size_t j = 0; j < output_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << output_dims[j];
         }
-        err << ", but layer " << parent->get_name() << " outputs with "
-            << "dimensions ";
-        for (size_t i = 0; i < parent_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << parent_dims[i];
+        err << ", but parent layer "
+            << "\"" << m_parent_layers[i]->get_name() << "\" "
+            << "outputs with dimensions ";
+        for (size_t j = 0; j < input_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << input_dims[j];
         }
         LBANN_ERROR(err.str());
       }

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -187,22 +187,15 @@ public:
   }
 
   void setup_dims() override {
-
-    // Initialize previous neuron tensor dimensions
     transform_layer::setup_dims();
-
-    // Initialize neuron tensor dimensions
-    for(int i=0; i<this->m_num_neuron_dims-1; ++i) {
-      const int effective_dim = (this->m_prev_neuron_dims[i+1]
-                                 + 2 * m_pads[i] - m_pool_dims[i] + 1);
-      this->m_neuron_dims[i+1] = ((effective_dim + m_strides[i] - 1)
-                                  / m_strides[i]);
+    const auto& input_dims = get_input_dims();
+    auto output_dims = input_dims;
+    for(size_t i = 0; i < output_dims.size() - 1; ++i) {
+      const int effective_dim = (input_dims[i+1] + 2 * m_pads[i]
+                                 - m_pool_dims[i] + 1);
+      output_dims[i+1] = (effective_dim + m_strides[i] - 1) / m_strides[i];
     }
-    this->m_num_neurons = std::accumulate(this->m_neuron_dims.begin(),
-                                          this->m_neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
+    set_output_dims(output_dims);
   }
 
   /// Initialize GPU objects
@@ -330,12 +323,13 @@ public:
 
     // Pool parameters
     const int local_width = local_input.Width();
-    const int num_channels = this->m_prev_neuron_dims[0];
-    const int num_per_output_channel = this->m_num_neurons / num_channels;
+    const auto& input_dims = get_input_dims();
+    const int num_channels = input_dims[0];
+    const int num_per_output_channel = get_output_size() / num_channels;
 
     // Initialize max pool indices if needed
     if(m_pool_mode == pool_mode::max) {
-      m_max_pool_indices.assign(this->m_num_neurons * local_width, 0);
+      m_max_pool_indices.assign(get_output_size() * local_width, 0);
     }
 
     // Initialize matrices
@@ -351,8 +345,8 @@ public:
       im2col(input_mat,
              im2col_mat,
              num_channels,
-             this->m_num_prev_neuron_dims - 1,
-             &this->m_prev_neuron_dims[1],
+             input_dims.size() - 1,
+             &input_dims[1],
              m_pads.data(),
              m_pool_dims.data(),
              m_strides.data());
@@ -360,7 +354,7 @@ public:
       if(m_pool_mode == pool_mode::max) {
         // Apply max pooling
         DataType *output_buffer = local_output.Buffer(0, sample);
-        int *indices_buffer = &m_max_pool_indices[sample * this->m_num_neurons];
+        int *indices_buffer = &m_max_pool_indices[sample * get_output_size()];
         #pragma omp parallel for
         for(int channel = 0; channel < num_channels; ++channel) {
           for(int j = 0; j < num_per_output_channel; ++j) {
@@ -416,8 +410,9 @@ public:
 
     // Pool parameters
     const int local_width = local_gradient_wrt_output.Width();
-    const int num_channels = this->m_prev_neuron_dims[0];
-    const int num_per_input_channel = this->m_num_neurons / num_channels;
+    const auto& input_dims = get_input_dims();
+    const int num_channels = input_dims[0];
+    const int num_per_input_channel = get_output_size() / num_channels;
 
     // Initialize matrices
     CPUMat im2col_mat(m_pool_size * num_channels, num_per_input_channel);
@@ -437,7 +432,7 @@ public:
         const DataType *gradient_wrt_output_buffer
           = local_gradient_wrt_output.LockedBuffer(0, sample);
         const int *indices_buffer
-          = &m_max_pool_indices[sample * this->m_num_neurons];
+          = &m_max_pool_indices[sample * get_output_size()];
         #pragma omp parallel for
         for(int channel = 0; channel < num_channels; ++channel) {
           for(int j = 0; j < num_per_input_channel; ++j) {
@@ -476,8 +471,8 @@ public:
       col2im(im2col_mat,
              gradient_wrt_input_col,
              num_channels,
-             this->m_num_prev_neuron_dims - 1,
-             &this->m_prev_neuron_dims[1],
+             input_dims.size() - 1,
+             &input_dims[1],
              m_pads.data(),
              m_pool_dims.data(),
              m_strides.data());

--- a/include/lbann/layers/transform/reduction.hpp
+++ b/include/lbann/layers/transform/reduction.hpp
@@ -56,12 +56,7 @@ class reduction_layer : public transform_layer {
     if (mode == reduction_mode::INVALID) {
       LBANN_ERROR("invalid reduction mode");
     }
-
-    // Initialize neuron tensor dimensions
-    this->m_num_neurons = 1;
-    this->m_num_neuron_dims = 1;
-    this->m_neuron_dims = {1};
-
+    set_output_dims({1});
   }
 
   reduction_layer* copy() const override { return new reduction_layer(*this); }
@@ -70,13 +65,6 @@ class reduction_layer : public transform_layer {
   El::Device get_device_allocation() const override { return Dev; }
 
  protected:
-
-  void setup_dims() override {
-    transform_layer::setup_dims();
-    this->m_num_neurons = 1;
-    this->m_num_neuron_dims = 1;
-    this->m_neuron_dims = {1};
-  }
 
   void fp_compute() override {
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -62,19 +62,21 @@ class sum_layer : public transform_layer {
 
   void setup_dims() override {
     transform_layer::setup_dims();
-    for (const auto& parent : this->m_parent_layers) {
-      const auto& parent_dims = parent->fp_output_dims(this);
-      if (m_neuron_dims != parent_dims) {
+    const auto& output_dims = get_output_dims();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      const auto& input_dims = get_input_dims(i);
+      if (input_dims != output_dims) {
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "
-            << "expects inputs with dimensions ";
-        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+            << "expects input tensors with dimensions ";
+        for (size_t j = 0; j < output_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << output_dims[j];
         }
-        err << ", but layer \"" << parent->get_name() << "\" outputs "
-            << "with dimensions ";
-        for (size_t i = 0; i < parent_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << parent_dims[i];
+        err << ", but parent layer "
+            << "\"" << m_parent_layers[i]->get_name() << "\" "
+            << "outputs with dimensions ";
+        for (size_t j = 0; j < input_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << input_dims[j];
         }
         LBANN_ERROR(err.str());
       }

--- a/include/lbann/layers/transform/uniform.hpp
+++ b/include/lbann/layers/transform/uniform.hpp
@@ -46,22 +46,12 @@ class uniform_layer : public transform_layer {
 
  public:
   uniform_layer(lbann_comm *comm,
-                 const std::vector<int>& neuron_dims,
-                 DataType min = DataType(0),
-                 DataType max = DataType(1))
+                std::vector<int> dims,
+                DataType min = DataType(0),
+                DataType max = DataType(1))
     : transform_layer(comm), m_min(min), m_max(max) {
-
-    // Record neuron dimensions
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-
-    // Uniform layer has no parents
+    set_output_dims(dims);
     m_expected_num_parent_layers = 0;
-
   }
   uniform_layer* copy() const override { return new uniform_layer(*this); }
   std::string get_type() const override { return "uniform"; }
@@ -79,17 +69,6 @@ class uniform_layer : public transform_layer {
   }
 
  protected:
-
-  void setup_dims() override {
-    const auto neuron_dims = this->m_neuron_dims;
-    transform_layer::setup_dims();
-    this->m_neuron_dims = neuron_dims;
-    this->m_num_neuron_dims = neuron_dims.size();
-    this->m_num_neurons = std::accumulate(neuron_dims.begin(),
-                                          neuron_dims.end(),
-                                          1,
-                                          std::multiplies<int>());
-  }
 
   void fp_compute() override {
     const auto& mean = (m_max + m_min) / 2;

--- a/include/lbann/layers/transform/unpooling.hpp
+++ b/include/lbann/layers/transform/unpooling.hpp
@@ -73,21 +73,29 @@ class unpooling_layer : public transform_layer {
   }
 
   void setup_dims() override {
-
-    // Initialize previous neuron tensor dimensions
     transform_layer::setup_dims();
 
-    // Check that previous neuron tensor is valid
-    if(this->m_num_prev_neurons != m_pooling_layer->m_num_neurons
-       || this->m_num_prev_neuron_dims != m_pooling_layer->m_num_neuron_dims
-       || this->m_prev_neuron_dims != m_pooling_layer->m_neuron_dims) {
-      throw lbann_exception("unpooling_layer: previous neuron tensor must match neuron tensor of corresponding pooling layer");
+    // Check that input tensor is valid
+    const auto& input_dims = get_input_dims();
+    const auto& pool_output_dims = m_pooling_layer->get_output_dims();
+    if (input_dims != pool_output_dims) {
+      std::stringstream err;
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "expects input tensors with dimensions ";
+      for (size_t i = 0; i < pool_output_dims.size(); ++i) {
+        err << (i > 0 ? " x " : "") << pool_output_dims[i];
+      }
+      err << ", but parent layer "
+          << "\"" << m_parent_layers[0]->get_name() << "\" "
+          << "outputs with dimensions ";
+      for (size_t i = 0; i < input_dims.size(); ++i) {
+        err << (i > 0 ? " x " : "") << input_dims[i];
+      }
+      LBANN_ERROR(err.str());
     }
 
-    // Initialize neuron tensor based on corresponding pooling layer
-    this->m_num_neurons = m_pooling_layer->m_num_prev_neurons;
-    this->m_num_neuron_dims = m_pooling_layer->m_num_prev_neuron_dims;
-    this->m_neuron_dims = m_pooling_layer->m_prev_neuron_dims;
+    // Initialize output tensor based on corresponding pooling layer
+    set_output_dims(m_pooling_layer->get_input_dims());
 
   }
 
@@ -142,8 +150,9 @@ class unpooling_layer : public transform_layer {
 
     // Get parameters
     const int local_width = prev_activations_local.Width();
-    const int num_channels = this->m_prev_neuron_dims[0];
-    const int num_per_input_channel = this->m_num_prev_neurons / num_channels;
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
+    const int num_per_input_channel = get_input_size() / num_channels;
     const int pool_size = m_pooling_layer->m_pool_size;
 
     // Initialize im2col matrix
@@ -159,7 +168,7 @@ class unpooling_layer : public transform_layer {
       const DataType *prev_activations_buffer
         = prev_activations_local.LockedBuffer(0, sample);
       const int *indices_buffer
-        = &m_pooling_layer->m_max_pool_indices[sample * this->m_num_prev_neurons];
+        = &m_pooling_layer->m_max_pool_indices[sample * get_input_size()];
       #pragma omp parallel for
       for(int channel = 0; channel < num_channels; ++channel) {
         for(int j = 0; j < num_per_input_channel; ++j) {
@@ -177,8 +186,8 @@ class unpooling_layer : public transform_layer {
       col2im(im2col_mat,
              output_mat,
              num_channels,
-             this->m_num_neuron_dims - 1,
-             this->m_neuron_dims.data() + 1,
+             output_dims.size() - 1,
+             &output_dims[1],
              m_pooling_layer->m_pads.data(),
              m_pooling_layer->m_pool_dims.data(),
              m_pooling_layer->m_strides.data(),
@@ -197,8 +206,9 @@ class unpooling_layer : public transform_layer {
 
     // Get parameters
     const int local_width = prev_error_signal_local.Width();
-    const int num_channels = this->m_prev_neuron_dims[0];
-    const int num_per_output_channel = this->m_num_prev_neurons / num_channels;
+    const auto& output_dims = get_output_dims();
+    const int num_channels = output_dims[0];
+    const int num_per_output_channel = get_input_size() / num_channels;
     const int pool_size = m_pooling_layer->m_pool_size;
 
     // Initialize im2col matrix
@@ -213,8 +223,8 @@ class unpooling_layer : public transform_layer {
       im2col(input_mat,
              im2col_mat,
              num_channels,
-             this->m_num_neuron_dims - 1,
-             this->m_neuron_dims.data() + 1,
+             output_dims.size() - 1,
+             &output_dims[1],
              m_pooling_layer->m_pads.data(),
              m_pooling_layer->m_pool_dims.data(),
              m_pooling_layer->m_strides.data());
@@ -222,7 +232,7 @@ class unpooling_layer : public transform_layer {
       // Propagate error signal based on pooling layer
       DataType *output_buffer = error_signal_local.Buffer(0, sample);
       const int *indices_buffer
-        = &m_pooling_layer->m_max_pool_indices[sample * this->m_num_prev_neurons];
+        = &m_pooling_layer->m_max_pool_indices[sample * get_input_size()];
       #pragma omp parallel for
       for(int channel = 0; channel < num_channels; ++channel) {
         for(int j = 0; j < num_per_output_channel; ++j) {

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -81,19 +81,21 @@ class weighted_sum_layer : public transform_layer {
 
   void setup_dims() override {
     transform_layer::setup_dims();
-    for (const auto& parent : this->m_parent_layers) {
-      const auto& parent_dims = parent->fp_output_dims(this);
-      if (m_neuron_dims != parent_dims) {
+    const auto& output_dims = get_output_dims();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      const auto& input_dims = get_input_dims(i);
+      if (input_dims != output_dims) {
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "
-            << "expects inputs with dimensions ";
-        for (size_t i = 0; i < m_neuron_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << m_neuron_dims[i];
+            << "expects input tensors with dimensions ";
+        for (size_t j = 0; j < output_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << output_dims[j];
         }
-        err << ", but layer \"" << parent->get_name() << "\" outputs "
-            << "with dimensions ";
-        for (size_t i = 0; i < parent_dims.size(); ++i) {
-          err << (i > 0 ? "x" : "") << parent_dims[i];
+        err << ", but parent layer "
+            << "\"" << m_parent_layers[i]->get_name() << "\" "
+            << "outputs with dimensions ";
+        for (size_t j = 0; j < input_dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << input_dims[j];
         }
         LBANN_ERROR(err.str());
       }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -373,6 +373,7 @@ int Layer::get_output_size(int output_index) const {
 void Layer::set_output_dims(std::vector<int> dims, int output_index) {
   if ((int) m_output_dims_list.size() != get_num_children()
       || (int) m_output_dims_list.size() <= output_index) {
+    // Handles case where dims are set before child layers are set
     m_output_dims_list.resize(std::max(get_num_children(),
                                        output_index + 1));
   }

--- a/src/models/greedy_layerwise_autoencoder.cpp
+++ b/src/models/greedy_layerwise_autoencoder.cpp
@@ -89,8 +89,8 @@ void greedy_layerwise_autoencoder::setup_layer_topology() {
 
     // Encoder input and decoder output should match
     std::vector<int> input_dims, output_dims;
-    input_dims = m_layers[encoder_start]->get_prev_neuron_dims();
-    output_dims = m_layers[decoder_end-1]->get_neuron_dims();
+    input_dims = m_layers[encoder_start]->get_input_dims();
+    output_dims = m_layers[decoder_end-1]->get_output_dims();
     if (input_dims != output_dims) {
       std::stringstream err;
       err << __FILE__ << " " << __LINE__ << " :: "
@@ -110,8 +110,8 @@ void greedy_layerwise_autoencoder::setup_layer_topology() {
     }
 
     // Encoder output and decoder input should match
-    output_dims = m_layers[encoder_end-1]->get_neuron_dims();
-    input_dims = m_layers[decoder_start]->get_prev_neuron_dims();
+    output_dims = m_layers[encoder_end-1]->get_output_dims();
+    input_dims = m_layers[decoder_start]->get_input_dims();
     if (input_dims != output_dims) {
       std::stringstream err;
       err << __FILE__ << " " << __LINE__ << " :: "

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -312,13 +312,16 @@ void model::permute_layers(const std::vector<int>& permutation) {
 std::string model::print_layer_description(const Layer* layer) const {
   if (layer == nullptr) return std::string();
   std::stringstream os;
+  /// @todo Clean up
   //std::string description = layer->get_description();
   os << std::setw(12) << layer->get_name() << ":[" << std::setw(18)
      << layer->get_type()
      << "(" << layer->get_device_allocation_string_short(layer->get_device_allocation()) << ")"
      <<  "] Set up a layer with input " << std::setw(7)
-     << layer->get_num_prev_neurons() << " and " << std::setw(7)
-     << layer->get_num_neurons() << " neurons.";
+     << (layer->get_num_parents() > 0 ? layer->get_input_size() : 0)
+     << " and " << std::setw(7)
+     << (layer->get_num_children() > 0 ? layer->get_output_size() : 0)
+     << " neurons.";
   std::string s = layer->get_topo_description();
   if(s != "") {
     os << " (" << s << ")";

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -182,7 +182,7 @@ Layer* construct_layer(lbann_comm* comm,
       }
       dims.push_back(dr->get_linearized_data_size());
     }
-    return new reshape_layer<layout, Dev>(comm, dims.size(), dims.data());
+    return new reshape_layer<layout, Dev>(comm, dims);
   }
   if (proto_layer.has_sum()) {
     return new sum_layer<layout, Dev>(comm);

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -71,22 +71,20 @@ void setup_fc_num_neurons(
     if (proto_layer.has_fully_connected()) {
       bool set_num_neurons = proto_layer.fully_connected().num_neurons_is_num_labels();
       if (set_num_neurons) {
-        int num_neurons = 0;
         for (auto t : data_readers) {
-          if (!t.second) continue;
-          if (t.second->get_role() == "train") {
-            num_neurons = t.second->get_num_labels();
+          if (t.second != nullptr && t.second->get_role() == "train") {
+            std::vector<int> dims(1, t.second->get_num_labels());
             auto&& fc_dp_cpu = dynamic_cast<fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::CPU>*>(l);
             auto&& fc_mp_cpu = dynamic_cast<fully_connected_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>*>(l);
 #ifdef LBANN_HAS_GPU
             auto&& fc_dp_gpu = dynamic_cast<fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::GPU>*>(l);
             auto&& fc_mp_gpu = dynamic_cast<fully_connected_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>*>(l);
 #endif // LBANN_HAS_GPU
-            if (fc_dp_cpu != nullptr) { fc_dp_cpu->set_num_neurons(num_neurons); }
-            if (fc_mp_cpu != nullptr) { fc_mp_cpu->set_num_neurons(num_neurons); }
+            if (fc_dp_cpu != nullptr) { fc_dp_cpu->set_output_dims(dims); }
+            if (fc_mp_cpu != nullptr) { fc_mp_cpu->set_output_dims(dims); }
 #ifdef LBANN_HAS_GPU
-            if (fc_dp_gpu != nullptr) { fc_dp_gpu->set_num_neurons(num_neurons); }
-            if (fc_mp_gpu != nullptr) { fc_mp_gpu->set_num_neurons(num_neurons); }
+            if (fc_dp_gpu != nullptr) { fc_dp_gpu->set_output_dims(dims); }
+            if (fc_mp_gpu != nullptr) { fc_mp_gpu->set_output_dims(dims); }
 #endif // LBANN_HAS_GPU
           }
         }

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -395,7 +395,7 @@ cudnnTensorDescriptor_t& data_parallel_layer_tensor_manager::get_prev_activation
     LBANN_ERROR("tensor manager is not managing a layer");
   }
   const auto& local_data = m_layer->get_local_prev_activations(parent_index);
-  const auto& dims = m_layer->get_prev_neuron_dims(parent_index);
+  const auto& dims = m_layer->get_input_dims(parent_index);
   set_num_parents(m_layer->get_num_parents());
   auto& desc = m_prev_activations[parent_index];
   set_data_parallel_tensor_desc(desc, dims, local_data);
@@ -407,7 +407,7 @@ cudnnTensorDescriptor_t& data_parallel_layer_tensor_manager::get_activations(int
     LBANN_ERROR("tensor manager is not managing a layer");
   }
   const auto& local_data = m_layer->get_local_activations(child_index);
-  const auto& dims = m_layer->get_neuron_dims(child_index);
+  const auto& dims = m_layer->get_output_dims(child_index);
   set_num_children(m_layer->get_num_children());
   auto& desc = m_activations[child_index];
   set_data_parallel_tensor_desc(desc, dims, local_data);
@@ -419,7 +419,7 @@ cudnnTensorDescriptor_t& data_parallel_layer_tensor_manager::get_prev_error_sign
     LBANN_ERROR("tensor manager is not managing a layer");
   }
   const auto& local_data = m_layer->get_local_prev_error_signals(child_index);
-  const auto& dims = m_layer->get_neuron_dims(child_index);
+  const auto& dims = m_layer->get_output_dims(child_index);
   set_num_children(m_layer->get_num_children());
   auto& desc = m_prev_error_signals[child_index];
   set_data_parallel_tensor_desc(desc, dims, local_data);
@@ -431,7 +431,7 @@ cudnnTensorDescriptor_t& data_parallel_layer_tensor_manager::get_error_signals(i
     LBANN_ERROR("tensor manager is not managing a layer");
   }
   const auto& local_data = m_layer->get_local_error_signals(parent_index);
-  const auto& dims = m_layer->get_prev_neuron_dims(parent_index);
+  const auto& dims = m_layer->get_input_dims(parent_index);
   set_num_parents(m_layer->get_num_parents());
   auto& desc = m_error_signals[parent_index];
   set_data_parallel_tensor_desc(desc, dims, local_data);


### PR DESCRIPTION
Problems in the old implementation:
- The base layer class was designed with the assumption that each layer had exactly one input tensor and one output tensor. This made it awkward to implement layers with multiple or no parents/children, especially if each input/output tensor had different dimensions.
- Even if a layer had one input and output, it maintained more objects than necessary (tensor dimensions, number of tensor dimensions, and tensor size for both input and output).
- The tensor dimensions were frequently manipulated by derived layer classes, violating data encapsulation.
- The "prev_neuron_dims"/"neuron_dims" notation was unclear to people not steeped in deep learningisms. I concede this complaint is just my personal taste.

Changelog:
- The base layer class maintains tensor dimensions for each output.
- The tensor dimension access functions have been reimplemented with thorough error checking. When input tensor dimensions are needed, the layer asks the appropriate parent layer for its output tensor dimensions. Tensor sizes are now computed on-the-fly.
- Derived classes can only interact with the tensor dimensions via the access functions.
- The "prev_neuron_dims"/"neuron_dims" notation is replaced with "input_dims"/"output_dims".
- Propagated changes to all derived layers. The concatenation and slice layers required the most substantive changes.
- Expanded tensor dimension error checking in some derived layers.

Gradient checking comes back clean and I don't notice significant changes in AlexNet and Resnet-50.