### PR TITLE
Temporarily move Bamboo tests from Spack to superbuild

### DIFF
--- a/bamboo/compiler_tests/build_script.sh
+++ b/bamboo/compiler_tests/build_script.sh
@@ -1,7 +1,53 @@
+set -e
 CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
+LBANN_DIR=$(git rev-parse --show-toplevel)
+DEBUG=''
 if [ "${CLUSTER}" != 'surface' ]; then
     source /usr/share/lmod/lmod/init/bash
     source /etc/profile.d/00-modulepath.sh
 fi
-LBANN_DIR=$(git rev-parse --show-toplevel)
-${LBANN_DIR}/scripts/build_lbann_lc.sh
+
+while :; do
+    case ${1} in
+        --compiler)
+            # Choose compiler
+            if [ -n "${2}" ]; then
+                COMPILER=${2}
+                shift
+            else
+                echo "\"${1}\" option requires a non-empty option argument" >&2
+                exit 1
+            fi
+            ;;
+
+        -d|--debug)
+            # Debug mode
+            DEBUG='--debug'
+            ;;
+        *)
+            # Break loop if there are no more options
+            break
+
+    esac
+    shift
+done
+
+if [ "${COMPILER}" == 'clang' ]; then
+    module load clang/4.0.0
+    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler clang ${DEBUG} --reconfigure
+fi
+
+if [ "${COMPILER}" == 'intel' ]; then
+    module load intel/18.0.0
+    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler intel ${DEBUG} --reconfigure
+fi
+
+if [ "${COMPILER}" == 'gcc4' ]; then
+    module load gcc/4.9.3
+    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler gnu ${DEBUG} --reconfigure
+fi
+
+if [ "${COMPILER}" == 'gcc7' ]; then
+    module load gcc/7.1.0
+    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler gnu ${DEBUG} --reconfigure
+fi

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -1,10 +1,14 @@
 import pytest
 import os, re, subprocess
 
-def test_compiler_build_script(cluster, dirname):
-    output_file_name = '%s/bamboo/compiler_tests/output/build_script_output.txt' % (dirname)
-    error_file_name = '%s/bamboo/compiler_tests/error/build_script_error.txt' % (dirname)
-    command = '%s/bamboo/compiler_tests/build_script.sh > %s 2> %s' % (dirname, output_file_name, error_file_name)
+def build_script(cluster, dirname, compiler, debug):
+    if debug:
+        build = 'debug'
+    else:
+        build = 'release'
+    output_file_name = '%s/bamboo/compiler_tests/output/%s_%s_%s_output.txt' % (dirname, cluster, compiler, build)
+    error_file_name = '%s/bamboo/compiler_tests/error/%s_%s_%s_error.txt' % (dirname, cluster, compiler, build)
+    command = '%s/bamboo/compiler_tests/build_script.sh --compiler %s %s> %s 2> %s' % (dirname, compiler, debug, output_file_name, error_file_name)
     return_code = os.system(command)
     if return_code != 0:
         output_file = open(output_file_name, 'r')
@@ -16,28 +20,54 @@ def test_compiler_build_script(cluster, dirname):
     assert return_code == 0
 
 def test_compiler_clang4_release(cluster, dirname):
-    skeleton_clang4(cluster, dirname, False)
+    #skeleton_clang4(cluster, dirname, False)
+    if cluster in ['ray', 'catalyst']:
+        build_script(cluster, dirname, 'clang', '')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def test_compiler_clang4_debug(cluster, dirname):
-    skeleton_clang4(cluster, dirname, True)
+    #skeleton_clang4(cluster, dirname, True)
+    if cluster in ['ray', 'catalyst']:
+        build_script(cluster, dirname, 'clang', '--debug')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def test_compiler_gcc4_release(cluster, dirname):
-    skeleton_gcc4(cluster, dirname, False)
+    #skeleton_gcc4(cluster, dirname, False)
+    build_script(cluster, dirname, 'gcc4', '')
 
 def test_compiler_gcc4_debug(cluster, dirname):
-    skeleton_gcc4(cluster, dirname, True)
+    #skeleton_gcc4(cluster, dirname, True)
+    build_script(cluster, dirname, 'gcc4', '--debug')
 
 def test_compiler_gcc7_release(cluster, dirname):
-    skeleton_gcc7(cluster, dirname, False)
+    #skeleton_gcc7(cluster, dirname, False)
+    if cluster == 'catalyst':
+        build_script(cluster, dirname, 'gcc7', '')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def test_compiler_gcc7_debug(cluster, dirname):
-    skeleton_gcc7(cluster, dirname, True)
+    #skeleton_gcc7(cluster, dirname, True)
+    if cluster == 'catalyst':
+        build_script(cluster, dirname, 'gcc7', '--debug')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def test_compiler_intel18_release(cluster, dirname):
-    skeleton_intel18(cluster, dirname, False)
+    #skeleton_intel18(cluster, dirname, False)
+    if cluster == 'catalyst':
+        build_script(cluster, dirname, 'intel', '')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def test_compiler_intel18_debug(cluster, dirname):
-    skeleton_intel18(cluster, dirname, True)
+    #skeleton_intel18(cluster, dirname, True)
+    if cluster == 'catalyst':
+        build_script(cluster, dirname, 'intel', '--debug')
+    else:
+        pytest.skip('Unsupported Cluster %s' % cluster)
 
 def skeleton_clang4(cluster, dir_name, debug, should_log=False):
     if cluster in ['catalyst', 'quartz']:

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -6,22 +6,26 @@ def pytest_addoption(parser):
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if cluster in ['catalyst', 'quartz']:
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/build/clang.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/build/intel.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
-        default_exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4_debug'] = '%s/build/clang.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7_debug'] = '%s/build/gnu.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18_debug'] = '%s/build/intel.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster == 'ray':
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/build/clang.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+
+        default_exes['clang4_debug'] = '%s/build/clang.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
+        default_exes['gcc4_debug'] = '%s/build/gnu.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
     if cluster in ['surface', 'pascal']:
         default_exes['gcc4'] = default_exes['default']
+        default_exes['gcc4_debug'] = '%s/build/gnu.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
 
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -6,18 +6,14 @@ def pytest_addoption(parser):
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if cluster in ['catalyst', 'quartz']:
-        default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/build/clang.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        #default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc7'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)  #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['intel18'] = '%s/build/intel.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
-    if cluster == 'pascal':
-        #default_exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        #default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        default_exes['gcc7'] = default_exes['default'] #'%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-        #default_exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_x86_64_gpu_mvapich2-2.2_openblas_rel/build/model_zoo/lbann' % (default_dirname, cluster)
     if cluster ==  'ray':
-        default_exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['gcc4'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster) #'%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+        default_exes['clang4'] = '%s/build/clang.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
 
     if cluster in ['surface', 'pascal']:
         default_exes['gcc4'] = default_exes['default']


### PR DESCRIPTION
Currently all our tests depend on spack builds completing to actually run. This PR modifies the compiler test to instead use the superbuild. This fixes the issue we see often where our build actually works fine, but fails in bamboo for spack specific reasons. I have been running these changes to test them out, and will continue to do so but they seem to work as intended. I will let someone else make the call on whether to merge this, as tomorrow is my last day. 

This also adds a clang build to the ray testing, as during the convo that spawned this pull request it was mentioned as a case of interest. I believe the ray clang compiler test was failing when I ran it, I will double check and post the build error in my weekly blog post. 