### PR TITLE
Warning macro deduces MPI rank by asking MPI.

### DIFF
--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -39,14 +39,14 @@
 #define LBANN_ERROR(message)                                    \
   do {                                                          \
     std::stringstream ss_LBANN_ERROR;                           \
-    ss_LBANN_ERROR << "LBANN error "                            \
+    ss_LBANN_ERROR << "LBANN error ";                           \
     int initialized_LBANN_ERROR = 0, finalized_LBANN_ERROR = 1; \
     MPI_Initialized(&initialized_LBANN_ERROR);                  \
     MPI_Finalized(&finalized_LBANN_ERROR);                      \
     if (initialized_LBANN_ERROR && !finalized_LBANN_ERROR) {    \
       int rank_LBANN_ERROR = 0;                                 \
       MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_ERROR);         \
-      ss_LBANN_ERROR << "on rank " << rank_LBANN_ERROR << " "   \
+      ss_LBANN_ERROR << "on rank " << rank_LBANN_ERROR << " ";  \
     }                                                           \
     ss_LBANN_ERROR << "(" << __FILE__ << ":" << __LINE__ << ")" \
                      << ": " << (message);                      \
@@ -57,14 +57,14 @@
 #define LBANN_WARNING(message)                                          \
   do {                                                                  \
     std::stringstream ss_LBANN_WARNING;                                 \
-    ss_LBANN_WARNING << "LBANN warning "                                \
+    ss_LBANN_WARNING << "LBANN warning ";                               \
     int initialized_LBANN_WARNING = 0, finalized_LBANN_WARNING = 1;     \
     MPI_Initialized(&initialized_LBANN_WARNING);                        \
     MPI_Finalized(&finalized_LBANN_WARNING);                            \
     if (initialized_LBANN_WARNING && !finalized_LBANN_WARNING) {        \
       int rank_LBANN_WARNING = 0;                                       \
       MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_WARNING);               \
-      ss_LBANN_WARNING << "on rank " << rank_LBANN_WARNING << " "       \
+      ss_LBANN_WARNING << "on rank " << rank_LBANN_WARNING << " ";      \
     }                                                                   \
     ss_LBANN_WARNING << "(" << __FILE__ << ":" << __LINE__ << ")"       \
                      << ": " << (message) << std::endl;                 \

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -46,11 +46,13 @@
   } while (0)
 
 // Macro to print a warning to standard error stream.
-#define LBANN_WARNING(message, comm)                                    \
+#define LBANN_WARNING(message)                                          \
   do {                                                                  \
+    int rank_LBANN_WARNING = 0;                                         \
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_WARNING);                 \
     std::stringstream ss_LBANN_WARNING;                                 \
     ss_LBANN_WARNING << "LBANN warning "                                \
-                     << "on rank " << comm.get_rank_in_world() << " "   \
+                     << "on rank " << rank_LBANN_WARNING << " "         \
                      << "(" << __FILE__ << ":" << __LINE__ << ")"       \
                      << ": " << (message) << std::endl;                 \
     std::cerr << ss_LBANN_WARNING.str();                                \

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -40,20 +40,33 @@
   do {                                                          \
     std::stringstream ss_LBANN_ERROR;                           \
     ss_LBANN_ERROR << "LBANN error "                            \
-                   << "(" << __FILE__ << ":" << __LINE__ << ")" \
-                   << ": " << (message);                        \
+    int initialized_LBANN_ERROR = 0, finalized_LBANN_ERROR = 1; \
+    MPI_Initialized(&initialized_LBANN_ERROR);                  \
+    MPI_Finalized(&finalized_LBANN_ERROR);                      \
+    if (initialized_LBANN_ERROR && !finalized_LBANN_ERROR) {    \
+      int rank_LBANN_ERROR = 0;                                 \
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_ERROR);         \
+      ss_LBANN_ERROR << "on rank " << rank_LBANN_ERROR << " "   \
+    }                                                           \
+    ss_LBANN_ERROR << "(" << __FILE__ << ":" << __LINE__ << ")" \
+                     << ": " << (message);                      \
     throw lbann::lbann_exception(ss_LBANN_ERROR.str());         \
   } while (0)
 
 // Macro to print a warning to standard error stream.
 #define LBANN_WARNING(message)                                          \
   do {                                                                  \
-    int rank_LBANN_WARNING = 0;                                         \
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_WARNING);                 \
     std::stringstream ss_LBANN_WARNING;                                 \
     ss_LBANN_WARNING << "LBANN warning "                                \
-                     << "on rank " << rank_LBANN_WARNING << " "         \
-                     << "(" << __FILE__ << ":" << __LINE__ << ")"       \
+    int initialized_LBANN_WARNING = 0, finalized_LBANN_WARNING = 1;     \
+    MPI_Initialized(&initialized_LBANN_WARNING);                        \
+    MPI_Finalized(&finalized_LBANN_WARNING);                            \
+    if (initialized_LBANN_WARNING && !finalized_LBANN_WARNING) {        \
+      int rank_LBANN_WARNING = 0;                                       \
+      MPI_Comm_rank(MPI_COMM_WORLD, &rank_LBANN_WARNING);               \
+      ss_LBANN_WARNING << "on rank " << rank_LBANN_WARNING << " "       \
+    }                                                                   \
+    ss_LBANN_WARNING << "(" << __FILE__ << ":" << __LINE__ << ")"       \
                      << ": " << (message) << std::endl;                 \
     std::cerr << ss_LBANN_WARNING.str();                                \
   } while (0)


### PR DESCRIPTION
This is a refinement on #506 to make printf debugging a little easier. For example:
```C++
int* ptr = nullptr_on_rank_1();
LBANN_WARNING(ptr);
int y = *ptr;
LBANN_WARNING(y);
```
will output something like:
```text
LBANN warning on rank 0 (/some/lbann/file.cpp:127): 0x7fffffffbaec
LBANN warning on rank 0 (/some/lbann/file.cpp:129): 100
LBANN warning on rank 1 (/some/lbann/file.cpp:127): 0
[pascal60:mpi_rank_1][error_sighandler] Caught error: Segmentation fault (signal 11)
```