### PR TITLE
Replacing El::Int with an IntType typedef.

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -72,6 +72,9 @@ using StarMRMat  = El::DistMatrix<lbann::DataType, El::STAR, El::MR  , El::ELEME
 using DistMat         = MCMRMat<El::Device::CPU>;
 using Mat        = El::Matrix<lbann::DataType, El::Device::CPU>; // Temporarily define as CPUMat
 
+/** Integer type. */
+using IntType = El::Int;
+
 // Datatype for model evaluation
 // Examples: timing, metrics, objective functions
 using EvalType = double;

--- a/include/lbann/callbacks/callback_imcomm.hpp
+++ b/include/lbann/callbacks/callback_imcomm.hpp
@@ -100,8 +100,8 @@ class lbann_callback_imcomm : public lbann_callback {
     /** Accumulated error (e.g. from quantization). */
     CPUMat error;
     /** If >0, reshape (local) gradients to these dimensions. */
-    El::Int reshape_height = 0;
-    El::Int reshape_width = 0;
+    IntType reshape_height = 0;
+    IntType reshape_width = 0;
     /** Adaptive quantization proportion. */
     int proportion = 32;
     /** Threshold quantization thresholds. */
@@ -131,7 +131,7 @@ class lbann_callback_imcomm : public lbann_callback {
    * Get a matrix that reinterprets mat as being height x width.
    * Assumes that mat.Height()*mat.Width() == height*width.
    */
-  void reshape_mat(AbsMat& mat, Mat& reshaped, El::Int height, El::Int width) {
+  void reshape_mat(AbsMat& mat, Mat& reshaped, IntType height, IntType width) {
     reshaped.Attach(height, width, mat.Buffer(), height);
   }
 

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -472,7 +472,7 @@ class generic_data_reader : public lbann_image_preprocessor {
     return &m_unused_indices[0];
   }
   /// Get a pointer to the fetched indices matrix.
-  El::Matrix<El::Int>* get_indices_fetched_per_mb() {
+  El::Matrix<IntType>* get_indices_fetched_per_mb() {
     return &m_indices_fetched_per_mb;
   }
   /// Set the number of iterations in each epoch.
@@ -792,7 +792,7 @@ class generic_data_reader : public lbann_image_preprocessor {
   bool m_master;
 
   /// 1-D Matrix of which indices were fetched in this mini-batch
-  El::Matrix<El::Int> m_indices_fetched_per_mb;
+  El::Matrix<IntType> m_indices_fetched_per_mb;
 
   friend class data_reader_merge_features;
   friend class data_reader_merge_samples;
@@ -847,7 +847,7 @@ inline void set_minibatch_item(Mat& M, const int mb_idx, const T* const ptr, con
                           " :: attempt to dereference a nullptr ");
   }
   for (size_t i = 0u; i < count; ++i) {
-    M.Set(static_cast<El::Int>(i), static_cast<El::Int>(mb_idx), static_cast<DataType>(ptr[i]));
+    M.Set(static_cast<IntType>(i), static_cast<IntType>(mb_idx), static_cast<DataType>(ptr[i]));
   }
 }
 

--- a/include/lbann/io/data_buffers/distributed_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/distributed_io_buffer.hpp
@@ -106,13 +106,13 @@ class distributed_io_buffer : public generic_io_buffer {
 
   void set_local_matrix_bypass(CPUMat *M_local, int idx) override {}
 
-  void set_std_matrix_view(El::Int cur_mini_batch_size, int idx) override {
+  void set_std_matrix_view(IntType cur_mini_batch_size, int idx) override {
     for (auto& buf : m_data_buffers) {
       El::View(*buf.second->M_local_v[idx], *buf.second->M_local[idx], El::ALL, El::IR(0, cur_mini_batch_size));
     }
   }
 
-  void setup_data(El::Int num_neurons, El::Int num_targets, El::Int max_minibatch_size) override {
+  void setup_data(IntType num_neurons, IntType num_targets, IntType max_minibatch_size) override {
     for (auto& buf : m_data_buffers) {
       buf.second->M_local[0]->Resize(num_neurons, max_minibatch_size);
       buf.second->Ms[0]->Resize(num_neurons, max_minibatch_size);

--- a/include/lbann/io/data_buffers/generic_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/generic_io_buffer.hpp
@@ -104,8 +104,8 @@ public:
   /** Return this buffer's type, e.g: "partitioned_io_buffer," "distributed_io_buffer," etc. */
   virtual std::string get_type() const = 0;
   virtual void set_local_matrix_bypass(CPUMat *M_local, int idx) = 0;
-  virtual void set_std_matrix_view(El::Int cur_mini_batch_size, int idx) = 0;
-  virtual void setup_data(El::Int num_neurons, El::Int num_targets, El::Int max_minibatch_size) = 0;
+  virtual void set_std_matrix_view(IntType cur_mini_batch_size, int idx) = 0;
+  virtual void setup_data(IntType num_neurons, IntType num_targets, IntType max_minibatch_size) = 0;
 
   virtual int fetch_to_local_matrix(generic_data_reader *data_reader, execution_mode mode) = 0;
   virtual void distribute_from_local_matrix(generic_data_reader *data_reader, execution_mode mode, AbsDistMat& sample, AbsDistMat& response) {}

--- a/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/partitioned_io_buffer.hpp
@@ -47,8 +47,8 @@ class partitioned_io_buffer : public generic_io_buffer {
   std::string get_type() const override { return "partitioned"; }
   /** Setup a bypass from to the activations matrices */
   void set_local_matrix_bypass(CPUMat *m, int idx) override { M_local[idx] = m; }
-  void set_std_matrix_view(El::Int cur_mini_batch_size, int idx) override {}
-  void setup_data(El::Int num_neurons, El::Int num_targets, El::Int max_minibatch_size) override {}
+  void set_std_matrix_view(IntType cur_mini_batch_size, int idx) override {}
+  void setup_data(IntType num_neurons, IntType num_targets, IntType max_minibatch_size) override {}
 
   int fetch_to_local_matrix(generic_data_reader *data_reader, execution_mode mode) override;
   void distribute_from_local_matrix(generic_data_reader *data_reader, execution_mode mode, AbsDistMat& sample, AbsDistMat& response) override;

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -43,10 +43,10 @@ public:
 
 protected:
 
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     El::LockedView(get_activations(), get_prev_activations());
   }
-  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+  void bp_setup_gradient_wrt_inputs(IntType mini_batch_size) override {
     El::LockedView(get_error_signals(), get_prev_error_signals());
   }
   void fp_compute() override {}

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -183,7 +183,7 @@ class generic_input_layer : public io_layer {
   /** Setup output tensors.
    *  Sets up the effective (global) mini-batch size.
    */
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
 
     // Determine model mini-batch size and effective mini-batch size
     // Note: If inter-model communication is activated, the effective
@@ -494,7 +494,7 @@ class generic_input_layer : public io_layer {
   /**
    * Return the sample indices fetched in the current mini-batch.
    */
-  El::Matrix<El::Int>* get_sample_indices_per_mb() override {
+  El::Matrix<IntType>* get_sample_indices_per_mb() override {
     generic_data_reader *dr = get_data_reader();
     return dr->get_indices_fetched_per_mb();
   }

--- a/include/lbann/layers/io/io_layer.hpp
+++ b/include/lbann/layers/io/io_layer.hpp
@@ -86,7 +86,7 @@ class io_layer : public Layer {
   /**
    * Return the sample indices fetched in the current mini-batch.
    */
-  El::Matrix<El::Int>* get_sample_indices_per_mb() override = 0;
+  El::Matrix<IntType>* get_sample_indices_per_mb() override = 0;
 
   /**
    * Get the dimensions of the underlying data.

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -182,7 +182,7 @@ class Layer {
   /** Set the model that manages this layer. */
   inline void set_model(model* m) { m_model = m; }
 
-  virtual El::Matrix<El::Int>* get_sample_indices_per_mb() { return nullptr; };
+  virtual El::Matrix<IntType>* get_sample_indices_per_mb() { return nullptr; };
 
   virtual bool save_to_checkpoint_shared(persist& p) const;
   virtual bool load_from_checkpoint_shared(persist& p);
@@ -357,7 +357,7 @@ class Layer {
    */
   virtual std::unique_ptr<AbsDistMat> construct_matrix(const El::Grid& grid,
                                                        std::string type,
-                                                       El::Int index);
+                                                       IntType index);
   /** Setup layer data.
    *  Called by the 'setup' function. Memory is allocated for
    *  distributed matrices.
@@ -377,12 +377,12 @@ class Layer {
    *  setup as a view or copy of the corresponding parent layer's
    *  output tensor.
    */
-  virtual void fp_setup_inputs(El::Int mini_batch_size);
+  virtual void fp_setup_inputs(IntType mini_batch_size);
   /** Setup output tensors.
    *  Called by the 'forward_prop' function. Each output tensor is
    *  resized to match the mini-batch size.
    */
-  virtual void fp_setup_outputs(El::Int mini_batch_size);
+  virtual void fp_setup_outputs(IntType mini_batch_size);
   /** Apply layer operation.
    *  Called by the 'forward_prop' function. Given the input tensors,
    *  the output tensors are populated with computed values.
@@ -398,12 +398,12 @@ class Layer {
    *  tensor is setup as a view or copy of the corresponding child
    *  layer's gradient w.r.t. input tensor.
    */
-  virtual void bp_setup_gradient_wrt_outputs(El::Int mini_batch_size);
+  virtual void bp_setup_gradient_wrt_outputs(IntType mini_batch_size);
   /** Setup gradient w.r.t. input tensors.
    *  Called by the 'back_prop' function. Each gradient w.r.t. input
    *  tensor is resized to match the mini-batch size.
    */
-  virtual void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size);
+  virtual void bp_setup_gradient_wrt_inputs(IntType mini_batch_size);
   /** Compute objective funciton gradients.
    *  Called by the 'back_prop' function. Given the input, output, and
    *  gradient w.r.t. output tensors, the gradient w.r.t. input

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -651,7 +651,7 @@ class base_convolution_layer : public learning_layer {
 
     // Matrix parameters
     const int output_size = local_output.Height();
-    const El::Int local_width = local_input.Width();
+    const IntType local_width = local_input.Width();
     std::vector<int> input_dims, output_dims;
     if (during_forward_prop) {
       input_dims = get_input_dims();
@@ -671,7 +671,7 @@ class base_convolution_layer : public learning_layer {
     const DMat<Dev> kernel_matrix(k, n, local_kernel.LockedBuffer(), k);
 
     // Iterate through input columns
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
 
       // Construct im2col matrix from current input column
       El::LockedView(input_col, local_input, El::ALL, El::IR(col));
@@ -708,7 +708,7 @@ class base_convolution_layer : public learning_layer {
 
     // Matrix parameters
     const int input_size = local_input.Height();
-    const El::Int local_width = local_input.Width();
+    const IntType local_width = local_input.Width();
     std::vector<int> input_dims, output_dims;
     if (during_forward_prop) {
       input_dims = get_input_dims();
@@ -728,7 +728,7 @@ class base_convolution_layer : public learning_layer {
     const DMat<Dev> kernel_matrix(m, k, local_kernel.LockedBuffer(), m);
 
     // Iterate through input columns
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
 
       // Apply transposed convolution to current input column
       input_col.LockedAttach(n, k, local_input.LockedBuffer(0, col), n);
@@ -762,19 +762,19 @@ class base_convolution_layer : public learning_layer {
     auto& local_output = get_local_activations();
 
     // Matrix parameters
-    const El::Int local_width = local_output.Width();
+    const IntType local_width = local_output.Width();
     const auto& output_dims = get_output_dims();
-    const El::Int num_output_channels = output_dims[0];
-    const El::Int num_per_output_channel = get_output_size() / num_output_channels;
+    const IntType num_output_channels = output_dims[0];
+    const IntType num_per_output_channel = get_output_size() / num_output_channels;
 
     // Apply bias to each output channel
     #pragma omp parallel for
-    for (El::Int channel = 0; channel < num_output_channels; ++channel) {
-      const El::Int row_start = channel * num_per_output_channel;
-      const El::Int row_end = (channel+1) * num_per_output_channel;
+    for (IntType channel = 0; channel < num_output_channels; ++channel) {
+      const IntType row_start = channel * num_per_output_channel;
+      const IntType row_end = (channel+1) * num_per_output_channel;
       const DataType bias_term = m_bias_scaling_factor * local_bias(channel, 0);
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = row_start; row < row_end; ++row) {
+      for (IntType col = 0; col < local_width; ++col) {
+        for (IntType row = row_start; row < row_end; ++row) {
           local_output(row, col) += bias_term;
         }
       }
@@ -791,7 +791,7 @@ class base_convolution_layer : public learning_layer {
     auto& local_bias_gradient = m_bias_gradient.Matrix();
 
     // Get convolution parameters
-    const El::Int local_width = local_input.Width();
+    const IntType local_width = local_input.Width();
     const auto& input_dims = get_input_dims();
     const auto& output_dims = get_output_dims();
     const int num_input_channels = input_dims[0];
@@ -805,12 +805,12 @@ class base_convolution_layer : public learning_layer {
     if (m_bias_scaling_factor != DataType(0) && bias_optimizer != nullptr) {
       #pragma omp parallel for
       for (int channel = 0; channel < num_output_channels; ++channel) {
-        const El::Int row_start = channel * num_per_output_channel;
-        const El::Int row_end = (channel+1) * num_per_output_channel;
+        const IntType row_start = channel * num_per_output_channel;
+        const IntType row_end = (channel+1) * num_per_output_channel;
         DataType sum = 0;
         DataType correction = 0;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
+        for (IntType col = 0; col < local_width; ++col) {
+          for (IntType row = row_start; row < row_end; ++row) {
             DataType term = local_gradient_wrt_output(row, col);
             term += correction;
             const DataType next_sum = sum + term;
@@ -844,7 +844,7 @@ class base_convolution_layer : public learning_layer {
     El::Zero(kernel_gradient_matrix);
 
     // Compute kernel gradient contributions from each data sample
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
       if (using_transposed_convolution) {
         const DMat<Dev> input_col(k, n, local_input.LockedBuffer(0,col), k);
         const DMat<Dev> gradient_wrt_output_col =

--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -147,12 +147,12 @@ public:
 private:
 
   /** Compute local contributions to mean squared error loss. */
-  static void local_fp_compute(El::Int height,
+  static void local_fp_compute(IntType height,
                                const AbsMat& local_prediction,
                                const AbsMat& local_ground_truth,
                                AbsMat& local_contribution);
   /** Compute local gradients. */
-  static void local_bp_compute(El::Int height,
+  static void local_bp_compute(IntType height,
                                const AbsMat& local_prediction,
                                const AbsMat& local_ground_truth,
                                const AbsMat& local_gradient_wrt_output,

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -44,7 +44,7 @@ template <data_layout T_layout, El::Device Dev>
 class top_k_categorical_accuracy_layer : public Layer {
 public:
 
-  top_k_categorical_accuracy_layer(lbann_comm *comm, El::Int k)
+  top_k_categorical_accuracy_layer(lbann_comm *comm, IntType k)
     : Layer(comm), m_k(k) {
     set_output_dims({1});
 
@@ -64,7 +64,7 @@ public:
  private:
 
   /** Parameter for top-k search. */
-  const El::Int m_k;
+  const IntType m_k;
   
 };
 

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -469,7 +469,7 @@ class batch_normalization : public regularizer_layer {
 
     // Matrix parameters
     const int width = input.Width();
-    const El::Int local_width = local_input.Width();
+    const IntType local_width = local_input.Width();
     const auto& output_dims = get_output_dims();
     const int num_channels = output_dims[0];
     const int channel_size = get_output_size() / num_channels;
@@ -492,10 +492,10 @@ class batch_normalization : public regularizer_layer {
       for (int channel = 0; channel < num_channels; ++channel) {
         DataType sum = zero;
         DataType sqsum = zero;
-        const El::Int row_start = channel * channel_size;
-        const El::Int row_end = (channel+1) * channel_size;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
+        const IntType row_start = channel * channel_size;
+        const IntType row_end = (channel+1) * channel_size;
+        for (IntType col = 0; col < local_width; ++col) {
+          for (IntType row = row_start; row < row_end; ++row) {
             const DataType x = local_input(row, col);
             sum += x;
             sqsum += x * x;
@@ -561,10 +561,10 @@ class batch_normalization : public regularizer_layer {
       const DataType bias = local_bias(channel, 0);
 
       // Apply batch normalization to inputs in channel
-      const El::Int row_start = channel * channel_size;
-      const El::Int row_end = (channel+1) * channel_size;
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = row_start; row < row_end; ++row) {
+      const IntType row_start = channel * channel_size;
+      const IntType row_end = (channel+1) * channel_size;
+      for (IntType col = 0; col < local_width; ++col) {
+        for (IntType row = row_start; row < row_end; ++row) {
           const DataType x = local_input(row, col);
           const DataType xhat = (x - mean) * inv_stdev;
           const DataType y = scale * xhat + bias;
@@ -601,7 +601,7 @@ class batch_normalization : public regularizer_layer {
     // Matrix parameters
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
     const int width = input.Width();
-    const El::Int local_width = local_input.Width();
+    const IntType local_width = local_input.Width();
     const auto& output_dims = get_output_dims();
     const int num_channels = output_dims[0];
     const int channel_size = get_output_size() / num_channels;
@@ -622,10 +622,10 @@ class batch_normalization : public regularizer_layer {
       DataType dbias = DataType(0);
 
       // Compute gradient contributions from local entries
-      const El::Int row_start = channel * channel_size;
-      const El::Int row_end = (channel+1) * channel_size;
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = row_start; row < row_end; ++row) {
+      const IntType row_start = channel * channel_size;
+      const IntType row_end = (channel+1) * channel_size;
+      for (IntType col = 0; col < local_width; ++col) {
+        for (IntType row = row_start; row < row_end; ++row) {
           const DataType x = local_input(row, col);
           const DataType xhat = (x - mean) * inv_stdev;
           const DataType dy = local_gradient_wrt_output(row, col);
@@ -693,10 +693,10 @@ class batch_normalization : public regularizer_layer {
         const auto& dvar_term = dvar * 2 / (num_per_sum - 1);
 
         // Compute error signal for current channel
-        const El::Int row_start = channel * channel_size;
-        const El::Int row_end = (channel+1) * channel_size;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
+        const IntType row_start = channel * channel_size;
+        const IntType row_end = (channel+1) * channel_size;
+        for (IntType col = 0; col < local_width; ++col) {
+          for (IntType row = row_start; row < row_end; ++row) {
             const auto& x = local_input(row, col);
             const auto& dy = local_gradient_wrt_output(row, col);
             const auto& dxhat = dy * scale;

--- a/include/lbann/layers/regularizers/selu_dropout.hpp
+++ b/include/lbann/layers/regularizers/selu_dropout.hpp
@@ -109,10 +109,10 @@ class selu_dropout : public regularizer_layer {
     } else {
 
       const auto *input_acts = &get_prev_activations();
-      const El::Int height = input_acts->Height();
-      const El::Int width = input_acts->Width();
-      const El::Int local_height = input_acts->LocalHeight();
-      const El::Int local_width = input_acts->LocalWidth();
+      const IntType height = input_acts->Height();
+      const IntType width = input_acts->Width();
+      const IntType local_height = input_acts->LocalHeight();
+      const IntType local_width = input_acts->LocalWidth();
 
       const auto& local_input_acts = input_acts->LockedMatrix();
       Mat& local_output_acts = get_local_activations();
@@ -121,8 +121,8 @@ class selu_dropout : public regularizer_layer {
       // Construct and apply mask and the affine transform.
       // TODO: Optimize.
       El::Bernoulli(*m_mask, height, width, m_keep_prob);
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = 0; row < local_height; ++row) {
+      for (IntType col = 0; col < local_width; ++col) {
+        for (IntType row = 0; row < local_height; ++row) {
           local_output_acts(row, col) = m_a *
             (local_input_acts(row, col)*local_mask(row, col) +
              m_alpha_prime*(1 - local_mask(row, col))) + m_b;
@@ -142,11 +142,11 @@ class selu_dropout : public regularizer_layer {
       const auto& local_prev_error_signal = get_local_prev_error_signals();
       Mat& local_error_signal = get_local_error_signals();
       Mat& local_mask = m_mask->Matrix();
-      const El::Int local_height = local_prev_error_signal.Height();
-      const El::Int local_width = local_prev_error_signal.Width();
+      const IntType local_height = local_prev_error_signal.Height();
+      const IntType local_width = local_prev_error_signal.Width();
       // Reweight with the affine scale factor and the dropout mask.
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = 0; row < local_height; ++row) {
+      for (IntType col = 0; col < local_width; ++col) {
+        for (IntType row = 0; row < local_height; ++row) {
           local_error_signal(row, col) =
             m_a * local_prev_error_signal(row, col) * local_mask(row, col);
         }

--- a/include/lbann/layers/transform/categorical_random.hpp
+++ b/include/lbann/layers/transform/categorical_random.hpp
@@ -75,15 +75,15 @@ class categorical_random_layer : public transform_layer {
 
     // Process each mini-batch sample
     #pragma omp parallel for
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
 
       // Determine index of output
-      El::Int index = local_height - 1;
+      IntType index = local_height - 1;
       if (mode == execution_mode::training) {
         // Choose first output with CDF above random number in (0,1)
         const auto& rand = rand_mat.GetLocal(0, col);
         DataType cdf = DataType(0);
-        for (El::Int row = 0; row < local_height; ++row) {
+        for (IntType row = 0; row < local_height; ++row) {
           cdf += local_input(row, col);
           if (rand < cdf) {
             index = row;

--- a/include/lbann/layers/transform/concatenation.hpp
+++ b/include/lbann/layers/transform/concatenation.hpp
@@ -39,7 +39,7 @@ template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El
 class concatenation_layer : public transform_layer {
 public:
 
-  concatenation_layer(lbann_comm *comm, El::Int concat_dim)
+  concatenation_layer(lbann_comm *comm, IntType concat_dim)
     : transform_layer(comm), m_concat_dim(concat_dim) {
     m_expected_num_parent_layers = -1; // No limit on parents
   }
@@ -106,7 +106,7 @@ protected:
     // Get concatenation points for first parent layer
     auto output_dims = get_input_dims(0);
     if (m_concat_dim < 0
-        || m_concat_dim >= (El::Int) output_dims.size()) {
+        || m_concat_dim >= (IntType) output_dims.size()) {
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
           << "has " << output_dims.size() << " dimensions, "
@@ -156,7 +156,7 @@ protected:
 
   }
 
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     const auto& num_inputs = get_num_parents();
     const auto& output_dims = get_output_dims();
 
@@ -216,7 +216,7 @@ protected:
 
   }
 
-  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+  void bp_setup_gradient_wrt_inputs(IntType mini_batch_size) override {
     const auto& num_inputs = get_num_parents();
     const auto& output_dims = get_output_dims();
 
@@ -284,9 +284,9 @@ protected:
 private:
 
   /** Tensor dimension to concatenation. */
-  El::Int m_concat_dim;
+  IntType m_concat_dim;
   /** Concatenation points for each child layer. */
-  std::vector<El::Int> m_concat_points;
+  std::vector<IntType> m_concat_points;
 
   /** View into input tensor. */
   std::unique_ptr<AbsDistMat> m_input_v;

--- a/include/lbann/layers/transform/crop.hpp
+++ b/include/lbann/layers/transform/crop.hpp
@@ -169,7 +169,7 @@ class crop_layer : public transform_layer {
     // Tensor dimensions
     const auto& input_dims = get_input_dims(0);
     const auto& output_dims = get_output_dims();
-    const El::Int num_dims = output_dims.size();
+    const IntType num_dims = output_dims.size();
 
     // Input and output tensors
     const auto& local_crop_pos = get_local_prev_activations(1);
@@ -178,11 +178,11 @@ class crop_layer : public transform_layer {
 
     // Crop each mini-batch sample
     #pragma omp parallel for
-    for (El::Int s = 0; s < local_input.Width(); ++s) {
+    for (IntType s = 0; s < local_input.Width(); ++s) {
 
       // Determine crop position
       std::vector<int> crop_offsets;
-      for (El::Int d = 0; d < num_dims; ++d) {
+      for (IntType d = 0; d < num_dims; ++d) {
         const auto& pos = local_crop_pos(d, s);
         if (pos < DataType(0) || pos >= DataType(1)) {
           std::stringstream err;
@@ -228,7 +228,7 @@ class crop_layer : public transform_layer {
     // Tensor dimensions
     const auto& input_dims = get_input_dims(0);
     const auto& output_dims = get_output_dims();
-    const El::Int num_dims = output_dims.size();
+    const IntType num_dims = output_dims.size();
 
     // Input and output tensors
     const auto& local_crop_pos = get_local_prev_activations(1);
@@ -238,11 +238,11 @@ class crop_layer : public transform_layer {
 
     // Crop each mini-batch sample
     #pragma omp parallel for
-    for (El::Int s = 0; s < local_gradient_wrt_output.Width(); ++s) {
+    for (IntType s = 0; s < local_gradient_wrt_output.Width(); ++s) {
 
       // Determine crop position
       std::vector<int> crop_offsets;
-      for (El::Int d = 0; d < num_dims; ++d) {
+      for (IntType d = 0; d < num_dims; ++d) {
         const auto& pos = local_crop_pos(d, s);
         if (pos < DataType(0) || pos >= DataType(1)) {
           LBANN_ERROR("crop position not in range [0,1)");

--- a/include/lbann/layers/transform/discrete_random.hpp
+++ b/include/lbann/layers/transform/discrete_random.hpp
@@ -91,14 +91,14 @@ class discrete_random_layer : public transform_layer {
 
     // Process each mini-batch sample
     #pragma omp parallel for
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
       const auto& input_ptr = local_input.LockedBuffer(0, col);
       const auto& output_ptr = local_output.Buffer(0, col);
       if (mode == execution_mode::training) {
         // Sample outputs from probability distribution
         std::vector<DataType> cdf(num_values);
         std::partial_sum(input_ptr, input_ptr + num_values, cdf.begin());
-        for (El::Int row = 0; row < num_outputs; ++row) {
+        for (IntType row = 0; row < num_outputs; ++row) {
           const int index = (std::lower_bound(cdf.begin(), cdf.end(),
                                               local_output(row, col))
                              - cdf.begin());

--- a/include/lbann/layers/transform/in_top_k.hpp
+++ b/include/lbann/layers/transform/in_top_k.hpp
@@ -41,7 +41,7 @@ template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El
 class in_top_k_layer : public transform_layer {
  public:
 
-  in_top_k_layer(lbann_comm *comm, El::Int k)
+  in_top_k_layer(lbann_comm *comm, IntType k)
     : transform_layer(comm), m_k(k) {
     if (m_k < 0) {
       std::stringstream err;
@@ -62,7 +62,7 @@ class in_top_k_layer : public transform_layer {
  private:
 
   /** Parameter for top-k search. */
-  const El::Int m_k;
+  const IntType m_k;
 
 };
 

--- a/include/lbann/layers/transform/reduction.hpp
+++ b/include/lbann/layers/transform/reduction.hpp
@@ -71,7 +71,7 @@ class reduction_layer : public transform_layer {
     // Local matrices
     const auto& local_input = get_local_prev_activations();
     auto& local_output = get_local_activations();
-    const El::Int input_size = local_input.Height();
+    const IntType input_size = local_input.Height();
 
     // Apply reduction
     switch (m_mode) {
@@ -98,7 +98,7 @@ class reduction_layer : public transform_layer {
     // Local matrices
     const auto& local_gradient_wrt_output = get_local_prev_error_signals();
     auto& local_gradient_wrt_input = get_local_error_signals();
-    const El::Int input_size = local_gradient_wrt_input.Height();
+    const IntType input_size = local_gradient_wrt_input.Height();
 
     // Compute gradients w.r.t. inputs
     switch (m_mode) {

--- a/include/lbann/layers/transform/reshape.hpp
+++ b/include/lbann/layers/transform/reshape.hpp
@@ -87,10 +87,10 @@ protected:
 
   }
 
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     El::LockedView(get_activations(), get_prev_activations());
   }
-  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+  void bp_setup_gradient_wrt_inputs(IntType mini_batch_size) override {
     El::LockedView(get_error_signals(), get_prev_error_signals());
   }
   void fp_compute() override {}

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -40,8 +40,8 @@ class slice_layer : public transform_layer {
 public:
 
   slice_layer(lbann_comm *comm,
-              El::Int slice_dim,
-              std::vector<El::Int> slice_points)
+              IntType slice_dim,
+              std::vector<IntType> slice_points)
     : transform_layer(comm),
       m_slice_dim(slice_dim),
       m_slice_points(slice_points) {
@@ -107,7 +107,7 @@ protected:
 
     // Check that slice parameters are valid
     std::stringstream err;
-    if (m_slice_dim < 0 || m_slice_dim >= (El::Int) input_dims.size()) {
+    if (m_slice_dim < 0 || m_slice_dim >= (IntType) input_dims.size()) {
       err << get_type() << " layer \"" << get_name() << "\" "
           << "has " << input_dims.size() << " dimensions, "
           << "but attempted to slice along dimension " << m_slice_dim;
@@ -148,7 +148,7 @@ protected:
 
   }
 
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     const auto& num_outputs = get_num_children();
     const auto& input_dims = get_input_dims();
 
@@ -209,7 +209,7 @@ protected:
 
   }
 
-  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+  void bp_setup_gradient_wrt_inputs(IntType mini_batch_size) override {
     const auto& num_outputs = get_num_children();
     const auto& input_dims = get_input_dims();
     
@@ -272,9 +272,9 @@ protected:
 private:
 
   /** Tensor dimension to slice. */
-  El::Int m_slice_dim;
+  IntType m_slice_dim;
   /** Slice points for each child layer. */
-  std::vector<El::Int> m_slice_points;
+  std::vector<IntType> m_slice_points;
 
   /** View into input tensor. */
   std::unique_ptr<AbsDistMat> m_input_v;

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -68,7 +68,7 @@ class split_layer : public transform_layer {
 
   protected:
 
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     const auto& input = get_prev_activations();
     for (int i = 0; i < get_num_children(); ++i) {
       El::LockedView(get_activations(i), input);

--- a/include/lbann/layers/transform/stop_gradient.hpp
+++ b/include/lbann/layers/transform/stop_gradient.hpp
@@ -48,7 +48,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
 protected:
-  void fp_setup_outputs(El::Int mini_batch_size) override {
+  void fp_setup_outputs(IntType mini_batch_size) override {
     El::LockedView(get_activations(), get_prev_activations());
   }
   void fp_compute() override {}

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -95,7 +95,7 @@ class sum_layer : public transform_layer {
     }
   }
 
-  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+  void bp_setup_gradient_wrt_inputs(IntType mini_batch_size) override {
     const auto& gradient_wrt_output = get_prev_error_signals();
     for (int i = 0; i < get_num_parents(); ++i) {
       El::LockedView(get_error_signals(i), gradient_wrt_output);

--- a/include/lbann/utils/quantizer.hpp
+++ b/include/lbann/utils/quantizer.hpp
@@ -57,7 +57,7 @@ class lbann_quantizer {
  public:
   /** We require that sizeof(DataType) <= sizeof(qtype) == sizeof(uqtype). */
   using uqtype = El::Unsigned;
-  using qtype = El::Int;
+  using qtype = IntType;
   /**
    * This represents a quantized version of a matrix.
    * Each column is quantized separately. The first two entries are floats
@@ -224,7 +224,7 @@ class lbann_quantizer {
    * @return Adaptive reconstruction values.
    */
   adaptive_reconstructions col_reconstruction(
-    const Mat& mat, const Mat& qerror, El::Int col,
+    const Mat& mat, const Mat& qerror, IntType col,
     const adaptive_thresholds threshes, bool sample = true);
 
   double get_proportion_time() const {
@@ -244,11 +244,11 @@ class lbann_quantizer {
   /** Number of bits per quantized word. */
   static const size_t NUM_BITS = sizeof(qtype) * 8;
   /** Number of samples to use in proportion_threshold. */
-  static const El::Int NUM_THRESHOLD_SAMPLES = 1024;
+  static const IntType NUM_THRESHOLD_SAMPLES = 1024;
   /** Number of samples to use in col_reconstruction. */
-  static const El::Int NUM_RECON_SAMPLES = 128;
+  static const IntType NUM_RECON_SAMPLES = 128;
   /** Samples to use to approximate column averages in onebit quantization. */
-  static const El::Int NUM_ONEBIT_SAMPLES = 128;
+  static const IntType NUM_ONEBIT_SAMPLES = 128;
   /** Factor used when computing header lengths in adaptive quantization. */
 #if LBANN_QUANTIZER_TERNARY
   static const int HEADER_FACTOR = 4;
@@ -256,7 +256,7 @@ class lbann_quantizer {
   static const int HEADER_FACTOR = 3;
 #endif
   /** Max factor by which adaptive quantization can exceed optimal amount. */
-  static const El::Int MAX_QUANTIZED_EXCESS = 4;
+  static const IntType MAX_QUANTIZED_EXCESS = 4;
 
   /** Time spent in proportion_threshold. */
   double proportion_time;
@@ -264,7 +264,7 @@ class lbann_quantizer {
   size_t quantized_count;
 
   /** Return the height of mat after quantization with onebit_quantize(). */
-  inline El::Int get_onebit_quantized_matrix_height(const Mat& mat) const {
+  inline IntType get_onebit_quantized_matrix_height(const Mat& mat) const {
     return (mat.Height() + (NUM_BITS-1)) / NUM_BITS + 2;
   }
 
@@ -325,7 +325,7 @@ class lbann_quantizer {
    * This number of threads is empirically determined.
    * @todo Make this configurable at compile time.
    */
-  inline int get_adaptive_quantization_threads(El::Int width) {
+  inline int get_adaptive_quantization_threads(IntType width) {
     int num_threads = omp_get_max_threads();
     if (width <= 64) {
       num_threads = 2;
@@ -348,7 +348,7 @@ class lbann_quantizer {
    * for the same width, OpenMP may reap its threads and add additional overhead
    * when invoking a parallel region with more threads.
    */
-  inline int get_adaptive_quantization_copy_threads(El::Int width) {
+  inline int get_adaptive_quantization_copy_threads(IntType width) {
     int num_threads = get_adaptive_quantization_threads(width);
     if (width >= 16384) {
       num_threads /= 2;

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -121,20 +121,20 @@ void init_data_seq_random(int seed = -1);
  * not change as the grid it is distributed over changes; that is, it will have
  * the same entries when mat spans any number of processes.
  */
-void gaussian_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType mean = 0.0f,
+void gaussian_fill(AbsDistMat& mat, IntType m, IntType n, DataType mean = 0.0f,
                    DataType stddev = 1.0f);
 /**
  * Make mat into an m x n matrix where each entry is an indepenent Bernoulli
  * random variable with parameter p.
  * This makes the same guarantees as gaussian_fill.
  */
-void bernoulli_fill(AbsDistMat& mat, El::Int m, El::Int n, double p = 0.5);
+void bernoulli_fill(AbsDistMat& mat, IntType m, IntType n, double p = 0.5);
 /**
  * Make mat into an m x n matrix where each entry is independently uniformly
  * sampled from a ball with the given center and radius.
  * This makes the same guarantees as gaussian_fill.
  */
-void uniform_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType center = 0.0f,
+void uniform_fill(AbsDistMat& mat, IntType m, IntType n, DataType center = 0.0f,
                   DataType radius = 1.0f);
 
 /**
@@ -143,20 +143,20 @@ void uniform_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType center = 0.0f,
  * This always ensures that the entries of the matrix do not change as the grid
  * it is distributed over changes.
  */
-void gaussian_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n,
+void gaussian_fill_procdet(AbsDistMat& mat, IntType m, IntType n,
                            DataType mean = 0.0f, DataType stddev = 1.0f);
 /**
  * Make mat into an m x n matrix where each entry is an independent Bernoulli
  * random variable with parameter p.
  * This makes the same guarantees as gaussian_fill_procdet.
  */
-void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p = 0.5);
+void bernoulli_fill_procdet(AbsDistMat& mat, IntType m, IntType n, double p = 0.5);
 /**
  * Make mat into an m x n matrix where each entry is independently uniformly
  * sampled from a ball with the given center and radius.
  * This makes the same guarantees as gaussian_fill_procdet.
  */
-void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n,
+void uniform_fill_procdet(AbsDistMat& mat, IntType m, IntType n,
                           DataType center = 0.0f, DataType radius = 1.0f);
 
 bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm);

--- a/include/lbann/weights/variance_scaling_initializers.hpp
+++ b/include/lbann/weights/variance_scaling_initializers.hpp
@@ -43,21 +43,21 @@ public:
   void fill(AbsDistMat& matrix) override;
   
   /** Set fan-in parameter. */
-  void set_fan_in(El::Int fan_in) { m_fan_in = fan_in; }
+  void set_fan_in(IntType fan_in) { m_fan_in = fan_in; }
   /** Set fan-out parameter. */
-  void set_fan_out(El::Int fan_out) { m_fan_out = fan_out; }
+  void set_fan_out(IntType fan_out) { m_fan_out = fan_out; }
 
 protected:
   /** Get probability distribution variance. */
-  virtual DataType get_variance(El::Int fan_in, El::Int fan_out) = 0;
+  virtual DataType get_variance(IntType fan_in, IntType fan_out) = 0;
   
 private:
   /** Probability distribution. */
   probability_distribution m_prob_dist;
   /** Fan-in parameter. */
-  El::Int m_fan_in;
+  IntType m_fan_in;
   /** Fan-out parameter.*/
-  El::Int m_fan_out;
+  IntType m_fan_out;
 
 };
 
@@ -73,7 +73,7 @@ public:
     return new glorot_initializer(*this);
   }
 protected:
-  DataType get_variance(El::Int fan_in, El::Int fan_out) override;
+  DataType get_variance(IntType fan_in, IntType fan_out) override;
 };
 
 /** He initializer.
@@ -87,7 +87,7 @@ public:
     return new he_initializer(*this);
   }
 protected:
-  DataType get_variance(El::Int fan_in, El::Int fan_out) override;
+  DataType get_variance(IntType fan_in, IntType fan_out) override;
 };
 
 /** LeCun initializer.
@@ -101,7 +101,7 @@ public:
     return new lecun_initializer(*this);
   }
 protected:
-  DataType get_variance(El::Int fan_in, El::Int fan_out) override;
+  DataType get_variance(IntType fan_in, IntType fan_out) override;
 };
 
 } // namespace lbann

--- a/src/callbacks/callback_check_dataset.cpp
+++ b/src/callbacks/callback_check_dataset.cpp
@@ -37,13 +37,13 @@ void lbann_callback_check_dataset::add_to_set(model *m, Layer *l, int64_t step, 
     return;
   }
 
-  El::Matrix<El::Int>* indices = l->get_sample_indices_per_mb();
+  El::Matrix<IntType>* indices = l->get_sample_indices_per_mb();
 
   std::set<long>::iterator it;
 
-  for(El::Int i = 0; i < indices->Height(); i++) {
-    for(El::Int j = 0; j < indices->Width(); j++) {
-      El::Int idx = indices->Get(i,j);
+  for(IntType i = 0; i < indices->Height(); i++) {
+    for(IntType j = 0; j < indices->Width(); j++) {
+      IntType idx = indices->Get(i,j);
       it = set.find(idx);
       if(it != set.end()) {
         throw lbann_exception(

--- a/src/callbacks/callback_check_init.cpp
+++ b/src/callbacks/callback_check_init.cpp
@@ -72,14 +72,14 @@ void lbann_callback_check_init::on_train_begin(model *m) {
 }
 
 bool lbann_callback_check_init::check_equal(const AbsMat& x, const AbsMat& y) const {
-  const El::Int height = x.Height();
-  const El::Int width = x.Width();
+  const IntType height = x.Height();
+  const IntType width = x.Width();
   if (height != y.Height() || width != y.Width() || x.LDim() != y.LDim()) {
     return false;
   }
   const DataType *x_buf = x.LockedBuffer();
   const DataType *y_buf = y.LockedBuffer();
-  for (El::Int i = 0; i < height * width; ++i) {
+  for (IntType i = 0; i < height * width; ++i) {
     if (x_buf[i] != y_buf[i]) {
       return false;
     }

--- a/src/callbacks/callback_checknan.cpp
+++ b/src/callbacks/callback_checknan.cpp
@@ -38,12 +38,12 @@ namespace {
  *  If a NaN entry is detected, return true and output the local entry
  *  position in row and col. mat is assumed to be a CPU matrix.
  */
-bool has_nan(const AbsDistMat& mat, El::Int& row, El::Int& col) {
+bool has_nan(const AbsDistMat& mat, IntType& row, IntType& col) {
   row = -1;
   col = -1;
   const auto& local_mat = mat.LockedMatrix();
-  for (El::Int j = 0; j < local_mat.Width(); ++j) {
-    for (El::Int i = 0; i < local_mat.Height(); ++i) {
+  for (IntType j = 0; j < local_mat.Width(); ++j) {
+    for (IntType i = 0; i < local_mat.Height(); ++i) {
       if (std::isnan(local_mat(i,j))) {
         row = i;
         col = j;
@@ -58,12 +58,12 @@ bool has_nan(const AbsDistMat& mat, El::Int& row, El::Int& col) {
  *  If an inf entry is detected, return true and output the entry
  *  position in row and col. mat is assumed to be a CPU matrix.
  */
-bool has_inf(const AbsDistMat& mat, El::Int& row, El::Int& col) {
+bool has_inf(const AbsDistMat& mat, IntType& row, IntType& col) {
   row = -1;
   col = -1;
   const auto& local_mat = mat.LockedMatrix();
-  for (El::Int j = 0; j < local_mat.Width(); ++j) {
-    for (El::Int i = 0; i < local_mat.Height(); ++i) {
+  for (IntType j = 0; j < local_mat.Width(); ++j) {
+    for (IntType i = 0; i < local_mat.Height(); ++i) {
       if (std::isinf(local_mat(i,j))) {
         row = i;
         col = j;
@@ -124,7 +124,7 @@ void lbann_callback_checknan::on_forward_prop_end(model *m, Layer *l) {
   std::stringstream err;
   const auto& num_outputs = l->get_num_children();
   for (int i = 0; i < num_outputs; ++i) {
-    El::Int row, col;
+    IntType row, col;
     AbsDistMatReadProxy<El::Device::CPU> mat_proxy(l->get_activations(i));
     if (has_nan(mat_proxy.GetLocked(), row, col)) {
       dump_network(m);
@@ -151,7 +151,7 @@ void lbann_callback_checknan::on_backward_prop_end(model *m, Layer *l) {
   std::stringstream err;
   const auto& num_inputs = l->get_num_parents();
   for (int i = 0; i < num_inputs; ++i) {
-    El::Int row, col;
+    IntType row, col;
     AbsDistMatReadProxy<El::Device::CPU> mat_proxy(l->get_error_signals(i));
     if (has_nan(mat_proxy.GetLocked(), row, col)) {
       dump_network(m);
@@ -179,7 +179,7 @@ void lbann_callback_checknan::on_backward_prop_end(model *m) {
   for (weights *w : m->get_weights()) {
     auto* opt = w->get_optimizer();
     if (opt != nullptr) {
-      El::Int row, col;
+      IntType row, col;
       AbsDistMatReadProxy<El::Device::CPU> mat_proxy(opt->get_gradient());
       if (has_nan(mat_proxy.GetLocked(), row, col)) {
         dump_network(m);
@@ -202,7 +202,7 @@ void lbann_callback_checknan::on_backward_prop_end(model *m) {
 void lbann_callback_checknan::on_batch_end(model *m) {
   std::stringstream err;
   for (weights *w : m->get_weights()) {
-    El::Int row, col;
+    IntType row, col;
     AbsDistMatReadProxy<El::Device::CPU> mat_proxy(w->get_values());
     if (has_nan(mat_proxy.GetLocked(), row, col)) {
       dump_network(m);

--- a/src/callbacks/callback_checksmall.cpp
+++ b/src/callbacks/callback_checksmall.cpp
@@ -76,10 +76,10 @@ void lbann_callback_checksmall::on_batch_end(model *m) {
 
 bool lbann_callback_checksmall::is_good(const AbsDistMat& m) {
   const AbsMat& local_mat = m.LockedMatrix();
-  const El::Int height = local_mat.Height();
-  const El::Int width = local_mat.Width();
-  for (El::Int col = 0; col < width; ++col) {
-    for (El::Int row = 0; row < height; ++row) {
+  const IntType height = local_mat.Height();
+  const IntType width = local_mat.Width();
+  for (IntType col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
       const DataType val = std::abs(local_mat(row, col));
       if (val > 0 && val <= m_threshold) {
         std::cout << "Found small value " << val << " "

--- a/src/callbacks/callback_dump_minibatch_sample_indices.cpp
+++ b/src/callbacks/callback_dump_minibatch_sample_indices.cpp
@@ -38,7 +38,7 @@ void lbann_callback_dump_minibatch_sample_indices::dump_to_file(model *m, Layer 
   // Print minibatch sample indices of input layers
   auto *input = dynamic_cast<generic_input_layer*>(l);
   if (input != nullptr) {
-    El::Matrix<El::Int>* indices = l->get_sample_indices_per_mb();
+    El::Matrix<IntType>* indices = l->get_sample_indices_per_mb();
     if (indices == nullptr
         || indices->Height() == 0
         || indices->Width() == 0) {

--- a/src/callbacks/callback_gradient_check.cpp
+++ b/src/callbacks/callback_gradient_check.cpp
@@ -101,13 +101,13 @@ void lbann_callback_gradient_check::on_test_begin(model *m) {
     const AbsDistMat& gradient = w->get_optimizer()->get_gradient();
 
     // Iterate through weights matrix entries
-    for (El::Int col = 0; col < weights_matrix.Width(); ++col) {
-      for (El::Int row = 0; row < weights_matrix.Height(); ++row) {
+    for (IntType col = 0; col < weights_matrix.Width(); ++col) {
+      for (IntType row = 0; row < weights_matrix.Height(); ++row) {
         const bool weight_is_local = weights_matrix.IsLocal(row, col);
-        const El::Int local_row = (weight_is_local ?
+        const IntType local_row = (weight_is_local ?
                                    weights_matrix.LocalRow(row) :
                                    0);
-        const El::Int local_col = (weight_is_local ?
+        const IntType local_col = (weight_is_local ?
                                    weights_matrix.LocalCol(col) :
                                    0);
         const DataType initial_weight = (weight_is_local ?

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -431,7 +431,7 @@ void lbann_comm::intermodel_allreduce(
     algo = get_default_allreduce_algorithm();
   }
   const int nprocs = get_num_models();
-  const El::Int small_message_threshold = 64*64;
+  const IntType small_message_threshold = 64*64;
   if (algo == allreduce_algorithm::DYNAMIC) {
     // For small messages and power-of-2 number of processes, use RD.
     if (!(nprocs & (nprocs - 1)) &&
@@ -542,14 +542,14 @@ void lbann_comm::pe_ring_allreduce(
   }
   // Compute the number of columns each processor sends.
   // If it doesn't divide evenly, give one extra to the earlier ranks.
-  const El::Int cols_per_proc = mat.Width() / nprocs;
-  const El::Int cols_remainder = mat.Width() % nprocs;
+  const IntType cols_per_proc = mat.Width() / nprocs;
+  const IntType cols_remainder = mat.Width() % nprocs;
   // Compute the lengths/ends of the slices.
-  std::vector<El::Int> slice_lengths(nprocs, cols_per_proc);
+  std::vector<IntType> slice_lengths(nprocs, cols_per_proc);
   for (int i = 0; i < cols_remainder; ++i) {
     slice_lengths[i] += 1;
   }
-  std::vector<El::Int> slice_ends(nprocs);
+  std::vector<IntType> slice_ends(nprocs);
   std::partial_sum(slice_lengths.begin(), slice_lengths.end(),
                    slice_ends.begin());
   std::vector<uint8_t *> max_recv_buffers(opts.max_reduces, nullptr);
@@ -762,14 +762,14 @@ void lbann_comm::ring_allreduce(
     return;  // Nothing to do.
   }
   // Compute the number of columns each processor sends.
-  const El::Int cols_per_proc = mat.Width() / nprocs;
-  const El::Int cols_remainder = mat.Width() % nprocs;
+  const IntType cols_per_proc = mat.Width() / nprocs;
+  const IntType cols_remainder = mat.Width() % nprocs;
   // Compute the lengths/ends of the slices.
-  std::vector<El::Int> slice_lengths(nprocs, cols_per_proc);
+  std::vector<IntType> slice_lengths(nprocs, cols_per_proc);
   for (int i = 0; i < cols_remainder; ++i) {
     slice_lengths[i] += 1;
   }
-  std::vector<El::Int> slice_ends(nprocs);
+  std::vector<IntType> slice_ends(nprocs);
   std::partial_sum(slice_lengths.begin(), slice_lengths.end(),
                    slice_ends.begin());
   uint8_t *max_recv_buf = get_collective_buffer(max_recv_count);
@@ -941,14 +941,14 @@ void lbann_comm::rabenseifner_allreduce(
                           " a power-of-2 number of participating processes");
   }
   // Compute the slices on each processor.
-  const El::Int cols_per_proc = mat.Width() / nprocs;
-  const El::Int cols_remainder = mat.Width() % nprocs;
+  const IntType cols_per_proc = mat.Width() / nprocs;
+  const IntType cols_remainder = mat.Width() % nprocs;
   // Compute the lengths/ends of the slices.
-  std::vector<El::Int> slice_lengths(nprocs, cols_per_proc);
+  std::vector<IntType> slice_lengths(nprocs, cols_per_proc);
   for (int i = 0; i < cols_remainder; ++i) {
     slice_lengths[i] += 1;
   }
-  std::vector<El::Int> slice_ends(nprocs);
+  std::vector<IntType> slice_ends(nprocs);
   std::partial_sum(slice_lengths.begin(), slice_lengths.end(),
                    slice_ends.begin());
   // Do a recursive-halving reduce-scatter.

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -90,7 +90,7 @@ int lbann::generic_data_reader::fetch_data(CPUMat& X) {
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size),
                                m_shuffled_indices.size());
   const int mb_size = std::min(
-    El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
+    IntType{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
     X.Width());
 
   if (!m_save_minibatch_indices) {
@@ -142,7 +142,7 @@ int lbann::generic_data_reader::fetch_labels(CPUMat& Y) {
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size),
                                m_shuffled_indices.size());
   const int mb_size = std::min(
-    El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
+    IntType{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
     Y.Width());
 
   El::Zeros(Y, Y.Height(), Y.Width());
@@ -180,7 +180,7 @@ int lbann::generic_data_reader::fetch_responses(CPUMat& Y) {
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size),
                                m_shuffled_indices.size());
   const int mb_size = std::min(
-    El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
+    IntType{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
     Y.Width());
 
   El::Zeros(Y, Y.Height(), Y.Width());

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -140,8 +140,8 @@ std::vector<image_data_reader::sample_t> image_data_reader::get_image_list_of_cu
   std::vector<sample_t> ret;
   ret.reserve(m_mini_batch_size);
 
-  for (El::Int i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
-    El::Int index = m_indices_fetched_per_mb.Get(i, 0);
+  for (IntType i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
+    IntType index = m_indices_fetched_per_mb.Get(i, 0);
     ret.push_back(m_image_list[index]);
   }
   return ret;

--- a/src/data_readers/data_reader_imagenet_patches.cpp
+++ b/src/data_readers/data_reader_imagenet_patches.cpp
@@ -135,7 +135,7 @@ std::vector<CPUMat> imagenet_reader_patches::create_datum_views(CPUMat& X, const
   }
 */
   std::vector<CPUMat> X_v(m_num_patches);
-  El::Int h = 0;
+  IntType h = 0;
   for(int i=0; i < m_num_patches; ++i) {
     El::View(X_v[i], X, El::IR(h, h + m_image_linearized_size), El::IR(mb_idx, mb_idx + 1));
     h = h + m_image_linearized_size;

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -590,9 +590,9 @@ std::vector<DataType> data_reader_jag::get_input(const size_t i) const {
 std::vector<CPUMat>
 data_reader_jag::create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
   std::vector<CPUMat> X_v(sizes.size());
-  El::Int h = 0;
+  IntType h = 0;
   for(size_t i=0u; i < sizes.size(); ++i) {
-    const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
+    const IntType h_end =  h + static_cast<IntType>(sizes[i]);
     El::View(X_v[i], X, El::IR(h, h_end), El::IR(mb_idx, mb_idx + 1));
     h = h_end;
   }

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -993,10 +993,10 @@ int data_reader_jag_conduit::check_exp_success(const size_t sample_id) const {
 std::vector<CPUMat>
 data_reader_jag_conduit::create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
   std::vector<CPUMat> X_v(sizes.size());
-  El::Int h = 0;
+  IntType h = 0;
 
   for(size_t i=0u; i < sizes.size(); ++i) {
-    const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
+    const IntType h_end =  h + static_cast<IntType>(sizes[i]);
     El::View(X_v[i], X, El::IR(h, h_end), El::IR(mb_idx, mb_idx + 1));
     h = h_end;
   }

--- a/src/data_readers/data_reader_jag_conduit_hdf5.cpp
+++ b/src/data_readers/data_reader_jag_conduit_hdf5.cpp
@@ -511,10 +511,10 @@ std::vector<data_reader_jag_conduit_hdf5::input_t> data_reader_jag_conduit_hdf5:
 std::vector<CPUMat>
 data_reader_jag_conduit_hdf5::create_datum_views(CPUMat& X, const std::vector<size_t>& sizes, const int mb_idx) const {
   std::vector<CPUMat> X_v(sizes.size());
-  El::Int h = 0;
+  IntType h = 0;
 
   for(size_t i=0u; i < sizes.size(); ++i) {
-    const El::Int h_end =  h + static_cast<El::Int>(sizes[i]);
+    const IntType h_end =  h + static_cast<IntType>(sizes[i]);
     El::View(X_v[i], X, El::IR(h, h_end), El::IR(mb_idx, mb_idx + 1));
     h = h_end;
   }

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -128,10 +128,10 @@ std::string mesh_reader::construct_filename(std::string channel, int data_id) {
 
 void mesh_reader::horizontal_flip(CPUMat& mat) {
   // TODO: Could probably optimize this for better locality.
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  for (El::Int row = 0; row < height; ++row) {
-    for (El::Int col = 0; col < (width / 2); ++col) {
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  for (IntType row = 0; row < height; ++row) {
+    for (IntType col = 0; col < (width / 2); ++col) {
       DataType tmp = mat(row, col);
       mat(row, col) = mat(row, width - col - 1);
       mat(row, width - col - 1) = tmp;
@@ -141,10 +141,10 @@ void mesh_reader::horizontal_flip(CPUMat& mat) {
 
 void mesh_reader::vertical_flip(CPUMat& mat) {
   // TODO: Could probably optimize this for better locality.
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  for (El::Int row = 0; row < (height / 2); ++row) {
-    for (El::Int col = 0; col < width; ++col) {
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  for (IntType row = 0; row < (height / 2); ++row) {
+    for (IntType col = 0; col < width; ++col) {
       DataType tmp = mat(row, col);
       mat(row, col) = mat(height - row - 1, col);
       mat(height - row - 1, col) = tmp;

--- a/src/data_readers/data_reader_mnist_siamese.cpp
+++ b/src/data_readers/data_reader_mnist_siamese.cpp
@@ -108,7 +108,7 @@ int data_reader_mnist_siamese::fetch_data(CPUMat& X) {
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size),
                                m_shuffled_indices.size());
   const int mb_size = std::min(
-    El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
+    IntType{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
     X.Width());
 
   El::Zeros(X, X.Height(), X.Width());
@@ -121,7 +121,7 @@ int data_reader_mnist_siamese::fetch_data(CPUMat& X) {
     sample_t index = std::make_pair(m_shuffled_indices[n], m_shuffled_indices2[n]);
     bool valid = fetch_datum(X, index, s, omp_get_thread_num());
     if (valid) {
-      El::Int index_coded = m_shuffled_indices[n] + m_shuffled_indices2[n]*(std::numeric_limits<label_t>::max()+1);
+      IntType index_coded = m_shuffled_indices[n] + m_shuffled_indices2[n]*(std::numeric_limits<label_t>::max()+1);
       m_indices_fetched_per_mb.Set(s, 0, index_coded);
     } else{
 #pragma omp critical
@@ -155,7 +155,7 @@ int data_reader_mnist_siamese::fetch_labels(CPUMat& Y) {
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size),
                                m_shuffled_indices.size());
   const int mb_size = std::min(
-    El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
+    IntType{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
     Y.Width());
 
   El::Zeros(Y, Y.Height(), Y.Width());

--- a/src/data_readers/data_reader_multi_images.cpp
+++ b/src/data_readers/data_reader_multi_images.cpp
@@ -90,7 +90,7 @@ void data_reader_multi_images::set_input_params(const int width, const int heigh
 
 std::vector<::Mat> data_reader_multi_images::create_datum_views(::Mat& X, const int mb_idx) const {
   std::vector<::Mat> X_v(m_num_img_srcs);
-  El::Int h = 0;
+  IntType h = 0;
   for(unsigned int i=0u; i < m_num_img_srcs; ++i) {
     El::View(X_v[i], X, El::IR(h, h + m_image_linearized_size), El::IR(mb_idx, mb_idx + 1));
     h = h + m_image_linearized_size;
@@ -140,8 +140,8 @@ std::vector<data_reader_multi_images::sample_t> data_reader_multi_images::get_im
   std::vector<sample_t> ret;
   ret.reserve(m_mini_batch_size);
 
-  for (El::Int i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
-    El::Int index = m_indices_fetched_per_mb.Get(i, 0);
+  for (IntType i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
+    IntType index = m_indices_fetched_per_mb.Get(i, 0);
     ret.push_back(m_image_list[index]);
   }
   return ret;

--- a/src/data_readers/data_reader_synthetic.cpp
+++ b/src/data_readers/data_reader_synthetic.cpp
@@ -47,9 +47,9 @@ bool data_reader_synthetic::fetch_datum(Mat& X, int data_id, int mb_idx, int) {
   auto X_v = El::View(X, El::ALL, El::IR(mb_idx, mb_idx + 1));
   std::normal_distribution<DataType> dist(DataType(0), DataType(1));
   auto& gen = get_fast_generator();
-  const El::Int height = X_v.Height();  // Width is 1.
+  const IntType height = X_v.Height();  // Width is 1.
   DataType * __restrict__ buf = X_v.Buffer();
-  for (El::Int i = 0; i < height; ++i) {
+  for (IntType i = 0; i < height; ++i) {
     buf[i] = dist(gen);
   }
   return true;

--- a/src/data_readers/data_reader_triplet.cpp
+++ b/src/data_readers/data_reader_triplet.cpp
@@ -125,8 +125,8 @@ std::vector<data_reader_triplet::sample_t> data_reader_triplet::get_image_list_o
   std::vector<sample_t> ret;
   ret.reserve(m_mini_batch_size);
 
-  for (El::Int i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
-    El::Int index = m_indices_fetched_per_mb.Get(i, 0);
+  for (IntType i = 0; i < m_indices_fetched_per_mb.Height(); ++i) {
+    IntType index = m_indices_fetched_per_mb.Get(i, 0);
     ret.emplace_back(m_samples.get_sample(index));
   }
   return ret;

--- a/src/io/data_buffers/distributed_io_buffer.cpp
+++ b/src/io/data_buffers/distributed_io_buffer.cpp
@@ -81,7 +81,7 @@ void lbann::distributed_io_buffer::distribute_from_local_matrix(generic_data_rea
       lbann_exception(err.str());
     }
     for (int i = 0; i < 2; i++) {
-      El::Int width = sample.Width();
+      IntType width = sample.Width();
       if(i == 1) { width = response.Width(); }
       CopyFromRoot((*buf->M_local[i])(El::ALL, El::IR(0, width)), *buf->Ms[i]);
     }

--- a/src/io/persist.cpp
+++ b/src/io/persist.cpp
@@ -75,8 +75,8 @@ bool lbann::persist::write_rank_distmat(persist_type type, const char *name, con
     throw lbann_exception("persist: invalid persist_type");
   }
   // skip all of this if matrix is not held on rank
-  const El::Int localHeight = M.LocalHeight();
-  const El::Int localWidth = M.LocalWidth();
+  const IntType localHeight = M.LocalHeight();
+  const IntType localWidth = M.LocalWidth();
   // If this is the case we will try to grab the matrix from model rank 0 on reload
   if(localHeight * localWidth == 0) { return true; }
      
@@ -100,12 +100,12 @@ bool lbann::persist::write_rank_distmat(persist_type type, const char *name, con
   m_bytes += write_rc;
 
   // now write the data for our part of the distributed matrix
-  const El::Int lDim = M.LDim();
+  const IntType lDim = M.LDim();
   if(localHeight == lDim) {
     // the local dimension in memory matches the local height,
     // so we can write our data in a single shot
     auto *buf = (void *) M.LockedBuffer();
-    El::Int bufsize = localHeight * localWidth * sizeof(DataType);
+    IntType bufsize = localHeight * localWidth * sizeof(DataType);
     write_rc = write(fd, buf, bufsize);
     if (write_rc != bufsize) {
       // error!
@@ -115,9 +115,9 @@ bool lbann::persist::write_rank_distmat(persist_type type, const char *name, con
     // TODO: if this padding is small, may not be a big deal to write it out anyway
     // we've got some padding along the first dimension
     // while storing the matrix in memory, avoid writing the padding
-    for(El::Int j = 0; j < localWidth; ++j) {
+    for(IntType j = 0; j < localWidth; ++j) {
       auto *buf = (void *) M.LockedBuffer(0, j);
-      El::Int bufsize = localHeight * sizeof(DataType);
+      IntType bufsize = localHeight * sizeof(DataType);
       write_rc = write(fd, buf, bufsize);
       if (write_rc != bufsize) {
         // error!
@@ -153,16 +153,16 @@ bool lbann::persist::read_rank_distmat(persist_type type, const char *name, AbsD
   m_bytes += read_rc;
 
   // resize our global matrix
-  El::Int height = header.height;
-  El::Int width  = header.width;
+  IntType height = header.height;
+  IntType width  = header.width;
   M.Resize(height, width);
   // TODO: check that header values match up
-  const El::Int localheight = header.localheight;
-  const El::Int localwidth = header.localwidth;
+  const IntType localheight = header.localheight;
+  const IntType localwidth = header.localwidth;
   if(M.ColStride() == 1 && M.RowStride() == 1) {
     if(M.Height() == M.LDim()) {
       auto *buf = (void *) M.Buffer();
-      El::Int bufsize = localheight * localwidth * sizeof(DataType);
+      IntType bufsize = localheight * localwidth * sizeof(DataType);
       read_rc = read(fd, buf, bufsize);
       if (read_rc != bufsize) {
         // error!
@@ -170,9 +170,9 @@ bool lbann::persist::read_rank_distmat(persist_type type, const char *name, AbsD
       }
       m_bytes += read_rc;
     } else {
-      for(El::Int j = 0; j <  localwidth; ++j) {
+      for(IntType j = 0; j <  localwidth; ++j) {
         auto *buf = (void *) M.Buffer(0, j);
-        El::Int bufsize = localheight * sizeof(DataType);
+        IntType bufsize = localheight * sizeof(DataType);
         read_rc = read(fd, buf, bufsize);
         if (read_rc != bufsize) {
           // error!
@@ -182,10 +182,10 @@ bool lbann::persist::read_rank_distmat(persist_type type, const char *name, AbsD
       }
     }
   } else {
-    const El::Int lDim = M.LDim();
+    const IntType lDim = M.LDim();
     if(localheight == lDim) {
       auto *buf = (void *) M.Buffer();
-      El::Int bufsize = localheight * localwidth * sizeof(DataType);
+      IntType bufsize = localheight * localwidth * sizeof(DataType);
       read_rc = read(fd, buf, bufsize);
       if (read_rc != bufsize) {
         // error!
@@ -193,9 +193,9 @@ bool lbann::persist::read_rank_distmat(persist_type type, const char *name, AbsD
       }
       m_bytes += read_rc;
     } else {
-      for(El::Int jLoc = 0; jLoc < localwidth; ++jLoc) {
+      for(IntType jLoc = 0; jLoc < localwidth; ++jLoc) {
         auto *buf = (void *) M.Buffer(0, jLoc);
-        El::Int bufsize = localheight * sizeof(DataType);
+        IntType bufsize = localheight * sizeof(DataType);
         read_rc = read(fd, buf, bufsize);
         if (read_rc != bufsize) {
           // error!
@@ -331,7 +331,7 @@ bool lbann::persist::write_distmat(persist_type type, const char *name, AbsDistM
   El::Write(*M, filename, El::BINARY, "");
   //Write_MPI(M, filename, BINARY, "");
 
-  uint64_t bytes = 2 * sizeof(El::Int) + M->Height() * M->Width() * sizeof(DataType);
+  uint64_t bytes = 2 * sizeof(IntType) + M->Height() * M->Width() * sizeof(DataType);
   m_bytes += bytes;
 
   return true;
@@ -357,7 +357,7 @@ bool lbann::persist::read_distmat(persist_type type, const char *name, AbsDistMa
   El::Read(*M, filename, El::BINARY, true);
   //Read_MPI(M, filename, BINARY, 1);
 
-  uint64_t bytes = 2 * sizeof(El::Int) + M->Height() * M->Width() * sizeof(DataType);
+  uint64_t bytes = 2 * sizeof(IntType) + M->Height() * M->Width() * sizeof(DataType);
   m_bytes += bytes;
 
   return true;
@@ -470,7 +470,7 @@ bool lbann::write_distmat(int fd, const char *name, DistMat *M, uint64_t *bytes)
   El::Write(*M, name, El::BINARY, "");
   //Write_MPI(M, name, BINARY, "");
 
-  uint64_t bytes_written = 2 * sizeof(El::Int) + M->Height() * M->Width() * sizeof(DataType);
+  uint64_t bytes_written = 2 * sizeof(IntType) + M->Height() * M->Width() * sizeof(DataType);
   *bytes += bytes_written;
 
   return true;
@@ -487,7 +487,7 @@ bool lbann::read_distmat(int fd, const char *name, DistMat *M, uint64_t *bytes) 
   El::Read(*M, name, El::BINARY, true);
   //Read_MPI(M, name, BINARY, 1);
 
-  uint64_t bytes_read = 2 * sizeof(El::Int) + M->Height() * M->Width() * sizeof(DataType);
+  uint64_t bytes_read = 2 * sizeof(IntType) + M->Height() * M->Width() * sizeof(DataType);
   *bytes += bytes_read;
 
   return true;

--- a/src/layers/activations/softmax.cpp
+++ b/src/layers/activations/softmax.cpp
@@ -84,8 +84,8 @@ void softmax_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
   auto& local_output = get_local_activations();
   auto& local_workspace = m_workspace->Matrix();
 
-  const El::Int local_height = local_input.Height();
-  const El::Int local_width = local_input.Width();
+  const IntType local_height = local_input.Height();
+  const IntType local_width = local_input.Width();
 
   // Find the maximum entry in each local column.
   if (local_height == 0) {
@@ -132,13 +132,13 @@ void softmax_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
   auto& local_grad_wrt_input = get_local_error_signals();
   auto& local_workspace = m_workspace->Matrix();
 
-  const El::Int local_height = local_output.Height();
-  const El::Int local_width = local_output.Width();
+  const IntType local_height = local_output.Height();
+  const IntType local_width = local_output.Width();
 
   // Compute dot products between output and gradient w.r.t. output.
   auto&& handle = El::GPUManager::cuBLASHandle();
   CHECK_CUBLAS(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE));
-  for (El::Int col = 0; col < local_width; ++col) {
+  for (IntType col = 0; col < local_width; ++col) {
     cublas::dot(handle, local_height,
                 local_output.LockedBuffer(0, col), 1,
                 local_grad_wrt_output.LockedBuffer(0, col), 1,

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -658,7 +658,7 @@ void Layer::setup_matrices(const El::Grid& grid) {
 
 std::unique_ptr<AbsDistMat> Layer::construct_matrix(const El::Grid& grid,
                                                     std::string type,
-                                                    El::Int index) {
+                                                    IntType index) {
 
   // Choose matrix distribution
   El::Distribution col_dist, row_dist;
@@ -864,7 +864,7 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
   }
 }
 
-void Layer::fp_setup_inputs(El::Int mini_batch_size) {
+void Layer::fp_setup_inputs(IntType mini_batch_size) {
   if (get_num_parents() < 1) { return; }
 
   // Determine distributed matrix alignment
@@ -903,7 +903,7 @@ void Layer::fp_setup_inputs(El::Int mini_batch_size) {
   
 }
 
-void Layer::fp_setup_outputs(El::Int mini_batch_size) {
+void Layer::fp_setup_outputs(IntType mini_batch_size) {
   if (get_num_children() < 1) { return; }
 
   // Determine distributed matrix alignment
@@ -922,7 +922,7 @@ void Layer::fp_setup_outputs(El::Int mini_batch_size) {
 
 }
 
-void Layer::bp_setup_gradient_wrt_outputs(El::Int mini_batch_size) {
+void Layer::bp_setup_gradient_wrt_outputs(IntType mini_batch_size) {
   for (int i = 0; i < get_num_children(); ++i) {
 
     // Initialize gradient w.r.t. output tensor
@@ -956,7 +956,7 @@ void Layer::bp_setup_gradient_wrt_outputs(El::Int mini_batch_size) {
   }
 }
 
-void Layer::bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) {
+void Layer::bp_setup_gradient_wrt_inputs(IntType mini_batch_size) {
   for (int i = 0; i < get_num_parents(); ++i) {
     auto& gradient_wrt_input = get_error_signals(i);
     gradient_wrt_input.Empty(false);

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -94,8 +94,8 @@ void fully_connected_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::fp_com
     const auto& local_bias = m_weights[1]->get_values().LockedMatrix();
     auto& local_output = output.Matrix();
     El::IndexDependentMap(local_output,
-                          (std::function<DataType(El::Int,El::Int,const DataType&)>)
-                          ([this,&local_bias](El::Int r, El::Int c,const DataType& z)
+                          (std::function<DataType(IntType,IntType,const DataType&)>)
+                          ([this,&local_bias](IntType r, IntType c,const DataType& z)
                            ->DataType {
                             return z + m_bias_scaling_factor * local_bias(r, 0);
                           }));
@@ -199,8 +199,8 @@ void fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_comp
   if(m_bias_scaling_factor != DataType(0)) {
     const auto& local_bias = m_weights[1]->get_values().LockedMatrix();
     El::IndexDependentMap(local_output,
-                          (std::function<DataType(El::Int,El::Int,const DataType&)>)
-                          ([this,&local_bias](El::Int r, El::Int c,const DataType& z)
+                          (std::function<DataType(IntType,IntType,const DataType&)>)
+                          ([this,&local_bias](IntType r, IntType c,const DataType& z)
                            ->DataType {
                             return z + m_bias_scaling_factor * local_bias(r, 0);
                           }));

--- a/src/layers/loss/cross_entropy.cpp
+++ b/src/layers/loss/cross_entropy.cpp
@@ -37,14 +37,14 @@ void local_fp_cpu(const AbsMat& local_prediction,
 
   // Useful constants
   const DataType zero = DataType(0);
-  const El::Int local_height = local_prediction.Height();
-  const El::Int local_width = local_prediction.Width();
+  const IntType local_height = local_prediction.Height();
+  const IntType local_width = local_prediction.Width();
 
   // Compute local contribution to cross entropy
 #pragma omp parallel for
-  for (El::Int col = 0; col < local_width; ++col) {
+  for (IntType col = 0; col < local_width; ++col) {
     DataType sum = zero;
-    for (El::Int row = 0; row < local_height; ++row) {
+    for (IntType row = 0; row < local_height; ++row) {
       const auto& xhat = local_ground_truth(row, col);
       if (xhat > zero) {
         const auto& x = local_prediction(row, col);
@@ -67,13 +67,13 @@ void local_bp_cpu(const AbsMat& local_prediction,
                                                                        
   // Useful constants
   const DataType zero = DataType(0);
-  const El::Int local_height = local_prediction.Height();
-  const El::Int local_width = local_prediction.Width();
+  const IntType local_height = local_prediction.Height();
+  const IntType local_width = local_prediction.Width();
 
   // Compute gradients
 #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const auto& x = local_prediction(row, col);
       const auto& xhat = local_ground_truth(row, col);
       const auto& dy = local_gradient_wrt_output(0, col);

--- a/src/layers/loss/mean_squared_error.cpp
+++ b/src/layers/loss/mean_squared_error.cpp
@@ -30,7 +30,7 @@ namespace lbann {
 
 namespace {
 
-void local_fp_cpu(El::Int height,
+void local_fp_cpu(IntType height,
                   const AbsMat& local_prediction,
                   const AbsMat& local_ground_truth,
                   AbsMat& local_contribution) {
@@ -41,9 +41,9 @@ void local_fp_cpu(El::Int height,
 
   // Compute local contribution to mean squared error
 #pragma omp parallel for
-  for (El::Int col = 0; col < local_width; ++col) {
+  for (IntType col = 0; col < local_width; ++col) {
     DataType sum = 0;
-    for (El::Int row = 0; row < local_height; ++row) {
+    for (IntType row = 0; row < local_height; ++row) {
       const auto& err = (local_prediction(row, col)
                          - local_ground_truth(row, col));
       sum += err * err;
@@ -53,7 +53,7 @@ void local_fp_cpu(El::Int height,
 
 }
 
-void local_bp_cpu(El::Int height,
+void local_bp_cpu(IntType height,
                   const AbsMat& local_prediction,
                   const AbsMat& local_ground_truth,
                   const AbsMat& local_gradient_wrt_output,
@@ -62,13 +62,13 @@ void local_bp_cpu(El::Int height,
                                                                        
   // Useful constants
   const DataType scale = DataType(2) / height;
-  const El::Int local_height = local_prediction.Height();
-  const El::Int local_width = local_prediction.Width();
+  const IntType local_height = local_prediction.Height();
+  const IntType local_width = local_prediction.Width();
 
   // Compute gradients
 #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const auto& err = (local_prediction(row, col)
                          - local_ground_truth(row, col));
       const auto& dy = local_gradient_wrt_output(0, col);
@@ -83,7 +83,7 @@ void local_bp_cpu(El::Int height,
 
 template <>
 void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
-     ::local_fp_compute(El::Int height,
+     ::local_fp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         AbsMat& local_contribution) {
@@ -93,7 +93,7 @@ void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
 
 template <>
 void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
-     ::local_bp_compute(El::Int height,
+     ::local_bp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         const AbsMat& local_gradient_wrt_output,
@@ -109,7 +109,7 @@ void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
 
 template <>
 void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
-     ::local_fp_compute(El::Int height,
+     ::local_fp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         AbsMat& local_contribution) {
@@ -119,7 +119,7 @@ void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
 
 template <>
 void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
-     ::local_bp_compute(El::Int height,
+     ::local_bp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         const AbsMat& local_gradient_wrt_output,

--- a/src/layers/loss/mean_squared_error.cu
+++ b/src/layers/loss/mean_squared_error.cu
@@ -75,7 +75,7 @@ __global__ void fp_kernel(int global_height,
     
 }
   
-void local_fp_gpu(El::Int height,
+void local_fp_gpu(IntType height,
                   const AbsMat& local_prediction,
                   const AbsMat& local_ground_truth,
                   AbsMat& local_contribution) {
@@ -131,7 +131,7 @@ __global__ void bp_kernel(int global_height,
     
 }
 
-void local_bp_gpu(El::Int height,
+void local_bp_gpu(IntType height,
                   const AbsMat& local_prediction,
                   const AbsMat& local_ground_truth,
                   const AbsMat& local_gradient_wrt_output,
@@ -163,7 +163,7 @@ void local_bp_gpu(El::Int height,
 
 template <>
 void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
-     ::local_fp_compute(El::Int height,
+     ::local_fp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         AbsMat& local_contribution) {
@@ -173,7 +173,7 @@ void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
 
 template <>
 void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
-     ::local_bp_compute(El::Int height,
+     ::local_bp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         const AbsMat& local_gradient_wrt_output,
@@ -189,7 +189,7 @@ void mean_squared_error_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
 
 template <>
 void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
-     ::local_fp_compute(El::Int height,
+     ::local_fp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         AbsMat& local_contribution) {
@@ -199,7 +199,7 @@ void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
 
 template <>
 void mean_squared_error_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
-     ::local_bp_compute(El::Int height,
+     ::local_bp_compute(IntType height,
                         const AbsMat& local_prediction,
                         const AbsMat& local_ground_truth,
                         const AbsMat& local_gradient_wrt_output,

--- a/src/layers/loss/top_k_categorical_accuracy.cu
+++ b/src/layers/loss/top_k_categorical_accuracy.cu
@@ -43,12 +43,12 @@ struct entry {
   /** Vector entry value. */
   DataType value;
   /** Vector entry index. */
-  El::Int index;
+  IntType index;
 
   /** Minimum possible value. */
   static constexpr DataType min_value = -std::numeric_limits<DataType>::infinity();
   /** Maximum possible index. */
-  static constexpr El::Int max_index = std::numeric_limits<El::Int>::max();
+  static constexpr IntType max_index = std::numeric_limits<IntType>::max();
 
 };
 
@@ -67,20 +67,20 @@ struct entry_compare : thrust::binary_function<entry,entry,bool> {
  *  the sparse vectors correspond to global row indices in the dense
  *  matrix.
  */
-__global__ void dense_matrix_to_sparse_vectors(El::Int local_vector_size,
-                                               El::Int local_matrix_height,
-                                               El::Int local_matrix_width,
-                                               El::Int global_matrix_height,
-                                               El::Int global_matrix_col_shift,
-                                               El::Int global_matrix_col_stride,
+__global__ void dense_matrix_to_sparse_vectors(IntType local_vector_size,
+                                               IntType local_matrix_height,
+                                               IntType local_matrix_width,
+                                               IntType global_matrix_height,
+                                               IntType global_matrix_col_shift,
+                                               IntType global_matrix_col_stride,
                                                const DataType* __restrict__ local_matrix,
-                                               El::Int local_matrix_ldim,
+                                               IntType local_matrix_ldim,
                                                entry* __restrict__ local_entries,
-                                               El::Int local_entries_ldim) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  const El::Int num_local_entries = local_vector_size * local_matrix_width;
-  for (El::Int i = gid; i < num_local_entries; i += num_threads) {
+                                               IntType local_entries_ldim) {
+  const IntType gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const IntType num_threads = blockDim.x * gridDim.x;
+  const IntType num_local_entries = local_vector_size * local_matrix_width;
+  for (IntType i = gid; i < num_local_entries; i += num_threads) {
     const auto& local_row = i % local_vector_size;
     const auto& local_col = i / local_vector_size;
     auto& current_entry = local_entries[local_row + local_col * local_entries_ldim];
@@ -107,13 +107,13 @@ __global__ void dense_matrix_to_sparse_vectors(El::Int local_vector_size,
  *    dim         = d(k)
  *    dim_stride  = d(k+1) * ... * d(n)
  */
-__global__ void fill_with_tensor_index(El::Int tensor_size,
-                                       El::Int dim,
-                                       El::Int dim_stride,
-                                       El::Int* tensor) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  for (El::Int i = gid; i < tensor_size; i += num_threads) {
+__global__ void fill_with_tensor_index(IntType tensor_size,
+                                       IntType dim,
+                                       IntType dim_stride,
+                                       IntType* tensor) {
+  const IntType gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const IntType num_threads = blockDim.x * gridDim.x;
+  for (IntType i = gid; i < tensor_size; i += num_threads) {
     tensor[i] = (i / dim_stride) % dim;
   }  
 }
@@ -123,17 +123,17 @@ __global__ void fill_with_tensor_index(El::Int tensor_size,
  *  vector. Note that we may get race conditions if a matrix column is
  *  not a one-hot vector.
  */
-__global__ void one_hot_matrix_to_indices(El::Int local_height,
-                                          El::Int local_width,
-                                          El::Int global_matrix_col_shift,
-                                          El::Int global_matrix_col_stride,
+__global__ void one_hot_matrix_to_indices(IntType local_height,
+                                          IntType local_width,
+                                          IntType global_matrix_col_shift,
+                                          IntType global_matrix_col_stride,
                                           const DataType* __restrict__ local_matrix,
-                                          El::Int local_matrix_ldim,
-                                          El::Int* __restrict__ indices) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  const El::Int local_size = local_height * local_width;
-  for (El::Int i = gid; i < local_size; i += num_threads) {
+                                          IntType local_matrix_ldim,
+                                          IntType* __restrict__ indices) {
+  const IntType gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const IntType num_threads = blockDim.x * gridDim.x;
+  const IntType local_size = local_height * local_width;
+  for (IntType i = gid; i < local_size; i += num_threads) {
     const auto& local_row = i % local_height;
     const auto& local_col = i / local_height;
     if (local_matrix[local_row + local_col * local_matrix_ldim] > DataType(0)) {
@@ -148,18 +148,18 @@ __global__ void one_hot_matrix_to_indices(El::Int local_height,
  *  Loss is one if the label index matches one of the top-k entries
  *  and is otherwise zero.
  */
-__global__ void compute_categorical_accuracy(El::Int k,
-                                             El::Int width,
-                                             El::Int max_entry,
+__global__ void compute_categorical_accuracy(IntType k,
+                                             IntType width,
+                                             IntType max_entry,
                                              const entry*  __restrict__ top_entries,
-                                             El::Int top_entries_ldim,
-                                             const El::Int*  __restrict__ label_indices,
+                                             IntType top_entries_ldim,
+                                             const IntType*  __restrict__ label_indices,
                                              DataType* __restrict__ loss,
-                                             El::Int loss_stride) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  const El::Int num_entries = width * k;
-  for (El::Int i = gid; i < num_entries; i += num_threads) {
+                                             IntType loss_stride) {
+  const IntType gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const IntType num_threads = blockDim.x * gridDim.x;
+  const IntType num_entries = width * k;
+  for (IntType i = gid; i < num_entries; i += num_threads) {
     const auto& ind = i % k;
     const auto& col = i / k;
     const auto& label_index = label_indices[col];
@@ -172,7 +172,7 @@ __global__ void compute_categorical_accuracy(El::Int k,
 
 /** GPU implementation of top-k categorical accuracy layer forward prop. */
 void fp_gpu(lbann_comm& comm,
-            El::Int k,
+            IntType k,
             const AbsDistMat& predictions,
             const AbsDistMat& labels,
             AbsDistMat& loss) {
@@ -187,9 +187,9 @@ void fp_gpu(lbann_comm& comm,
   const auto& local_predictions = predictions.LockedMatrix();
   const auto& local_labels = labels.LockedMatrix();
   auto& local_loss = loss.Matrix();
-  const El::Int height = predictions.Height();
-  const El::Int local_height = local_predictions.Height();
-  const El::Int local_width = local_predictions.Width();
+  const IntType height = predictions.Height();
+  const IntType local_height = local_predictions.Height();
+  const IntType local_width = local_predictions.Width();
 
   // Trivial cases
   if (k < 1) {
@@ -212,7 +212,7 @@ void fp_gpu(lbann_comm& comm,
   auto&& stream = El::GPUManager::Stream();
   cuda::thrust::allocator<> alloc(stream);
   using entry_array = thrust::device_vector<entry, cuda::thrust::allocator<entry>>;
-  using index_array = thrust::device_vector<El::Int, cuda::thrust::allocator<El::Int>>;
+  using index_array = thrust::device_vector<IntType, cuda::thrust::allocator<IntType>>;
 
   // Get label indices
   index_array label_indices(local_width);

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -45,8 +45,8 @@ void fp_cpu(lbann_comm& comm,
   const auto& mini_batch_size = input.Width();
   value = DataType(0);
 #pragma omp parallel for reduction(+:value) collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       value += local_input(row, col);
     }
   }
@@ -101,7 +101,7 @@ void fp_gpu(lbann_comm& comm,
     sum_d.Resize(local_width + 1, 1);
     ones_d.Resize(std::max(local_height, local_width), 1);
     El::Fill(ones_d, DataType(1));
-    for (El::Int col = 0; col < local_width; ++col) {
+    for (IntType col = 0; col < local_width; ++col) {
       cublas::dot(handle,
                   local_height,
                   local_input.LockedBuffer(0, col), 1,

--- a/src/metrics/boolean_accuracy.cpp
+++ b/src/metrics/boolean_accuracy.cpp
@@ -30,17 +30,17 @@ namespace lbann {
 
 EvalType boolean_accuracy_metric::evaluate_compute(const AbsDistMat& prediction,
                                                    const AbsDistMat& ground_truth) {
-  const El::Int height = prediction.Height();
-  const El::Int local_height = prediction.LocalHeight();
-  const El::Int local_width = prediction.LocalWidth();
+  const IntType height = prediction.Height();
+  const IntType local_height = prediction.LocalHeight();
+  const IntType local_width = prediction.LocalWidth();
   const Mat& prediction_local = prediction.LockedMatrix();
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of predictions.
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const bool true_val = ground_truth_local(row, col) > DataType(0.5);
       const bool pred_val = prediction_local(row, col) > DataType(0.5);
       sum += EvalType(true_val == pred_val);

--- a/src/metrics/boolean_false_negatives.cpp
+++ b/src/metrics/boolean_false_negatives.cpp
@@ -30,17 +30,17 @@ namespace lbann {
 
 EvalType boolean_false_negatives_metric::evaluate_compute(
   const AbsDistMat& prediction, const AbsDistMat& ground_truth) {
-  const El::Int height = prediction.Height();
-  const El::Int local_height = prediction.LocalHeight();
-  const El::Int local_width = prediction.LocalWidth();
+  const IntType height = prediction.Height();
+  const IntType local_height = prediction.LocalHeight();
+  const IntType local_width = prediction.LocalWidth();
   const Mat& prediction_local = prediction.LockedMatrix();
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of predictions.
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const bool true_val = ground_truth_local(row, col) > DataType(0.5);
       const bool pred_val = prediction_local(row, col) > DataType(0.5);
       sum += EvalType((true_val != pred_val) && true_val);

--- a/src/metrics/boolean_false_positives.cpp
+++ b/src/metrics/boolean_false_positives.cpp
@@ -30,17 +30,17 @@ namespace lbann {
 
 EvalType boolean_false_positives_metric::evaluate_compute(
   const AbsDistMat& prediction, const AbsDistMat& ground_truth) {
-  const El::Int height = prediction.Height();
-  const El::Int local_height = prediction.LocalHeight();
-  const El::Int local_width = prediction.LocalWidth();
+  const IntType height = prediction.Height();
+  const IntType local_height = prediction.LocalHeight();
+  const IntType local_width = prediction.LocalWidth();
   const Mat& prediction_local = prediction.LockedMatrix();
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Compute sum of predictions.
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const bool true_val = ground_truth_local(row, col) > DataType(0.5);
       const bool pred_val = prediction_local(row, col) > DataType(0.5);
       sum += EvalType((true_val != pred_val) && pred_val);

--- a/src/metrics/mean_absolute_deviation.cpp
+++ b/src/metrics/mean_absolute_deviation.cpp
@@ -43,8 +43,8 @@ EvalType mean_absolute_deviation_metric::evaluate_compute(const AbsDistMat& pred
   // Compute sum of squared errors
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = prediction_local(row, col);
       const EvalType error = true_val - pred_val;

--- a/src/metrics/mean_squared_error.cpp
+++ b/src/metrics/mean_squared_error.cpp
@@ -43,8 +43,8 @@ EvalType mean_squared_error_metric::evaluate_compute(const AbsDistMat& predictio
   // Compute sum of squared errors
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = prediction_local(row, col);
       const EvalType error = true_val - pred_val;

--- a/src/metrics/r2.cpp
+++ b/src/metrics/r2.cpp
@@ -51,8 +51,8 @@ EvalType r2_metric::evaluate_compute(const AbsDistMat& prediction,
   EvalType ss_res = 0;
   EvalType ss_tot = 0;
   #pragma omp parallel for reduction(+:ss_res,ss_tot) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = prediction_local(row, col);
       const EvalType val1 = true_val - pred_val;

--- a/src/objective_functions/loss_functions/binary_cross_entropy.cpp
+++ b/src/objective_functions/loss_functions/binary_cross_entropy.cpp
@@ -117,13 +117,13 @@ void binary_cross_entropy::differentiate_compute(const AbsDistMat& predictions,
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       #ifdef LBANN_DEBUG

--- a/src/objective_functions/loss_functions/cross_entropy.cpp
+++ b/src/objective_functions/loss_functions/cross_entropy.cpp
@@ -71,13 +71,13 @@ void cross_entropy::differentiate_compute(const AbsDistMat& predictions,
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       gradient_local(row, col) = (true_val != DataType(0) ?
                                   - true_val / predictions_local(row, col) :

--- a/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
+++ b/src/objective_functions/loss_functions/cross_entropy_with_uncertainty.cpp
@@ -146,13 +146,13 @@ void cross_entropy_with_uncertainty::differentiate_compute(const AbsDistMat& pre
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       DataType& grad_val = gradient_local(row, col);
       if (true_val != DataType(0)) {

--- a/src/objective_functions/loss_functions/geom_negloglike.cpp
+++ b/src/objective_functions/loss_functions/geom_negloglike.cpp
@@ -67,13 +67,13 @@ void geom_negloglike::differentiate_compute(const AbsDistMat& predictions,
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       gradient_local(row, col) = (true_val / (DataType(1) - pred_val)

--- a/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
+++ b/src/objective_functions/loss_functions/mean_absolute_deviation.cpp
@@ -36,16 +36,16 @@ EvalType mean_absolute_deviation_loss::finish_evaluate_compute(
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Matrix parameters
-  const El::Int height = predictions.Height();
-  const El::Int width = predictions.Width();
-  const El::Int local_height = predictions_local.Height();
-  const El::Int local_width = predictions_local.Width();
+  const IntType height = predictions.Height();
+  const IntType width = predictions.Width();
+  const IntType local_height = predictions_local.Height();
+  const IntType local_width = predictions_local.Width();
 
   // Compute sum of errors
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = predictions_local(row, col);
       const EvalType error = true_val - pred_val;
@@ -70,14 +70,14 @@ void mean_absolute_deviation_loss::differentiate_compute(const AbsDistMat& predi
 
   // Matrix parameters
   const int height = gradient.Height();
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   const DataType scale = DataType(1) / height;
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       DataType& grad_val = gradient_local(row, col);

--- a/src/objective_functions/loss_functions/mean_absolute_error.cpp
+++ b/src/objective_functions/loss_functions/mean_absolute_error.cpp
@@ -36,16 +36,16 @@ EvalType mean_absolute_error_loss::finish_evaluate_compute(
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Matrix parameters
-  const El::Int height = predictions.Height();
-  const El::Int width = predictions.Width();
-  const El::Int local_height = predictions_local.Height();
-  const El::Int local_width = predictions_local.Width();
+  const IntType height = predictions.Height();
+  const IntType width = predictions.Width();
+  const IntType local_height = predictions_local.Height();
+  const IntType local_width = predictions_local.Width();
 
   // Compute sum of absolute errors
   EvalType sum = 0;
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = predictions_local(row, col);
       const EvalType error = true_val - pred_val;
@@ -70,14 +70,14 @@ void mean_absolute_error_loss::differentiate_compute(const AbsDistMat& predictio
 
   // Matrix parameters
   const int height = gradient.Height();
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   const DataType scale = DataType(2) / height;
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       if(pred_val > true_val) {

--- a/src/objective_functions/loss_functions/mean_squared_error.cpp
+++ b/src/objective_functions/loss_functions/mean_squared_error.cpp
@@ -36,16 +36,16 @@ void mean_squared_error_loss::start_evaluate_compute(
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   // Matrix parameters
-  const El::Int height = predictions.Height();
-  const El::Int width = predictions.Width();
-  const El::Int local_height = predictions_local.Height();
-  const El::Int local_width = predictions_local.Width();
+  const IntType height = predictions.Height();
+  const IntType width = predictions.Width();
+  const IntType local_height = predictions_local.Height();
+  const IntType local_width = predictions_local.Width();
 
   // Compute sum of squared errors
   EvalType sum = EvalType(0);
   #pragma omp parallel for reduction(+:sum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const EvalType true_val = ground_truth_local(row, col);
       const EvalType pred_val = predictions_local(row, col);
       const EvalType error = true_val - pred_val;
@@ -74,14 +74,14 @@ void mean_squared_error_loss::differentiate_compute(const AbsDistMat& prediction
 
   // Matrix parameters
   const int height = gradient.Height();
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   const DataType scale = DataType(2) / height;
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       gradient_local(row, col) = (pred_val - true_val) * scale;

--- a/src/objective_functions/loss_functions/poisson_negloglike.cpp
+++ b/src/objective_functions/loss_functions/poisson_negloglike.cpp
@@ -68,13 +68,13 @@ void poisson_negloglike::differentiate_compute(const AbsDistMat& predictions,
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       gradient_local(row, col) = DataType(1) - true_val / pred_val; // \f[1 - k/\lambda\f]

--- a/src/objective_functions/loss_functions/polya_negloglike.cpp
+++ b/src/objective_functions/loss_functions/polya_negloglike.cpp
@@ -232,13 +232,13 @@ void polya_negloglike::differentiate_compute(const AbsDistMat& predictions,
   Mat& gradient_local = gradient.Matrix();
 
   // Matrix parameters
-  const El::Int local_height = gradient_local.Height();
-  const El::Int local_width = gradient_local.Width();
+  const IntType local_height = gradient_local.Height();
+  const IntType local_width = gradient_local.Width();
 
   // Compute gradient
   #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_width; ++col) {
-    for (El::Int row = 0; row < local_height; ++row) {
+  for (IntType col = 0; col < local_width; ++col) {
+    for (IntType row = 0; row < local_height; ++row) {
       const DataType true_val = ground_truth_local(row, col);
       const DataType pred_val = predictions_local(row, col);
       const DataType alpha_sum = alpha_sums_local(0, col);

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -34,24 +34,24 @@ namespace {
 
   /** Compute the entry-wise sum of squares of a local matrix. */
   EvalType sum_of_squares(const Mat& mat) {
-    const El::Int height = mat.Height();
-    const El::Int width = mat.Width();
-    const El::Int ldim = mat.LDim();
+    const IntType height = mat.Height();
+    const IntType width = mat.Width();
+    const IntType ldim = mat.LDim();
     const auto& __restrict__ buf = mat.LockedBuffer();
     EvalType sqsum = EvalType(0);
     if (ldim == height) {
       // Parallelize single loop if data is contiguous
-      const El::Int size = height*width;
+      const IntType size = height*width;
       #pragma omp parallel for reduction(+:sqsum)
-      for (El::Int i = 0; i < size; ++i) {
+      for (IntType i = 0; i < size; ++i) {
         const EvalType val = buf[i];
         sqsum += val * val;
       }
     } else {
       // Parallelize double loop if data is not contiguous
       #pragma omp parallel for reduction(+:sqsum) collapse(2)
-      for (El::Int j = 0; j < width; ++j) {
-        for (El::Int i = 0; i < height; ++i) {
+      for (IntType j = 0; j < width; ++j) {
+        for (IntType i = 0; i < height; ++i) {
           const EvalType val = buf[i + j*ldim];
           sqsum += val * val;
         }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -201,7 +201,7 @@ Layer* construct_layer(lbann_comm* comm,
   }
   if (proto_layer.has_slice()) {
     const auto& params = proto_layer.slice();
-    const auto& slice_points = parse_list<El::Int>(params.slice_points());
+    const auto& slice_points = parse_list<IntType>(params.slice_points());
     return new slice_layer<layout, Dev>(comm,
                                         params.slice_axis(),
                                         slice_points);

--- a/src/utils/quantizer.cpp
+++ b/src/utils/quantizer.cpp
@@ -45,27 +45,27 @@ lbann_quantizer::~lbann_quantizer() {
 void lbann_quantizer::onebit_quantize(
   const Mat& mat, QuantizedMatrix& qmat, Mat& qerror, bool sample) {
   // Set up the quantized matrix. (+2 for the averages.)
-  const El::Int qheight = get_onebit_quantized_matrix_height(mat);
-  const El::Int qwidth = mat.Width();
+  const IntType qheight = get_onebit_quantized_matrix_height(mat);
+  const IntType qwidth = mat.Width();
   qmat.Resize(qheight, qwidth);
 
-  const El::Int width = mat.Width();
-  const El::Int height = mat.Height();
-  const El::Int ldim = mat.LDim();
-  const El::Int qmat_ldim = qmat.LDim();
+  const IntType width = mat.Width();
+  const IntType height = mat.Height();
+  const IntType ldim = mat.LDim();
+  const IntType qmat_ldim = qmat.LDim();
   const DataType *__restrict__ mat_buf = mat.LockedBuffer();
   DataType *__restrict__ qerror_buf = qerror.Buffer();
   qtype *__restrict__ qmat_buf = qmat.Buffer();
   #pragma omp parallel for schedule(static)
-  for (El::Int col = 0; col < width; ++col) {
+  for (IntType col = 0; col < width; ++col) {
     // First compute the positive and negative column averages.
     DataType pos_sum = 0.0f;
     DataType neg_sum = 0.0f;
     El::Unsigned num_pos = 0;
     El::Unsigned num_neg = 0;
     if (height <= NUM_ONEBIT_SAMPLES || !sample) {
-      for (El::Int row = 0; row < height; ++row) {
-        const El::Int pos = row + col * ldim;
+      for (IntType row = 0; row < height; ++row) {
+        const IntType pos = row + col * ldim;
         const DataType val = mat_buf[pos] + qerror_buf[pos];
         if (val >= 0.0f) {
           pos_sum += val;
@@ -78,8 +78,8 @@ void lbann_quantizer::onebit_quantize(
     } else {
       // Randomly sample NUM_ONEBIT_SAMPLES to approximate.
       fast_rng_gen& gen = get_fast_generator();
-      for (El::Int i = 0; i < NUM_ONEBIT_SAMPLES; ++i) {
-        const El::Int pos = fast_rand_int(gen, height);
+      for (IntType i = 0; i < NUM_ONEBIT_SAMPLES; ++i) {
+        const IntType pos = fast_rand_int(gen, height);
         const DataType val = mat_buf[pos] + qerror_buf[pos];
         if (val >= 0.0f) {
           pos_sum += val;
@@ -109,15 +109,15 @@ void lbann_quantizer::onebit_quantize(
     qmat.Set(1, col, tmp);
 
     // Now quantize the column, NUM_BITS entries at a time.
-    El::Int qrow = 2;
-    for (El::Int row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
+    IntType qrow = 2;
+    for (IntType row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
       uqtype q = 0;
       for (uqtype bit = 0; bit < NUM_BITS; ++bit) {
-        El::Int row = row_chunk + bit;
+        IntType row = row_chunk + bit;
         if (row >= height) {
           break;
         }
-        const El::Int pos = row + col * ldim;
+        const IntType pos = row + col * ldim;
         const DataType val = mat_buf[pos] + qerror_buf[pos];
         if (val >= 0.0f) {
           q |= uqtype(1) << bit;
@@ -138,15 +138,15 @@ void lbann_quantizer::onebit_quantize(const DistMat& mat, QuantizedMatrix& qmat,
 }
 
 void lbann_quantizer::onebit_unquantize(const QuantizedMatrix& qmat, Mat& mat) {
-  const El::Int width = mat.Width();
-  const El::Int height = mat.Height();
-  const El::Int ldim = mat.LDim();
-  const El::Int qmat_ldim = qmat.LDim();
+  const IntType width = mat.Width();
+  const IntType height = mat.Height();
+  const IntType ldim = mat.LDim();
+  const IntType qmat_ldim = qmat.LDim();
   const qtype *__restrict__ qmat_buf = qmat.LockedBuffer();
   DataType *__restrict__ mat_buf = mat.Buffer();
   #pragma omp parallel for schedule(static)
-  for (El::Int col = 0; col < width; ++col) {
-    El::Int qrow = 2;
+  for (IntType col = 0; col < width; ++col) {
+    IntType qrow = 2;
     // Extract the averages.
     qtype tmp = qmat.Get(0, col);
     DataType avg_pos;
@@ -155,10 +155,10 @@ void lbann_quantizer::onebit_unquantize(const QuantizedMatrix& qmat, Mat& mat) {
     DataType avg_neg;
     memcpy(&avg_neg, &tmp, sizeof(avg_neg));
     // Unquantize this column.
-    for (El::Int row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
+    for (IntType row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
       auto q = (uqtype) qmat_buf[qrow + col * qmat_ldim];
       for (size_t bit = 0; bit < NUM_BITS; ++bit) {
-        El::Int row = row_chunk + bit;
+        IntType row = row_chunk + bit;
         if (row >= height) {
           break;
         }
@@ -176,15 +176,15 @@ void lbann_quantizer::onebit_unquantize(const QuantizedMatrix& qmat,
 
 void lbann_quantizer::onebit_unquantize_add(const QuantizedMatrix& qmat,
     Mat& mat) {
-  const El::Int width = mat.Width();
-  const El::Int height = mat.Height();
-  const El::Int ldim = mat.LDim();
-  const El::Int qmat_ldim = qmat.LDim();
+  const IntType width = mat.Width();
+  const IntType height = mat.Height();
+  const IntType ldim = mat.LDim();
+  const IntType qmat_ldim = qmat.LDim();
   const qtype *__restrict__ qmat_buf = qmat.LockedBuffer();
   DataType *__restrict__ mat_buf = mat.Buffer();
   #pragma omp parallel for schedule(static)
-  for (El::Int col = 0; col < width; ++col) {
-    El::Int qrow = 2;
+  for (IntType col = 0; col < width; ++col) {
+    IntType qrow = 2;
     // Extract the averages.
     qtype tmp = qmat.Get(0, col);
     DataType avg_pos;
@@ -193,10 +193,10 @@ void lbann_quantizer::onebit_unquantize_add(const QuantizedMatrix& qmat,
     DataType avg_neg;
     memcpy(&avg_neg, &tmp, sizeof(avg_neg));
     // Unquantize this column.
-    for (El::Int row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
+    for (IntType row_chunk = 0; row_chunk < height; row_chunk += NUM_BITS) {
       auto q = (uqtype) qmat_buf[qrow + col * qmat_ldim];
       for (size_t bit = 0; bit < NUM_BITS; ++bit) {
-        El::Int row = row_chunk + bit;
+        IntType row = row_chunk + bit;
         if (row >= height) {
           break;
         }
@@ -273,9 +273,9 @@ void lbann_quantizer::intermodel_sum_onebit_quantized(
 void lbann_quantizer::threshold_quantize(const Mat& mat, ThreshQuantized& quant,
     Mat& qerror, DataType pos_thresh,
     DataType neg_thresh, bool delta) {
-  const El::Int ldim = mat.LDim();
-  const El::Int width = mat.Width();
-  const El::Int height = mat.Height();
+  const IntType ldim = mat.LDim();
+  const IntType width = mat.Width();
+  const IntType height = mat.Height();
   if (ldim != qerror.LDim()) {
     std::cout << "ldims don't match!" << std::endl;
   }
@@ -284,8 +284,8 @@ void lbann_quantizer::threshold_quantize(const Mat& mat, ThreshQuantized& quant,
   std::vector<ThreshQuantized> thread_qs(omp_get_max_threads());
   if (delta) {
     El::Unsigned prev_pos = 0;
-    for (El::Int col = 0; col < width; ++col) {
-      for (El::Int row = 0; row < height; ++row) {
+    for (IntType col = 0; col < width; ++col) {
+      for (IntType row = 0; row < height; ++row) {
         const El::Unsigned pos = row + col * ldim;
         const DataType val = mat_buf[pos] + qerror_buf[pos];
         if (val >= pos_thresh) {
@@ -307,8 +307,8 @@ void lbann_quantizer::threshold_quantize(const Mat& mat, ThreshQuantized& quant,
     {
       const int tid = omp_get_thread_num();
       #pragma omp for schedule(static)
-      for (El::Int col = 0; col < width; ++col) {
-        for (El::Int row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
+        for (IntType row = 0; row < height; ++row) {
           const El::Unsigned pos = row + col * ldim;
           const DataType val = mat_buf[pos] + qerror_buf[pos];
           if (val >= pos_thresh) {
@@ -501,9 +501,9 @@ lbann_quantizer::adaptive_thresholds lbann_quantizer::proportion_threshold(
   const Mat& mat, const Mat& qerror, int proportion, bool sample) {
   double proportion_start = get_time();
   std::vector<DataType> entries;
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType *__restrict__ mat_buf = mat.LockedBuffer();
   const DataType *__restrict__ qerror_buf = qerror.LockedBuffer();
   // Bail out if needed.
@@ -513,9 +513,9 @@ lbann_quantizer::adaptive_thresholds lbann_quantizer::proportion_threshold(
   if (width * height <= NUM_THRESHOLD_SAMPLES || !sample) {
     // Copy entire matrix into vector.
     entries.reserve(width * height);
-    for (El::Int col = 0; col < width; ++col) {
-      const El::Int col_offset = col * ldim;
-      for (El::Int row = 0; row < height; ++row) {
+    for (IntType col = 0; col < width; ++col) {
+      const IntType col_offset = col * ldim;
+      for (IntType row = 0; row < height; ++row) {
         const El::Unsigned pos = row + col_offset;
         entries.emplace_back(mat_buf[pos] + qerror_buf[pos]);
       }
@@ -537,7 +537,7 @@ lbann_quantizer::adaptive_thresholds lbann_quantizer::proportion_threshold(
     }
   }
   // Determine the number of entries to keep.
-  El::Int num_to_keep = std::max(1, (int) entries.size() / proportion);
+  IntType num_to_keep = std::max(1, (int) entries.size() / proportion);
   // Determine the threshold values.
   // This finds the num_to_keep'th value if sample were sorted by magnitude
   // and assigns it to the appropriate threshold, then checks the upper portion
@@ -580,7 +580,7 @@ lbann_quantizer::adaptive_thresholds lbann_quantizer::proportion_threshold(
 }
 
 lbann_quantizer::adaptive_reconstructions lbann_quantizer::col_reconstruction(
-  const Mat& mat, const Mat& qerror, El::Int col,
+  const Mat& mat, const Mat& qerror, IntType col,
   const adaptive_thresholds threshes, bool sample) {
   DataType pos_sum = 0.0f;
   El::Unsigned pos_count = 0;
@@ -590,12 +590,12 @@ lbann_quantizer::adaptive_reconstructions lbann_quantizer::col_reconstruction(
   DataType zero_sum = 0.0f;
   El::Unsigned zero_count = 0;
 #endif
-  const El::Int height = mat.Height();
-  const El::Int col_offset = col * mat.LDim();
+  const IntType height = mat.Height();
+  const IntType col_offset = col * mat.LDim();
   const DataType *__restrict__ mat_buf = mat.LockedBuffer();
   const DataType *__restrict__ qerror_buf = qerror.LockedBuffer();
   if (height <= NUM_RECON_SAMPLES || !sample) {
-    for (El::Int row = 0; row < height; ++row) {
+    for (IntType row = 0; row < height; ++row) {
       const El::Unsigned pos = row + col_offset;
       const DataType val = mat_buf[pos] + qerror_buf[pos];
       if (val >= threshes.pos_thresh) {

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -220,7 +220,7 @@ void init_data_seq_random(int seed) {
 #endif
 }
 
-void gaussian_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType mean,
+void gaussian_fill(AbsDistMat& mat, IntType m, IntType n, DataType mean,
                    DataType stddev) {
 #ifndef LBANN_DETERMINISTIC
   El::Gaussian(mat, m, n, mean, stddev);
@@ -229,7 +229,7 @@ void gaussian_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType mean,
 #endif  // LBANN_PARALLEL_DETERMINISTIC
 }
 
-void bernoulli_fill(AbsDistMat& mat, El::Int m, El::Int n, double p) {
+void bernoulli_fill(AbsDistMat& mat, IntType m, IntType n, double p) {
 #ifndef LBANN_DETERMINISTIC
   El::Bernoulli(mat, m, n, p);
 #else
@@ -237,7 +237,7 @@ void bernoulli_fill(AbsDistMat& mat, El::Int m, El::Int n, double p) {
 #endif  // LBANN_PARALLEL_DETERMINISTIC
 }
 
-void uniform_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType center,
+void uniform_fill(AbsDistMat& mat, IntType m, IntType n, DataType center,
                   DataType radius) {
 #ifndef LBANN_DETERMINISTIC
   El::Uniform(mat, m, n, center, radius);
@@ -246,15 +246,15 @@ void uniform_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType center,
 #endif  // LBANN_PARALLEL_DETERMINISTIC
 }
 
-void gaussian_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, DataType mean,
+void gaussian_fill_procdet(AbsDistMat& mat, IntType m, IntType n, DataType mean,
                            DataType stddev) {
   CircMat<El::Device::CPU> vals(m, n, mat.Grid(), 0);
   if (vals.Participating()) {
     auto& local_vals = vals.Matrix();
     auto& gen = get_generator();
     std::normal_distribution<DataType> dist(mean, stddev);
-    for (El::Int col = 0; col < local_vals.Width(); ++col) {
-      for (El::Int row = 0; row < local_vals.Height(); ++row) {
+    for (IntType col = 0; col < local_vals.Width(); ++col) {
+      for (IntType row = 0; row < local_vals.Height(); ++row) {
         local_vals(row, col) = dist(gen);
       }
     }
@@ -262,14 +262,14 @@ void gaussian_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, DataType mean,
   El::Copy(vals, mat);
 }
 
-void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p) {
+void bernoulli_fill_procdet(AbsDistMat& mat, IntType m, IntType n, double p) {
   CircMat<El::Device::CPU> vals(m, n, mat.Grid(), 0);
   if (vals.Participating()) {
     auto& local_vals = vals.Matrix();
     auto& gen = get_generator();
     std::bernoulli_distribution dist(p);
-    for (El::Int col = 0; col < local_vals.Width(); ++col) {
-      for (El::Int row = 0; row < local_vals.Height(); ++row) {
+    for (IntType col = 0; col < local_vals.Width(); ++col) {
+      for (IntType row = 0; row < local_vals.Height(); ++row) {
         local_vals(row, col) = dist(gen);
       }
     }
@@ -277,7 +277,7 @@ void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p) {
   El::Copy(vals, mat);
 }
 
-void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, DataType center,
+void uniform_fill_procdet(AbsDistMat& mat, IntType m, IntType n, DataType center,
                           DataType radius) {
   CircMat<El::Device::CPU> vals(m, n, mat.Grid(), 0);
   if (vals.Participating()) {
@@ -285,8 +285,8 @@ void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, DataType center
     auto& gen = get_generator();
     std::uniform_real_distribution<DataType> dist(center - radius,
                                                   center + radius);
-    for (El::Int col = 0; col < local_vals.Width(); ++col) {
-      for (El::Int row = 0; row < local_vals.Height(); ++row) {
+    for (IntType col = 0; col < local_vals.Width(); ++col) {
+      for (IntType row = 0; row < local_vals.Height(); ++row) {
         local_vals(row, col) = dist(gen);
       }
     }

--- a/src/utils/statistics.cpp
+++ b/src/utils/statistics.cpp
@@ -38,16 +38,16 @@ void entrywise_mean_and_stdev(const Mat& data,
   // the loop.
 
   // Matrix dimensions
-  const El::Int height = data.Height();
-  const El::Int width = data.Width();
-  const El::Int size = height * width;
+  const IntType height = data.Height();
+  const IntType width = data.Width();
+  const IntType size = height * width;
 
   // Compute sums over matrix entries
   const DataType shift = data(0, 0);
   DataType shifted_sum = 0;
   DataType shifted_sqsum = 0;
-  for(El::Int col = 0; col < width; ++col) {
-    for(El::Int row = 0; row < height; ++row) {
+  for(IntType col = 0; col < width; ++col) {
+    for(IntType row = 0; row < height; ++row) {
       const DataType shifted_val = data(row, col) - shift;
       shifted_sum += shifted_val;
       shifted_sqsum += shifted_val * shifted_val;
@@ -69,9 +69,9 @@ void entrywise_mean_and_stdev(const AbsDistMat& data,
                               DataType& stdev) {
 
   // Matrix dimensions
-  const El::Int size = data.Height() * data.Width();
-  const El::Int local_height = data.LocalHeight();
-  const El::Int local_width = data.LocalWidth();
+  const IntType size = data.Height() * data.Width();
+  const IntType local_height = data.LocalHeight();
+  const IntType local_width = data.LocalWidth();
 
   // Local matrices
   const Mat& local_data = data.LockedMatrix();
@@ -80,8 +80,8 @@ void entrywise_mean_and_stdev(const AbsDistMat& data,
   DataType sum = 0;
   DataType sqsum = 0;
   #pragma omp parallel for reduction(+:sum,sqsum) collapse(2)
-  for(El::Int col = 0; col < local_width; ++col) {
-    for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType col = 0; col < local_width; ++col) {
+    for(IntType row = 0; row < local_height; ++row) {
       const DataType val = local_data(row, col);
       sum += val;
       sqsum += val * val;
@@ -102,8 +102,8 @@ void columnwise_mean_and_stdev(const Mat& data,
                                Mat& stdevs) {
 
   // Matrix dimensions
-  const El::Int height = data.Height();
-  const El::Int width = data.Width();
+  const IntType height = data.Height();
+  const IntType width = data.Width();
 
   // Initialize outputs
   means.Resize(1, width);
@@ -111,11 +111,11 @@ void columnwise_mean_and_stdev(const Mat& data,
 
   // Compute mean and standard deviation of each matrix column
   #pragma omp parallel for
-  for(El::Int col = 0; col < width; ++col) {
+  for(IntType col = 0; col < width; ++col) {
     const DataType shift = data(0, col);
     DataType shifted_sum = 0;
     DataType shifted_sqsum = 0;
-    for(El::Int row = 0; row < height; ++row) {
+    for(IntType row = 0; row < height; ++row) {
       const DataType shifted_val = data(row, col) - shift;
       shifted_sum += shifted_val;
       shifted_sqsum += shifted_val * shifted_val;
@@ -148,9 +148,9 @@ void columnwise_sums_and_sqsums(const AbsDistMat& data,
 #endif // #ifdef LBANN_DEBUG
 
   // Matrix dimensions
-  const El::Int width = data.Width();
-  const El::Int local_height = data.LocalHeight();
-  const El::Int local_width = data.LocalWidth();
+  const IntType width = data.Width();
+  const IntType local_height = data.LocalHeight();
+  const IntType local_width = data.LocalWidth();
 
   // Initialize outputs
   sums.Resize(1, width);
@@ -163,10 +163,10 @@ void columnwise_sums_and_sqsums(const AbsDistMat& data,
 
   // Compute sum and sum of squares of each matrix column
   #pragma omp parallel for
-  for(El::Int col = 0; col < local_width; ++col) {
+  for(IntType col = 0; col < local_width; ++col) {
     DataType sum_val = 0;
     DataType sqsum_val = 0;
-    for(El::Int row = 0; row < local_height; ++row) {
+    for(IntType row = 0; row < local_height; ++row) {
       const DataType val = local_data(row, col);
       sum_val += val;
       sqsum_val += val * val;
@@ -196,15 +196,15 @@ void columnwise_mean_and_stdev(const AbsDistMat& data,
 #endif // #ifdef LBANN_DEBUG
 
   // Matrix dimensions
-  const El::Int height = data.Height();
-  const El::Int local_width = data.LocalWidth();
+  const IntType height = data.Height();
+  const IntType local_width = data.LocalWidth();
 
   columnwise_sums_and_sqsums(data, means, stdevs);
   // Local matrices
   Mat& local_means = means.Matrix();
   Mat& local_stdevs = stdevs.Matrix();
 
-  for(El::Int col = 0; col < local_width; ++col) {
+  for(IntType col = 0; col < local_width; ++col) {
     const DataType mean = local_means(0, col) / height;
     const DataType sqmean = local_stdevs(0, col) / height;
     const DataType var = std::max(sqmean - mean * mean, DataType(0));
@@ -220,34 +220,34 @@ void rowwise_mean_and_stdev(const Mat& data,
                             Mat& stdevs) {
 
   // Matrix dimensions
-  const El::Int height = data.Height();
-  const El::Int width = data.Width();
+  const IntType height = data.Height();
+  const IntType width = data.Width();
 
   // Initialize outputs
   means.Resize(height, 1);
   stdevs.Resize(height, 1);
 
   // Iterate through row blocks
-  const El::Int block_size = 16;
+  const IntType block_size = 16;
   #pragma omp parallel for
-  for(El::Int row_start = 0; row_start < height; row_start += block_size) {
-    const El::Int row_end = std::min(row_start + block_size, height);
+  for(IntType row_start = 0; row_start < height; row_start += block_size) {
+    const IntType row_end = std::min(row_start + block_size, height);
 
     // Initialize shift and sums for each row
     auto *shifts = new DataType[block_size];
-    for(El::Int row = row_start; row < row_end; ++row) {
+    for(IntType row = row_start; row < row_end; ++row) {
       means(row, 0) = 0;
       stdevs(row, 0) = 0;
       shifts[row-row_start] = data(row, 0);
     }
 
     // Iterate through blocks in row block
-    for(El::Int col_start = 0; col_start < width; col_start += block_size) {
-      const El::Int col_end = std::min(col_start + block_size, width);
+    for(IntType col_start = 0; col_start < width; col_start += block_size) {
+      const IntType col_end = std::min(col_start + block_size, width);
 
       // Compute sums by iterating through block entries
-      for(El::Int col = col_start; col < col_end; ++col) {
-        for(El::Int row = row_start; row < row_end; ++row) {
+      for(IntType col = col_start; col < col_end; ++col) {
+        for(IntType row = row_start; row < row_end; ++row) {
           const DataType shift = shifts[row - row_start];
           const DataType shifted_val = data(row, col) - shift;
           means(row, 0) += shifted_val;
@@ -258,7 +258,7 @@ void rowwise_mean_and_stdev(const Mat& data,
     }
 
     // Compute mean and standard deviation of each row
-    for(El::Int row = row_start; row < row_end; ++row) {
+    for(IntType row = row_start; row < row_end; ++row) {
       const DataType shifted_mean = means(row, 0) / width;
       const DataType shifted_sqmean = stdevs(row, 0) / width;
       const DataType mean = shifted_mean + shifts[row - row_start];
@@ -292,9 +292,9 @@ void rowwise_sums_and_sqsums(const AbsDistMat& data,
 #endif // #ifdef LBANN_DEBUG
 
   // Matrix dimensions
-  const El::Int height = data.Height();
-  const El::Int local_height = data.LocalHeight();
-  const El::Int local_width = data.LocalWidth();
+  const IntType height = data.Height();
+  const IntType local_height = data.LocalHeight();
+  const IntType local_width = data.LocalWidth();
 
   // Initialize outputs
   sums.Resize(height, 1);
@@ -306,18 +306,18 @@ void rowwise_sums_and_sqsums(const AbsDistMat& data,
   Mat& local_sqsum = sqsums.Matrix();
 
   // Iterate through row blocks
-  const El::Int block_size = 16;
+  const IntType block_size = 16;
   #pragma omp parallel for
-  for(El::Int row_start = 0; row_start < local_height; row_start += block_size) {
-    const El::Int row_end = std::min(row_start + block_size, local_height);
+  for(IntType row_start = 0; row_start < local_height; row_start += block_size) {
+    const IntType row_end = std::min(row_start + block_size, local_height);
 
     // Iterate through blocks in row block
-    for(El::Int col_start = 0; col_start < local_width; col_start += block_size) {
-      const El::Int col_end = std::min(col_start + block_size, local_width);
+    for(IntType col_start = 0; col_start < local_width; col_start += block_size) {
+      const IntType col_end = std::min(col_start + block_size, local_width);
 
       // Compute sums by iterating through block entries
-      for(El::Int col = col_start; col < col_end; ++col) {
-        for(El::Int row = row_start; row < row_end; ++row) {
+      for(IntType col = col_start; col < col_end; ++col) {
+        for(IntType row = row_start; row < row_end; ++row) {
           const DataType val = local_data(row, col);
           local_sum(row, 0) += val;
           local_sqsum(row, 0) += val * val;
@@ -340,8 +340,8 @@ void rowwise_mean_and_stdev(const AbsDistMat& data,
                             AbsDistMat& stdevs) {
 
 
-  const El::Int width = data.Width();
-  const El::Int local_height = data.LocalHeight();
+  const IntType width = data.Width();
+  const IntType local_height = data.LocalHeight();
 
   rowwise_sums_and_sqsums(data, means, stdevs);
 
@@ -351,7 +351,7 @@ void rowwise_mean_and_stdev(const AbsDistMat& data,
 
   // Compute mean and standard deviation of each matrix row
   #pragma omp parallel for
-  for(El::Int row = 0; row < local_height; ++row) {
+  for(IntType row = 0; row < local_height; ++row) {
     const DataType mean = local_means(row, 0) / width;
     const DataType sqmean = local_stdevs(row, 0) / width;
     const DataType var = std::max(sqmean - mean * mean, DataType(0));
@@ -383,10 +383,10 @@ void columnwise_covariance(const AbsDistMat& data1,
   }
 
   // Matrix dimensions
-  const El::Int height = data1.Height();
-  const El::Int width = data1.Width();
-  const El::Int local_height = data1.LocalHeight();
-  const El::Int local_width = data1.LocalWidth();
+  const IntType height = data1.Height();
+  const IntType width = data1.Width();
+  const IntType local_height = data1.LocalHeight();
+  const IntType local_width = data1.LocalWidth();
 
   // Initialize covariance
   covs.Resize(1, width);
@@ -400,11 +400,11 @@ void columnwise_covariance(const AbsDistMat& data1,
 
   // Accumulate sum and divide to get covariance
   #pragma omp parallel for
-  for(El::Int col = 0; col < local_width; ++col) {
+  for(IntType col = 0; col < local_width; ++col) {
     DataType sum = 0;
     const DataType mean1 = local_means1(0, col);
     const DataType mean2 = local_means2(0, col);
-    for(El::Int row = 0; row < local_height; ++row) {
+    for(IntType row = 0; row < local_height; ++row) {
       const DataType val1 = local_data1(row, col);
       const DataType val2 = local_data2(row, col);
       sum += (val1 - mean1) * (val2 - mean2);

--- a/src/utils/summary.cpp
+++ b/src/utils/summary.cpp
@@ -461,21 +461,21 @@ void lbann_summary::flush_histograms() {
 
 DataType lbann_summary::local_sum(const Mat& mat) const {
   // Note there are more numerically stable ways to compute a sum.
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType * __restrict__ mat_buf = mat.LockedBuffer();
   auto sum = DataType(0);
   if (ldim == height) {
-    const El::Int size = height*width;
+    const IntType size = height*width;
 #pragma omp parallel for reduction(+:sum)
-    for (El::Int i = 0; i < size; ++i) {
+    for (IntType i = 0; i < size; ++i) {
       sum += mat_buf[i];
     }
   } else {
 #pragma omp parallel for reduction(+:sum) collapse(2)
-    for (El::Int row = 0; row < height; ++row) {
-      for (El::Int col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
         sum += mat_buf[row + col * ldim];
       }
     }
@@ -486,24 +486,24 @@ DataType lbann_summary::local_sum(const Mat& mat) const {
 void lbann_summary::local_sum_sqsum(
   const Mat& mat, DataType& sum, DataType& sqsum) const {
   // Note there are more numerically stable ways to compute a sum.
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType * __restrict__ mat_buf = mat.LockedBuffer();
   sum = DataType(0);
   sqsum = DataType(0);
   if (ldim == height) {
-    const El::Int size = height*width;
+    const IntType size = height*width;
 #pragma omp parallel for reduction(+:sum,sqsum)
-    for (El::Int i = 0; i < size; ++i) {
+    for (IntType i = 0; i < size; ++i) {
       const DataType val = mat_buf[i];
       sum += val;
       sqsum += val*val;
     }
   } else {
 #pragma omp parallel for reduction(+:sum,sqsum) collapse(2)
-    for (El::Int row = 0; row < height; ++row) {
-      for (El::Int col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
         const DataType val = mat_buf[row + col*ldim];
         sum += val;
         sqsum += val * val;
@@ -513,21 +513,21 @@ void lbann_summary::local_sum_sqsum(
 }
 
 DataType lbann_summary::local_min(const Mat& mat) const {
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType * __restrict__ mat_buf = mat.LockedBuffer();
   auto min = std::numeric_limits<DataType>::max();
   if (ldim == height) {
-    const El::Int size = height*width;
+    const IntType size = height*width;
 #pragma omp parallel for reduction(min:min)
-    for (El::Int i = 0; i < size; ++i) {
+    for (IntType i = 0; i < size; ++i) {
       min = std::min(min, mat_buf[i]);
     }
   } else {
 #pragma omp parallel for reduction(min:min) collapse(2)
-    for (El::Int row = 0; row < height; ++row) {
-      for (El::Int col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
         min = std::min(min, mat_buf[row + col*ldim]);
       }
     }
@@ -536,21 +536,21 @@ DataType lbann_summary::local_min(const Mat& mat) const {
 }
 
 DataType lbann_summary::local_max(const Mat& mat) const {
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType * __restrict__ mat_buf = mat.LockedBuffer();
   auto max = std::numeric_limits<DataType>::min();
   if (ldim == height) {
-    const El::Int size = height*width;
+    const IntType size = height*width;
 #pragma omp parallel for reduction(max:max)
-    for (El::Int i = 0; i < size; ++i) {
+    for (IntType i = 0; i < size; ++i) {
       max = std::max(max, mat_buf[i]);
     }
   } else {
 #pragma omp parallel for reduction(max:max) collapse(2)
-    for (El::Int row = 0; row < height; ++row) {
-      for (El::Int col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
         max = std::max(max, mat_buf[row + col*ldim]);
       }
     }
@@ -560,21 +560,21 @@ DataType lbann_summary::local_max(const Mat& mat) const {
 
 DataType lbann_summary::local_2norm(const Mat& mat) const {
   // Note there are more numerically stable ways to compute this.
-  const El::Int height = mat.Height();
-  const El::Int width = mat.Width();
-  const El::Int ldim = mat.LDim();
+  const IntType height = mat.Height();
+  const IntType width = mat.Width();
+  const IntType ldim = mat.LDim();
   const DataType * __restrict__ mat_buf = mat.LockedBuffer();
   auto norm = DataType(0);
   if (ldim == height) {
-    const El::Int size = height*width;
+    const IntType size = height*width;
 #pragma omp parallel for reduction(+:norm)
-    for (El::Int i = 0; i < size; ++i) {
+    for (IntType i = 0; i < size; ++i) {
       norm += mat_buf[i] * mat_buf[i];
     }
   } else {
 #pragma omp parallel for reduction(+:norm) collapse(2)
-    for (El::Int row = 0; row < height; ++row) {
-      for (El::Int col = 0; col < width; ++col) {
+    for (IntType row = 0; row < height; ++row) {
+      for (IntType col = 0; col < width; ++col) {
         norm += mat_buf[row + col * ldim] * mat_buf[row + col * ldim];
       }
     }

--- a/src/weights/variance_scaling_initializers.cpp
+++ b/src/weights/variance_scaling_initializers.cpp
@@ -72,21 +72,21 @@ void variance_scaling_initializer::fill(AbsDistMat& matrix) {
     std::stringstream err;
     err << "variance scaling initializer is only supported with "
         << "Gaussian and uniform probability distributions "
-        << "(dist=" << El::Int(m_prob_dist) << ")";
+        << "(dist=" << IntType(m_prob_dist) << ")";
     LBANN_ERROR(err.str());
   }
   
 }
 
-DataType glorot_initializer::get_variance(El::Int fan_in, El::Int fan_out) {
+DataType glorot_initializer::get_variance(IntType fan_in, IntType fan_out) {
   return DataType(2) / (fan_in + fan_out);
 }
 
-DataType he_initializer::get_variance(El::Int fan_in, El::Int fan_out) {
+DataType he_initializer::get_variance(IntType fan_in, IntType fan_out) {
   return DataType(2) / fan_in;
 }
 
-DataType lecun_initializer::get_variance(El::Int fan_in, El::Int fan_out) {
+DataType lecun_initializer::get_variance(IntType fan_in, IntType fan_out) {
   return DataType(1) / fan_in;
 }
 

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -395,8 +395,8 @@ void weights::write_proto(lbann_data::WeightsData* proto) const {
   values.SetRoot(0); /// @todo What if world master is not process 0?
   if (m_comm->am_world_master()) {
     const auto& local_values = values.LockedMatrix();
-    const El::Int height = local_values.Height();
-    const El::Int width = local_values.Width();
+    const IntType height = local_values.Height();
+    const IntType width = local_values.Width();
     /// @todo OpenMP parallelization
     /** @todo Our matrices are column-major while Numpy expects
      *  row-major matrices. This row-wise iteration is fine for
@@ -405,8 +405,8 @@ void weights::write_proto(lbann_data::WeightsData* proto) const {
      *  matrix. This is what we need for quantization on convolution
      *  kernel weights.
      */
-    for (El::Int i = 0; i < height; ++i) {
-      for (El::Int j = 0; j < width; ++j) {
+    for (IntType i = 0; i < height; ++i) {
+      for (IntType j = 0; j < width; ++j) {
         proto->add_data(local_values(i,j));
       }
     }


### PR DESCRIPTION
This is preparatory work toward using a consistent integer datatype (see Issue #91). This pull requests adds the `IntType` type, which is just a typedef of `El::Int`. Then it find-replaces every instance of `El::Int` into an `IntType`. There are no other changes.

The next step is to change the `int` type into `IntType`, which will be much more non-trivial.