### PR TITLE
fix jag_store macro check on conduit existence

### DIFF
--- a/include/lbann/data_store/jag_store.hpp
+++ b/include/lbann/data_store/jag_store.hpp
@@ -27,9 +27,9 @@
 #ifndef _JAG_STORE_HPP__
 #define _JAG_STORE_HPP__
 
-#ifdef LBANN_HAS_CONDUIT
-
 #include "lbann_config.hpp" 
+
+#ifdef LBANN_HAS_CONDUIT
 
 #include "conduit/conduit.hpp"
 #include "conduit/conduit_relay.hpp"

--- a/src/data_store/jag_store.cpp
+++ b/src/data_store/jag_store.cpp
@@ -1,6 +1,7 @@
+#include "lbann/data_store/jag_store.hpp"
+
 #ifdef LBANN_HAS_CONDUIT
 
-#include "lbann/data_store/jag_store.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/options.hpp"


### PR DESCRIPTION
Fix the order of the macro definition check and the inclusion of the header that defines the macro definition
Together with PR #575, this PR fixes the issue #566.