### PR TITLE
Remove redundant gradient clearing

### DIFF
--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -275,9 +275,6 @@ void optimizer::step() {
     LBANN_ERROR(err.str());
   }
 
-  // Clear gradients
-  clear_gradient();
-
   m_step_time += get_time() - step_start;
 
 }


### PR DESCRIPTION
We call each optimizer's `clear_gradient` method twice, which is redundant. The first call is at the beginning of `train_mini_batch`, prior to beginning forward prop. The second call is at the end of each optimizer's `step` method. This results in a significant number of unneeded memsets. @timmoon10 suggested leaving the one at the beginning of each mini-batch and eliding the call at the end of each optimization step.

Checked ResNet-50 on Pascal and saw no performance issues and learning looked fine. Passes gradient checking with `model_mnist_conv_graph.prototext` (on eight nodes).

Would appreciate a second look over to make sure this doesn't affect some of our stranger cases like weight sharing.