### PR TITLE
Stick to CMake 3.9.2 as the latest version, 3.12.1, has several issues

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -305,7 +305,8 @@ else
 fi
 
 if [ ${CLUSTER} == "ray" -o ${CLUSTER} == "sierra" ]; then
-    module load cmake
+	# the latest version, 3.12.1, has several issues
+    module load cmake/3.9.2
     CMAKE_PATH=$(dirname $(which cmake))
 fi
 


### PR DESCRIPTION
At least nvcc doesn't work. @benson31 also sees some more issues.