### PR TITLE
Bugfix for GPU sort layer backprop.

### DIFF
--- a/src/layers/transform/sort.cu
+++ b/src/layers/transform/sort.cu
@@ -92,7 +92,7 @@ void sort_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
     const ::thrust::device_ptr<const DataType> grad_wrt_out(local_gradient_wrt_output.LockedBuffer(0, col));
     ::thrust::device_ptr<DataType> grad_wrt_in(local_gradient_wrt_input.Buffer(0, col));
     ::thrust::scatter(thrust::cuda::par(alloc).on(stream),
-                      inds, inds + local_height, grad_wrt_out,
+                      grad_wrt_out, grad_wrt_out + local_height, inds,
                       grad_wrt_in);
   }
   


### PR DESCRIPTION
I mixed up the argument order for the Thrust scatter routine (https://thrust.github.io/doc/group__scattering.html). Manual inspection of the sort layer error signals shows everything is correct.

Pinging @LukeJaffe.