### PR TITLE
Use the exported conduit targets in the FindCONDUIT module

### DIFF
--- a/cmake/modules/FindCONDUIT.cmake
+++ b/cmake/modules/FindCONDUIT.cmake
@@ -3,61 +3,38 @@
 #   - CONDUIT_LIBRARIES
 #   - CONDUIT_INCLUDE_DIRS
 #
-# Also creates an imported target CONDUIT
 
-# Find the header
-find_path(CONDUIT_INCLUDE_DIRS conduit/conduit_relay.h
+find_file(CONDUIT_CMAKE_FILE conduit.cmake
   HINTS ${LBANN_CONDUIT_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
-  PATH_SUFFIXES include
+  PATH_SUFFIXES lib/cmake lib/cmake/conduit
   NO_DEFAULT_PATH
-  DOC "Directory with CONDUIT header.")
-find_path(CONDUIT_INCLUDE_DIRS conduit/conduit_relay.h)
+  DOC "CONDUIT target file.")
+find_file(CONDUIT_CMAKE_FILE conduit.cmake)
 
-# Find the library
-find_library(CONDUIT_RELAY_LIBRARY conduit_relay
-  HINTS ${LBANN_CONDUIT_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
-  PATH_SUFFIXES lib64 lib
-  NO_DEFAULT_PATH
-  DOC "The CONDUIT_RELAY library.")
-find_library(CONDUIT_RELAY_LIBRARY conduit_relay)
-
-# Find the library
-find_library(CONDUIT_LIBRARY conduit
-  HINTS ${LBANN_CONDUIT_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
-  PATH_SUFFIXES lib64 lib
-  NO_DEFAULT_PATH
-  DOC "The CONDUIT library.")
-find_library(CONDUIT_LIBRARY conduit)
+if (CONDUIT_CMAKE_FILE AND NOT TARGET conduit)
+  include("${CONDUIT_CMAKE_FILE}")
+endif ()
 
 # Standard handling of the package arguments
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CONDUIT
-  DEFAULT_MSG
-  CONDUIT_RELAY_LIBRARY CONDUIT_LIBRARY CONDUIT_INCLUDE_DIRS)
+  DEFAULT_MSG CONDUIT_CMAKE_FILE)
 
 # Setup the imported target
 if (NOT TARGET CONDUIT::CONDUIT)
   add_library(CONDUIT::CONDUIT INTERFACE IMPORTED)
 endif (NOT TARGET CONDUIT::CONDUIT)
 
-# Set the include directories for the target
-set_property(TARGET CONDUIT::CONDUIT APPEND
-  PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CONDUIT_INCLUDE_DIRS})
-
 # Set the link libraries for the target
 set_property(TARGET CONDUIT::CONDUIT APPEND
-  PROPERTY INTERFACE_LINK_LIBRARIES ${CONDUIT_RELAY_LIBRARY})
-set_property(TARGET CONDUIT::CONDUIT APPEND
-  PROPERTY INTERFACE_LINK_LIBRARIES ${CONDUIT_LIBRARY})
+  PROPERTY INTERFACE_LINK_LIBRARIES conduit conduit_relay conduit_blueprint)
 
 #
 # Cleanup
 #
 
 # Set the include directories
-mark_as_advanced(FORCE CONDUIT_INCLUDE_DIRS)
+mark_as_advanced(FORCE CONDUIT_CMAKE_FILE)
 
 # Set the libraries
 set(CONDUIT_LIBRARIES CONDUIT::CONDUIT)
-mark_as_advanced(FORCE CONDUIT_RELAY_LIBRARY)
-mark_as_advanced(FORCE CONDUIT_LIBRARY)

--- a/cmake/modules/FindCONDUIT.cmake
+++ b/cmake/modules/FindCONDUIT.cmake
@@ -11,6 +11,13 @@ find_file(CONDUIT_CMAKE_FILE conduit.cmake
   DOC "CONDUIT target file.")
 find_file(CONDUIT_CMAKE_FILE conduit.cmake)
 
+find_path(CONDUIT_INCLUDE_DIRS conduit/conduit_relay.h
+  HINTS ${LBANN_CONDUIT_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
+  PATH_SUFFIXES include
+  NO_DEFAULT_PATH
+  DOC "Directory with CONDUIT header.")
+find_path(CONDUIT_INCLUDE_DIRS conduit/conduit_relay.h)
+
 if (CONDUIT_CMAKE_FILE AND NOT TARGET conduit)
   include("${CONDUIT_CMAKE_FILE}")
 endif ()
@@ -28,6 +35,9 @@ endif (NOT TARGET CONDUIT::CONDUIT)
 # Set the link libraries for the target
 set_property(TARGET CONDUIT::CONDUIT APPEND
   PROPERTY INTERFACE_LINK_LIBRARIES conduit conduit_relay conduit_blueprint)
+
+set_property(TARGET CONDUIT::CONDUIT APPEND
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CONDUIT_INCLUDE_DIRS}")
 
 #
 # Cleanup


### PR DESCRIPTION
Modify the FindCONDUIT module to work with the exported conduit targets. Hopefully addresses some of @JaeseungYeom build issues.