### PR TITLE
Synthetic data reader improvements

### DIFF
--- a/include/lbann/data_readers/data_reader_synthetic.hpp
+++ b/include/lbann/data_readers/data_reader_synthetic.hpp
@@ -31,10 +31,17 @@
 #include "data_reader.hpp"
 
 namespace lbann {
+
+/**
+ * Data reader for generating random samples.
+ * Samples are different every time.
+ */
 class data_reader_synthetic : public generic_data_reader {
  public:
   //@todo: add what data distribution to use
   data_reader_synthetic(int num_samples, int num_features, bool shuffle = true);
+  data_reader_synthetic(int num_samples, std::vector<int> dims,
+                        int num_labels, bool shuffle = true);
   data_reader_synthetic(const data_reader_synthetic&) = default;
   data_reader_synthetic& operator=(const data_reader_synthetic&) = default;
   ~data_reader_synthetic() override {}
@@ -47,27 +54,28 @@ class data_reader_synthetic : public generic_data_reader {
 
   void load() override;
 
-  int get_num_samples() const {
-    return m_num_samples;
-  }
-  int get_num_features() const {
-    return m_num_features;
-  }
-
+  int get_num_labels() const override { return m_num_labels; }
+  
   int get_linearized_data_size() const override {
-    return m_num_features;
+    return std::accumulate(m_dimensions.begin(), m_dimensions.end(), 1,
+                           std::multiplies<int>());
   }
 
   const std::vector<int> get_data_dims() const override {
-    return {m_num_features};
+    return m_dimensions;
   }
 
  protected:
   bool fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) override;
+  bool fetch_label(Mat& Y, int data_id, int mb_idx, int tid) override;
 
  private:
-  int  m_num_samples; //rows
-  int  m_num_features; //cols
+  /** Number of samples in the dataset. */
+  int m_num_samples;
+  /** Number of labels in the dataset. */
+  int m_num_labels;
+  /** Shape of the data. */
+  std::vector<int> m_dimensions;
 };
 
 }  // namespace lbann

--- a/model_zoo/data_readers/data_reader_synthetic_imagenet.prototext
+++ b/model_zoo/data_readers/data_reader_synthetic_imagenet.prototext
@@ -3,20 +3,21 @@ data_reader {
     name: "synthetic"
     role: "train"
     shuffle: true
-    num_samples: 240000
-    synth_dimensions: "1024"
-    num_labels: 0
-    validation_percent: 0.1
+    num_samples: 1281167
+    num_labels: 1000
+    synth_dimensions: "3 224 224"
+    validation_percent: 0.01
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
   }
+
   reader {
     name: "synthetic"
     role: "test"
     shuffle: true
-    num_samples: 32000
-    synth_dimensions: "1024"
-    num_labels: 0
+    num_samples: 50000
+    num_labels: 1000
+    synth_dimensions: "3 224 224"
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
   }

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -50,9 +50,9 @@ message Reader {
   int32 max_files_to_load = 1000;
   //------------------  end of only for jag_conduit  -----------------------
 
-  int32 num_labels = 99; //for imagenet
+  int32 num_labels = 99; //for imagenet and synthetic
   int64 num_samples = 100; //only for synthetic
-  int64 num_features = 101; //only for synthetic
+  string synth_dimensions = 101; //only for synthetic
   //csv attributes
   string separator = 102;
   int32 skip_cols = 103;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -222,7 +222,9 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       }
 
     } else if (name == "synthetic") {
-      reader = new data_reader_synthetic(readme.num_samples(), readme.num_features(), shuffle);
+      reader = new data_reader_synthetic(
+        readme.num_samples(), proto::parse_list<int>(readme.synth_dimensions()),
+        readme.num_labels(), shuffle);
     } else if (name == "mesh") {
       reader = new mesh_reader(shuffle);
     } else {
@@ -342,10 +344,9 @@ void init_data_readers(lbann::lbann_comm *comm, const lbann_data::LbannPB& p, st
       } else if (name == "cifar10") {
         reader_validation = new cifar10_reader(shuffle);
         (*(cifar10_reader *)reader_validation) = (*(cifar10_reader *)reader);
-        /*
-        } else if (name == "synthetic") {
-        reader_validation = new data_reader_synthetic(shuffle);
-        */
+      } else if (name == "synthetic") {
+        reader_validation = new data_reader_synthetic(*(data_reader_synthetic *)reader);
+        (*(data_reader_synthetic *) reader_validation) = (*(data_reader_synthetic *)reader);
       } else if (name == "mesh") {
         reader_validation = new mesh_reader(shuffle);
         (*(mesh_reader *)reader_validation) = (*(mesh_reader *)reader);


### PR DESCRIPTION
This updates the synthetic data reader to support generating fake data with arbitrary dimensions. This means it can now be used as a substitute for things like ImageNet, when you wish to discard IO/etc.

This also no longer uses `El::Gaussian` because it's called from multiple threads, leading to bad performance.