### PR TITLE
Debugging VRAM

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -9,6 +9,7 @@ set_full_path(THIS_DIR_HEADERS
   callback_debug.hpp
   callback_debug_io.hpp
   callback_dump_activations.hpp
+  callback_dump_error_signals.hpp
   callback_dump_gradients.hpp
   callback_dump_minibatch_sample_indices.hpp
   callback_dump_weights.hpp

--- a/include/lbann/callbacks/callback_dump_error_signals.hpp
+++ b/include/lbann/callbacks/callback_dump_error_signals.hpp
@@ -1,0 +1,63 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_DUMP_ERROR_SIGNALS_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_DUMP_ERROR_SIGNALS_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+
+namespace lbann {
+
+/** Dump gradients w.r.t. inputs to file.
+ *  After each layer performs a backward prop step, this callback will
+ *  dump the gradients w.r.t. inputs (the "error signals") to a
+ *  human-readable ASCII file. This is slow and produces a lot of output.
+ */
+class lbann_callback_dump_error_signals : public lbann_callback {
+ public:
+
+  /** Constructor.
+   *  @param basename The basename for output files.
+   */
+  lbann_callback_dump_error_signals(std::string basename = "")
+    : lbann_callback(), m_basename(basename) {}
+  lbann_callback_dump_error_signals* copy() const override {
+    return new lbann_callback_dump_error_signals(*this);
+  }
+  std::string name() const override { return "dump error signals"; }
+
+  /** Write error signals to file after each backward prop step. */
+  void on_backward_prop_end(model *m, Layer *l) override;
+  
+ private:
+  /** Basename for output files. */
+  std::string m_basename;
+
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_CALLBACKS_CALLBACK_DUMP_ERROR_SIGNALS_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -151,6 +151,7 @@
 #include "lbann/callbacks/callback_imcomm.hpp"
 #include "lbann/callbacks/callback_dump_weights.hpp"
 #include "lbann/callbacks/callback_dump_activations.hpp"
+#include "lbann/callbacks/callback_dump_error_signals.hpp"
 #include "lbann/callbacks/callback_dump_gradients.hpp"
 #include "lbann/callbacks/callback_dump_minibatch_sample_indices.hpp"
 #include "lbann/callbacks/callback_early_stopping.hpp"

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -149,14 +149,16 @@ public:
   /** Allocate GPU buffer. */
   pointer allocate(size_type size) {
     value_type* buffer = nullptr;
+    if (size > 0) {
 #ifdef HYDROGEN_HAVE_CUB
-    auto& memory_pool = El::cub::MemoryPool();
-    CHECK_CUDA(memory_pool.DeviceAllocate(reinterpret_cast<void**>(&buffer),
-                                          size * sizeof(value_type),
-                                          m_stream));
+      auto& memory_pool = El::cub::MemoryPool();
+      CHECK_CUDA(memory_pool.DeviceAllocate(reinterpret_cast<void**>(&buffer),
+                                            size * sizeof(value_type),
+                                            m_stream));
 #else
-    CHECK_CUDA(cudaMalloc(&buffer, size * sizeof(value_type)));
+      CHECK_CUDA(cudaMalloc(&buffer, size * sizeof(value_type)));
 #endif // HYDROGEN_HAVE_CUB
+    }
     return pointer(buffer);
   }
 
@@ -164,12 +166,15 @@ public:
    *  'size' is unused and maintained for compatibility with Thrust.
    */
   void deallocate(pointer buffer, size_type size = 0) {
+    auto&& ptr = buffer.get();
+    if (ptr != nullptr) {
 #ifdef HYDROGEN_HAVE_CUB
-    auto& memory_pool = El::cub::MemoryPool();
-    CHECK_CUDA(memory_pool.DeviceFree(buffer.get()));
+      auto& memory_pool = El::cub::MemoryPool();
+      CHECK_CUDA(memory_pool.DeviceFree(ptr));
 #else
-    CHECK_CUDA(cudaFree(buffer.get()));
+      CHECK_CUDA(cudaFree(ptr));
 #endif // HYDROGEN_HAVE_CUB
+    }
   }
 
 };

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -46,8 +46,9 @@
     const cudnnStatus_t status_CHECK_CUDNN = (cudnn_call);      \
     if (status_CHECK_CUDNN != CUDNN_STATUS_SUCCESS) {           \
       cudaDeviceReset();                                        \
-      LBANN_ERROR(std::string("cuDNN error: ")                  \
-                  + cudnnGetErrorString(status_CHECK_CUDNN));   \
+      LBANN_ERROR(std::string("cuDNN error (")                  \
+                  + cudnnGetErrorString(status_CHECK_CUDNN)     \
+                  + std::string(")"));                          \
     }                                                           \
     LBANN_CUDA_SYNC(false);                                     \
   } while (0)

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -9,6 +9,7 @@ set_full_path(THIS_DIR_SOURCES
   callback_debug.cpp
   callback_debug_io.cpp
   callback_dump_activations.cpp
+  callback_dump_error_signals.cpp
   callback_dump_gradients.cpp
   callback_dump_minibatch_sample_indices.cpp
   callback_dump_weights.cpp

--- a/src/callbacks/callback_dump_error_signals.cpp
+++ b/src/callbacks/callback_dump_error_signals.cpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_dump_error_signals.hpp"
+
+namespace lbann {
+
+void lbann_callback_dump_error_signals::on_backward_prop_end(model *m, Layer *l) {
+
+  // Write each activation matrix to file
+  for (int i = 0; i < l->get_num_parents(); ++i) {
+
+    // File name
+    std::stringstream file;
+    file << m_basename
+         << "model" << m->get_comm()->get_model_rank() << "-"
+         << "epoch" << m->get_cur_epoch() << "-"
+         << "step" << m->get_cur_step() << "-"
+         << l->get_name() << "-"
+         << "ErrorSignals";
+    if (l->get_num_parents() > 1) { file << i; }
+
+    // Write activations to file
+    El::Write(l->get_error_signals(i), file.str(), El::ASCII);
+
+  }
+
+}
+
+}  // namespace lbann

--- a/src/layers/activations/CMakeLists.txt
+++ b/src/layers/activations/CMakeLists.txt
@@ -9,6 +9,7 @@ if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
     abs.cu
+    relu.cu
     sigmoid.cu
     softmax.cu
     )

--- a/src/layers/activations/relu.cpp
+++ b/src/layers/activations/relu.cpp
@@ -28,7 +28,6 @@
 
 namespace lbann {
 
-// Model-parallel CPU forward/backward prop
 template <>
 void relu_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::fp_compute() {
   entrywise_activation_layer::fp_compute_cpu();
@@ -37,8 +36,6 @@ template <>
 void relu_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::bp_compute() {
   entrywise_activation_layer::bp_compute_cpu();
 }
-
-// Data-parallel CPU forward/backward prop
 template <>
 void relu_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
   entrywise_activation_layer::fp_compute_cpu();
@@ -47,110 +44,5 @@ template <>
 void relu_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
   entrywise_activation_layer::bp_compute_cpu();
 }
-
-#ifdef LBANN_HAS_GPU
-
-// Model-parallel GPU forward/backward prop
-template <>
-void relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
-#ifndef LBANN_HAS_CUDNN
-  LBANN_ERROR("cuDNN not detected");
-#else
-  const DataType zero = DataType(0);
-  const DataType one = DataType(1);
-  const auto& local_input = get_local_prev_activations();
-  auto& local_output = get_local_activations();
-  if (local_input.Height() > 0 && local_input.Width() > 0) {
-    CHECK_CUDNN(cudnnActivationForward(cudnn::get_handle(),
-                                       m_activation_cudnn_desc,
-                                       &one,
-                                       m_tensors_cudnn_desc.get_prev_activations(),
-                                       local_input.LockedBuffer(),
-                                       &zero,
-                                       m_tensors_cudnn_desc.get_activations(),
-                                       local_output.Buffer()));
-  }
-#endif // LBANN_HAS_CUDNN
-}
-
-template <>
-void relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
-#ifndef LBANN_HAS_CUDNN
-  LBANN_ERROR("cuDNN not detected");
-#else
-  const DataType zero = DataType(0);
-  const DataType one = DataType(1);
-  const auto& local_input = get_local_prev_activations();
-  const auto& local_output = get_local_activations();
-  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
-  auto& local_gradient_wrt_input = get_local_error_signals();
-  if (local_input.Height() > 0 && local_input.Width() > 0) {
-    CHECK_CUDNN(cudnnActivationBackward(cudnn::get_handle(),
-                                        m_activation_cudnn_desc,
-                                        &one,
-                                        m_tensors_cudnn_desc.get_activations(),
-                                        local_output.LockedBuffer(),
-                                        m_tensors_cudnn_desc.get_prev_error_signals(),
-                                        local_gradient_wrt_output.LockedBuffer(),
-                                        m_tensors_cudnn_desc.get_prev_activations(),
-                                        local_input.LockedBuffer(),
-                                        &zero,
-                                        m_tensors_cudnn_desc.get_error_signals(),
-                                        local_gradient_wrt_input.Buffer()));
-  }
-#endif // LBANN_HAS_CUDNN
-}
-
-// Data-parallel GPU forward/backward prop
-template <>
-void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
-#ifndef LBANN_HAS_CUDNN
-  LBANN_ERROR("cuDNN not detected");
-#else
-  const DataType zero = DataType(0);
-  const DataType one = DataType(1);
-  const auto& local_input = get_local_prev_activations();
-  auto& local_output = get_local_activations();
-  if (local_input.Height() > 0 && local_input.Width() > 0) {
-    CHECK_CUDNN(cudnnActivationForward(cudnn::get_handle(),
-                                       m_activation_cudnn_desc,
-                                       &one,
-                                       m_tensors_cudnn_desc.get_prev_activations(),
-                                       local_input.LockedBuffer(),
-                                       &zero,
-                                       m_tensors_cudnn_desc.get_activations(),
-                                       local_output.Buffer()));
-  }
-#endif // LBANN_HAS_CUDNN
-}
-template <>
-void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
-#ifndef LBANN_HAS_CUDNN
-  LBANN_ERROR("cuDNN not detected");
-#else
-  const DataType zero = DataType(0);
-  const DataType one = DataType(1);
-  const auto& local_input = get_local_prev_activations();
-  const auto& local_output = get_local_activations();
-  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
-  auto& local_gradient_wrt_input = get_local_error_signals();
-  if (local_input.Height() > 0 && local_input.Width() > 0) {
-    CHECK_CUDNN(cudnnActivationBackward(cudnn::get_handle(),
-                                        m_activation_cudnn_desc,
-                                        &one,
-                                        m_tensors_cudnn_desc.get_activations(),
-                                        local_output.LockedBuffer(),
-                                        m_tensors_cudnn_desc.get_prev_error_signals(),
-                                        local_gradient_wrt_output.LockedBuffer(),
-                                        m_tensors_cudnn_desc.get_prev_activations(),
-                                        local_input.LockedBuffer(),
-                                        &zero,
-                                        m_tensors_cudnn_desc.get_error_signals(),
-                                        local_gradient_wrt_input.Buffer()));
-  }
-#endif // LBANN_HAS_CUDNN
-}
-
-#endif // LBANN_HAS_GPU
 
 } // namespace lbann

--- a/src/layers/activations/relu.cu
+++ b/src/layers/activations/relu.cu
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/activations/relu.hpp"
+#include "lbann/utils/cuda.hpp"
+
+namespace lbann {
+namespace {
+
+__global__ void fp_kernel(int height, int width,
+                          const DataType* __restrict__ input,
+                          int input_leading_dim,
+                          DataType* __restrict__ output,
+                          int output_leading_dim) {
+  const auto& gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& size = height * width;
+  const auto& num_threads = blockDim.x * gridDim.x;
+  for (int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_leading_dim];
+    auto& y = output[row + col * output_leading_dim];
+    y = cuda::max(x, DataType(0));
+  }
+}
+
+__global__ void bp_kernel(int height, int width,
+                          const DataType* __restrict__ input,
+                          int input_leading_dim,
+                          const DataType* __restrict__ gradient_wrt_output,
+                          int gradient_wrt_output_leading_dim,
+                          DataType* __restrict__ gradient_wrt_input,
+                          int gradient_wrt_input_leading_dim) {
+  const auto& gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& size = height * width;
+  const auto& num_threads = blockDim.x * gridDim.x;
+  for (int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_leading_dim];
+    const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_leading_dim];
+    auto& dx = gradient_wrt_input[row + col * gradient_wrt_input_leading_dim];
+    if (x > DataType(0)) {
+      dx = dy;
+    } else {
+      dx = DataType(0);
+    }
+  }
+}
+
+void fp(const AbsMat& input, AbsMat& output) {
+  const auto& height = input.Height();
+  const auto& width = input.Width();
+  const auto& block_dim = 256;
+  const auto& grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    fp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+      height, width,
+      input.LockedBuffer(), input.LDim(),
+      output.Buffer(), output.LDim());
+  }
+}
+
+void bp(const AbsMat& input,
+        const AbsMat& gradient_wrt_output,
+        AbsMat& gradient_wrt_input) {
+  const auto& height = input.Height();
+  const auto& width = input.Width();
+  const auto& block_dim = 256;
+  const auto& grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    bp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+      height, width,
+      input.LockedBuffer(), input.LDim(),
+      gradient_wrt_output.LockedBuffer(), gradient_wrt_output.LDim(),
+      gradient_wrt_input.Buffer(), gradient_wrt_input.LDim());
+  }
+}
+
+} // namespace
+
+template <>
+void relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
+  fp(get_local_prev_activations(), get_local_activations());
+}
+template <>
+void relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
+  bp(get_local_prev_activations(),
+     get_local_prev_error_signals(),
+     get_local_error_signals());
+}
+template <>
+void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+  fp(get_local_prev_activations(), get_local_activations());
+}
+template <>
+void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
+  bp(get_local_prev_activations(),
+     get_local_prev_error_signals(),
+     get_local_error_signals());
+}
+  
+} // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -341,6 +341,10 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                                params.interval(),
                                                layer_names);
   }
+  if (proto_cb.has_dump_error_signals()) {
+    const auto& params = proto_cb.dump_error_signals();
+    return new lbann_callback_dump_error_signals(params.basename());
+  }
   if (proto_cb.has_dump_gradients()) {
     const auto& params = proto_cb.dump_gradients();
     return new lbann_callback_dump_gradients(params.basename(),

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -275,10 +275,7 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_crop()) {
     const auto& params = proto_layer.crop();
     const auto& dims = parse_list<int>(params.dims());
-    if (layout == data_layout::DATA_PARALLEL
-        && Dev == El::Device::CPU) {
-      return new crop_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(comm, dims);
-    }
+    return new crop_layer<layout, Dev>(comm, dims);
   }
   if (proto_layer.has_categorical_random()) {
     if (layout == data_layout::DATA_PARALLEL

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -412,6 +412,7 @@ message Callback {
    CallbackSummary summary = 3;
    CallbackDumpWeights dump_weights = 4;
    CallbackDumpActivations dump_activations = 5;
+   CallbackDumpErrorSignals dump_error_signals = 35;
    CallbackDumpGradients dump_gradients = 6;
    CallbackDumpMBIndices dump_mb_indices = 7;
    CallbackDispIOStats disp_io_stats = 8;
@@ -498,6 +499,10 @@ message CallbackDumpActivations {
   int64 interval = 2;
   string layer_names = 3; //layer(s) at which to dump activations e.g., "relu1 relu4 relu12"
 
+}
+
+message CallbackDumpErrorSignals {
+  string basename = 1;
 }
 
 message CallbackDumpGradients {

--- a/viz/.gitignore
+++ b/viz/.gitignore
@@ -1,0 +1,2 @@
+graph.dot
+graph.pdf


### PR DESCRIPTION
### Description
This PR is made up of miscellaneous changes to fix runtime errors in VRAM. VRAM now runs, although I need to do some more finangling to get it to learn.

### Changelog:
- Reimplemented the crop layer. It now has a GPU implementation and (inefficient) model-parallel implementation.
- Added a callback that dumps error signals to file.
- The GPU ReLU layer now uses custom CUDA kernels. It turns out cuDNN activation functions make certain assumptions when tensor data isn't contiguous (e.g. when activations and error signals are matrix views). It's easier to write CUDA kernels than to work around cuDNN's limitations.
- Added a .gitignore file to hide model visualizer output files.

### Validation
- Gradient checks on model_zoo/tests/model_mnist_conv_graph.prototext come back clean. (05e1fcd)
- Reasonable results with AlexNet on ImageNet-10 (15.0%/59.0% top-1/top-5 training accuracy, 7.87 training objective function, 27.7%/75.4% top-1/top-5 validation accuracy, 7.23 validation objective function, 15.9s training time for epoch 0 on 1 Pascal node). (05e1fcd)
- No change in performance with Resnet-50 on ImageNet-1K with 16 Pascal nodes (1083 sec/epoch in 05e1fcd vs 1062 sec/epoch in d9923f8).