### PR TITLE
Reconcile redundant weight values after each epoch

### DIFF
--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -344,6 +344,11 @@ class model {
   virtual void update_weights();
   /** Update layers step. */
   virtual bool update_layers();
+  /** Reconcile weight values.
+   *  If weight values are duplicated across multiple processes, they
+   *  are set to the average across the processes.
+   */
+  virtual void reconcile_weight_values();
 
   ////////////////////////////////////////////////////////////
   // Callbacks

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -181,6 +181,17 @@ public:
   /** Set an entry in the weight matrix. */
   void set_value(DataType value, int row, int col);
 
+  /** Reconcile weight values.
+   *  If weight values are duplicated across multiple processes, they
+   *  are set to the average across the processes.
+   */
+  void reconcile_values();
+  /** Asynchronously reconcile weight values.
+   *  If weight values are duplicated across multiple processes, they
+   *  are set to the average across the processes.
+   */
+  void reconcile_values(Al::request& req);
+  
   // -----------------------------------------------
   // Freezing
   // -----------------------------------------------

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -360,6 +360,22 @@ void weights::set_value(DataType value, int row, int col) {
 
 }
 
+void weights::reconcile_values() {
+  auto& values = get_values();
+  if (values.RedundantSize() > 1) {
+    values *= DataType(1) / values.RedundantSize();
+    m_comm->allreduce(values, values.RedundantComm());
+  }
+}
+
+void weights::reconcile_values(Al::request& req) {
+  auto& values = get_values();
+  if (values.RedundantSize() > 1) {
+    values *= DataType(1) / values.RedundantSize();
+    m_comm->nb_allreduce(values, values.RedundantComm(), req);
+  }
+}
+  
 // -----------------------------------------------
 // Checkpointing
 // -----------------------------------------------


### PR DESCRIPTION
Many of our weights are stored redundantly, especially for data-parallel layers, and we perform computation independently during the update step. This is very nice for reducing communication, but it opens the door for numerical errors to accumulate. Pessimistically, training a model on ImageNet-1K involves ~5000 update steps per epoch, ~100 epochs, and ~1e-7 numerical error at each step. I think it would be good practice to periodically make sure all of our processes actually have the same weight values. This is roughly as expensive as a backprop step, but it only happens once per epoch.

Hopefully this will improve the divergence we're seeing in DenseNet (see #303), but it's far from certain. We got reasonable results on AlexNet and Resnet-50, so numerical error in these cases were relatively small or not disruptive.

### Validation
- Gradient checks on model_zoo/tests/model_mnist_conv_graph.prototext come back clean. (c46d86d)
- Reasonable results with AlexNet on ImageNet-10 (14.8%/58.8% top-1/top-5 training accuracy, 7.88 training objective function, 27.7%/75.4% top-1/top-5 validation accuracy, 7.23 validation objective function, 19.1s training time for epoch 0 on 1 Pascal node). (c46d86d)
- Observed a performance regression with Resnet-50 on ImageNet-1K (average of 1230 sec/epoch with 16 Pascal nodes, excluding first epoch). I need to run experiments on the develop branch to see whether this regression is meaningful. (c46d86d)