### PR TITLE
Layer tensor refactor

### DIFF
--- a/include/lbann/layers/io/target/generic_target_layer.hpp
+++ b/include/lbann/layers/io/target/generic_target_layer.hpp
@@ -85,9 +85,7 @@ class generic_target_layer : public Layer {
     return true;
   }
 
-  virtual AbsDistMat& get_prediction() { return get_prev_activations(0); }
   virtual const AbsDistMat& get_prediction() const { return get_prev_activations(0); }
-  virtual AbsDistMat& get_ground_truth() { return get_prev_activations(1); }
   virtual const AbsDistMat& get_ground_truth() const { return get_prev_activations(1); }
 };
 

--- a/include/lbann/layers/io/target/reconstruction.hpp
+++ b/include/lbann/layers/io/target/reconstruction.hpp
@@ -73,7 +73,6 @@ class reconstruction_layer : public generic_target_layer {
 
   void bp_compute() override {}
 
-  AbsDistMat& get_ground_truth() override { return get_prev_activations(1); }
   const AbsDistMat& get_ground_truth() const override { return get_prev_activations(1); }
 
 public:

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -194,24 +194,6 @@ class Layer {
   /** Write layer to proto file */
   virtual void write_proto(lbann_data::Layer* proto) const;
 
-  /** Send forward propagation output to a child layer.
-   *  On output, fp_output is either a matrix view or copy of the
-   *  appropriate activation tensor.
-   */
-  virtual void get_fp_output(AbsDistMat& fp_output, const Layer* child) const;
-  /** Send backward propagation output to a parent layer.
-   *  On output, bp_output is either a matrix view or copy of the
-   *  appropriate error signal tensor.
-   */
-  virtual void get_bp_output(AbsDistMat& bp_output, const Layer* parent) const;
-
-  /** Add to the layer's error signal. */
-  virtual void add_to_error_signal(const AbsDistMat& error_signals,
-                                   DataType scale = DataType(1),
-                                   int parent_index = 0) {
-    El::Axpy(scale, error_signals, *m_error_signals[parent_index]);
-  }
-
   /** Get parent layers. */
   inline std::vector<const Layer*>& get_parent_layers() { return m_parent_layers; }
   /** Get parent layers. (const) */
@@ -286,37 +268,29 @@ class Layer {
    */
   int get_output_size(int output_index = 0) const;
 
-  /** Get previous activation tensor. */
-  AbsDistMat& get_prev_activations(int parent_index = 0);
   /** Get activation tensor. */
   AbsDistMat& get_activations(int child_index = 0);
-  /** Get previous error signal tensor. */
-  AbsDistMat& get_prev_error_signals(int child_index = 0);
   /** Get error signal tensor. */
   AbsDistMat& get_error_signals(int parent_index = 0);
-  /** Get previous activation tensor. (const) */
+  /** Get previous activation tensor. */
   const AbsDistMat& get_prev_activations(int parent_index = 0) const;
-  /** Get activation tensor. (const) */
+  /** Get activation tensor. */
   const AbsDistMat& get_activations(int child_index = 0) const;
-  /** Get previous error signal tensor. (const) */
+  /** Get previous error signal tensor. */
   const AbsDistMat& get_prev_error_signals(int child_index = 0) const;
-  /** Get error signal tensor. (const) */
+  /** Get error signal tensor. */
   const AbsDistMat& get_error_signals(int parent_index = 0) const;
-  /** Get local portion of previous activation tensor. */
-  AbsMat& get_local_prev_activations(int parent_index = 0);
   /** Get local portion of activation tensor. */
   AbsMat& get_local_activations(int child_index = 0);
-  /** Get local portion of previous error signal tensor. */
-  AbsMat& get_local_prev_error_signals(int child_index = 0);
   /** Get local portion of error signal tensor. */
   AbsMat& get_local_error_signals(int parent_index = 0);
-  /** Get local portion of previous activation tensor. (const) */
+  /** Get local portion of previous activation tensor. */
   const AbsMat& get_local_prev_activations(int parent_index = 0) const;
-  /** Get local portion of activation tensor. (const) */
+  /** Get local portion of activation tensor. */
   const AbsMat& get_local_activations(int child_index = 0) const;
-  /** Get local portion of previous error signal tensor. (const) */
+  /** Get local portion of previous error signal tensor. */
   const AbsMat& get_local_prev_error_signals(int child_index = 0) const;
-  /** Get local portion of error signal tensor. (const) */
+  /** Get local portion of error signal tensor. */
   const AbsMat& get_local_error_signals(int parent_index = 0) const;
 
   /** Get reference to LBANN communicator. */
@@ -474,6 +448,11 @@ class Layer {
 
   /** Deallocate distributed matrices. */
   void deallocate_matrices();
+
+  /** Get activation tensor corresponding to child layer. */
+  const AbsDistMat& get_activations(const Layer& child) const;
+  /** Get error signal tensor corresponding to parent layer. */
+  const AbsDistMat& get_error_signals(const Layer& parent) const;
 
 };
 

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -305,35 +305,6 @@ class Layer {
   /** Reference to LBANN communicator. */
   lbann_comm *m_comm;
 
-  /** Previous activation matrices.
-   *  Forward propagation inputs from each parent layer. These are
-   *  typically matrix views where each column is a flattened tensor
-   *  corresponding to a mini-batch sample. The matrices are owned by
-   *  the layer.
-   */
-  std::vector<AbsDistMat*> m_prev_activations;
-  /** Activation matrices.
-   *  Forward propagation outputs to each child layer. These are
-   *  typically matrices where each column is a flattened tensor
-   *  corresponding to a mini-batch sample. The matrices are owned by
-   *  the layer.
-   */
-  std::vector<AbsDistMat*> m_activations;
-  /** Error signal matrices.
-   *  Backward propagation inputs from each child layer. These are
-   *  typically matrix views where each column is a flattened tensor
-   *  corresponding to a mini-batch sample. The matrices are owned by
-   *  the layer.
-   */
-  std::vector<AbsDistMat*> m_prev_error_signals;
-  /** Error signal matrices.
-   *  Backward propagation outputs to each parent layer. These are
-   *  typically matrices where each column is a flattened tensor
-   *  corresponding to a mini-batch sample. The matrices are owned by
-   *  the layer.
-   */
-  std::vector<AbsDistMat*> m_error_signals;
-
   /** References to layer weights. */
   std::vector<weights*> m_weights;
 
@@ -441,6 +412,23 @@ class Layer {
 
   /** Dimensions of output tensors. */
   std::vector<std::vector<int>> m_output_dims_list;
+
+  /** Input tensors.
+   *  Each matrix column corresponds to a flattened mini-batch sample.
+   */
+  std::vector<AbsDistMat*> m_inputs;
+  /** Output tensors.
+   *  Each matrix column corresponds to a flattened mini-batch sample.
+   */
+  std::vector<AbsDistMat*> m_outputs;
+  /** Objective function gradients w.r.t. the output tensors.
+   *  Each matrix column corresponds to a flattened mini-batch sample.
+   */
+  std::vector<AbsDistMat*> m_gradient_wrt_outputs;
+  /** Objective function gradients w.r.t. the input tensors.
+   *  Each matrix column corresponds to a flattened mini-batch sample.
+   */
+  std::vector<AbsDistMat*> m_gradient_wrt_inputs;
 
   /** Instantiate distributed matrices. */
   template <data_layout T, El::Device Dev>

--- a/include/lbann/layers/regularizers/selu_dropout.hpp
+++ b/include/lbann/layers/regularizers/selu_dropout.hpp
@@ -108,13 +108,13 @@ class selu_dropout : public regularizer_layer {
       El::Copy(get_prev_activations(), get_activations());
     } else {
 
-      AbsDistMat *input_acts = &get_prev_activations();
+      const auto *input_acts = &get_prev_activations();
       const El::Int height = input_acts->Height();
       const El::Int width = input_acts->Width();
       const El::Int local_height = input_acts->LocalHeight();
       const El::Int local_width = input_acts->LocalWidth();
 
-      Mat& local_input_acts = input_acts->Matrix();
+      const auto& local_input_acts = input_acts->LockedMatrix();
       Mat& local_output_acts = get_local_activations();
       Mat& local_mask = m_mask->Matrix();
 
@@ -139,7 +139,7 @@ class selu_dropout : public regularizer_layer {
       El::Copy(get_prev_error_signals(), get_error_signals());
     } else {
 
-      Mat& local_prev_error_signal = get_local_prev_error_signals();
+      const auto& local_prev_error_signal = get_local_prev_error_signals();
       Mat& local_error_signal = get_local_error_signals();
       Mat& local_mask = m_mask->Matrix();
       const El::Int local_height = local_prev_error_signal.Height();

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -86,8 +86,8 @@ class split_layer : public transform_layer {
 
   void fp_compute() override {
     const auto& input = get_prev_activations();
-    for (auto& output : this->m_activations) {
-      El::LockedView(*output, input);
+    for (int i = 0; i < get_num_children(); ++i) {
+      El::LockedView(get_activations(i), input);
     }
   }
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -98,8 +98,8 @@ class sum_layer : public transform_layer {
 
   void bp_compute() override {
     const auto& gradient_wrt_output = get_prev_error_signals();
-    for (auto* gradient_wrt_input : this->m_error_signals) {
-      El::LockedView(*gradient_wrt_input, gradient_wrt_output);
+    for (int i = 0; i < get_num_parents(); ++i) {
+      El::LockedView(get_error_signals(i), gradient_wrt_output);
     }
   }
 

--- a/src/objective_functions/loss_functions/loss_function.cpp
+++ b/src/objective_functions/loss_functions/loss_function.cpp
@@ -133,7 +133,8 @@ void loss_function::differentiate() {
   const AbsDistMat& ground_truth = target->get_ground_truth();
   El::Zeros(*m_gradient, prediction.Height(), prediction.Width());
   differentiate_compute(prediction, ground_truth, *m_gradient);
-  target->add_to_error_signal(*m_gradient, DataType(m_scale_factor));
+  El::Axpy(DataType(m_scale_factor), *m_gradient,
+           target->get_error_signals());
 }
 
 }  // namespace lbann


### PR DESCRIPTION
Changes in base layer class:
- Removed redundant tensor access functions, e.g. `get_fp_output()` and `get_bp_output()`.
- Removed inappropriate non-const tensor access functions, e.g. `get_prev_activations()` and `get_prev_error_signals()`.
- We now explicitly force distributed matrices to have the same alignment.
- Tensors are now private class members.
- Tensors are stored in `unique_ptr`s (see #155).