### PR TITLE
Fix performance regression in metrics

### DIFF
--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -58,8 +58,6 @@ private:
   EvalType m_scale;
   /** Evaluated value. */
   DataType m_value;
-  /** Non-blocking allreduce request. */
-  Al::request m_allreduce_req;
   
 };
 


### PR DESCRIPTION
In practice, metrics would call a non-blocking allreduce and then almost immediately afterward, wait on the allreduce. This adds significant overhead. For now, switching back to a blocking allreduce improves performance.