### PR TITLE
Stack trace refactor

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -1186,6 +1186,12 @@ void lbann_comm::broadcast(const int root, T* data, const int count, const El::m
 template<>
 void lbann_comm::broadcast<std::string>(const int root, std::string& str, const El::mpi::Comm c);
 
+/** Get the current rank within MPI_COMM_WORLD.
+ *  This function is safe to call even if MPI has not initialized or
+ *  has been finalized. In either case it returns a negative value.
+ */
+int get_rank_in_world();
+
 } // namespace lbann
 
 #endif  // LBANN_COMM_HPP_INCLUDED

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -74,10 +74,6 @@ public:
    *  Reports the exception message and the stack trace.
    */
   void print_report(std::ostream& os = std::cerr) const;
-  /** Write human-readable report to file.
-   *  The file name has the form "<base_name>_rank<MPI rank>.txt".
-   */
-  void write(std::string base_name = "stack_trace") const;
   
 private:
   /** Human-readable exception message. */

--- a/include/lbann/utils/stack_trace.hpp
+++ b/include/lbann/utils/stack_trace.hpp
@@ -23,71 +23,37 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef __STACK_TRACE_HPP__
-#define __STACK_TRACE_HPP__
+#ifndef LBANN_UTILS_STACK_TRACE_HPP_INCLUDED
+#define LBANN_UTILS_STACK_TRACE_HPP_INCLUDED
 
-#include <csignal>
 #include <string>
 
 namespace lbann {
 namespace stack_trace {
 
-/**
- * This module contains functions for printing a stack trace
- * when either a signal is caught or an lbann exception is thrown.
- * Default behavior: processes write to cerr. The cmd line option
- * "--stack_trace_to_file" will additionally cause each processor
- * to attempt to write its stack trace to
- *    "stack_trace_<rank_in_world>.txt"
- *
- * To use in your driver, you need to call register_handler() after
- * the call to options::get()->init(), and also include the option
- * --catch_signals on the command line
+/** Get human-readable stack trace.
+ *  Ignores stack frames within the lbann::stack_trace and
+ *  lbann::lbann_exception namespaces. Calls non-reentrant functions,
+ *  so behaviour may be undefined if used within a signal handler.
  */
+std::string get();
 
-/** For internal use; made public for testing.
- *  called by initialize()
+/** Register signal handler.
+ *  Initializes a signal handler that prints an error message and
+ *  stack trace to the standard error stream when a signal is
+ *  detected. If desired, it also writes to the file
+ *  "stack_trace_rank<MPI rank>.txt". 
+ *  
+ *  This functionality is somewhat risky since the handler calls
+ *  non-reentrant functions, which can result in undefined behavior
+ *  (see https://www.ibm.com/developerworks/library/l-reent/). That
+ *  said, it is possible (likely?) that our handler will work
+ *  correctly. And if there's a SIGSEV and it doesn't, nothing much is
+ *  lost (IMO).
  */
-void set_lbann_stack_trace_world_rank(int rank);
-
-/** For internal use; made public for testing.
- *  Attempts to print a stack trace. Calls non-reentrant
- *  functions, so behaviour may be undefined if used within
- *  a signal handler. Can be used when exceptions are thrown
- *  without undefined behavior.
- */
-void print_stack_trace();
-
-
-/** For internal use; made public for testing.
- *  Attempts to print a stack trace when an lbann_exception
- *  is thrown. Called by lbann_exception() ctor.
- */
-void print_lbann_exception_stack_trace(std::string m);
-
-/** For internal use; made public for testing.
- * called by print_lbann_signal_stack_trace().
- */ 
-std::string sig_name(int signal);
-
-
-/** Register our signal handler; This is called in initialize(),
- *  but only if the cmd line option "--catch_signals" is present.
- *  It is not active by default, because the handler calls non-reentrant,
- *  functions, which can result in undefined behavior. 
- *  See: https://www.ibm.com/developerworks/library/l-reent/
- *  for discussion. That said, it is possible (likely?) that our
- *  handler will work correctly. And if there's a SIGSEV and it
- *  doesn't, nothing much is lost (IMO). 
- */
-void register_handler();
-
-/** For internal use; made public for testing. */
-void lbann_signal_handler(int signal);
-
+void register_signal_handler(bool write_to_file = false);
 
 } //namespace stack_trace 
 } //namespace lbann
 
-
-#endif
+#endif // LBANN_UTILS_STACK_TRACE_HPP_INCLUDED

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
     if (!opts->has_bool("disable_signal_handler")) {
       stack_trace::register_signal_handler(opts->has_bool("stack_trace_to_file"));
     }
-
+    
     //to activate, must specify --st_on on cmd line
     stack_profiler::get()->activate(comm->get_rank_in_world());
 
@@ -305,7 +305,12 @@ int main(int argc, char *argv[]) {
   } catch (lbann_exception& e) {
     e.print_report();
     if (options::get()->has_bool("stack_trace_to_file")) {
-      e.write();
+      std::stringstream ss("stack_trace");
+      const auto& rank = get_rank_in_world();
+      if (rank >= 0) { ss << "_rank" << rank; }
+      ss << ".txt";
+      std::ofstream fs(ss.str().c_str());
+      e.print_report(fs);
     }
     El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/stack_trace.hpp"
 #include "lbann/utils/stack_profiler.hpp"
 #include "lbann/data_store/generic_data_store.hpp"
 #include <cstdlib>
@@ -67,11 +68,10 @@ int main(int argc, char *argv[]) {
       return 0;
     }
 
-
-
     //this must be called after call to opts->init();
-    //must also specify "--catch-signals" on cmd line
-    stack_trace::register_handler();
+    if (!opts->has_bool("disable_signal_handler")) {
+      stack_trace::register_signal_handler(opts->has_bool("stack_trace_to_file"));
+    }
 
     //to activate, must specify --st_on on cmd line
     stack_profiler::get()->activate(comm->get_rank_in_world());
@@ -303,7 +303,11 @@ int main(int argc, char *argv[]) {
     delete model;
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    if (options::get()->has_bool("stack_trace_to_file")) {
+      e.write();
+    }
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -118,7 +118,8 @@ int main(int argc, char *argv[]) {
     }
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }
@@ -320,7 +321,8 @@ model * build_model_from_prototext(int argc, char **argv,
 #endif
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -129,9 +129,6 @@ int main(int argc, char *argv[]) {
 
   } catch (lbann_exception& e) {
     e.print_report();
-    if (options::get()->has_bool("stack_trace_to_file")) {
-      e.write();
-    }
     El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -128,7 +128,11 @@ int main(int argc, char *argv[]) {
     }
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    if (options::get()->has_bool("stack_trace_to_file")) {
+      e.write();
+    }
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }
@@ -328,7 +332,8 @@ model * build_model_from_prototext(int argc, char **argv,
 #endif
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -115,7 +115,11 @@ int main(int argc, char *argv[]) {
     }
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    if (options::get()->has_bool("stack_trace_to_file")) {
+      e.write();
+    }
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }
@@ -309,7 +313,8 @@ model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &p
 #endif
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions
   }

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -116,9 +116,6 @@ int main(int argc, char *argv[]) {
 
   } catch (lbann_exception& e) {
     e.print_report();
-    if (options::get()->has_bool("stack_trace_to_file")) {
-      e.write();
-    }
     El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -82,10 +82,6 @@ lbann_comm* initialize(int& argc, char**& argv, int seed) {
   init_random(seed);
   init_data_seq_random(seed);
 
-  //initialization for stack tracing when a signal is raised
-  //or an lbann_exception thrown.
-  stack_trace::set_lbann_stack_trace_world_rank(comm->get_rank_in_world());
-
   return comm;
 }
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -1235,4 +1235,14 @@ void lbann_comm::lbann_comm_abort(std::string msg) {
   throw lbann_exception(msg);
 }
 
+int get_rank_in_world() {
+  int initialized = 0, finalized = 1, rank = -1;
+  MPI_Initialized(&initialized);
+  MPI_Finalized(&finalized);
+  if (initialized && !finalized) {
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  }
+  return rank;
+}
+
 }  // namespace lbann

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -102,25 +102,18 @@ int lbann::generic_data_reader::fetch_data(CPUMat& X) {
   }
 
   else {
-    #pragma omp parallel for
+    std::string error_message;
+#pragma omp parallel for
     for (int s = 0; s < mb_size; s++) {
-      // Catch exceptions within the OpenMP thread.
-      try {
-        int n = m_current_pos + (s * m_sample_stride);
-        int index = m_shuffled_indices[n];
-        bool valid = fetch_datum(X, index, s, omp_get_thread_num());
-        if (!valid) {
-          throw lbann_exception(
-            std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-            " :: generic data reader load error: datum not valid");
-        }
-        m_indices_fetched_per_mb.Set(s, 0, index);
-      } catch (lbann_exception& e) {
-        lbann_report_exception(e);
-      } catch (std::exception& e) {
-        El::ReportException(e);
+      int n = m_current_pos + (s * m_sample_stride);
+      int index = m_shuffled_indices[n];
+      bool valid = fetch_datum(X, index, s, omp_get_thread_num());
+      if (!valid) {
+#pragma omp critical
+        error_message = "invalid datum (index " + std::to_string(index) + ")";
       }
     }
+    if (!error_message.empty()) { LBANN_ERROR(error_message); }
 
     /// Allow each thread to perform any postprocessing necessary on the
     /// data source prior to fetching data
@@ -155,25 +148,18 @@ int lbann::generic_data_reader::fetch_labels(CPUMat& Y) {
  // }
 
 //  else {
-    #pragma omp parallel for
+    std::string error_message;
+#pragma omp parallel for
     for (int s = 0; s < mb_size; s++) {
-      // Catch exceptions within the OpenMP thread.
-      try {
-        int n = m_current_pos + (s * m_sample_stride);
-        int index = m_shuffled_indices[n];
-
-        bool valid = fetch_label(Y, index, s, omp_get_thread_num());
-        if (!valid) {
-          throw lbann_exception(
-            std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-            " :: generic data reader load error: label not valid");
-        }
-      } catch (lbann_exception& e) {
-        lbann_report_exception(e);
-      } catch (std::exception& e) {
-        El::ReportException(e);
+      int n = m_current_pos + (s * m_sample_stride);
+      int index = m_shuffled_indices[n];
+      bool valid = fetch_label(Y, index, s, omp_get_thread_num());
+      if (!valid) {
+#pragma omp critical
+        error_message = "invalid label (index " + std::to_string(index) + ")";
       }
     }
+    if (!error_message.empty()) { LBANN_ERROR(error_message); }
   //}
   return mb_size;
 }
@@ -193,25 +179,18 @@ int lbann::generic_data_reader::fetch_responses(CPUMat& Y) {
     Y.Width());
 
   El::Zeros(Y, Y.Height(), Y.Width());
-  #pragma omp parallel for
+  std::string error_message;
+#pragma omp parallel for
   for (int s = 0; s < mb_size; s++) {
-    // Catch exceptions within the OpenMP thread.
-    try {
-      int n = m_current_pos + (s * m_sample_stride);
-      int index = m_shuffled_indices[n];
-
-      bool valid = fetch_response(Y, index, s, omp_get_thread_num());
-      if (!valid) {
-        throw lbann_exception(
-          std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-          " :: generic data reader load error: response not valid");
-      }
-    } catch (lbann_exception& e) {
-      lbann_report_exception(e);
-    } catch (std::exception& e) {
-      El::ReportException(e);
+    int n = m_current_pos + (s * m_sample_stride);
+    int index = m_shuffled_indices[n];
+    bool valid = fetch_response(Y, index, s, omp_get_thread_num());
+    if (!valid) {
+#pragma omp critical
+      error_message = "invalid response (index " + std::to_string(index) + ")";
     }
   }
+  if (!error_message.empty()) { LBANN_ERROR(error_message); }
   return mb_size;
 }
 

--- a/src/data_readers/data_reader_mnist_siamese.cpp
+++ b/src/data_readers/data_reader_mnist_siamese.cpp
@@ -114,26 +114,21 @@ int data_reader_mnist_siamese::fetch_data(CPUMat& X) {
   El::Zeros(X, X.Height(), X.Width());
   El::Zeros(m_indices_fetched_per_mb, mb_size, 1);
 
-  #pragma omp parallel for
+  std::string error_message;
+#pragma omp parallel for
   for (int s = 0; s < mb_size; s++) {
-    // Catch exceptions within the OpenMP thread.
-    try {
-      int n = m_current_pos + (s * m_sample_stride);
-      sample_t index = std::make_pair(m_shuffled_indices[n], m_shuffled_indices2[n]);
-      bool valid = fetch_datum(X, index, s, omp_get_thread_num());
-      if (!valid) {
-        throw lbann_exception(
-          std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-          " :: generic data reader load error: datum not valid");
-      }
+    int n = m_current_pos + (s * m_sample_stride);
+    sample_t index = std::make_pair(m_shuffled_indices[n], m_shuffled_indices2[n]);
+    bool valid = fetch_datum(X, index, s, omp_get_thread_num());
+    if (valid) {
       El::Int index_coded = m_shuffled_indices[n] + m_shuffled_indices2[n]*(std::numeric_limits<label_t>::max()+1);
       m_indices_fetched_per_mb.Set(s, 0, index_coded);
-    } catch (lbann_exception& e) {
-      lbann_report_exception(e);
-    } catch (std::exception& e) {
-      El::ReportException(e);
+    } else{
+#pragma omp critical
+      error_message = "invalid datum";
     }
   }
+  if (!error_message.empty()) { LBANN_ERROR(error_message); }
 
   /// Allow each thread to perform any postprocessing necessary on the
   /// data source prior to fetching data
@@ -171,25 +166,18 @@ int data_reader_mnist_siamese::fetch_labels(CPUMat& Y) {
  // }
 
 //  else {
-    #pragma omp parallel for
+    std::string error_message;
+#pragma omp parallel for
     for (int s = 0; s < mb_size; s++) {
-      // Catch exceptions within the OpenMP thread.
-      try {
-        int n = m_current_pos + (s * m_sample_stride);
-        sample_t index = std::make_pair(m_shuffled_indices[n], m_shuffled_indices2[n]);
-
-        bool valid = fetch_label(Y, index, s, omp_get_thread_num());
-        if (!valid) {
-          throw lbann_exception(
-            std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-            " :: generic data reader load error: label not valid");
-        }
-      } catch (lbann_exception& e) {
-        lbann_report_exception(e);
-      } catch (std::exception& e) {
-        El::ReportException(e);
+      int n = m_current_pos + (s * m_sample_stride);
+      sample_t index = std::make_pair(m_shuffled_indices[n], m_shuffled_indices2[n]);
+      bool valid = fetch_label(Y, index, s, omp_get_thread_num());
+      if (!valid) {
+#pragma omp critical
+        error_message = "invalid label";
       }
     }
+    if (!error_message.empty()) { LBANN_ERROR(error_message); }
   //}
   return mb_size;
 }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   cnpy_utils.cpp
   cublas.cpp
   cudnn.cpp
+  exception.cpp
   file_utils.cpp
   graph.cpp
   im2col.cpp

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/stack_trace.hpp"
+#include "lbann/comm.hpp"
+
+namespace lbann {
+  
+exception::exception(std::string message)
+  : m_message(message),
+    m_stack_trace(stack_trace::get()) {
+
+  // Construct default message if none is provided
+  if (m_message.empty()) {
+    std::stringstream ss("LBANN exception");
+    const auto& rank = get_rank_in_world();
+    if (rank >= 0) {
+      ss << " on rank " << rank;
+    }
+    m_message = ss.str();
+  }
+      
+}
+
+const char* exception::what() const noexcept {
+  return m_message.c_str();
+}
+
+void exception::print_report(std::ostream& os) const {
+  std::stringstream ss;
+  ss << "****************************************************************"
+     << std::endl
+     << m_message << std::endl;
+  if (!m_stack_trace.empty()) {
+    ss << "Stack trace:" << std::endl
+       << m_stack_trace;
+  }
+  ss << "****************************************************************"
+     << std::endl;
+  os << ss.str();
+}
+ 
+void exception::write(std::string base_name) const {
+
+  // Construct file name
+  std::stringstream ss(base_name);
+  const auto& rank = get_rank_in_world();
+  if (rank >= 0) { ss << "_rank" << rank; }
+  ss << ".txt";
+  const auto& file_name = ss.str();
+
+  // Write stack trace to file
+  std::ofstream fs;
+  fs.open(file_name.c_str());
+  print_report(fs);
+  
+}
+
+} // namespace lbann

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -63,21 +63,5 @@ void exception::print_report(std::ostream& os) const {
      << std::endl;
   os << ss.str();
 }
- 
-void exception::write(std::string base_name) const {
-
-  // Construct file name
-  std::stringstream ss(base_name);
-  const auto& rank = get_rank_in_world();
-  if (rank >= 0) { ss << "_rank" << rank; }
-  ss << ".txt";
-  const auto& file_name = ss.str();
-
-  // Write stack trace to file
-  std::ofstream fs;
-  fs.open(file_name.c_str());
-  print_report(fs);
-  
-}
 
 } // namespace lbann

--- a/src/utils/stack_trace.cpp
+++ b/src/utils/stack_trace.cpp
@@ -25,237 +25,136 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/utils/stack_trace.hpp"
-#include "lbann/utils/options.hpp"
-#include <execinfo.h>
-#include <dlfcn.h>
-#include <cxxabi.h>
+#include "lbann/utils/exception.hpp"
+#include "lbann/comm.hpp"
+#include <algorithm>
+#include <vector>
 #include <string>
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <unistd.h>
+#include <iomanip>
 
+#include <execinfo.h>
+#include <dlfcn.h>
+#include <cxxabi.h>
+// #include <unistd.h>
+#include <csignal>
 
 namespace lbann {
-
 namespace stack_trace {
 
-static std::ofstream to_file;
+std::string get() {
+  std::stringstream ss;
 
-static int my_lbann_tracing_id = 0;
-
-struct sigaction sa;
-
-void set_lbann_stack_trace_world_rank(int rank) {
-  my_lbann_tracing_id = rank;
-}
-
-// optionally opens "to_file" for writing; returns 'false' if
-// we tried to open the file, but failed
-static bool open_output_file() {
-  options * opts = options::get();
-  bool success = true;
-  if (opts->has_bool("stack_trace_to_file") && opts->get_bool("stack_trace_to_file")) {
-    std::stringstream b;
-    b << "stack_trace_" << my_lbann_tracing_id << ".txt";
-    to_file.open(b.str().c_str());
-    if (! to_file.is_open()) {
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << " failed to open file: " << b.str() << " for writing";
-
-      //todo: can this be done better? Can't throw exception, else
-      //      we go into an infinite loop
-      std::cerr << err.str() << std::endl;
-      success = false;
-    }
-  }
-  return success;
-}
-
-static void close_output_file() {
-  if (to_file.is_open()) {
-    to_file.close();
-  }
-}
-
-void print_stack_trace() {
-  if (to_file.is_open()) {
-    to_file << "\n**************************************************************************\n";
-  }
-
-  #define MAX_STACK_FRAMES 64
-  static void *stack_traces[MAX_STACK_FRAMES];
-  int trace_size = backtrace(stack_traces, MAX_STACK_FRAMES);
-  char **messages = backtrace_symbols(stack_traces, trace_size);
-  Dl_info info;
-  for (int i=0; i<trace_size; i++) {
-    std::cerr << "rank: " << my_lbann_tracing_id << " :: ";
-    dladdr(stack_traces[i], &info);
-    if (info.dli_sname != NULL) {
-      char *demangled_name = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, nullptr);
-      if (demangled_name != NULL) {
-        std::string test(demangled_name);
-        /*if (test.find("__libc_start_main") != std::string::npos) {
-          i = 100000;
-          break;
-        }
-        */
-        if (test.find("lbann::stack_trace::print_stack_trace") == std::string::npos && test.find("lbann::stack_trace::print_lbann_exception_stack_trace") == std::string::npos) {
-          std::cerr << demangled_name << std::endl;
-          if (to_file.is_open()) {
-            to_file << "  >>>> " << demangled_name << std::endl;
-          }
-        }
-        free(demangled_name);
-      } else {
-        std::cerr << "demangling failed for: " << info.dli_sname << std::endl;
-        if (to_file.is_open()) {
-          to_file << "  >>>> demangling failed for: " << info.dli_sname << std::endl;
-        }
-      }
-    } else {
-      std::cerr << "dli_sname == NULL for: " << stack_traces[i] << " backtrace message was: " << messages[i] << std::endl;
-      if (to_file.is_open()) {
-        to_file << "  >>>> dli_sname == NULL for: " << stack_traces[i] << " backtrace message was: " << messages[i] << std::endl;
-      }
-    }
-  }
-  std::cerr << std::endl;
-
-  if (to_file.is_open()) {
-    to_file.close();
-  }
-
-  std::cerr << "sleeping for two seconds to give all procs a chance to write ...\n";
-  sleep(2);
-}
-
-
-void print_lbann_exception_stack_trace(std::string m) {
-  if (! open_output_file()) {
-    return;
-  }
+  // Stack frames to ignore
+  const std::vector<std::string> ignored_frames
+    = {"lbann::stack_trace",
+       "lbann::lbann_exception"};
   
-  std::stringstream s;
-  s << "\n**************************************************************************\n"
-    << " This lbann_exception is about to be thrown:" << m << "\n\n"
-    << " Am now attempting to print the stack trace ...\n"
-    << "**************************************************************************\n";
-  if (to_file.is_open()) {
-    to_file << s.str();
-  }
-  std::cerr << s.str();
-  print_stack_trace();
-  close_output_file();
-}
+  // Get stack frames
+  std::vector<void*> frames(128, nullptr);
+  const auto& frames_size = backtrace(frames.data(), frames.size());
+  frames.resize(frames_size, nullptr);
 
-
-std::string sig_name(int signal) {
-  std::string r;
-  switch (signal) {
-    case 1 : 
-      r = "SIGHUP"; break;
-    case 2 :
-      r = "SIGINT"; break;
-    case 3 :
-      r = "SIGQUIT"; break;
-    case 4 :
-      r = "SIGILL"; break;
-    case 5 :
-      r = "SIGTRAP"; break;
-    case 6 :
-      r = "SIGABRT"; break;
-    case 7 :
-      r = "SIGBUS"; break;
-    case 8 :
-      r = "SIGFPE"; break;
-    case 9 :
-      r = "SIGKILL"; break;
-    case 10 :
-      r = "SIGUSR1"; break;
-    case 11 :
-      r = "SIGSEGV"; break;
-    case 12 :
-      r = "SIGUSR2"; break;
-    case 13 :
-      r = "SIGPIPE"; break;
-    case 14 :
-      r = "SIGALRM"; break;
-    case 15 :
-      r = "SIGTERM"; break;
-    case 16 :
-      r = "SIGSTKFLT"; break;
-    case 17 :
-      r = "SIGCHLD"; break;
-    case 18 :
-      r = "SIGCONT"; break;
-    case 19 :
-      r = "SIGSTOP"; break;
-    case 20 :
-      r = "SIGTSTP"; break;
-    case 21 :
-      r = "SIGTTIN"; break;
-    case 22 :
-      r = "SIGTTOU"; break;
-    case 23 :
-      r = "SIGURG"; break;
-    case 24 :
-      r = "SIGXCPU"; break;
-    case 25 :
-      r = "SIGXFSZ"; break;
-    case 26 :
-      r = "SIGVTALRM"; break;
-    case 27 :
-      r = "SIGPROF"; break;
-    case 28 :
-      r = "SIGWINCH"; break;
-    case 29 :
-      r = "SIGPOLL"; break;
-    case 30 :
-      r = "SIGPWR"; break;
-    case 31 :
-      r = "SIGSYS"; break;
-    default :
-      std::stringstream s;
-      s << "unknown signal #" << signal;
-      r = s.str();
-  }
-  return r;
-}
-
-void register_handler() {
-  options *opts = options::get();
-  if (opts->has_bool("catch_signals") and opts->get_bool("catch_signals")) {
-    sa.sa_handler = &lbann_signal_handler;
-    sa.sa_flags = SA_RESTART;
-    sigfillset(&sa.sa_mask);
-
-    for (int i=0; i<40; i++) {
-      sigaction(i, &sa, NULL);
+  // Get demangled stack frame names
+  auto* symbols = backtrace_symbols(frames.data(), frames.size());
+  for (size_t i = 0; i < frames.size(); ++i) {
+    ss << std::setw(4) << i << ": ";
+    Dl_info info;
+    dladdr(frames[i], &info);
+    if (info.dli_sname != nullptr) {
+      auto* name = abi::__cxa_demangle(info.dli_sname,
+                                       nullptr, nullptr, nullptr);
+      if (name == nullptr) {
+        ss << info.dli_sname << " (demangling failed)";
+      } else if (std::all_of(ignored_frames.begin(),
+                             ignored_frames.end(),
+                             [name](const std::string& str) {
+                               return str.find(name) == std::string::npos;
+                             })) {
+        ss << name;
+      }
+      std::free(name);
+    } else {
+      if (symbols != nullptr) { ss << symbols[i] << " "; }
+      ss << "(could not find stack frame symbol)";
     }
+    ss << std::endl;
+  }
+  std::free(symbols);
+  
+  return ss.str();
+}
+  
+namespace {
+
+/** Get human-readable name for signal.
+ *  See /usr/include/bits/signum.h for signal explanations.
+ */
+std::string signal_name(int signal) {
+  switch (signal) {
+  case 1:  return "SIGHUP";
+  case 2:  return "SIGINT";
+  case 3:  return "SIGQUIT";
+  case 4:  return "SIGILL";
+  case 5:  return "SIGTRAP";
+  case 6:  return "SIGABRT";
+  case 7:  return "SIGBUS";
+  case 8:  return "SIGFPE";
+  case 9:  return "SIGKILL";
+  case 10: return "SIGUSR1";
+  case 11: return "SIGSEGV";
+  case 12: return "SIGUSR2";
+  case 13: return "SIGPIPE";
+  case 14: return "SIGALRM";
+  case 15: return "SIGTERM";
+  case 16: return "SIGSTKFLT";
+  case 17: return "SIGCHLD";
+  case 18: return "SIGCONT";
+  case 19: return "SIGSTOP";
+  case 20: return "SIGTSTP";
+  case 21: return "SIGTTIN";
+  case 22: return "SIGTTOU";
+  case 23: return "SIGURG";
+  case 24: return "SIGXCPU";
+  case 25: return "SIGXFSZ";
+  case 26: return "SIGVTALRM";
+  case 27: return "SIGPROF";
+  case 28: return "SIGWINCH";
+  case 29: return "SIGPOLL";
+  case 30: return "SIGPWR";
+  case 31: return "SIGSYS";
+  default: return "signal " + std::to_string(signal);
   }
 }
 
+/** Whether to write to file when a signal is detected. */
+bool write_to_file_on_signal = false;
+  
+/** Signal handler.
+ *  Output signal name and stack trace to standard output and to a
+ *  file (if desired).
+ */
+void handle_signal(int signal) {
+  std::stringstream ss;
+  ss << "Caught " << signal_name(signal);
+  const auto& rank = get_rank_in_world();
+  if (rank >= 0) { ss << " on rank " << rank; }
+  throw exception(ss.str());
+}
 
-void lbann_signal_handler(int signal) {
-std::cerr << "starting lbann_signal_handler\n";
-  if (! open_output_file()) {
-    return;
+} // namespace
+
+void register_signal_handler(bool write_to_file) {
+  write_to_file_on_signal = write_to_file;
+  static struct sigaction sa;
+  sa.sa_handler = &handle_signal;
+  sa.sa_flags = SA_RESTART;
+  sigfillset(&sa.sa_mask);
+  for (int i=0; i<40; i++) {
+    sigaction(i, &sa, NULL);
   }
-  std::stringstream s;
-  s <<  
-         "\n**************************************************************************\n"
-         " Caught this signal: " << sig_name(signal) << "\n"
-         " Note: see /usr/include/bits/signum.h for signal explanations\n"
-         " Am now attempting to print the stack trace ...\n"
-         "**************************************************************************\n";
-  if (to_file.is_open()) {
-    to_file << s.str();
-  }
-  std::cerr << s.str();
-  print_stack_trace();
-  close_output_file();
 }
 
 } //namespace stack_trace 

--- a/tests/test_shuffled_indices.cpp
+++ b/tests/test_shuffled_indices.cpp
@@ -122,7 +122,8 @@ int main(int argc, char *argv[]) {
     }
 
   } catch (lbann_exception& e) {
-    lbann_report_exception(e, comm);
+    e.print_report();
+    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   }
 
   finalize(comm);


### PR DESCRIPTION
This PR does code cleanup and output prettying for the exception and stack trace reporting:
- Error messages and stack traces are printed in a unified block, which helps readability and reduces the  window for asynchronous printf jumbling.
- Signal handling functionality is enabled by default in main driver.
- Added a self-contained `stack_trace::get()` function that writes the stack trace to a string. This string is printed to `std::cerr` or to file elsewhere as needed, e.g. when an exception is caught.
- Separated declaration and implementation of `exception` class.
- Renamed `lbann_exception` to `exception` to reduce redundancy. Note that this class is in the `lbann` namespace, so it is clearly distinguished from `std::exception`. `lbann_exception` is retained as a typedef for the sake of backward compatibility.
- Added helper function `get_rank_in_world()` to safely determine MPI rank at any point in program.

Sample error message:
```text
****************************************************************
Caught signal 11 (segmentation violation) on rank 1
Stack trace:
   0: lbann::stack_trace::get[abi:cxx11]()
   1: lbann::exception::exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
   2: /usr/workspace/wsa/moon13/src/lbann/build/gnu.Release.catalyst.llnl.gov/lbann/build/liblbann.so(+0x9c0976) [0x2aaaab68f976] (could not find stack frame symbol)
   3: /usr/lib64/libpthread.so.0(+0xf680) [0x2aaaacb27680] (could not find stack frame symbol)
   4: lbann::Layer::Layer(lbann::lbann_comm*)
   5: lbann::generic_input_layer::generic_input_layer(lbann::lbann_comm*, int, std::map<execution_mode, lbann::generic_data_reader*, std::less<execution_mode>, std::allocator<std::pair<execution_mode const, lbann::generic_data_reader*> > >, bool, data_reader_target_mode)
...
   9: lbann::proto::construct_model(lbann::lbann_comm*, std::map<execution_mode, lbann::generic_data_reader*, std::less<execution_mode>, std::allocator<std::pair<execution_mode const, lbann:\
:generic_data_reader*> > > const&, lbann_data::Optimizer const&, lbann_data::Model const&)
  10: /usr/workspace/wsa/moon13/src/lbann/build/gnu.Release.catalyst.llnl.gov/lbann/build/model_zoo/lbann() [0x4046ee] (could not find stack frame symbol)
  11: __libc_start_main (demangling failed)
  12: /usr/workspace/wsa/moon13/src/lbann/build/gnu.Release.catalyst.llnl.gov/lbann/build/model_zoo/lbann() [0x4051c0] (could not find stack frame symbol)
****************************************************************
```
