### PR TITLE
adding support to specify use_scalars, use_images, use_inputs in data…

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit_hdf5.hpp
@@ -134,6 +134,10 @@ class data_reader_jag_conduit_hdf5 : public generic_data_reader {
 
   void set_image_dims(const int width, const int height, const int ch=1);
 
+  void set_use_images(bool b) { m_use_images = b; }
+  void set_use_inputs(bool b) { m_use_inputs = b; }
+  void set_use_scalars(bool b) { m_use_scalars = b; }
+
  protected:
   virtual void set_defaults();
   virtual bool replicate_processor(const cv_process& pp);
@@ -166,8 +170,6 @@ class data_reader_jag_conduit_hdf5 : public generic_data_reader {
   std::vector< std::pair<size_t, const ch_t*> > get_image_ptrs(const size_t i) const;
 
   jag_store * get_jag_store() const { return m_jag_store; }
-
- protected:
 
   int m_image_width; ///< image width
   int m_image_height; ///< image height
@@ -213,6 +215,10 @@ class data_reader_jag_conduit_hdf5 : public generic_data_reader {
   std::unordered_map<int, std::string> m_success_map;
 
   std::set<std::string> m_emi_selectors;
+
+  bool m_use_scalars;
+  bool m_use_inputs;
+  bool m_use_images;
 };
 
 

--- a/src/data_readers/data_reader_jag_conduit_hdf5.cpp
+++ b/src/data_readers/data_reader_jag_conduit_hdf5.cpp
@@ -239,14 +239,30 @@ void data_reader_jag_conduit_hdf5::load() {
     }
   
     m_jag_store->set_comm(m_comm);
-    m_jag_store->load_inputs();
-    //m_jag_store.load_scalars();
-  
-    std::vector<std::string> image_names;
-    for (auto t : m_emi_selectors) {
-      image_names.push_back(t);
+    if (m_use_inputs) {
+      if (is_master()) {
+        std::cerr << "USING INPUTS\n";
+      }
+      m_jag_store->load_inputs();
+    }  
+    if (m_use_scalars) {
+      if (is_master()) {
+        std::cerr << "USING SCALARS\n";
+      }  
+      m_jag_store->load_scalars();
     }
-    m_jag_store->load_images(image_names);
+  
+    if (m_use_images) {
+      if (is_master()) {
+        std::cerr << "USING IMAGES\n";
+      }  
+      std::vector<std::string> image_names;
+      for (auto t : m_emi_selectors) {
+        image_names.push_back(t);
+      }
+      m_jag_store->load_images(image_names);
+    }  
+
     m_jag_store->setup(names);
   }
 

--- a/src/data_store/jag_store.cpp
+++ b/src/data_store/jag_store.cpp
@@ -105,7 +105,7 @@ void jag_store::setup(
       get_default_keys(test_file, test_sample_id, "inputs", master);
     }
     if (m_load_scalars) {
-      get_default_keys(test_file, test_sample_id, "scalars", master);
+      get_default_keys(test_file, test_sample_id, "outputs/scalars", master);
     }
   }
 
@@ -142,7 +142,7 @@ void jag_store::setup(
           m_data_inputs[idx].push_back( node.to_float64() );
         }
         for (auto scalar_name : m_scalars_to_load) {
-          const std::string key = "/" + t + "/inputs/" + scalar_name;
+          const std::string key = "/" + t + "/outputs/scalars/" + scalar_name;
           conduit::relay::io::hdf5_read(hdf5_file_hnd, key, node);
           //this is fragile; will break if input_t changes
           m_data_inputs[idx].push_back( node.to_float64() );
@@ -191,6 +191,7 @@ void jag_store::get_default_keys(std::string &filename, std::string &sample_id, 
   conduit::Node n2;
 
   const std::string key = "/" + sample_id + "/" + key1;
+
   std::vector<std::string> children;
   conduit::relay::io::hdf5_group_list_child_names(hdf5_file_hnd, key, children);
   for (auto t : children) {

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -351,6 +351,9 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
   } else if (name =="jag_conduit_hdf5") {
     data_reader_jag_conduit_hdf5* reader_jag = new data_reader_jag_conduit_hdf5(pp, shuffle);
     reader_jag->set_image_dims(width, height);
+    reader_jag->set_use_images(pb_readme.use_images());
+    reader_jag->set_use_scalars(pb_readme.use_scalars());
+    reader_jag->set_use_inputs(pb_readme.use_inputs());
     reader = reader_jag;
     if (master) std::cout << reader->get_type() << " is set" << std::endl;
     return;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -48,6 +48,11 @@ message Reader {
   repeated int32 independent = 97;
   repeated int32 dependent = 98;
   int32 max_files_to_load = 1000;
+
+  // for jag_conduit_hdf5
+  bool use_scalars = 1001;
+  bool use_images = 1002;
+  bool use_inputs = 1003;
   //------------------  end of only for jag_conduit  -----------------------
 
   int32 num_labels = 99; //for imagenet and synthetic


### PR DESCRIPTION
… reader prototext
you must include in you data_reader_jag_conduit_hdf5.prototext file:
use_images: true
use_scalars: true
use_inputs: true
Else the values will default to 'false'