### PR TITLE
enable partitioning 1B jag dataset amongst data readers

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -36,6 +36,7 @@
 #include "lbann/io/file_io.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/data_readers/image_preprocessor.hpp"
+#include "lbann/utils/options.hpp"
 #include <cassert>
 #include <algorithm>
 #include <string>
@@ -92,7 +93,8 @@ class generic_data_reader : public lbann_image_preprocessor {
     m_is_partitioned(false),
     m_partition_overlap(0),
     m_partition_mode(0),
-    m_procs_per_partition(1)
+    m_procs_per_partition(1),
+    m_jag_partitioned(false)
   {}
   generic_data_reader(const generic_data_reader&) = default;
   generic_data_reader& operator=(const generic_data_reader&) = default;
@@ -232,6 +234,13 @@ class generic_data_reader : public lbann_image_preprocessor {
    */
   virtual void set_role(std::string role) {
     m_role = role;
+    if (options::get()->has_string("jag_partitioned")
+        && get_role() == "train") {
+      m_jag_partitioned = true;
+      if (is_master()) {
+        std::cerr << "USING JAG DATA PARTITIONING\n";
+      }
+    }
   }
 
   /**
@@ -357,7 +366,11 @@ class generic_data_reader : public lbann_image_preprocessor {
   }
   /// Set the sample stride
   void set_sample_stride(const int s) {
-    m_sample_stride = s;
+    if (m_jag_partitioned) {
+      m_sample_stride = 1;
+    } else {
+      m_sample_stride = s;
+    }
   }
   /// Return the sample stride.
   int get_sample_stride() const {
@@ -373,7 +386,11 @@ class generic_data_reader : public lbann_image_preprocessor {
   }
   /// Return the base offset.
   void set_base_offset(const int s) {
-    m_base_offset = s;
+    if (m_jag_partitioned) {
+      m_base_offset = 0;
+    } else {
+      m_base_offset = s;
+    }
   }
   /// Return the base offset.
   int get_base_offset() const {
@@ -838,6 +855,10 @@ class generic_data_reader : public lbann_image_preprocessor {
    int m_procs_per_partition;
 
   std::vector<std::vector<char>> m_thread_buffer;
+
+  /// special handling for 1B jag; each reader
+  /// owns a unique subset of the data
+  bool m_jag_partitioned;
 };
 
 template<typename T>


### PR DESCRIPTION
To turn on the partitioning, include the cmd line option --jag_partitioned