### PR TITLE
Update profiling annotations

### DIFF
--- a/include/lbann/callbacks/profiler.hpp
+++ b/include/lbann/callbacks/profiler.hpp
@@ -45,14 +45,24 @@ class lbann_callback_profiler : public lbann_callback {
   }
   void on_epoch_begin(model *m) override;
   void on_epoch_end(model *m) override;
+  void on_validation_begin(model *m) override;
+  void on_validation_end(model *m) override;
+  void on_test_begin(model *m) override;
+  void on_test_end(model *m) override;
   void on_batch_begin(model *m) override;
   void on_batch_end(model *m) override;
+  void on_batch_evaluate_begin(model *m) override;
+  void on_batch_evaluate_end(model *m) override;
   void on_forward_prop_begin(model *m) override;
   void on_forward_prop_end(model *m) override;
+  void on_evaluate_forward_prop_begin(model *m) override;
+  void on_evaluate_forward_prop_end(model *m) override;
   void on_backward_prop_begin(model *m) override;
   void on_backward_prop_end(model *m) override;
   void on_forward_prop_begin(model *m, Layer *l) override;
   void on_forward_prop_end(model *m, Layer *l) override;
+  void on_evaluate_forward_prop_begin(model *m, Layer *l) override;
+  void on_evaluate_forward_prop_end(model *m, Layer *l) override;
   void on_backward_prop_begin(model *m, Layer *l) override;
   void on_backward_prop_end(model *m, Layer *l) override;
   void on_optimize_begin(model *m) override;
@@ -61,12 +71,6 @@ class lbann_callback_profiler : public lbann_callback {
   void on_optimize_end(model *m, weights *w) override;
   std::string name() const override { return "profiler"; }
  private:
-  static const int num_colors = 20;
-  // http://there4.io/2012/05/02/google-chart-color-list/
-  const int colors[num_colors] = {0x3366CC, 0xDC3912, 0xFF9900, 0x109618, 0x990099, 0x3B3EAC,
-                                  0x0099C6, 0xDD4477, 0x66AA00, 0xB82E2E, 0x316395, 0x994499,
-                                  0x22AA99, 0xAAAA11, 0x6633CC, 0xE67300, 0x8B0707, 0x329262,
-                                  0x5574A6, 0x3B3EAC};
   /** Get a color to use in the profiler for a layer. */
   int get_color(Layer *l);
   /** Whether to synchronize the when setting up profile regions. */

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -12,6 +12,7 @@ set_full_path(THIS_DIR_HEADERS
   number_theory.hpp
   omp_diagnostics.hpp
   options.hpp
+  profiling.hpp
   prototext.hpp
   quantizer.hpp
   quantizer_impl.hpp

--- a/include/lbann/utils/profiling.hpp
+++ b/include/lbann/utils/profiling.hpp
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// profiling .hpp .cpp - Various routines for interfacing with profilers
+///////////////////////////////////////////////////////////////////////////////
+
+namespace lbann {
+
+// Colors to use for profiling.
+constexpr int num_prof_colors = 20;
+// http://there4.io/2012/05/02/google-chart-color-list/
+constexpr int prof_colors[num_prof_colors] = {
+  0x3366CC, 0xDC3912, 0xFF9900, 0x109618, 0x990099, 0x3B3EAC,
+  0x0099C6, 0xDD4477, 0x66AA00, 0xB82E2E, 0x316395, 0x994499,
+  0x22AA99, 0xAAAA11, 0x6633CC, 0xE67300, 0x8B0707, 0x329262,
+  0x5574A6, 0x3B3EAC};
+
+void prof_region_begin(const char *s, int c, bool sync);
+void prof_region_end(const char *s, bool sync);
+
+}  // namespace lbann

--- a/src/callbacks/callback_summary.cpp
+++ b/src/callbacks/callback_summary.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/callback_summary.hpp"
+#include "lbann/utils/profiling.hpp"
 
 namespace lbann {
 
@@ -45,6 +46,7 @@ void lbann_callback_summary::on_train_begin(model *m) {
 }
 
 void lbann_callback_summary::on_batch_end(model *m) {
+  prof_region_begin("summary-batch", prof_colors[0], false);
   m->summarize_stats(*m_summarizer);
   if (m_mat_interval > 0 && m->get_cur_step() % m_mat_interval == 0) {
     m->summarize_matrices(*m_summarizer);
@@ -65,9 +67,11 @@ void lbann_callback_summary::on_batch_end(model *m) {
                               m->get_cur_step());
   m_summarizer->reduce_scalar("global_barriers", global_barriers,
                               m->get_cur_step());
+  prof_region_end("summary-batch", false);
 }
 
 void lbann_callback_summary::on_epoch_end(model *m) {
+  prof_region_begin("summary-epoch", prof_colors[0], false);
   for (const auto& met : m->get_metrics()) {
     EvalType train_score = met->get_mean_value(m->get_execution_mode());
     // Replace spaces with _ for consistency.
@@ -79,9 +83,11 @@ void lbann_callback_summary::on_epoch_end(model *m) {
   }
   save_histograms(m);
   m_summarizer->flush();
+  prof_region_end("summary-epoch", false);
 }
 
 void lbann_callback_summary::on_test_end(model *m) {
+  prof_region_begin("summary-test", prof_colors[0], false);
   lbann_comm *comm = m->get_comm();
   for (auto&& met : m->get_metrics()) {
     EvalType test_score = met->get_mean_value(m->get_execution_mode());
@@ -97,6 +103,7 @@ void lbann_callback_summary::on_test_end(model *m) {
   for (auto&& layer : m->get_layers()) {
     layer->reset_counters();
   }
+  prof_region_end("summary-test", false);
 }
 
 void lbann_callback_summary::save_histograms(model *m) {

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,7 @@ set_full_path(THIS_DIR_SOURCES
   number_theory.cpp
   omp_diagnostics.cpp
   options.cpp
+  profiling.cpp
   protobuf_utils.cpp
   quantizer.cpp
   random.cpp

--- a/src/utils/profiling.cpp
+++ b/src/utils/profiling.cpp
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// profiling .hpp .cpp - Various routines for interfacing with profilers
+///////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/base.hpp"
+#include "lbann/utils/profiling.hpp"
+#if defined(LBANN_SCOREP)
+#include <scorep/SCOREP_User.h>
+#elif defined(LBANN_NVPROF)
+#include "nvToolsExt.h"
+#include "nvToolsExtCuda.h"
+#include "nvToolsExtCudaRt.h"
+#include "cuda_runtime.h"
+#endif
+
+namespace lbann {
+
+#if defined(LBANN_SCOREP)
+void prof_region_begin(const char *s, int, bool) {
+  SCOREP_USER_REGION_BY_NAME_BEGIN(s, SCOREP_USER_REGION_TYPE_COMMON);
+  return;
+}
+void prof_region_end(const char *s, bool) {
+  SCOREP_USER_REGION_BY_NAME_END(s);
+  return;
+}
+#elif defined(LBANN_NVPROF)
+void prof_region_begin(const char *s, int c, bool sync) {
+  if (sync) {
+    El::GPUManager::SynchronizeDevice();
+  }
+  // Doesn't work with gcc 4.9
+  // nvtxEventAttributes_t ev = {0};
+  nvtxEventAttributes_t ev;  
+  memset(&ev, 0, sizeof(nvtxEventAttributes_t));
+  ev.version = NVTX_VERSION;   
+  ev.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+  ev.colorType = NVTX_COLOR_ARGB;
+  ev.color = c;
+  ev.messageType = NVTX_MESSAGE_TYPE_ASCII;     
+  ev.message.ascii = s; 
+  nvtxRangePushEx(&ev);
+}
+void prof_region_end(const char *, bool sync) {
+  if (sync) {
+    El::GPUManager::SynchronizeDevice();
+  }
+  nvtxRangePop();
+}
+#else
+void prof_region_begin(const char *, int, bool) {
+  return;
+}
+void prof_region_end(const char *, bool) {
+  return;
+}
+#endif
+
+}  // namespace lbann


### PR DESCRIPTION
This adds profiling annotations to validation, testing, and the summarizer. The summarizer is included because it can be rather expensive and this helps explain a lot of what is otherwise whitespace.

I also moved some code around to facilitate adding profiling annotations elsewhere if/when needed.