### PR TITLE
Nicer pattern for GPU activation layers

### DIFF
--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -27,7 +27,7 @@
 #ifndef LBANN_LAYER_ACTIVATION_RELU_HPP_INCLUDED
 #define LBANN_LAYER_ACTIVATION_RELU_HPP_INCLUDED
 
-#include "lbann/layers/activations/activation.hpp"
+#include "lbann/layers/layer.hpp"
 
 namespace lbann {
 
@@ -36,35 +36,16 @@ namespace lbann {
  *  See https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
  */
 template <data_layout T_layout, El::Device Dev>
-class relu_layer : public entrywise_activation_layer {
+class relu_layer : public Layer {
 public:
-
-  relu_layer(lbann_comm *comm) : entrywise_activation_layer(comm) {}
+  relu_layer(lbann_comm *comm) : Layer(comm) {}
   relu_layer* copy() const override { return new relu_layer(*this); }
   std::string get_type() const override { return "ReLU"; }
-
-  /** Returns description of ctor params */
-  std::string get_description() const override {
-    return std::string {} +
-     " relu" + " dataLayout: " + this->get_data_layout_string(get_data_layout());
-  }
-
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-
 protected:
-
-  DataType activation(DataType x) const override {
-    return x > DataType(0) ? x : DataType(0);
-  }
-
-  DataType activation_derivative(DataType x) const override {
-    return x > DataType(0) ? DataType(1) : DataType(0);
-  }
-
   void fp_compute() override;
   void bp_compute() override;
-
 };
 
 } // namespace lbann

--- a/include/lbann/layers/activations/sigmoid.hpp
+++ b/include/lbann/layers/activations/sigmoid.hpp
@@ -27,7 +27,7 @@
 #ifndef LBANN_LAYER_ACTIVATION_SIGMOID_HPP_INCLUDED
 #define LBANN_LAYER_ACTIVATION_SIGMOID_HPP_INCLUDED
 
-#include "lbann/layers/activations/activation.hpp"
+#include "lbann/layers/layer.hpp"
 #include "lbann/utils/cuda.hpp"
 
 // Output is strictly in (0,1) to avoid numerical issues
@@ -36,52 +36,20 @@
 namespace lbann {
 
 /** Sigmoid activation function.
+ *  \f[ \sigma(x) = \frac{1}{1 + e^{-x}} \f]
  *  See https://en.wikipedia.org/wiki/Sigmoid_function
  */
 template <data_layout T_layout, El::Device Dev>
-class sigmoid_layer : public entrywise_activation_layer {
+class sigmoid_layer : public Layer {
 public:
-  sigmoid_layer(lbann_comm *comm) : entrywise_activation_layer(comm) {}
-
+  sigmoid_layer(lbann_comm *comm) : Layer(comm) {}
   sigmoid_layer* copy() const override { return new sigmoid_layer(*this); }
   std::string get_type() const override { return "sigmoid"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-
  protected:
-
-  DataType activation(DataType x) const override {
-    constexpr DataType one = 1;
-    DataType y = 1 / (one + std::exp(-x));
-#ifdef LBANN_ENABLE_SIGMOID_CUTOFF
-    if (y <= eps) { y = eps; }
-    else if (y >= one - eps) { y = one - eps; }
-#endif // LBANN_ENABLE_SIGMOID_CUTOFF
-    return y;
-  }
-
-  DataType activation_derivative(DataType x) const override {
-    constexpr DataType one = 1;
-    const auto& y = activation(x); 
-#ifdef LBANN_ENABLE_SIGMOID_CUTOFF
-    if (y <= eps || y >= one - eps) { return DataType(0); }
-#endif // LBANN_ENABLE_SIGMOID_CUTOFF
-    return y * (one - y);
-  }
-
   void fp_compute() override;
   void bp_compute() override;
-
-private:
-
-#ifdef LBANN_ENABLE_SIGMOID_CUTOFF
-  /** Cutoff value for output.
-   *  If sigmoid cutoff is enabled, outputs are guaranteed to be in
-   *  the interval [eps, 1-eps].
-   */
-  static constexpr DataType eps = std::numeric_limits<DataType>::epsilon();
-#endif // LBANN_ENABLE_SIGMOID_CUTOFF
-  
 };
   
 } // namespace lbann

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -5,6 +5,7 @@ set_full_path(THIS_DIR_HEADERS
   cuda.hpp
   cudnn.hpp
   dataset.hpp
+  entrywise_operator.hpp
   exception.hpp
   glob.hpp
   im2col.hpp

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -310,6 +310,10 @@ void apply_entrywise_unary_operator(const AbsDistMat& input,
                                                 output.Matrix());
 }
 
+/** Apply an entry-wise binary operator to GPU data.
+ *  The input and output data must be on GPU, have the same
+ *  dimensions, and be aligned.
+ */
 template <typename BinaryOperator>
 void apply_entrywise_binary_operator(const AbsDistMat& input1,
                                      const AbsDistMat& input2,

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -79,10 +79,10 @@
 namespace lbann {
 namespace cuda {
 
-#ifdef __CUDACC__
 // -------------------------------------------------------------
 // Device functions
 // -------------------------------------------------------------
+#ifdef __CUDACC__
 
 // Atomic add functions
 #if __CUDA_ARCH__ >= 530
@@ -138,6 +138,204 @@ __device__ __inline__ double max(double x, double y) { return fmax(x, y); }
   
 #endif // __CUDACC__
   
+// -------------------------------------------------------------
+// Helper functions for entrywise operations
+// -------------------------------------------------------------
+#ifdef __CUDACC__
+
+/** CUDA kernel to apply an entry-wise unary operator. */
+template <typename UnaryOperator>
+__global__
+void entrywise_unary_operator_kernel(El::Int height, El::Int width,
+                                     const DataType* __restrict__ input,
+                                     El::Int input_ldim,
+                                     DataType* __restrict__ output,
+                                     El::Int output_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  UnaryOperator op;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_ldim];
+    auto& y = output[row + col * output_ldim];
+    y = op(x);
+  }
+}
+
+/** CUDA kernel to apply an entry-wise binary operator. */
+template <typename BinaryOperator>
+__global__
+void entrywise_binary_operator_kernel(El::Int height, El::Int width,
+                                     const DataType* __restrict__ input1,
+                                     El::Int input1_ldim,
+                                     const DataType* __restrict__ input2,
+                                     El::Int input2_ldim,
+                                     DataType* __restrict__ output,
+                                     El::Int output_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  BinaryOperator op;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x1 = input1[row + col * input1_ldim];
+    const auto& x2 = input2[row + col * input2_ldim];
+    auto& y = output[row + col * output_ldim];
+    y = op(x1, x2);
+  }
+}
+
+/** Apply an entry-wise unary operator to GPU data.
+ *  The input and output data must be on GPU and must have the same
+ *  dimensions.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsMat& input,
+                                    AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("input is not on GPU");
+  } else if (output.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("output is not on GPU");
+  } else if (input.Height() != output.Height()
+             || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input.Height();
+  const El::Int width = input.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    entrywise_unary_operator_kernel<UnaryOperator>
+      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+        height, width, input.LockedBuffer(), input.LDim(),
+        output.Buffer(), output.LDim());
+  }
+  
+}
+
+/** Apply an entry-wise binary operator to GPU data.
+ *  The input and output data must be on GPU and must have the same
+ *  dimensions.
+ */
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsMat& input1,
+                                     const AbsMat& input2,
+                                     AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input1.GetDevice() != El::Device::GPU
+      || input2.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("input is not on GPU");
+  } else if (output.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("output is not on GPU");
+  } else if (input1.Height() != input2.Height()
+             || input1.Width() != input2.Width()
+             || input1.Height() != output.Height()
+             || input1.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input1.Height();
+  const El::Int width = input1.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    entrywise_binary_operator_kernel<BinaryOperator>
+      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+        height, width,
+        input1.LockedBuffer(), input1.LDim(),
+        input2.LockedBuffer(), input2.LDim(),
+        output.Buffer(), output.LDim());
+  }
+  
+}
+
+  
+/** Apply an entry-wise unary operator to GPU data.
+ *  The input and output data must be on GPU, have the same
+ *  dimensions, and be aligned.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsDistMat& input,
+                                    AbsDistMat& output) {
+  std::stringstream err;
+  if (input.Height() != output.Height()
+      || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_unary_operator<UnaryOperator>(input.LockedMatrix(),
+                                                output.Matrix());
+}
+
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsDistMat& input1,
+                                     const AbsDistMat& input2,
+                                     AbsDistMat& output) {
+  if (input1.Height() != input2.Height()
+      || input1.Width() != input2.Width()
+      || input1.Height() != output.Height()
+      || input1.Width() != output.Width()) {
+    std::stringstream err;
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input1.DistData() != input2.DistData()
+             || input1.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_binary_operator<BinaryOperator>(input1.LockedMatrix(),
+                                                  input2.LockedMatrix(),
+                                                  output.Matrix());
+}
+  
+#endif // __CUDACC__
+
 // -------------------------------------------------------------
 // Utilities for Thrust
 // -------------------------------------------------------------

--- a/include/lbann/utils/entrywise_operator.hpp
+++ b/include/lbann/utils/entrywise_operator.hpp
@@ -1,0 +1,184 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_ENTRYWISE_OPERATOR_HPP
+#define LBANN_UTILS_ENTRYWISE_OPERATOR_HPP
+
+#include "lbann/base.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+  
+/** Apply an entry-wise unary operator to CPU data.
+ *  The input and output data must be on CPU and must have the same
+ *  dimensions.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsMat& input,
+                                    AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input.GetDevice() != El::Device::CPU) {
+    LBANN_ERROR("input is not on CPU");
+  } else if (output.GetDevice() != El::Device::CPU) {
+    LBANN_ERROR("output is not on CPU");
+  } else if (input.Height() != output.Height()
+             || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Apply unary operator
+  if (input.Contiguous() && output.Contiguous()) {
+    const auto* input_buffer = input.LockedBuffer();
+    auto* output_buffer = output.Buffer();
+    const size_t size = input.Height() * input.Width();
+#pragma omp parallel for
+    for (size_t i = 0; i < size; ++i) {
+      UnaryOperator op;
+      output_buffer[i] = op(input_buffer[i]);
+    }
+  } else {
+#pragma omp parallel for collapse(2)
+    for (El::Int col = 0; col < input.Width(); ++col) {
+      for (El::Int row = 0; row < input.Height(); ++row) {
+        UnaryOperator op;
+        output(row, col) = op(input(row, col));
+      }
+    }
+  }
+  
+}
+
+/** Apply an entry-wise binary operator to CPU data.
+ *  The input and output data must be on CPU and must have the same
+ *  dimensions.
+ */
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsMat& input1,
+                                     const AbsMat& input2,
+                                     AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input1.GetDevice() != El::Device::CPU
+      || input2.GetDevice() != El::Device::CPU) {
+    LBANN_ERROR("input is not on CPU");
+  } else if (output.GetDevice() != El::Device::CPU) {
+    LBANN_ERROR("output is not on CPU");
+  } else if (input1.Height() != input2.Height()
+             || input1.Width() != input2.Width()
+             || input1.Height() != output.Height()
+             || input1.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Apply binary operator
+  if (input1.Contiguous() && input2.Contiguous()
+      && output.Contiguous()) {
+    const auto* input1_buffer = input1.LockedBuffer();
+    const auto* input2_buffer = input2.LockedBuffer();
+    auto* output_buffer = output.Buffer();
+    const size_t size = input1.Height() * input1.Width();
+#pragma omp parallel for
+    for (size_t i = 0; i < size; ++i) {
+      BinaryOperator op;
+      output_buffer[i] = op(input1_buffer[i], input2_buffer[i]);
+    }
+  } else {
+#pragma omp parallel for collapse(2)
+    for (El::Int col = 0; col < input1.Width(); ++col) {
+      for (El::Int row = 0; row < input1.Height(); ++row) {
+        BinaryOperator op;
+        output(row, col) = op(input1(row, col), input2(row, col));
+      }
+    }
+  }
+
+}
+
+/** Apply an entry-wise unary operator to CPU data.
+ *  The input and output data must be on CPU, have the same
+ *  dimensions, and be aligned.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsDistMat& input,
+                                    AbsDistMat& output) {
+  std::stringstream err;
+  if (input.Height() != output.Height()
+      || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_unary_operator<UnaryOperator>(input.LockedMatrix(),
+                                                output.Matrix());
+}
+
+/** Apply an entry-wise binary operator to GPU data.
+ *  The input and output data must be on GPU, have the same
+ *  dimensions, and be aligned.
+ */
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsDistMat& input1,
+                                     const AbsDistMat& input2,
+                                     AbsDistMat& output) {
+  if (input1.Height() != input2.Height()
+      || input1.Width() != input2.Width()
+      || input1.Height() != output.Height()
+      || input1.Width() != output.Width()) {
+    std::stringstream err;
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input1.DistData() != input2.DistData()
+             || input1.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_binary_operator<BinaryOperator>(input1.LockedMatrix(),
+                                                  input2.LockedMatrix(),
+                                                  output.Matrix());
+}
+
+} // namespace lbann
+
+#endif // LBANN_UTILS_ENTRYWISE_OPERATOR_HPP

--- a/src/layers/activations/relu.cu
+++ b/src/layers/activations/relu.cu
@@ -33,7 +33,7 @@ namespace {
 
 /** Entry-wise operator. */
 struct op {
-  __device__ DataType operator()(DataType x) const {
+  inline __device__ DataType operator()(DataType x) const {
     return x > DataType(0) ? x : DataType(0);
   }
 };
@@ -44,7 +44,7 @@ struct op {
  *  \f$ \frac{dL}{dx} = \frac{dL}{dy} f'(x) \f$.
  */
 struct op_backprop {
-  __device__ DataType operator()(DataType x, DataType dy) const {
+  inline __device__ DataType operator()(DataType x, DataType dy) const {
     return x > DataType(0) ? dy : DataType(0);
   }
 };

--- a/src/layers/activations/sigmoid.cpp
+++ b/src/layers/activations/sigmoid.cpp
@@ -25,24 +25,68 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/layers/activations/sigmoid.hpp"
+#include "lbann/utils/entrywise_operator.hpp"
 
 namespace lbann {
 
-template <>
-void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
-  entrywise_activation_layer::fp_compute();
-}
-template <>
-void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
-  entrywise_activation_layer::bp_compute();
-}
+namespace {
+
+// Useful constants
+constexpr DataType zero = 0;
+constexpr DataType one = 1;
+constexpr DataType eps = std::numeric_limits<DataType>::epsilon();
+
+/** Entry-wise operator. */
+struct op {
+  inline DataType operator()(DataType x) const {
+    const DataType y = 1 / (one + std::exp(-x));
+#ifdef LBANN_ENABLE_SIGMOID_CUTOFF
+    if (y <= eps)            { return eps; }
+    else if (y >= one - eps) { return one - eps; }
+#endif // LBANN_ENABLE_SIGMOID_CUTOFF
+    return y;
+  }
+};
+  
+/** Entry-wise operator for backprop.
+ *  If the forward propagation step computes \f$ y = f(x) \f$, the
+ *  backward propagation step computes
+ *  \f$ \frac{dL}{dx} = \frac{dL}{dy} f'(x) \f$.
+ */
+struct op_backprop {
+  inline DataType operator()(DataType x, DataType dy) const {
+    const auto& y = op()(x);
+#ifdef LBANN_ENABLE_SIGMOID_CUTOFF
+    if (y <= eps || y >= one - eps) { return zero; }
+#endif // LBANN_ENABLE_SIGMOID_CUTOFF
+    return dy * y * (one - y);
+  }
+};
+  
+} // namespace
+
+// Template instantiation
 template <>
 void sigmoid_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::fp_compute() {
-  entrywise_activation_layer::fp_compute();
+  apply_entrywise_unary_operator<op>(get_prev_activations(),
+                                     get_activations());
 }
 template <>
 void sigmoid_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::bp_compute() {
-  entrywise_activation_layer::bp_compute();
+  apply_entrywise_binary_operator<op_backprop>(get_prev_activations(),
+                                               get_prev_error_signals(),
+                                               get_error_signals());
 }
-
+template <>
+void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
+  apply_entrywise_unary_operator<op>(get_prev_activations(),
+                                     get_activations());
+}
+template <>
+void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
+  apply_entrywise_binary_operator<op_backprop>(get_prev_activations(),
+                                               get_prev_error_signals(),
+                                               get_error_signals());
+}
+  
 } // namespace lbann

--- a/src/layers/activations/sigmoid.cu
+++ b/src/layers/activations/sigmoid.cu
@@ -26,134 +26,109 @@
 
 #include "math.h"
 #include "lbann/layers/activations/sigmoid.hpp"
+#include <limits>
 
 namespace lbann {
 namespace {
 
 // Sigmoid function
 #if __CUDA_ARCH__ >= 530
-__device__ inline __half sigmoid(__half x) {
+inline __device__ __half sigmoid(__half x) {
   static_cast<void>(static_cast<__half (*)(__half)>(sigmoid)); // Suppress "unused function" warning
   return __hdiv(__float2half(1.f),
                 __hadd(__float2half(1.f), hexp(__hneg(x))));
 }
 #endif // __CUDA_ARCH__ >= 530
-__device__ inline float sigmoid(float x) {
+inline __device__ float sigmoid(float x) {
   static_cast<void>(static_cast<float (*)(float)>(sigmoid)); // Suppress "unused function" warning
   return 1 / (1.0f + expf(-x));
 }
-__device__ inline double sigmoid(double x) {
+inline __device__ double sigmoid(double x) {
   static_cast<void>(static_cast<double (*)(double)>(sigmoid)); // Suppress "unused function" warning
   return 1 / (1.0 + exp(-x));
 }
+
+// Machine epsilon
+#ifdef __CUDACC_RELAXED_CONSTEXPR__
+template <typename T>
+inline __device__ T epsilon() {
+  return std::numeric_limits<T>::epsilon();
+}
+#else // __CUDACC_RELAXED_CONSTEXPR__
+template <typename T>
+inline __device__ T epsilon();
+#if __CUDA_ARCH__ >= 530
+template <>
+inline __device__ __half epsilon<__half>() {
+  static_cast<void>(static_cast<__half (*)()>(epsilon<__half>)); // Suppress "unused function" warning
+  return __float2half(0.0009765625f);
+}
+#endif // __CUDA_ARCH__ >= 530
+template <>
+inline __device__ float epsilon<float>()   {
+  static_cast<void>(static_cast<float (*)()>(epsilon<float>)); // Suppress "unused function" warning
+  return FLT_EPSILON;
+}
+template <>
+inline __device__ double epsilon<double>() {
+  static_cast<void>(static_cast<double (*)()>(epsilon<double>)); // Suppress "unused function" warning
+  return DBL_EPSILON;
+}
+#endif // __CUDACC_RELAXED_CONSTEXPR__
   
-__global__ void fp_kernel(El::Int height, El::Int width,
-                          const DataType* __restrict__ input,
-                          El::Int input_leading_dim,
-                          DataType* __restrict__ output,
-                          El::Int output_leading_dim,
-                          DataType eps) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int size = height * width;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  for (El::Int pos = gid; pos < size; pos += num_threads) {
-    const auto& row = pos % height;
-    const auto& col = pos / height;
-    const auto& x = input[row + col * input_leading_dim];
-    auto y = sigmoid(x);
+/** Entry-wise operator. */
+struct op {
+  inline __device__ DataType operator()(DataType x) const {
+    const DataType y = sigmoid(x);
 #ifdef LBANN_ENABLE_SIGMOID_CUTOFF
-    if (y <= eps) { y = eps; }
-    else if (y >= DataType(1) - eps) { y = DataType(1) - eps; }
+    const DataType eps = epsilon<DataType>();
+    if (y <= eps) { return eps; }
+    else if (y >= DataType(1) - eps) { return DataType(1) - eps; }
 #endif // LBANN_ENABLE_SIGMOID_CUTOFF
-    output[row + col * output_leading_dim] = y;
+    return y;
   }
-}
-
-__global__ void bp_kernel(El::Int height, El::Int width,
-                          const DataType* __restrict__ input,
-                          El::Int input_leading_dim,
-                          const DataType* __restrict__ gradient_wrt_output,
-                          El::Int gradient_wrt_output_leading_dim,
-                          DataType* __restrict__ gradient_wrt_input,
-                          El::Int gradient_wrt_input_leading_dim,
-                          DataType eps) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int size = height * width;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  for (El::Int pos = gid; pos < size; pos += num_threads) {
-    const auto& row = pos % height;
-    const auto& col = pos / height;
-    const auto& x = input[row + col * input_leading_dim];
-    const auto& y = sigmoid(x);
-    const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_leading_dim];
-    auto& dx = gradient_wrt_input[row + col * gradient_wrt_input_leading_dim];
+};
+  
+/** Entry-wise operator for backprop.
+ *  If the forward propagation step computes \f$ y = f(x) \f$, the
+ *  backward propagation step computes
+ *  \f$ \frac{dL}{dx} = \frac{dL}{dy} f'(x) \f$.
+ */
+struct op_backprop {
+  inline __device__  DataType operator()(DataType x, DataType dy) const {
+    const auto& y = op()(x);
 #ifdef LBANN_ENABLE_SIGMOID_CUTOFF
-    if (y <= eps || y >= DataType(1) - eps) {
-      dx = DataType(0);
-      continue;
-    }
+    const DataType eps = epsilon<DataType>();
+    if (y <= eps || y >= DataType(1) - eps) { return DataType(0); }
 #endif // LBANN_ENABLE_SIGMOID_CUTOFF
-    dx = dy * y * (DataType(1) - y);
+    return dy * y * (DataType(1) - y);
   }
-}
-
-void fp(const AbsMat& input, AbsMat& output, DataType eps) {
-  const auto& height = input.Height();
-  const auto& width = input.Width();
-  const auto& block_dim = 256;
-  const auto& grid_dim = (height * width + block_dim - 1) / block_dim;
-  if (grid_dim > 0) {
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    fp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
-      height, width,
-      input.LockedBuffer(), input.LDim(),
-      output.Buffer(), output.LDim(),
-      eps);
-  }
-}
-
-void bp(const AbsMat& input,
-        const AbsMat& gradient_wrt_output,
-        AbsMat& gradient_wrt_input,
-        DataType eps) {
-  const auto& height = input.Height();
-  const auto& width = input.Width();
-  const auto& block_dim = 256;
-  const auto& grid_dim = (height * width + block_dim - 1) / block_dim;
-  if (grid_dim > 0) {
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    bp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
-      height, width,
-      input.LockedBuffer(), input.LDim(),
-      gradient_wrt_output.LockedBuffer(), gradient_wrt_output.LDim(),
-      gradient_wrt_input.Buffer(), gradient_wrt_input.LDim(),
-      eps);
-  }
-}
+};
   
 } // namespace
 
-template <>
-void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
-  fp(get_local_prev_activations(), get_local_activations(), eps);
-}
-template <>
-void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
-  bp(get_local_prev_activations(),
-     get_local_prev_error_signals(),
-     get_local_error_signals(),
-     eps);
-}
+// Template instantiation
 template <>
 void sigmoid_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
-  fp(get_local_prev_activations(), get_local_activations(), eps);
+  cuda::apply_entrywise_unary_operator<op>(get_prev_activations(),
+                                           get_activations());
 }
 template <>
 void sigmoid_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
-  bp(get_local_prev_activations(),
-     get_local_prev_error_signals(),
-     get_local_error_signals(),
-     eps);
+  cuda::apply_entrywise_binary_operator<op_backprop>(get_prev_activations(),
+                                                     get_prev_error_signals(),
+                                                     get_error_signals());
+}
+template <>
+void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+  cuda::apply_entrywise_unary_operator<op>(get_prev_activations(),
+                                           get_activations());
+}
+template <>
+void sigmoid_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
+  cuda::apply_entrywise_binary_operator<op_backprop>(get_prev_activations(),
+                                                     get_prev_error_signals(),
+                                                     get_error_signals());
 }
 
 } // namespace lbann


### PR DESCRIPTION
### Description
This PR introduces a nicer pattern to implement entry-wise layers on the GPU (mainly the activation layers). Instead of having to implement and launch a custom CUDA kernel for each layer, we just have to implement structs with operator() as a device function (one for forward prop and one for backprop). We then call a templated function that launches CUDA kernels internally, similar to Thrust's transform function (https://thrust.github.io/doc/group__transformations.html). I've implemented ReLU with this new interface as a test case.

### Question
I propose that we change the CPU activation layers to match this implementation. The CPU version is a bit nicer since we just have to implement two virtual functions, but CUDA kernels don't support polymorphism. My attempts to kludge it by passing around device function pointers have not had any success.

### Validation
- Reasonable results with AlexNet on ImageNet-10 (14.3%/58.8% top-1/top-5 training accuracy, 7.88 training objective function, 27.7%/75.4% top-1/top-5 validation accuracy, 7.22 validation objective function, 40.8s training time for epoch 0 on 1 Pascal node). (630d4ff)
- Got ~1140 sec/epoch with Resnet-50 on ImageNet-1K (16 Pascal nodes). I'll need to run more experiments to see if this is a performance regression or just Pascal being slow. (630d4ff)
