### PR TITLE
Align all matrices to rank 0.

### DIFF
--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -853,7 +853,8 @@ void Layer::fp_setup_inputs(El::Int mini_batch_size) {
 
   // Determine distributed matrix alignment
   const auto& alignment_dist
-    = m_parent_layers.front()->get_activations(*this).DistData();
+    // = m_parent_layers.front()->get_activations(*this).DistData();
+    = get_prev_activations().DistData();
 
   // Iterate through input tensors
   for (int i = 0; i < get_num_parents(); ++i) {
@@ -894,7 +895,7 @@ void Layer::fp_setup_outputs(El::Int mini_batch_size) {
   const bool align_outputs = get_num_parents() > 0;
   const auto& alignment_dist = (align_outputs ?
                                 get_prev_activations().DistData() :
-                                El::DistData());
+                                get_activations().DistData());
 
   // Initialize output tensors
   for (int i = 0; i < get_num_children(); ++i) {


### PR DESCRIPTION
There are still some bugs that show up when distributed matrices have arbitrary alignment (#550), so this PR forces all distributed matrices to use the default alignment.