### PR TITLE
Strange bugfix for #586.

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -438,7 +438,7 @@ class lbann_comm {
   template <typename T>
   T scatter(int root, const El::mpi::Comm c) {
     T val = {};
-    El::mpi::Scatter((T*) nullptr, 0, &val, 1, root, c);
+    El::mpi::Scatter((T*) nullptr, 1, &val, 1, root, c);
     bytes_received += sizeof(T);
     return val;
   }


### PR DESCRIPTION
It appears that calling MVAPICH's MPI_Scatter more than 16 times with 8-31 processes will cause it to just not work. The number of nodes has no effect. I see this error with MVAPICH 2.2 and MVAPICH 2.3 (I tried the latter with GCC, Clang, and Intel), but not with OpenMPI. Weird stuff.

Equally weird is the workaround. According to the MPICH documentation (https://www.mpich.org/static/docs/v3.1/www3/MPI_Scatter.html), the sendcount parameter is only significant at the root process. However, if I change the value at non-root processes to anything but zero (including negatives), everything seems to work again.

<details> <summary> Minimum reproducer </summary>

```c
#include <stdlib.h>
#include <mpi.h>
#include <stdio.h>

int main(int argc, char** argv) {
  // Initialize the MPI environment
  int world_size, world_rank;
  MPI_Init(NULL, NULL);
  MPI_Comm_size(MPI_COMM_WORLD, &world_size);
  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);

  // Initialize the send buffer
  int* send = NULL;
  if (world_rank == 0) {
    send = (int*) malloc(world_size * sizeof(int));
  }

  // Repeatedly call MPI_Scatter
  const int max_iter = 100;
  int iter;
  for (iter = 0; iter < max_iter; ++iter) {
    int recv = -1;
    if (world_rank == 0) {
      int i;
      for (i = 0; i < world_size; ++i) {
        send[i] = 10000 * i + iter;
      }
    }
    if (world_rank == 0) {
      MPI_Scatter(send, 1, MPI_INT, &recv, 1, MPI_INT, 0, MPI_COMM_WORLD);
    } else {
      MPI_Scatter(NULL, 0, MPI_INT, &recv, 1, MPI_INT, 0, MPI_COMM_WORLD);
    }
    fprintf(stdout,
            "Rank %d recieved %d (iter %d)\n",
            world_rank, recv, iter);
  }

  // Finalize the MPI environment.
  if (send != NULL) { free(send); }
  MPI_Finalize();
}
```

</details>