### PR TITLE
Model automatically adds evaluation layers

### DIFF
--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -45,6 +45,13 @@ public:
   /** Get evaluated value. */
   EvalType get_value(bool scaled = true);
 
+  /** Construct an evaluation layer.
+   *  The caller is responsible for deallocating the layer.
+   */
+  static abstract_evaluation_layer* construct(lbann_comm *comm,
+                                              data_layout layout,
+                                              El::Device device);
+  
 protected:
 
   abstract_evaluation_layer(lbann_comm *comm);

--- a/include/lbann/metrics/layer_metric.hpp
+++ b/include/lbann/metrics/layer_metric.hpp
@@ -47,8 +47,12 @@ class layer_metric : public metric {
   std::string name() const override;
   std::string get_unit() const override { return m_unit; }
 
-  void set_evaluation_layer(abstract_evaluation_layer* l) { m_evaluation_layer = l; }
-  abstract_evaluation_layer* get_evaluation_layer() const { return m_evaluation_layer; }
+  /** Set corresponding layer. */
+  void set_layer(Layer& l);
+  /** Get corresponding layer. */
+  Layer& get_layer();
+  /** Get corresponding layer (const). */
+  const Layer& get_layer() const;
 
  protected:
   
@@ -73,9 +77,12 @@ class layer_metric : public metric {
    *  If the unit is "%", the reported value is multiplied by 100.
    */
   std::string m_unit;
-  /** Metric value source. */
-  abstract_evaluation_layer* m_evaluation_layer;
+  /** Corresponding layer. */
+  Layer* m_layer;
 
+  /** Get corresponding evaluation layer. */
+  abstract_evaluation_layer& get_evaluation_layer();
+  
 };
 
 }  // namespace lbann

--- a/include/lbann/metrics/layer_metric.hpp
+++ b/include/lbann/metrics/layer_metric.hpp
@@ -54,6 +54,11 @@ class layer_metric : public metric {
   /** Get corresponding layer (const). */
   const Layer& get_layer() const;
 
+  /** Get list of pointers to layers. */
+  std::vector<Layer*> get_layer_pointers() const override;
+  /** Set list of pointers to layers. */
+  void set_layer_pointers(std::vector<Layer*> layers) override;
+  
  protected:
   
   void setup(model& m) override;

--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -142,9 +142,9 @@ class metric {
   const generic_target_layer& get_target_layer() const;
 
   /** Get list of pointers to layers. */
-  std::vector<Layer*> get_layer_pointers() const;
+  virtual std::vector<Layer*> get_layer_pointers() const;
   /** Set list of pointers to layers. */
-  void set_layer_pointers(std::vector<Layer*> layers);
+  virtual void set_layer_pointers(std::vector<Layer*> layers);
 
   /** Get the time spent in evaluation for this metric (const). */
   EvalType get_evaluate_time() const { return m_evaluate_time; }

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -393,6 +393,14 @@ class model {
  private:
   /** Search layer graph and add all connected layers. */
   void add_connected_layers();
+  /** Insert evaluation layers where needed.
+   *  If an objective function layer term or a layer metric
+   *  corresponds to a layer that is not an evaluation layer, an
+   *  evaluation layer is added as a child of the original layer and
+   *  set as the corresponding layer to the layer term or layer
+   *  metric.
+   */
+  void add_evaluation_layers();
   /** Insert dummy layers after layers with too few children.
    *  If a layer expects more child layers than it has, add dummy
    *  layers until it has enough children.

--- a/include/lbann/objective_functions/layer_term.hpp
+++ b/include/lbann/objective_functions/layer_term.hpp
@@ -33,15 +33,18 @@
 namespace lbann {
 
 class layer_term : public objective_function_term {
- public:
+public:
   layer_term(EvalType scale_factor = EvalType(1));
   layer_term* copy() const override { return new layer_term(*this); } 
   std::string name() const override { return "evaluation layer term"; }
 
-  void set_evaluation_layer(abstract_evaluation_layer* l);
-
-  abstract_evaluation_layer* get_evaluation_layer();
-
+  /** Set corresponding layer. */
+  void set_layer(Layer& l);
+  /** Get corresponding layer. */
+  Layer& get_layer();
+  /** Get corresponding layer (const). */
+  const Layer& get_layer() const;
+  
   void setup(model& m) override;
 
   void start_evaluation() override;
@@ -52,6 +55,11 @@ class layer_term : public objective_function_term {
   
   void compute_weight_regularization() override {};
 
+private:
+  
+  /** Get corresponding evaluation layer. */
+  abstract_evaluation_layer& get_evaluation_layer();
+  
 };
 
 } // namespace lbann

--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -12,7 +12,7 @@ model {
   ###################################################
 
   objective_function {
-    layer_term { layer: "cross_entropy_eval" }
+    layer_term { layer: "cross_entropy" }
     l2_weight_regularization {
       scale_factor: 0.0005
     }
@@ -25,14 +25,14 @@ model {
   metric {
     layer_metric {
       name: "categorical accuracy"
-      layer: "top1_accuracy_eval"
+      layer: "top1_accuracy"
       unit: "%"
     }
   }
   metric {
     layer_metric {
       name: "top-5 categorical accuracy"
-      layer: "top5_accuracy_eval"
+      layer: "top5_accuracy"
       unit: "%"
     }
   }
@@ -320,37 +320,19 @@ model {
     data_layout: "data_parallel"
     cross_entropy {}    
   }
-  layer {
-    name: "cross_entropy_eval"
-    parents: "cross_entropy"
-    data_layout: "data_parallel"
-    evaluation {}    
-  }
 
-  layer {
+layer {
     name: "top1_accuracy"
     parents: "prob labels"
     data_layout: "data_parallel"
     top_k_categorical_accuracy { k: 1 }
   }
-  layer {
-    name: "top1_accuracy_eval"
-    parents: "top1_accuracy"
-    data_layout: "data_parallel"
-    evaluation {}
-  }
 
-  layer {
+layer {
     name: "top5_accuracy"
     parents: "prob labels"
     data_layout: "data_parallel"
     top_k_categorical_accuracy { k: 5 }
-  }
-  layer {
-    name: "top5_accuracy_eval"
-    parents: "top5_accuracy"
-    data_layout: "data_parallel"
-    evaluation {}
   }
 
 }

--- a/model_zoo/models/resnet50/model_resnet50.prototext
+++ b/model_zoo/models/resnet50/model_resnet50.prototext
@@ -12,7 +12,7 @@ model {
   ###################################################
 
   objective_function {
-    layer_term { layer: "cross_entropy_eval" }
+    layer_term { layer: "cross_entropy" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -25,14 +25,14 @@ model {
   metric {
     layer_metric {
       name: "categorical accuracy"
-      layer: "top1_accuracy_eval"
+      layer: "top1_accuracy"
       unit: "%"
     }
   }
   metric {
     layer_metric {
       name: "top-5 categorical accuracy"
-      layer: "top5_accuracy_eval"
+      layer: "top5_accuracy"
       unit: "%"
     }
   }
@@ -1884,34 +1884,16 @@ model {
     cross_entropy {}    
   }
   layer {
-    name: "cross_entropy_eval"
-    parents: "cross_entropy"
-    data_layout: "data_parallel"
-    evaluation {}    
-  }
-  layer {
     name: "top1_accuracy"
     parents: "prob labels"
     data_layout: "data_parallel"
     top_k_categorical_accuracy { k: 1 }
   }
   layer {
-    name: "top1_accuracy_eval"
-    parents: "top1_accuracy"
-    data_layout: "data_parallel"
-    evaluation {}
-  }
-  layer {
     name: "top5_accuracy"
     parents: "prob labels"
     data_layout: "data_parallel"
     top_k_categorical_accuracy { k: 5 }
-  }
-  layer {
-    name: "top5_accuracy_eval"
-    parents: "top5_accuracy"
-    data_layout: "data_parallel"
-    evaluation {}
   }
 
 }

--- a/model_zoo/tests/model_mnist_conv_graph.prototext
+++ b/model_zoo/tests/model_mnist_conv_graph.prototext
@@ -11,7 +11,7 @@ model {
   # Objective function
   ###################################################
   objective_function {
-    layer_term { layer: "cross_entropy_eval" }
+    layer_term { layer: "cross_entropy" }
   }
 
   ###################################################
@@ -223,12 +223,6 @@ model {
     parents: "prob labels"
     data_layout: "model_parallel"
     cross_entropy {}
-  }
-  layer {
-    name: "cross_entropy_eval"
-    parents: "cross_entropy"
-    data_layout: "model_parallel"
-    evaluation {}
   }
 
 }

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -159,4 +159,33 @@ void abstract_evaluation_layer::bp_compute() {
   El::Fill(get_error_signals(), DataType(m_scale));
 }
 
+abstract_evaluation_layer*
+abstract_evaluation_layer::construct(lbann_comm *comm,
+                                     data_layout layout,
+                                     El::Device device) {
+#define EVAL_LAYER_CONSTRUCT(T_layout, T_device)                \
+  do {                                                          \
+    if (layout == T_layout && device == T_device) {             \
+      return new evaluation_layer<T_layout, T_device>(comm);    \
+    }                                                           \
+  } while (false)
+  EVAL_LAYER_CONSTRUCT(data_layout::DATA_PARALLEL, El::Device::CPU);
+  EVAL_LAYER_CONSTRUCT(data_layout::MODEL_PARALLEL, El::Device::CPU);
+#ifdef LBANN_HAS_GPU
+  EVAL_LAYER_CONSTRUCT(data_layout::DATA_PARALLEL, El::Device::GPU);
+  EVAL_LAYER_CONSTRUCT(data_layout::MODEL_PARALLEL, El::Device::GPU);
+#endif // LBANN_HAS_GPU
+#undef EVAL_LAYER_CONSTRUCT
+
+  // Could not construct evaluation layer
+  std::stringstream err;
+  err << "attempted to construct evaluation layer "
+      << "with invalid parameters "
+      << "(data layout type " << static_cast<int>(layout) << ", "
+      << "device type " << static_cast<int>(device) << ")";
+  LBANN_ERROR(err.str());
+  return nullptr;
+
+}
+  
 } // namespace lbann

--- a/src/metrics/layer_metric.cpp
+++ b/src/metrics/layer_metric.cpp
@@ -60,18 +60,16 @@ const Layer& layer_metric::get_layer() const {
   return *m_layer;
 }
 
-abstract_evaluation_layer& layer_metric::get_evaluation_layer() {
-  auto& l = get_layer();
-  auto* eval = dynamic_cast<abstract_evaluation_layer*>(&l);
-  if (eval == nullptr) {
-    std::stringstream err;
-    err << "attempted to get the evaluation layer corresponding to "
-        << "layer metric \"" << name() << "\", "
-        << "but it currently corresponds to "
-        << l.get_type() << " layer \"" << l.get_name() << "\"";
-    LBANN_ERROR(err.str());
-  }
-  return *eval;
+std::vector<Layer*> layer_metric::get_layer_pointers() const {
+  auto layer_pointers = metric::get_layer_pointers();
+  layer_pointers.push_back(m_layer);
+  return layer_pointers;
+}
+
+void layer_metric::set_layer_pointers(std::vector<Layer*> layers) {
+  metric::set_layer_pointers(std::vector<Layer*>(layers.begin(),
+                                                 layers.end() - 1));
+  m_layer = layers.back();
 }
   
 void layer_metric::setup(model& m) {
@@ -87,6 +85,20 @@ EvalType layer_metric::evaluate(execution_mode mode,
   get_statistics()[mode].add_value(value * mini_batch_size,
                                    mini_batch_size);
   return value;
+}
+
+abstract_evaluation_layer& layer_metric::get_evaluation_layer() {
+  auto& l = get_layer();
+  auto* eval = dynamic_cast<abstract_evaluation_layer*>(&l);
+  if (eval == nullptr) {
+    std::stringstream err;
+    err << "attempted to get the evaluation layer corresponding to "
+        << "layer metric \"" << name() << "\", "
+        << "but it currently corresponds to "
+        << l.get_type() << " layer \"" << l.get_name() << "\"";
+    LBANN_ERROR(err.str());
+  }
+  return *eval;
 }
 
 } // namespace lbann

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -32,6 +32,9 @@
 #include "lbann/layers/io/input/generic_input_layer.hpp"
 #include "lbann/layers/transform/dummy.hpp"
 #include "lbann/layers/transform/split.hpp"
+#include "lbann/layers/transform/evaluation.hpp"
+#include "lbann/objective_functions/layer_term.hpp"
+#include "lbann/metrics/layer_metric.hpp"
 #include "lbann/utils/random.hpp"
 #include <string>
 #include <unistd.h>
@@ -447,6 +450,7 @@ void model::setup_layer_topology() {
   }
 
   // Add utility layers if needed
+  add_evaluation_layers();
   add_dummy_layers();
   add_split_layers();
 
@@ -561,6 +565,66 @@ void model::add_connected_layers() {
 
 }
 
+void model::add_evaluation_layers() {
+
+  // Add evaluation layers corresponding to objective function layer terms
+  for (auto* t : m_objective_function->get_terms()) {
+    auto* term = dynamic_cast<layer_term*>(t);
+    if (term != nullptr) {
+      auto* l = &term->get_layer();
+      const size_t pos = (std::find(m_layers.begin(), m_layers.end(), l)
+                          - m_layers.begin());
+      if (pos >= m_layers.size()) {
+        std::stringstream err;
+        err << "an objective function layer term corresponds to "
+            << "layer \"" << l->get_name() << "\", "
+            << "which is not in current model";
+        LBANN_ERROR(err.str());
+      }
+      if (dynamic_cast<abstract_evaluation_layer*>(l) == nullptr) {
+        auto* eval = abstract_evaluation_layer::construct(
+                       l->get_comm(),
+                       l->get_data_layout(),
+                       l->get_device_allocation());
+        eval->set_name(l->get_name() + "_eval");
+        l->add_child_layer(eval);
+        eval->add_parent_layer(l);
+        term->set_layer(*eval);
+        m_layers.insert(m_layers.begin() + pos + 1, eval);
+      }
+    }
+  }
+
+  // Add evaluation layers corresponding to layer metrics
+  for (auto* m : m_metrics) {
+    auto* met = dynamic_cast<layer_metric*>(m);
+    if (met != nullptr) {
+      auto* l = &met->get_layer();
+      const size_t pos = (std::find(m_layers.begin(), m_layers.end(), l)
+                          - m_layers.begin());
+      if (pos >= m_layers.size()) {
+        std::stringstream err;
+        err << "layer metric \"" << met->name() << "\" "
+            << "corresponds to layer \"" << l->get_name() << "\", "
+            << "which is not in current model";
+        LBANN_ERROR(err.str());
+      }
+      if (dynamic_cast<abstract_evaluation_layer*>(l) == nullptr) {
+        auto* eval = abstract_evaluation_layer::construct(
+                       l->get_comm(),
+                       l->get_data_layout(),
+                       l->get_device_allocation());
+        eval->set_name(l->get_name() + "_eval");
+        l->add_child_layer(eval);
+        eval->add_parent_layer(l);
+        met->set_layer(*eval);
+        m_layers.insert(m_layers.begin() + pos + 1, eval);
+      }
+    }
+  }
+
+}
+  
 void model::add_dummy_layers() {
   for (size_t i = 0; i < m_layers.size(); ++i) {
     auto layer = m_layers[i];

--- a/src/objective_functions/layer_term.cpp
+++ b/src/objective_functions/layer_term.cpp
@@ -31,60 +31,54 @@ namespace lbann {
 layer_term::layer_term(EvalType scale_factor)
   : objective_function_term(scale_factor) {}
 
-void layer_term::set_evaluation_layer(abstract_evaluation_layer* l) {
-  if (l == nullptr) {
-    this->m_layers.clear();
-  } else {
-    this->m_layers.assign(1, l);
-  }
+void layer_term::set_layer(Layer& l) {
+  set_layer_pointers({&l});
 }
 
-abstract_evaluation_layer* layer_term::get_evaluation_layer() {
-  if (m_layers.empty()) {
-    return nullptr;
-  } else {
-    return dynamic_cast<abstract_evaluation_layer*>(this->m_layers.front());
+Layer& layer_term::get_layer() {
+  // Idiom from Item 3, p. 23 in "Effective C++", 3rd ed., by Scott Meyers.
+  return *(const_cast<Layer*>(&static_cast<const layer_term&>(*this).get_layer()));
+}
+const Layer& layer_term::get_layer() const {
+  const auto& layer_pointers = get_layer_pointers();
+  if (layer_pointers.empty() || layer_pointers.front() == nullptr) {
+    LBANN_ERROR("attempted to get the layer corresponding to "
+                "an objective function layer term, "
+                "but no such layer has been set");
   }
+  return *layer_pointers.front();
 }
 
+abstract_evaluation_layer& layer_term::get_evaluation_layer() {
+  auto& l = get_layer();
+  auto* eval = dynamic_cast<abstract_evaluation_layer*>(&l);
+  if (eval == nullptr) {
+    std::stringstream err;
+    err << "attempted to get the evaluation layer corresponding to "
+        << "an objective function layer term, "
+        << "but the layer term currently corresponds to "
+        << l.get_type() << " layer \"" << l.get_name() << "\"";
+    LBANN_ERROR(err.str());
+  }
+  return *eval;
+}
+  
 void layer_term::setup(model& m) {
   objective_function_term::setup(m);
-  std::stringstream err;
-
-  // Make sure layer term points to an evaluation layer
-  if (this->m_layers.size() != 1) {
-    err << "objective function layer term points to an invalid number of layers "
-        << "(expected 1, found " << this->m_layers.size() << ")";
-    LBANN_ERROR(err.str());
-  }
-  auto&& l = this->m_layers.front();
-  auto&& eval = dynamic_cast<abstract_evaluation_layer*>(l);
-  if (l == nullptr) {
-    LBANN_ERROR("objective function layer term points to a null pointer");
-  } else if (eval == nullptr) {
-    err << "objective function layer term points to "
-        << l->get_type() << " layer \"" << l->get_name() << "\", "
-        << "which is not an evaluation layer";
-    LBANN_ERROR(err.str());
-  }
-
-  // Set scaling factor
-  eval->set_scale(m_scale_factor);
-
+  get_evaluation_layer().set_scale(m_scale_factor);
 }
 
 void layer_term::start_evaluation() {}
 
 EvalType layer_term::finish_evaluation() {
   if (m_scale_factor == EvalType(0)) { return EvalType(0); }
-  auto&& eval = dynamic_cast<abstract_evaluation_layer*>(this->m_layers.front());
-  eval->set_scale(m_scale_factor);
-  return eval->get_value();
+  auto& eval = get_evaluation_layer();
+  eval.set_scale(m_scale_factor);
+  return eval.get_value();
 }
 
 void layer_term::differentiate() {
-  auto&& eval = dynamic_cast<abstract_evaluation_layer*>(this->m_layers.front());
-  eval->set_scale(m_scale_factor);
+  get_evaluation_layer().set_scale(m_scale_factor);
 }
 
 }  // namespace lbann


### PR DESCRIPTION
The practitioner can now set up objective function layer terms and layer metrics to point to arbitrary layers. During the model setup phase, evaluation layers are automatically inserted as children of the original layers. Gradient checks pass and I don't see significant behavior changes in AlexNet and Resnet-50.

Note that there is ambiguous behavior if the original layer outputs different output to different children, e.g. the input layer outputs data samples and labels to its two children. The practitioner is still responsible for constructing an unambiguous model prototext.