### PR TITLE
Exception immediately prints report to stderr.

### DIFF
--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -67,7 +67,12 @@ namespace lbann {
  */
 class exception : public std::exception {
 public:
-  exception(std::string message="");
+
+  /** Constructor.
+   *  By default, a human-readable report is immediately printed to
+   *  the standard error stream.
+   */
+  exception(std::string message = "", bool print = true);
   const char* what() const noexcept override;
 
   /** Print human-readable report to stream.

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -93,8 +93,8 @@ int main(int argc, char *argv[]) {
     // Set algorithmic blocksize
     if (pb_model->block_size() == 0 and master) {
       std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: model does not provide a valid block size: " << pb_model->block_size();
-      throw lbann_exception(err.str());
+      err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
+      LBANN_ERROR(err.str());
     }
     El::SetBlocksize(pb_model->block_size());
 
@@ -319,8 +319,7 @@ int main(int argc, char *argv[]) {
     // for freeing dynamically allocated memory
     delete model;
 
-  } catch (lbann_exception& e) {
-    e.print_report();
+  } catch (exception& e) {
     if (options::get()->has_bool("stack_trace_to_file")) {
       std::stringstream ss("stack_trace");
       const auto& rank = get_rank_in_world();
@@ -329,9 +328,9 @@ int main(int argc, char *argv[]) {
       std::ofstream fs(ss.str().c_str());
       e.print_report(fs);
     }
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
+    El::ReportException(e);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   // free all resources by El and MPI

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -117,11 +117,8 @@ int main(int argc, char *argv[]) {
       delete t;
     }
 
-  } catch (lbann_exception& e) {
-    e.print_report();
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   // free all resources by El and MPI
@@ -152,8 +149,8 @@ model * build_model_from_prototext(int argc, char **argv,
 
     // Set algorithmic blocksize
     if (pb_model->block_size() == 0 and master) {
-      err << __FILE__ << " " << __LINE__ << " :: model does not provide a valid block size: " << pb_model->block_size();
-      throw lbann_exception(err.str());
+      err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
+      LBANN_ERROR(err.str());
     }
     El::SetBlocksize(pb_model->block_size());
 
@@ -338,7 +335,6 @@ model * build_model_from_prototext(int argc, char **argv,
 #endif
 
   } catch (lbann_exception& e) {
-    e.print_report();
     El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
     El::ReportException(e);  // Elemental exceptions

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -127,11 +127,8 @@ int main(int argc, char *argv[]) {
       delete t;
     }
 
-  } catch (lbann_exception& e) {
-    e.print_report();
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   // free all resources by El and MPI
@@ -162,8 +159,8 @@ model * build_model_from_prototext(int argc, char **argv,
 
     // Set algorithmic blocksize
     if (pb_model->block_size() == 0 and master) {
-      err << __FILE__ << " " << __LINE__ << " :: model does not provide a valid block size: " << pb_model->block_size();
-      throw lbann_exception(err.str());
+      err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
+      LBANN_ERROR(err.str());
     }
     El::SetBlocksize(pb_model->block_size());
 
@@ -345,11 +342,8 @@ model * build_model_from_prototext(int argc, char **argv,
       }
 #endif
 
-  } catch (lbann_exception& e) {
-    e.print_report();
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   return model;

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -114,11 +114,8 @@ int main(int argc, char *argv[]) {
       delete t;
     }
 
-  } catch (lbann_exception& e) {
-    e.print_report();
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   // free all resources by El and MPI
@@ -147,8 +144,8 @@ model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &p
 
     // Set algorithmic blocksize
     if (pb_model->block_size() == 0 and master) {
-      err << __FILE__ << " " << __LINE__ << " :: model does not provide a valid block size: " << pb_model->block_size();
-      throw lbann_exception(err.str());
+      err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
+      LBANN_ERROR(err.str());
     }
     El::SetBlocksize(pb_model->block_size());
 
@@ -326,11 +323,8 @@ model * build_model_from_prototext(int argc, char **argv, lbann_data::LbannPB &p
       }
 #endif
 
-  } catch (lbann_exception& e) {
-    e.print_report();
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
   } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    El::ReportException(e);
   }
 
   return model;

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -30,7 +30,7 @@
 
 namespace lbann {
   
-exception::exception(std::string message)
+exception::exception(std::string message, bool print)
   : m_message(message),
     m_stack_trace(stack_trace::get()) {
 
@@ -43,7 +43,10 @@ exception::exception(std::string message)
     }
     m_message = ss.str();
   }
-      
+
+  // Print report to standard error stream
+  if (print) { print_report(std::cerr); }
+  
 }
 
 const char* exception::what() const noexcept {


### PR DESCRIPTION
This is a workaround for bug caused by enabling the signal handler in #539. The signal handler can activate after an exception is thrown but before it is caught, printing out a less informative stack trace and terminating the program.

This solution isn't very elegant since it gives the exception constructor a non-obvious side effect (although there is an option to disable the printing).