### PR TITLE
Signal handler conforms to POSIX C standard.

### DIFF
--- a/include/lbann/utils/stack_trace.hpp
+++ b/include/lbann/utils/stack_trace.hpp
@@ -40,18 +40,19 @@ std::string get();
 
 /** Register signal handler.
  *  Initializes a signal handler that prints an error message and
- *  stack trace to the standard error stream when a signal is
- *  detected. If desired, it also writes to the file
- *  "stack_trace_rank<MPI rank>.txt". 
+ *  stack trace to the standard error stream when a fatal signal is
+ *  detected. If a file name base is provided, it also writes to the
+ *  file "<file_base>_rank<MPI rank>.txt".
+ *
+ *  Fatal signals are those that cause an abnormal termination by
+ *  default, according to the POSIX C standard
+ *  (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html).
  *  
  *  This functionality is somewhat risky since the handler calls
  *  non-reentrant functions, which can result in undefined behavior
- *  (see https://www.ibm.com/developerworks/library/l-reent/). That
- *  said, it is possible (likely?) that our handler will work
- *  correctly. And if there's a SIGSEV and it doesn't, nothing much is
- *  lost (IMO).
+ *  (see https://www.ibm.com/developerworks/library/l-reent/).
  */
-void register_signal_handler(bool write_to_file = false);
+void register_signal_handler(std::string file_base = "");
 
 } //namespace stack_trace 
 } //namespace lbann

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -70,7 +70,9 @@ int main(int argc, char *argv[]) {
 
     //this must be called after call to opts->init();
     if (!opts->has_bool("disable_signal_handler")) {
-      stack_trace::register_signal_handler(opts->has_bool("stack_trace_to_file"));
+      std::string file_base = (opts->has_bool("stack_trace_to_file") ?
+                               "stack_trace" : "");
+      stack_trace::register_signal_handler(file_base);
     }
     
     //to activate, must specify --st_on on cmd line


### PR DESCRIPTION
The signal handler will only handle signals that cause abnormal termination according to the POSIX C standard (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/signal.h.html). This should close #556 since signal 28 isn't in the POSIX C standard.

@ndryden brought up a good point that the POSIX C standard is not always followed strictly. For instance, the standard specifies that SIGTRAP causes a termination, but it's something used by gdb. That being said, I think it is unwise to choose which signals to handle based on folklore and I'm unable/unwilling to maintain such code. If there's a better spec (TODO: check the Linux spec), it is a perfectly fine design question about which one to follow.