### PR TITLE
Bugfix for relatively small fully-connected layers

### DIFF
--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -128,7 +128,9 @@ void l2_weight_regularization::start_evaluation() {
       if (vals.Participating()
           && vals.GetLocalDevice() == El::Device::GPU
           && vals.RedundantRank() == i % vals.RedundantSize()) {
-        if (vals.LDim() == vals.LocalHeight()) {
+        if (vals.LocalWidth() < 1 || vals.LocalHeight() < 1) {
+        } else if (vals.LocalWidth() == 1
+                   || vals.LDim() == vals.LocalHeight()) {
           cublas::dot(handle,
                       vals.LocalHeight() * vals.LocalWidth(),
                       vals.LockedBuffer(), 1,


### PR DESCRIPTION
@samadejacobs has observed that fully-connected layers sometimes throw errors related to non-contiguous matrices, even when all matrices involved are contiguous. I've run into similar errors when running VRAM.

It seems we treat matrices with no local data as non-contiguous. This PR fixes this bug and made problems disappear on my experiments.

Note that we still don't properly support non-contiguous matrices (#544).