### PR TITLE
Manually setting thread affinity on Pascal.

### DIFF
--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -7,7 +7,7 @@ MODEL_PROTO="--model=${LBANN_DIR}/model_zoo/models/alexnet/model_alexnet.protote
 READER_PROTO="--reader=${LBANN_DIR}/model_zoo/data_readers/data_reader_imagenet.prototext"
 OPTIMIZER_PROTO="--optimizer=${LBANN_DIR}/model_zoo/optimizers/opt_sgd.prototext"
 IMAGENET_CLASSES= # options: 10, 100, 300, 1000 (leave blank to use other dataset)
-BUILD=          # default: Release
+BUILD=            # default: Release
 
 # Hardware configuration
 NUM_NODES=      # default: number of allocated nodes (1 if none)
@@ -269,13 +269,13 @@ esac
 case ${SCHEDULER} in
     slurm)
         MPIRUN="srun --nodes=${NUM_NODES} --ntasks=${NUM_PROCS}"
-        case ${HAS_GPU} in
-            YES|yes|TRUE|true|ON|on|1)
-                case ${CLUSTER} in
-                    surface|pascal|ray)
-                        MPIRUN="${MPIRUN} --nvidia_compute_mode=default"
-                        ;;
-                esac
+        case ${CLUSTER} in
+            surface|ray)
+                MPIRUN="${MPIRUN} --nvidia_compute_mode=default"
+                ;;
+            pascal)
+                MPIRUN="${MPIRUN} --mpibind=off --cpu_bind=mask_cpu:0x000001ff,0x0003fe00  --nvidia_compute_mode=default"
+                ;;
         esac
         MPIRUN1="srun --nodes=${NUM_NODES} --ntasks=${NUM_NODES}"
         MPIRUN2="srun --nodes=${NUM_NODES} --ntasks=$((2*${NUM_NODES}))"
@@ -369,7 +369,12 @@ case ${USE_GPU} in
         echo "export MV2_USE_CUDA=1"                    >> ${BATCH_SCRIPT}
         ;;
 esac
-echo ""
+case ${CLUSTER} in
+    pascal)
+        echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}
+        echo "export AL_PROGRESS_RANKS_PER_NUMA_NODE=2" >> ${BATCH_SCRIPT}
+    ;;
+esac
 echo ""                                                 >> ${BATCH_SCRIPT}
 
 # Cache dataset in node-local memory

--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -82,7 +82,7 @@ case ${CLUSTER} in
         ;;
     "surface")
         SCHEDULER=slurm
-        PARTITION=${PARTITION:-gpgpu}
+        PARTITION=${PARTITION:-pbatch}
         ACCOUNT=${ACCOUNT:-hpclearn}
         CACHE_DIR=${CACHE_DIR:-/tmp/${USER}}
         CORES_PER_NODE=16
@@ -373,7 +373,7 @@ case ${CLUSTER} in
     pascal)
         echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}
         echo "export AL_PROGRESS_RANKS_PER_NUMA_NODE=2" >> ${BATCH_SCRIPT}
-    ;;
+        ;;
 esac
 echo ""                                                 >> ${BATCH_SCRIPT}
 


### PR DESCRIPTION
I recently saw a 50x performance degradation on Pascal when I built with Aluminum. Profiling shows that the slowdown happens in NCCL allreduce kernels, which end up taking >99% of the GPU runtime. Whatever the cause, I recovered expected performance when I manually set thread affinity to accommodate Pascal's weird topology (see the timing experiments in #557).