### PR TITLE
Fix build failure on Surface

### DIFF
--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -271,10 +271,10 @@ case ${SCHEDULER} in
         MPIRUN="srun --nodes=${NUM_NODES} --ntasks=${NUM_PROCS}"
         case ${CLUSTER} in
             surface|ray)
-                MPIRUN="${MPIRUN} --nvidia_compute_mode=default"
+                MPIRUN="${MPIRUN} --mpibind=off --nvidia_compute_mode=default"
                 ;;
             pascal)
-                MPIRUN="${MPIRUN} --mpibind=off --cpu_bind=mask_cpu:0x000001ff,0x0003fe00  --nvidia_compute_mode=default"
+                MPIRUN="${MPIRUN} --mpibind=off --nvidia_compute_mode=default --cpu_bind=mask_cpu:0x000001ff,0x0003fe00"
                 ;;
         esac
         MPIRUN1="srun --nodes=${NUM_NODES} --ntasks=${NUM_NODES}"

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -10,11 +10,10 @@ ARCH=$(uname -m)
 ################################################################
 
 COMPILER=gnu
-if [ "${CLUSTER}" == "pascal" ]; then
-	# The latest GCC version on Pascal is 7, which is not supported by nvcc.
-	# Version 6.1.0 does not work with CUDA 9.1, either.
-	COMPILER=gnu
-	module load gcc/4.9.3
+if [ "${CLUSTER}" == "surface" -o "${CLUSTER}" == "pascal" ]; then
+    # NVCC in CUDA 9.1 does not support GCC versions later than 6
+    COMPILER=gnu
+    module load gcc/4.9.3
 fi
 if [ "${ARCH}" == "x86_64" ]; then
     MPI=mvapich2
@@ -301,13 +300,8 @@ if [ ${USE_MODULES} -ne 0 ]; then
     module load cmake/3.9.2
     CMAKE_PATH=$(dirname $(which cmake))
 else
-    if [ "${CLUSTER}" == "surface" ]; then
-        use git-2.8.0
-        CMAKE_PATH=/usr/workspace/wsb/brain/utils/toss2/cmake-3.9.6/bin
-    else
-        use git
-        CMAKE_PATH=/usr/workspace/wsb/brain/utils/toss2/cmake-3.9.6/bin
-    fi
+    use git
+    CMAKE_PATH=/usr/workspace/wsb/brain/utils/toss2/cmake-3.9.6/bin
 fi
 
 if [ ${CLUSTER} == "ray" -o ${CLUSTER} == "sierra" ]; then


### PR DESCRIPTION
The TOSS 3 update on Surface broke the build script, so this attempts to fix some of the issues. LBANN now builds correctly on Surface, but crashes in MVAPICH during runtime:
```text
[surface146:mpi_rank_0][cudaipc_init_dynamic] [src/mpid/ch3/channels/mrail/src/gen2/ibv_cuda_ipc.c:486] cuda failed with 11
```
The corresponding CUDA error is `cudaErrorInvalidValue`, so some API call is being fed something wrong.

Of course, it may be worthwhile to completely abandon Surface now that it its reaching the end of its life. If we take this option, we should scrub it from our build scripts, experiment scripts, and documentation to make clear we no longer support it.