### PR TITLE
Mean squared error layer and GPU abs layer

### DIFF
--- a/include/lbann/layers/loss/CMakeLists.txt
+++ b/include/lbann/layers/loss/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
   cross_entropy.hpp
+  mean_squared_error.hpp
   top_k_categorical_accuracy.hpp
   )
 

--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -1,0 +1,169 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_LOSS_MEAN_SQUARED_ERROR_HPP_INCLUDED
+#define LBANN_LAYERS_LOSS_MEAN_SQUARED_ERROR_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+
+namespace lbann {
+
+template <data_layout T_layout, El::Device Dev>
+class mean_squared_error_layer : public Layer {
+public:
+
+  mean_squared_error_layer(lbann_comm *comm) : Layer(comm) {
+    set_output_dims({1});
+    m_expected_num_parent_layers = 2;
+  }
+
+  mean_squared_error_layer(const mean_squared_error_layer& other)
+    : Layer(other) {
+    m_workspace.reset(other.m_workspace ?
+                      other.m_workspace->Copy() :
+                      nullptr);
+  }
+
+  mean_squared_error_layer& operator=(const mean_squared_error_layer& other) {
+    Layer::operator=(other);
+    m_workspace.reset(other.m_workspace ?
+                      other.m_workspace->Copy() :
+                      nullptr);
+    return *this;
+  }
+
+  mean_squared_error_layer* copy() const override { return new mean_squared_error_layer(*this); }
+  std::string get_type() const override { return "mean squared error"; }
+  data_layout get_data_layout() const override { return T_layout; }
+  El::Device get_device_allocation() const override { return Dev; }
+
+  void setup_dims() override {
+    Layer::setup_dims();
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      const auto& prediction_dims = get_input_dims(0);
+      const auto& ground_truth_dims = get_input_dims(1);
+      std::stringstream err;
+      err << get_type() << " layer \"" << get_name() << "\" has ";
+      for (size_t i = 0; i < prediction_dims.size(); ++i) {
+        err << (i > 0 ? "x" : "") << prediction_dims[i];
+      }
+      err << " prediction tensor "
+          << "from layer \"" << parents[0]->get_name() << "\" and ";
+      for (size_t i = 0; i < ground_truth_dims.size(); ++i) {
+        err << (i > 0 ? "x" : "") << ground_truth_dims[i];
+      }
+      err << " ground truth tensor "
+          << "from layer \"" << parents[1]->get_name() << "\"";
+      LBANN_ERROR(err.str());
+    }
+  }
+  
+  void setup_data() override {
+    Layer::setup_data();
+
+    // Initialize workspace
+    const auto& input_dist = get_prev_activations(0).DistData();
+    m_workspace.reset(AbsDistMat::Instantiate(*input_dist.grid,
+                                              input_dist.root,
+                                              El::STAR,
+                                              input_dist.rowDist,
+                                              (input_dist.blockHeight == 1
+                                               && input_dist.blockWidth == 1 ?
+                                               El::ELEMENT : El::BLOCK),
+                                              input_dist.device));
+#ifdef HYDROGEN_HAVE_CUB
+    if (m_workspace->GetLocalDevice() == El::Device::GPU) {
+      m_workspace->Matrix().SetMemoryMode(1); // CUB memory pool
+    }
+#endif // HYDROGEN_HAVE_CUB
+    
+  }
+
+  void fp_compute() override {
+
+    // Initialize workspace
+    m_workspace->Empty();
+    m_workspace->AlignWith(get_prev_activations());
+    m_workspace->Resize(1, get_prev_activations().Width());
+
+    // Compute local contributions and accumulate
+    /// @todo Consider reduce rather than allreduce
+    local_fp_compute(get_input_size(),
+                     get_local_prev_activations(0),
+                     get_local_prev_activations(1),
+                     m_workspace->Matrix());
+    m_comm->allreduce(*m_workspace, m_workspace->RedundantComm());
+    El::Copy(*m_workspace, get_activations());
+
+    // Clean up
+    m_workspace->Empty();
+    
+  }
+  
+  void bp_compute() override {
+
+    // Initialize workspace
+    m_workspace->Empty();
+    m_workspace->AlignWith(get_prev_activations());
+    El::Copy(get_prev_error_signals(), *m_workspace);
+
+    // Compute local gradients
+    local_bp_compute(get_input_size(),
+                     get_local_prev_activations(0),
+                     get_local_prev_activations(1),
+                     m_workspace->LockedMatrix(),
+                     get_local_error_signals(0),
+                     get_local_error_signals(1));
+
+    // Clean up
+    m_workspace->Empty();
+
+  }
+
+private:
+
+  /** Compute local contributions to mean squared error loss. */
+  static void local_fp_compute(El::Int height,
+                               const AbsMat& local_prediction,
+                               const AbsMat& local_ground_truth,
+                               AbsMat& local_contribution);
+  /** Compute local gradients. */
+  static void local_bp_compute(El::Int height,
+                               const AbsMat& local_prediction,
+                               const AbsMat& local_ground_truth,
+                               const AbsMat& local_gradient_wrt_output,
+                               AbsMat& local_gradient_wrt_prediction,
+                               AbsMat& local_gradient_wrt_ground_truth);
+
+  /** Workspace matrix. */
+  std::unique_ptr<AbsDistMat> m_workspace;
+  
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_LOSS_MEAN_SQUARED_ERROR_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -67,6 +67,7 @@
 
 /// Loss Layers
 #include "lbann/layers/loss/cross_entropy.hpp"
+#include "lbann/layers/loss/mean_squared_error.hpp"
 #include "lbann/layers/loss/top_k_categorical_accuracy.hpp"
 
 /// Transform Layers

--- a/model_zoo/tests/model_mnist_ridge_regression.prototext
+++ b/model_zoo/tests/model_mnist_ridge_regression.prototext
@@ -1,5 +1,5 @@
 model {
-  name: "sequential_model"
+  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 32
   block_size: 256
@@ -12,7 +12,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mse" }
     l2_weight_regularization {
       scale_factor: 0.01
     }
@@ -22,27 +22,13 @@ model {
   # Metrics
   ###################################################
 
-  metric { mean_squared_error {} }
+  metric { layer_metric { layer: "mse" } }
 
   ###################################################
   # Callbacks
   ###################################################
-  callback {
-    print {
-      interval: 1
-    }
-  }
-  callback {
-    timer {
-    }
-  }
-  callback {
-    summary {
-      dir: "."
-      batch_interval: 1
-      mat_interval: 25
-    }
-  }
+  callback { print {} }
+  callback { timer {} }
   callback {
     gradient_check {
       verbose: false
@@ -51,44 +37,43 @@ model {
   }
 
   ###################################################
-  # start of layers
+  # Layers
   ###################################################
 
-  #######
-  # INPUT
-  #######
   layer {
     name: "data"
+    children: "image label"
     data_layout: "data_parallel"
-    children: "fc target"
     input {
       io_buffer: "partitioned"
     }
   }
-
-  #################
-  # FULLY_CONNECTED
-  #################
+  layer {
+    name: "image"
+    parents: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    name: "label"
+    parents: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
   layer {
     name: "fc"
+    parents: "image"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 10
       has_bias: true
     }
   }
-
-  ########
-  # Target
-  ########
   layer {
-    parents: "fc data"
-    name: "target"
-    data_layout: "data_parallel"
-    target {}
+    parents: "fc label"
+    name: "mse"
+    data_layout: "model_parallel"
+    mean_squared_error {}
   }
 
-  ###################################################
-  # end of layers
-  ###################################################
 }

--- a/src/layers/activations/CMakeLists.txt
+++ b/src/layers/activations/CMakeLists.txt
@@ -8,6 +8,7 @@ set_full_path(THIS_DIR_SOURCES
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
+    abs.cu
     sigmoid.cu
     softmax.cu
     )

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -540,26 +540,8 @@ void Layer::setup() {
 void Layer::setup_pointers() {
   std::stringstream err;
 
-  // Check that the number of parents/children are valid
-  if(m_expected_num_parent_layers >= 0
-     && get_num_parents() != m_expected_num_parent_layers) {
-    err << get_type() << " layer \"" << get_name() << "\" "
-        << "has an invalid number of parent layers "
-        << "(expected " << m_expected_num_parent_layers << ", "
-        << "found " << get_num_parents() << ")";
-    LBANN_ERROR(err.str());
-  }
-  if(m_expected_num_child_layers >= 0
-     && get_num_children() != m_expected_num_child_layers) {
-    err << get_type() << " layer \"" << get_name() << "\" "
-        << "has an invalid number of child layers "
-        << "(expected " << m_expected_num_child_layers << ", "
-        << "found " << get_num_children() << ")";
-    LBANN_ERROR(err.str());
-  }
-
   // Check that the parent pointers are valid
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < m_parent_layers.size(); ++i) {
     const auto* parent = m_parent_layers[i];
     if (parent == nullptr) {
       err << "layer \"" << get_name() << "\" "
@@ -578,7 +560,7 @@ void Layer::setup_pointers() {
   }
 
   // Check that the child pointers are valid
-  for (int i = 0; i < get_num_children(); ++i) {
+  for (size_t i = 0; i < m_child_layers.size(); ++i) {
     const auto* child = m_child_layers[i];
     if (child == nullptr) {
       err << "layer \"" << get_name() << "\" "
@@ -594,6 +576,40 @@ void Layer::setup_pointers() {
           << "\"" << child->get_name() << "\"";
       LBANN_ERROR(err.str());
     }
+  }
+  
+  // Check that the number of parents/children are valid
+  if(m_expected_num_parent_layers >= 0
+     && get_num_parents() != m_expected_num_parent_layers) {
+    err << get_type() << " layer \"" << get_name() << "\" "
+        << "expects " << m_expected_num_parent_layers << " "
+        << "parent layer" << (m_expected_num_parent_layers != 1 ? "s" : "")
+        << ", but found " << get_num_parents();
+    if (get_num_parents() > 0) {
+      err << " (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        err << (i > 0 ? ", " : "")
+            << "\"" << m_parent_layers[i]->get_name() << "\"";
+      }
+      err << ")";
+    }
+    LBANN_ERROR(err.str());
+  }
+  if(m_expected_num_child_layers >= 0
+     && get_num_children() != m_expected_num_child_layers) {
+    err << get_type() << " layer \"" << get_name() << "\" "
+        << "expects " << m_expected_num_child_layers << " "
+        << "child layer" << (m_expected_num_child_layers != 1 ? "s" : "")
+        << ", but found " << get_num_children();
+    if (get_num_children() > 0) {
+      err << " (";
+      for (int i = 0; i < get_num_children(); ++i) {
+        err << (i > 0 ? ", " : "")
+            << "\"" << m_child_layers[i]->get_name() << "\"";
+      }
+      err << ")";
+    }
+    LBANN_ERROR(err.str());
   }
 
 }

--- a/src/layers/loss/CMakeLists.txt
+++ b/src/layers/loss/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   cross_entropy.cpp
+  mean_squared_error.cpp
   top_k_categorical_accuracy.cpp
   )
 
@@ -8,6 +9,7 @@ if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
     cross_entropy.cu
+    mean_squared_error.cu
     top_k_categorical_accuracy.cu
     )
 endif ()

--- a/src/layers/loss/mean_squared_error.cpp
+++ b/src/layers/loss/mean_squared_error.cpp
@@ -1,0 +1,136 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/loss/mean_squared_error.hpp"
+
+namespace lbann {
+
+namespace {
+
+void local_fp_cpu(El::Int height,
+                  const AbsMat& local_prediction,
+                  const AbsMat& local_ground_truth,
+                  AbsMat& local_contribution) {
+
+  // Useful constants
+  const auto& local_height = local_prediction.Height();
+  const auto& local_width = local_prediction.Width();
+
+  // Compute local contribution to mean squared error
+#pragma omp parallel for
+  for (El::Int col = 0; col < local_width; ++col) {
+    DataType sum = 0;
+    for (El::Int row = 0; row < local_height; ++row) {
+      const auto& err = (local_prediction(row, col)
+                         - local_ground_truth(row, col));
+      sum += err * err;
+    }
+    local_contribution(0, col) = sum / height;
+  }
+
+}
+
+void local_bp_cpu(El::Int height,
+                  const AbsMat& local_prediction,
+                  const AbsMat& local_ground_truth,
+                  const AbsMat& local_gradient_wrt_output,
+                  AbsMat& local_gradient_wrt_prediction,
+                  AbsMat& local_gradient_wrt_ground_truth) {
+                                                                       
+  // Useful constants
+  const DataType scale = DataType(2) / height;
+  const El::Int local_height = local_prediction.Height();
+  const El::Int local_width = local_prediction.Width();
+
+  // Compute gradients
+#pragma omp parallel for collapse(2)
+  for (El::Int col = 0; col < local_width; ++col) {
+    for (El::Int row = 0; row < local_height; ++row) {
+      const auto& err = (local_prediction(row, col)
+                         - local_ground_truth(row, col));
+      const auto& dy = local_gradient_wrt_output(0, col);
+      local_gradient_wrt_prediction(row, col) = scale * err * dy;
+      local_gradient_wrt_ground_truth(row, col) = - scale * err * dy;
+    }
+  }
+
+}
+
+} // namespace
+
+template <>
+void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
+     ::local_fp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        AbsMat& local_contribution) {
+  local_fp_cpu(height, local_prediction, local_ground_truth,
+               local_contribution);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
+     ::local_bp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        const AbsMat& local_gradient_wrt_output,
+                        AbsMat& local_gradient_wrt_prediction,
+                        AbsMat& local_gradient_wrt_ground_truth) {
+  local_bp_cpu(height,
+               local_prediction,
+               local_ground_truth,
+               local_gradient_wrt_output,
+               local_gradient_wrt_prediction,
+               local_gradient_wrt_ground_truth);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+     ::local_fp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        AbsMat& local_contribution) {
+  local_fp_cpu(height, local_prediction, local_ground_truth,
+               local_contribution);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+     ::local_bp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        const AbsMat& local_gradient_wrt_output,
+                        AbsMat& local_gradient_wrt_prediction,
+                        AbsMat& local_gradient_wrt_ground_truth) {
+  local_bp_cpu(height,
+               local_prediction,
+               local_ground_truth,
+               local_gradient_wrt_output,
+               local_gradient_wrt_prediction,
+               local_gradient_wrt_ground_truth);
+}
+
+} // namespace lbann

--- a/src/layers/loss/mean_squared_error.cu
+++ b/src/layers/loss/mean_squared_error.cu
@@ -1,0 +1,216 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/loss/mean_squared_error.hpp"
+
+namespace lbann {
+
+namespace {
+
+template <int block_size>
+__global__ void fp_kernel(int global_height,
+                          int local_height, int local_width,
+                          const DataType* __restrict__ prediction,
+                          int prediction_ldim,
+                          const DataType* __restrict__ ground_truth,
+                          int ground_truth_ldim,
+                          DataType* __restrict__ contribution) {
+  
+  // Indices
+  const int tid = threadIdx.x;
+  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const int bidy = blockIdx.y;
+  const int nthreadsx = blockDim.x * gridDim.x;
+
+  // Compute local contribution for each matrix column
+  for (int col = bidy; col < local_width; col += gridDim.y) {
+
+    // Compute contributions for each thread
+    DataType private_contribution = DataType(0);
+    for (int row = gidx; row < local_height; row += nthreadsx) {
+      const auto& err = (prediction[row + col * prediction_ldim]
+                         - ground_truth[row + col * ground_truth_ldim]);
+      private_contribution += err * err;
+    }
+
+    // Shared memory reduction to get contribution for each block
+    /// @todo unroll loops
+    __shared__ DataType shared_contribution[block_size];
+    shared_contribution[tid] = private_contribution;
+    for (int stride = block_size / 2; stride > 0; stride /= 2) {
+      __syncthreads();
+      if (tid < stride) {
+        shared_contribution[tid] += shared_contribution[tid + stride];
+      }
+    }
+    if (tid == 0) {
+      shared_contribution[0] /= global_height;
+      cuda::atomic_add(&contribution[col], shared_contribution[0]);
+    }
+    
+  }
+    
+}
+  
+void local_fp_gpu(El::Int height,
+                  const AbsMat& local_prediction,
+                  const AbsMat& local_ground_truth,
+                  AbsMat& local_contribution) {
+  El::Zero(local_contribution);
+  const auto& local_height = local_prediction.Height();
+  const auto& local_width = local_prediction.Width();
+  if (local_height > 0 && local_width > 0) {
+    const int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (local_height + block_size - 1) / block_size;
+    grid_dims.y = local_width;
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    fp_kernel<block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        height, local_height, local_width,
+        local_prediction.LockedBuffer(), local_prediction.LDim(),
+        local_ground_truth.LockedBuffer(), local_ground_truth.LDim(),
+        local_contribution.Buffer());
+  }
+}
+
+template <int block_size>
+__global__ void bp_kernel(int global_height,
+                          int local_height, int local_width,
+                          const DataType* __restrict__ prediction,
+                          int prediction_ldim,
+                          const DataType* __restrict__ ground_truth,
+                          int ground_truth_ldim,
+                          const DataType* __restrict__ gradient_wrt_output,
+                          DataType* __restrict__ gradient_wrt_prediction,
+                          int gradient_wrt_prediction_ldim,
+                          DataType* __restrict__ gradient_wrt_ground_truth,
+                          int gradient_wrt_ground_truth_ldim) {
+  
+  // Indices
+  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const int bidy = blockIdx.y;
+  const int nthreadsx = blockDim.x * gridDim.x;
+
+  // Compute gradients
+  for (int col = bidy; col < local_width; col += gridDim.y) {
+    const auto& dy = gradient_wrt_output[col];
+    for (int row = gidx; row < local_height; row += nthreadsx) {
+      const auto& err = (prediction[row + col * prediction_ldim]
+                         - ground_truth[row + col * ground_truth_ldim]);
+      auto& dx = gradient_wrt_prediction[row + col * gradient_wrt_prediction_ldim];
+      auto& dxhat = gradient_wrt_ground_truth[row + col * gradient_wrt_ground_truth_ldim];
+      dx = 2 * err * dy / global_height;
+      dxhat = - 2 * err * dy / global_height;
+    }
+  }
+    
+}
+
+void local_bp_gpu(El::Int height,
+                  const AbsMat& local_prediction,
+                  const AbsMat& local_ground_truth,
+                  const AbsMat& local_gradient_wrt_output,
+                  AbsMat& local_gradient_wrt_prediction,
+                  AbsMat& local_gradient_wrt_ground_truth) {
+  const auto& local_height = local_prediction.Height();
+  const auto& local_width = local_prediction.Width();
+  if (local_height > 0 && local_width > 0) {
+    const int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (local_height + block_size - 1) / block_size;
+    grid_dims.y = local_width;
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    bp_kernel<block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        height, local_height, local_width,
+        local_prediction.LockedBuffer(), local_prediction.LDim(),
+        local_ground_truth.LockedBuffer(), local_ground_truth.LDim(),
+        local_gradient_wrt_output.LockedBuffer(),
+        local_gradient_wrt_prediction.Buffer(),
+        local_gradient_wrt_prediction.LDim(),
+        local_gradient_wrt_ground_truth.Buffer(),
+        local_gradient_wrt_ground_truth.LDim());
+  }
+}
+
+} // namespace
+
+template <>
+void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
+     ::local_fp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        AbsMat& local_contribution) {
+  local_fp_gpu(height, local_prediction, local_ground_truth,
+               local_contribution);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
+     ::local_bp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        const AbsMat& local_gradient_wrt_output,
+                        AbsMat& local_gradient_wrt_prediction,
+                        AbsMat& local_gradient_wrt_ground_truth) {
+  local_bp_gpu(height,
+               local_prediction,
+               local_ground_truth,
+               local_gradient_wrt_output,
+               local_gradient_wrt_prediction,
+               local_gradient_wrt_ground_truth);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::local_fp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        AbsMat& local_contribution) {
+  local_fp_gpu(height, local_prediction, local_ground_truth,
+               local_contribution);
+}
+
+template <>
+void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::local_bp_compute(El::Int height,
+                        const AbsMat& local_prediction,
+                        const AbsMat& local_ground_truth,
+                        const AbsMat& local_gradient_wrt_output,
+                        AbsMat& local_gradient_wrt_prediction,
+                        AbsMat& local_gradient_wrt_ground_truth) {
+  local_bp_gpu(height,
+               local_prediction,
+               local_ground_truth,
+               local_gradient_wrt_output,
+               local_gradient_wrt_prediction,
+               local_gradient_wrt_ground_truth);
+}
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -444,6 +444,9 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_cross_entropy()) {
     return new cross_entropy_layer<layout, Dev>(comm);
   }
+  if (proto_layer.has_mean_squared_error()) {
+    return new mean_squared_error_layer<layout, Dev>(comm);
+  }
   if (proto_layer.has_top_k_categorical_accuracy()) {
     const auto& params = proto_layer.top_k_categorical_accuracy();
     return new top_k_categorical_accuracy_layer<layout, Dev>(comm, params.k());

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -799,7 +799,8 @@ message Layer {
 
    // loss layers
    CrossEntropy cross_entropy = 60;
-   TopKCategoricalAccuracy top_k_categorical_accuracy = 61;
+   MeanSquaredError mean_squared_error = 61;
+   TopKCategoricalAccuracy top_k_categorical_accuracy = 62;
 
    // target Layers
    Target target = 18;


### PR DESCRIPTION
This PR implements layers needed by @samadejacobs. I have not yet implemented an L2 norm layer, but it can be mimicked for now by using a mean squared error with zero ground truth and a scaling factor of input_size / 2.

When I run model_zoo/tests/model_mnist_ridge_regression.prototext, I get the exact same results as before. Gradient checking on that model comes back clean.