### PR TITLE
Feature hydrogen aluminum integration updates

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -84,6 +84,41 @@ struct request {
 
 } // namespace Al
 
+/* Notes on Synchronization
+ *
+ * The updated interface exposes a synchronization handle/device
+ * tagging mechanism used by Hydrogen: El::SyncInfo<D>, where D is an
+ * El::Device. When operating on Matrix objects, this should be
+ * handled automagically, assuming the Matrix is setup properly. Users
+ * must be aware of this when making MPI calls through Hydrogen or
+ * through lbann_comm with raw data buffers (T[]).
+ *
+ * When dealing with El::Matrix objects, users should be aware of the
+ * following. There is no synchronization for CPU objects
+ * (El::SyncInfo<El::Device::CPU> is an empty struct), but GPU Matrix
+ * objects now have an associated stream and event. These are
+ * GPUManager::Stream() and GPUManager::Event() by default, resp., but
+ * can be overriden by a user. Note: the Matrix never owns these; it
+ * will not free these resources at destruction. There are many
+ * methods in which multiple El::Matrix objects might interact. This
+ * should work properly; otherwise, report bugs to benson31.
+ *
+ * When dealing with raw data (T[]), users should be aware of the
+ * following. In the near future, all El::mpi functions will have an
+ * El::SyncInfo object as their last parameter, and it will be a
+ * required parameter. In lbann_comm, this means that when the call
+ * trickles down to an El::mpi function, an appropriate El::SyncInfo
+ * must be available. Since many of LBANN's uses of this interface are
+ * for communicating CPU buffers, there is "shortcut" API that assumes
+ * the data is CPU memory, thus providing the default
+ * El::SyncInfo<El::Device::CPU> object to El::mpi. If a user wishes
+ * to communicate GPU data, they must use the "full" API, which adds a
+ * final El::SyncInfo parameter to the function. This ensures the
+ * appropriate synchronization semantics, especially when working with
+ * Aluminum as the communication frontend.
+ */
+
+
 /**
  * Manage communication.
  * This supports separate models, each of which are split over potentially
@@ -100,7 +135,7 @@ class lbann_comm {
    * defaulting to every process in one model.
    */
   lbann_comm(int procs_per_model = 0,
-             const El::mpi::Comm world = El::mpi::COMM_WORLD);
+             El::mpi::Comm world = El::mpi::COMM_WORLD);
   /** Don't allow copying; it doesn't make sense for the communicator. */
   lbann_comm(const lbann_comm&) = delete;
   /** Don't allow assignment; it doesn't make sense for the communicator. */
@@ -202,12 +237,12 @@ class lbann_comm {
 
   /// Broadcast a scalar value over an arbitrary communicator
   template < typename T, bool S = is_instantiated_El_mpi_type<T>::value >
-  void broadcast(int root, T& val, const El::mpi::Comm c);
+  void broadcast(int root, T& val, El::mpi::Comm c);
 
   template <typename T>
-  void broadcast_custom(int root, T& val, const El::mpi::Comm c) const;
+  void broadcast_custom(int root, T& val, El::mpi::Comm c) const;
   template <typename T>
-  void broadcast_native(int root, T& val, const El::mpi::Comm c) const;
+  void broadcast_native(int root, T& val, El::mpi::Comm c) const;
 
   /// World broadcast of a scalar.
   template <typename T>
@@ -277,10 +312,11 @@ class lbann_comm {
    * Resize vector<> over an arbitrary communicator to match the one on root.
    */
   template <typename T>
-  size_t resize(const int root, std::vector<T> &data, const El::mpi::Comm c) {
+  size_t resize(const int root, std::vector<T> &data, El::mpi::Comm c) {
+    auto const rank_c = El::mpi::Rank(c);
     size_t count = data.size();
-    El::mpi::Broadcast(&count, 1, root, c, El::SyncInfo<El::Device::CPU>{});
-    count_bytes_broadcast(sizeof(size_t), El::mpi::Rank(c), root);
+    El::mpi::Broadcast(&count, 1, root, std::move(c), El::SyncInfo<El::Device::CPU>{});
+    count_bytes_broadcast(sizeof(size_t), rank_c, root);
     data.resize(count);
     return count;
   }
@@ -290,12 +326,12 @@ class lbann_comm {
    * vector<> for non-root processes will be resized as needed.
    */
   template <typename T>
-  void broadcast(const int root, std::vector<T> &data, const El::mpi::Comm c) {
+  void broadcast(const int root, std::vector<T> &data, El::mpi::Comm c) {
     const int count = static_cast<int>(resize(root, data, c));
     if (count <= 0) {
       return;
     }
-    broadcast<T>(root, data.data(), count, c, El::SyncInfo<El::Device::CPU>{});
+    broadcast<T>(root, data.data(), count, std::move(c), El::SyncInfo<El::Device::CPU>{});
   }
   /// Broadcast vector<> to world.
   template <typename T>
@@ -353,14 +389,14 @@ class lbann_comm {
               << "this doesn't work!";
       lbann_comm_abort(err.str());
     }
-    El::mpi::AllGather<T>(src.data(), src.size(), rcs.data(), rcv_counts.data(), rcv_disp.data(), c);
+    El::mpi::AllGather<T>(src.data(), src.size(), rcs.data(), rcv_counts.data(), rcv_disp.data(), std::move(c));
   }
   /**
    * Allgatherv over a model communicator;
    * all vectors must be correctly sized prior to entry.
    */
   template <typename T>
-  void model_all_gather(std::vector<T> &src, std::vector<T> &rcs, std::vector<int> &rcv_counts, std::vector<int> &rcv_disp, const El::mpi::Comm c) {
+  void model_all_gather(std::vector<T> &src, std::vector<T> &rcs, std::vector<int> &rcv_counts, std::vector<int> &rcv_disp) {
     all_gather(src, rcs, rcv_counts, rcv_disp, get_model_comm());
   }
   /**
@@ -368,8 +404,8 @@ class lbann_comm {
    * std::vector<T> &data must be correctly sized prior to entry.
    */
   template <typename T>
-  void all_gather(T &src, std::vector<T> &data, const El::mpi::Comm c) {
-    El::mpi::AllGather(&src, 1, data.data(), 1, c,
+  void all_gather(T &src, std::vector<T> &data, El::mpi::Comm c) {
+    El::mpi::AllGather(&src, 1, data.data(), 1, std::move(c),
                        El::SyncInfo<El::Device::CPU>{});
   }
   /**
@@ -439,47 +475,52 @@ class lbann_comm {
   }
   /** Scalar gather (for non-root processes). */
   template <typename T>
-  void gather(T snd, int root, const El::mpi::Comm c) {
+  void gather(T snd, int root, El::mpi::Comm c) {
     bytes_sent += sizeof(T);
-    El::mpi::Gather(&snd, 1, (T*) nullptr, 0, root, c);
+    El::mpi::Gather(&snd, 1, (T*) nullptr, 0, root, std::move(c));
   }
   /** Scalar gather (for root processes). */
   template <typename T>
-  void gather(T snd, T *rcv, const El::mpi::Comm c) {
-    El::mpi::Gather(&snd, 1, rcv, 1, El::mpi::Rank(c), c);
-    bytes_received += sizeof(T) * (El::mpi::Size(c) - 1);
+  void gather(T snd, T *rcv, El::mpi::Comm c) {
+    auto const size_c = El::mpi::Size(c);
+    auto const rank_c = El::mpi::Rank(c);
+    El::mpi::Gather(&snd, 1, rcv, 1, rank_c, std::move(c));
+    bytes_received += sizeof(T) * (size_c - 1);
   }
   /** Scalar gather (for root processes). */
   template <typename T>
-  void gather(T snd, std::vector<T>& rcv, const El::mpi::Comm c) {
-    gather(snd, rcv.data(), c);
+  void gather(T snd, std::vector<T>& rcv, El::mpi::Comm c) {
+    gather(snd, rcv.data(), std::move(c));
   }
   /** Scalar-array gather (for non-root processes). */
   template <typename T>
-  void gather(T *snd, int count, int root, const El::mpi::Comm c) {
+  void gather(T *snd, int count, int root, El::mpi::Comm c) {
     bytes_sent += sizeof(T) * count;
-    El::mpi::Gather(snd, count, (T*) nullptr, 0, root, c);
+    El::mpi::Gather(snd, count, (T*) nullptr, 0, root, std::move(c));
   }
   /** Scalar-array gather (for root processes). */
   template <typename T>
-  void gather(T *snd, int count, T *rcv, const El::mpi::Comm c) {
-    El::mpi::Gather(snd, count, rcv, count, El::mpi::Rank(c), c);
-    bytes_received += sizeof(T) * count * (El::mpi::Size(c) - 1);
+  void gather(T *snd, int count, T *rcv, El::mpi::Comm c) {
+    auto const size_c = El::mpi::Size(c);
+    auto const rank_c = El::mpi::Rank(c);
+    El::mpi::Gather(snd, count, rcv, count, rank_c, std::move(c));
+    bytes_received += sizeof(T) * count * (size_c - 1);
   }
   /** Scalar scatter (for non-root processes). */
   template <typename T>
-  T scatter(int root, const El::mpi::Comm c) {
+  T scatter(int root, El::mpi::Comm c) {
     T val = {};
-    El::mpi::Scatter((T*) nullptr, 1, &val, 1, root, c);
+    El::mpi::Scatter((T*) nullptr, 1, &val, 1, root, std::move(c));
     bytes_received += sizeof(T);
     return val;
   }
   /** Scalar scatter (for root processes). */
   template <typename T>
-  T scatter(T *snd, const El::mpi::Comm c) {
+  T scatter(T *snd, El::mpi::Comm c) {
     bytes_sent += sizeof(T) * (El::mpi::Size(c) - 1);
     T val = {};
-    El::mpi::Scatter(snd, 1, &val, 1, El::mpi::Rank(c), c);
+    auto root = El::mpi::Rank(c);
+    El::mpi::Scatter(snd, 1, &val, 1, root, std::move(c));
     return val;
   }
   /** Inter-model reduce (for non-root processes). */
@@ -514,18 +555,20 @@ class lbann_comm {
   }
   /** Scalar reduce (for non-root processes). */
   template <typename T>
-  void reduce(T snd, int root, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+  void reduce(T snd, int root, El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
     bytes_sent += sizeof(T);
-    El::mpi::Reduce(&snd, (T*) NULL, 1, op, root, c,
+    El::mpi::Reduce(&snd, (T*) NULL, 1, op, root, std::move(c),
                     El::SyncInfo<El::Device::CPU>{});
   }
   /** Scalar reduce (for root processes). */
   template <typename T>
-  T reduce(T snd, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+  T reduce(T snd, El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
     T val = {};
-    El::mpi::Reduce(&snd, &val, 1, op, El::mpi::Rank(c), c,
+    auto const size_c = El::mpi::Size(c);
+    auto const rank_c = El::mpi::Rank(c);
+    El::mpi::Reduce(&snd, &val, 1, op, rank_c, std::move(c),
                     El::SyncInfo<El::Device::CPU>{});
-    bytes_received += sizeof(T) * (El::mpi::Size(c) - 1);
+    bytes_received += sizeof(T) * (size_c - 1);
     return val;
   }
 
@@ -567,8 +610,10 @@ class lbann_comm {
   template <typename T, El::Device D>
   void reduce(T *snd, int count, T *rcv, El::mpi::Comm c, El::mpi::Op op, El::SyncInfo<D> const& syncInfo) {
     if (snd == rcv) { snd = MPI_IN_PLACE; }
-    El::mpi::Reduce(snd, rcv, count, op, El::mpi::Rank(c), std::move(c), syncInfo);
-    bytes_received += sizeof(T) * count * (El::mpi::Size(c) - 1);
+    auto const rank_c = El::mpi::Rank(c);
+    auto const size_c = El::mpi::Size(c);
+    El::mpi::Reduce(snd, rcv, count, op, rank_c, std::move(c), syncInfo);
+    bytes_received += sizeof(T) * count * (size_c - 1);
   }
   /** Inter-model all-reduce. */
   template <typename T>
@@ -587,10 +632,11 @@ class lbann_comm {
   }
   /** Scalar allreduce. */
   template <typename T>
-  T allreduce(T snd, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+  T allreduce(T snd, El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+    auto const size_c = El::mpi::Size(c);
     bytes_sent += sizeof(T);
-    allreduce(&snd, 1, c, op);
-    bytes_received += sizeof(T) * (El::mpi::Size(c) - 1);
+    allreduce(&snd, 1, std::move(c), op);
+    bytes_received += sizeof(T) * (size_c - 1);
     return snd;
   }
 
@@ -598,7 +644,8 @@ class lbann_comm {
   // assuming this is intended as a CPU-only call.
   /** Scalar-array allreduce. */
   template <typename T>
-  void allreduce(T *snd, int count, T *rcv, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+  void allreduce(T *snd, int count, T *rcv, El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+    auto const size_c = El::mpi::Size(c);
     bytes_sent += count * sizeof(T);
 #ifdef LBANN_HAS_ALUMINUM
 #ifdef LBANN_ALUMINUM_MPI_PASSTHROUGH
@@ -609,14 +656,15 @@ class lbann_comm {
     ::Al::Allreduce<::Al::MPIBackend>(
       snd, rcv, count, mpi_op_to_al_op(op), *get_al_comm(c), algo);
 #else
-    El::mpi::AllReduce(snd, rcv, count, op, c,
+    El::mpi::AllReduce(snd, rcv, count, op, std::move(c),
                        El::SyncInfo<El::Device::CPU>{});
 #endif
-    bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
+    bytes_received += count * sizeof(T) * (size_c - 1);
   }
   /** In-place scalar-array allreduce. */
   template <typename T>
-  void allreduce(T *data, int count, const El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+  void allreduce(T *data, int count, El::mpi::Comm c, El::mpi::Op op = El::mpi::SUM) {
+    auto const size_c = El::mpi::Size(c);
     bytes_sent += count * sizeof(T);
 #ifdef LBANN_HAS_ALUMINUM
 #ifdef LBANN_ALUMINUM_MPI_PASSTHROUGH
@@ -627,25 +675,25 @@ class lbann_comm {
     ::Al::Allreduce<::Al::MPIBackend>(
       data, count, mpi_op_to_al_op(op), *get_al_comm(c), algo);
 #else
-    El::mpi::AllReduce(data, count, op, c,
+    El::mpi::AllReduce(data, count, op, std::move(c),
                        El::SyncInfo<El::Device::CPU>{});
 #endif
-    bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
+    bytes_received += count * sizeof(T) * (size_c - 1);
   }
   /** Matrix allreduce. */
   void allreduce(AbsMat& m,
-                 const El::mpi::Comm c,
+                 El::mpi::Comm c,
                  El::mpi::Op op = El::mpi::SUM);
   /** Matrix allreduce. */
   void allreduce(AbsDistMat& m,
-                 const El::mpi::Comm c,
+                 El::mpi::Comm c,
                  El::mpi::Op op = El::mpi::SUM);
   /** Non-blocking matrix allreduce.
    *  If LBANN has not been built with Aluminum, then this calls a
    *  blocking matrix allreduce.
    */
   void nb_allreduce(AbsMat& m,
-                    const El::mpi::Comm c,
+                    El::mpi::Comm c,
                     Al::request& req,
                     El::mpi::Op op = El::mpi::SUM);
   /** Non-blocking matrix allreduce.
@@ -653,7 +701,7 @@ class lbann_comm {
    *  blocking matrix allreduce.
    */
   void nb_allreduce(AbsDistMat& m,
-                    const El::mpi::Comm c,
+                    El::mpi::Comm c,
                     Al::request& req,
                     El::mpi::Op op = El::mpi::SUM);
   /** Non-blocking in-place scalar-array allreduce.
@@ -662,7 +710,7 @@ class lbann_comm {
    *  This currently only supports host pointers (i.e. the MPI backend).
    */
   template <typename T>
-  void nb_allreduce(T *data, int count, const El::mpi::Comm c, Al::request& req,
+  void nb_allreduce(T *data, int count, El::mpi::Comm c, Al::request& req,
                     El::mpi::Op op = El::mpi::SUM) {
 #ifdef LBANN_HAS_ALUMINUM
     bytes_sent += count * sizeof(T);
@@ -671,7 +719,7 @@ class lbann_comm {
       data, count, mpi_op_to_al_op(op), *get_al_comm(c), req.mpi_req);
     bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
 #else
-    allreduce(data, count, c, op);
+    allreduce(data, count, std::move(c), op);
 #endif  // LBANN_HAS_ALUMINUM
   }
 
@@ -728,9 +776,9 @@ class lbann_comm {
   }
   template <typename T>
   void nb_tagged_send(const T *data, int count, int rank, int tag,
-               El::mpi::Request<T>& req, const El::mpi::Comm c) {
+               El::mpi::Request<T>& req, El::mpi::Comm c) {
     bytes_sent += sizeof(T) * count;
-    El::mpi::TaggedISend(data, count, rank, tag, c, req);
+    El::mpi::TaggedISend(data, count, rank, tag, std::move(c), req);
   }
   template <typename T> void nb_send(const T *data, int count, int model,
                                      El::mpi::Request<T>& req) {
@@ -780,8 +828,8 @@ class lbann_comm {
   }
   template <typename T> void nb_tagged_recv(
                T *data, int count, int rank, int tag,
-               El::mpi::Request<T>& req, const El::mpi::Comm c) {
-    El::mpi::TaggedIRecv(data, count, rank, tag, c, req);
+               El::mpi::Request<T>& req, El::mpi::Comm c) {
+    El::mpi::TaggedIRecv(data, count, rank, tag, std::move(c), req);
     bytes_received += sizeof(T) * count;
   }
 
@@ -1056,7 +1104,7 @@ class lbann_comm {
    */
   template <El::Device D>
   void pe_ring_allreduce(
-                         const El::mpi::Comm comm, DMat<D>& mat, int max_recv_count,
+    const El::mpi::Comm comm, DMat<D>& mat, int max_recv_count,
     std::function<uint8_t *(AbsMat&, El::IR, El::IR, int&, bool, int)> send_transform,
     std::function<int(uint8_t *, AbsMat&)> recv_transform,
     std::function<int(uint8_t *, AbsMat&, bool)> recv_apply_transform,
@@ -1219,41 +1267,43 @@ class lbann_comm {
 };
 
 template <typename T, bool S>
-void lbann_comm::broadcast(int root, T& val, const El::mpi::Comm c) {
+void lbann_comm::broadcast(int root, T& val, El::mpi::Comm c) {
+  auto const rank_c = El::mpi::Rank(c);
   if (S) {
     // Avoid linking error from uninstantiated El::mpi routine if !S by converting T to El::byte
     using TT = typename interpret_as_byte_if_needed<S, T>::type;
-    broadcast_native<TT>(root, reinterpret_cast<TT&>(val), c);
+    broadcast_native<TT>(root, reinterpret_cast<TT&>(val), std::move(c));
   } else {
-    broadcast_custom(root, val, c);
+    broadcast_custom(root, val, std::move(c));
   }
-  count_bytes_broadcast(sizeof(T), El::mpi::Rank(c), root);
+  count_bytes_broadcast(sizeof(T), rank_c, root);
 }
 
 template <typename T>
-void lbann_comm::broadcast_native(int root, T& val, const El::mpi::Comm c) const {
-  El::mpi::Broadcast(val, root, c, El::SyncInfo<El::Device::CPU>{});
+void lbann_comm::broadcast_native(int root, T& val, El::mpi::Comm c) const {
+  El::mpi::Broadcast(val, root, std::move(c), El::SyncInfo<El::Device::CPU>{});
 }
 
 template <typename T>
-void lbann_comm::broadcast_custom(int root, T& val, const El::mpi::Comm c) const {
+void lbann_comm::broadcast_custom(int root, T& val, El::mpi::Comm c) const {
  const int bytes =  static_cast<int>(sizeof(T));
- El::mpi::Broadcast<El::byte>(reinterpret_cast<El::byte*>(&val), bytes, root, c,
+ El::mpi::Broadcast<El::byte>(reinterpret_cast<El::byte*>(&val), bytes, root, std::move(c),
                               El::SyncInfo<El::Device::CPU>{});
 }
 
 template <typename T, El::Device D, bool S>
 void lbann_comm::broadcast(const int root, T* data, const int count, El::mpi::Comm c, El::SyncInfo<D> const& syncInfo) {
+  auto const rank_c = El::mpi::Rank(c);
   const int size = static_cast<int>(S? count : sizeof(T)*count);
   // Avoid linking error from uninstantiated El::mpi routine if !S by converting T to El::byte
   using TT = typename interpret_as_byte_if_needed<S, T>::type;
-  El::mpi::Broadcast<TT>(reinterpret_cast<TT*>(data), size, root, c, syncInfo);
-  count_bytes_broadcast(sizeof(T)*count, El::mpi::Rank(c), root);
+  El::mpi::Broadcast<TT>(reinterpret_cast<TT*>(data), size, root, std::move(c), syncInfo);
+  count_bytes_broadcast(sizeof(T)*count, rank_c, root);
 }
 
 /// Broadcast std::string over an arbitrary communicator.
 template<>
-void lbann_comm::broadcast<std::string>(const int root, std::string& str, const El::mpi::Comm c);
+void lbann_comm::broadcast<std::string>(const int root, std::string& str, El::mpi::Comm c);
 
 /** Get the current rank within MPI_COMM_WORLD.
  *  This function is safe to call even if MPI has not initialized or

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -361,7 +361,7 @@ bool load_model_weights(std::string ckpt_dir, model * m){
     closeread(fd, latest);
     if(temp_comm->am_model_master())
       sprintf(latest, "%s/shared.model.%d.epoch.%d.step.%d/", ckpt_dir.c_str(), temp_comm->get_model_rank(), epochLast, stepLast);
-    temp_comm->model_broadcast(0, &(latest[0]), sizeof(latest));
+    temp_comm->model_broadcast(0, &(latest[0]), sizeof(latest), El::SyncInfo<El::Device::CPU>{});
   }
 
   DIR *weight_dir;

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -210,8 +210,7 @@ bool lbann_callback_checkpoint::checkpoint(model *m) {
       p.open_checkpoint(epochdir);
     }
     // Need to give other ranks knowledge of checkpoint dir for writing of rank specific rng state
-    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir),
-                          El::SyncInfo<El::Device::CPU>{});
+    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir));
     m->save_to_checkpoint_shared(p);
     // close our checkpoint
     p.close_checkpoint();
@@ -330,8 +329,7 @@ bool lbann_callback_checkpoint::restart(model *m) {
       p.open_restart(epochdir);
     }
     // Ensure all ranks have access to checkpoint dir, needed for loading rank specific rng state
-    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir),
-                          El::SyncInfo<El::Device::CPU>{});
+    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir));
     m->load_from_checkpoint_shared(p);
     if(comm->am_model_master())
       p.close_restart();

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -81,20 +81,20 @@ bool lbann_callback_checkpoint::need_checkpoint(model *m) {
   if (!m_checkpoint_shared && m_checkpoint_epochs > 0 && (p.get_cb_type() == callback_type::epoch || p.get_cb_type() == callback_type::validation)){
       m_checkpoint_shared = (cur_epoch > 0) && (cur_epoch % m_checkpoint_epochs == 0);
     }
-    
+
   if(!m_checkpoint_dist && m_ckpt_dist_epochs > 0 && (p.get_cb_type() == callback_type::epoch || p.get_cb_type() == callback_type::validation)){
       m_checkpoint_dist = (cur_epoch > 0) && (cur_epoch % m_ckpt_dist_epochs == 0);
   }
-  
+
   // If we are at the end of a training mb step and the training mb step lands on defined interval, trigger checkpoint
   if (!m_checkpoint_shared && m_checkpoint_steps > 0) {
     m_checkpoint_shared = (m->get_cur_step() > 0) && (m->get_cur_step() % m_checkpoint_steps == 0);
   }
-  
+
   if(!m_checkpoint_dist && m_ckpt_dist_steps > 0){
       m_checkpoint_dist = (m->get_cur_step() > 0) && (m->get_cur_step() % m_ckpt_dist_steps == 0);
   }
-  
+
   // check the clock if time-based checkpoint is enabled
   if (!m_checkpoint_shared && m_checkpoint_secs != 0.0) {
     // have rank 0 determine whether we should checkpoint
@@ -108,12 +108,12 @@ bool lbann_callback_checkpoint::need_checkpoint(model *m) {
       m_checkpoint_shared = (current >= next);
     }
     comm->model_broadcast(0, m_checkpoint_shared);
-  } 
-  // If either checkpoint version is triggered, return true, otherwise false.   
+  }
+  // If either checkpoint version is triggered, return true, otherwise false.
   return (m_checkpoint_shared || m_checkpoint_dist);
 }
 
-// Print last checkpoint to file, used to determine which checkpoint to load from. 
+// Print last checkpoint to file, used to determine which checkpoint to load from.
 static bool write_latest(const char *dir, const char *name, int epoch, int train) {
   // define filename
   char filename[1024];
@@ -199,7 +199,7 @@ bool lbann_callback_checkpoint::checkpoint(model *m) {
     // Print latest checkpoint to file
     if (comm->am_model_master()) {
       write_latest(dir, "last.distributed.checkpoint", epoch, step);
-    } 
+    }
   }
   // Shared checkpoint, logic identical to Distributed.i
   if(m_checkpoint_shared){
@@ -209,15 +209,16 @@ bool lbann_callback_checkpoint::checkpoint(model *m) {
     if (comm->am_model_master()) {
       p.open_checkpoint(epochdir);
     }
-      // Need to give other ranks knowledge of checkpoint dir for writing of rank specific rng state
-    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir));
+    // Need to give other ranks knowledge of checkpoint dir for writing of rank specific rng state
+    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir),
+                          El::SyncInfo<El::Device::CPU>{});
     m->save_to_checkpoint_shared(p);
     // close our checkpoint
     p.close_checkpoint();
     if (comm->am_model_master()) {
       write_latest(dir, "last.shared.checkpoint", epoch, step);
     }
-   }
+  }
 
   uint64_t bytes_count = p.get_bytes();
 
@@ -252,17 +253,17 @@ bool lbann_callback_checkpoint::restart(model *m) {
   int step_dist = -1;
   lbann_comm *comm = m->get_comm();
   int shared = 1;
-  // Grab latest checkpoint information, checks for latest in dist and shared, restarts from most recent between the two. 
+  // Grab latest checkpoint information, checks for latest in dist and shared, restarts from most recent between the two.
   if (comm->am_model_master()) {
     if(m_per_rank_dir.length()){
       snprintf(dir, sizeof(dir), "%s/%s", m_per_rank_dir.c_str(), m_checkpoint_dir.c_str());
       read_latest(dir, "last.distributed.checkpoint", &epoch_dist, &step_dist);
-    } 
+    }
     if(m_checkpoint_dir.length()){
       strcpy(dir, m_checkpoint_dir.c_str());
       read_latest(dir, "last.shared.checkpoint", &epoch, &step);
     }
-    
+
     if(epoch > epoch_dist){
       strcpy(dir, m_checkpoint_dir.c_str());
       shared = 1;
@@ -278,7 +279,7 @@ bool lbann_callback_checkpoint::restart(model *m) {
       shared = 0;
     }
   }
-  // Update other ranks on where we are loading from. 
+  // Update other ranks on where we are loading from.
   // TODO: we would want to prepend dir with the model name and model rank:
   // m->get_name() + '.' + std::to_string(comm->get_model_rank()) + '.'
 #if 1
@@ -314,7 +315,7 @@ bool lbann_callback_checkpoint::restart(model *m) {
     printf("Restart: epoch %d ...\n", epoch);
     fflush(stdout);
   }
-  
+
   char epochdir[1024];
   // Create dir to restart from based off last recorded checkpoint (or overriden values in last.shared[distributed].checkpoint
   if(!shared){
@@ -329,12 +330,13 @@ bool lbann_callback_checkpoint::restart(model *m) {
       p.open_restart(epochdir);
     }
     // Ensure all ranks have access to checkpoint dir, needed for loading rank specific rng state
-    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir));
+    comm->model_broadcast(0, &(p.m_checkpoint_dir[0]), sizeof(p.m_checkpoint_dir),
+                          El::SyncInfo<El::Device::CPU>{});
     m->load_from_checkpoint_shared(p);
     if(comm->am_model_master())
       p.close_restart();
   }
-  
+
   // close our checkpoint
   uint64_t bytes_count = p.get_bytes();
   // let user know we've completed reading our restart

--- a/src/data_store/data_store_image.cpp
+++ b/src/data_store/data_store_image.cpp
@@ -809,7 +809,8 @@ void data_store_image::read_file_sizes() {
     }
   }
 
-  m_comm->broadcast(0, s2.data(), s2.size(), m_comm->get_model_comm());
+  m_comm->broadcast(0, s2.data(), s2.size(), m_comm->get_model_comm(),
+                    El::SyncInfo<El::Device::CPU>{});
   for (size_t j=0; j<s2.size(); j+=2) {
     m_file_sizes[s2[j]] = s2[j+1];
   }

--- a/src/data_store/data_store_image.cpp
+++ b/src/data_store/data_store_image.cpp
@@ -809,8 +809,7 @@ void data_store_image::read_file_sizes() {
     }
   }
 
-  m_comm->broadcast(0, s2.data(), s2.size(), m_comm->get_model_comm(),
-                    El::SyncInfo<El::Device::CPU>{});
+  m_comm->broadcast(0, s2.data(), s2.size(), m_comm->get_model_comm());
   for (size_t j=0; j<s2.size(); j+=2) {
     m_file_sizes[s2[j]] = s2[j+1];
   }

--- a/src/data_store/data_store_pilot2_molecular.cpp
+++ b/src/data_store/data_store_pilot2_molecular.cpp
@@ -167,8 +167,7 @@ void data_store_pilot2_molecular::build_nabor_map() {
     work.resize(sz);
     neighbors_8 = work.data();
   }
-  m_comm->world_broadcast<double>(0, neighbors_8, sz,
-                                  El::SyncInfo<El::Device::CPU>{});
+  m_comm->world_broadcast<double>(0, neighbors_8, sz);
 
   //fill in the nabors map
   for (auto data_id : (*m_shuffled_indices)) {

--- a/src/data_store/data_store_pilot2_molecular.cpp
+++ b/src/data_store/data_store_pilot2_molecular.cpp
@@ -167,7 +167,8 @@ void data_store_pilot2_molecular::build_nabor_map() {
     work.resize(sz);
     neighbors_8 = work.data();
   }
-  m_comm->world_broadcast<double>(0, neighbors_8, sz);
+  m_comm->world_broadcast<double>(0, neighbors_8, sz,
+                                  El::SyncInfo<El::Device::CPU>{});
 
   //fill in the nabors map
   for (auto data_id : (*m_shuffled_indices)) {
@@ -266,7 +267,7 @@ void data_store_pilot2_molecular::exchange_data() {
   for (auto data_id : required_molecules) {
     m_my_molecules[data_id].resize(num_features);
     m_comm->nb_tagged_recv<double>(
-          m_my_molecules[data_id].data(), num_features, m_owner_rank, 
+          m_my_molecules[data_id].data(), num_features, m_owner_rank,
           data_id, recv_req[jj++], m_comm->get_world_comm());
   }
 
@@ -280,7 +281,7 @@ void data_store_pilot2_molecular::exchange_data() {
       send_req[p].resize(required_molecules.size());
       for (auto data_id : required_molecules) {
         m_comm->nb_tagged_send<double>(
-           m_data[data_id].data(), num_features, p, 
+           m_data[data_id].data(), num_features, p,
            data_id, send_req[p][jj++], m_comm->get_world_comm());
       }
     }

--- a/src/layers/loss/top_k_categorical_accuracy.cu
+++ b/src/layers/loss/top_k_categorical_accuracy.cu
@@ -130,7 +130,7 @@ __global__ void fill_with_tensor_index(El::Int tensor_size,
   const El::Int num_threads = blockDim.x * gridDim.x;
   for (El::Int i = gid; i < tensor_size; i += num_threads) {
     tensor[i] = (i / dim_stride) % dim;
-  }  
+  }
 }
 
 /** Get indices corresponding to one-hot matrix.
@@ -156,7 +156,7 @@ __global__ void one_hot_matrix_to_indices(El::Int local_height,
                                 + local_row * global_matrix_col_stride);
       indices[local_col] = global_row;
     }
-  }  
+  }
 }
 
 /** Compute categorical accuracy for each matrix column.
@@ -182,7 +182,7 @@ __global__ void compute_categorical_accuracy(El::Int k,
         && label_index <= max_entry) {
       loss[col * loss_stride] = DataType(1);
     }
-  }  
+  }
 }
 
 /** GPU implementation of top-k categorical accuracy layer forward prop. */
@@ -249,7 +249,9 @@ void fp_gpu(lbann_comm& comm,
     El::mpi::AllReduce(label_indices.data().get(),
                        label_indices.size(),
                        El::mpi::MIN,
-                       col_comm);
+                       col_comm,
+                       El::SyncInfo<El::Device::GPU>{stream,
+                               El::GPUManager::Event()});
   }
 
   // Find top-k entries in each column of local prediction matrix
@@ -336,7 +338,7 @@ void fp_gpu(lbann_comm& comm,
                                    local_width,
                                    cudaMemcpyDeviceToDevice,
                                    stream));
-    }   
+    }
   }
 
   // Compute categorical accuracy

--- a/src/layers/transform/in_top_k.cpp
+++ b/src/layers/transform/in_top_k.cpp
@@ -107,7 +107,7 @@ void fp_cpu(lbann_comm& comm,
                     top_entries.size() * sizeof(entry),
                     reinterpret_cast<El::byte*>(global_top_entries.data()),
                     top_entries.size() * sizeof(entry),
-                    col_comm, El::SyncInfo<El::Device::CPU>{});
+                    col_comm);
 #pragma omp parallel for
     for (El::Int col = 0; col < local_width; ++col) {
       std::vector<entry> col_entries(col_comm_size * k);

--- a/src/layers/transform/in_top_k.cpp
+++ b/src/layers/transform/in_top_k.cpp
@@ -83,7 +83,7 @@ void fp_cpu(lbann_comm& comm,
   // Column communicator
   auto&& col_comm = input.ColComm();
   const auto& col_comm_size = El::mpi::Size(col_comm);
-  
+
   // Find top-k entries in each column of local input matrix
   std::vector<entry> top_entries(local_width * k);
 #pragma omp parallel for
@@ -99,7 +99,7 @@ void fp_cpu(lbann_comm& comm,
                            &top_entries[col*k] + k,
                            entry::compare);
   }
-  
+
   // Find top-k entries in each column of global input matrix
   if (col_comm_size > 1) {
     std::vector<entry> global_top_entries(col_comm_size * local_width * k);
@@ -107,7 +107,7 @@ void fp_cpu(lbann_comm& comm,
                     top_entries.size() * sizeof(entry),
                     reinterpret_cast<El::byte*>(global_top_entries.data()),
                     top_entries.size() * sizeof(entry),
-                    col_comm);
+                    col_comm, El::SyncInfo<El::Device::CPU>{});
 #pragma omp parallel for
     for (El::Int col = 0; col < local_width; ++col) {
       std::vector<entry> col_entries(col_comm_size * k);
@@ -135,7 +135,7 @@ void fp_cpu(lbann_comm& comm,
       }
     }
   }
-  
+
 }
 
 } // namespace

--- a/src/layers/transform/in_top_k.cu
+++ b/src/layers/transform/in_top_k.cu
@@ -188,6 +188,7 @@ void fp_gpu(lbann_comm& comm,
 
   // GPU objects
   auto&& stream = El::GPUManager::Stream();
+  auto&& event = El::GPUManager::Event();
   cuda::thrust::allocator<> alloc(stream);
   using entry_array = thrust::device_vector<entry, cuda::thrust::allocator<entry>>;
   using index_array = thrust::device_vector<El::Int, cuda::thrust::allocator<El::Int>>;
@@ -240,7 +241,7 @@ void fp_gpu(lbann_comm& comm,
                     top_entries.size() * sizeof(entry),
                     reinterpret_cast<El::byte*>(global_top_entries.data().get()),
                     top_entries.size() * sizeof(entry),
-                    col_comm, El::SyncInfo<El::Device::GPU>{stream, nullptr});
+                    col_comm, El::SyncInfo<El::Device::GPU>{stream, event});
     fill_with_tensor_index<<<grid_dim, block_dim, 0, stream>>>(
       num_entries, local_width, k, global_top_entries_cols.data().get());
     thrust::sort_by_key(thrust::cuda::par(alloc).on(stream),

--- a/src/layers/transform/in_top_k.cu
+++ b/src/layers/transform/in_top_k.cu
@@ -114,7 +114,7 @@ __global__ void fill_with_tensor_index(El::Int tensor_size,
   const El::Int num_threads = blockDim.x * gridDim.x;
   for (El::Int i = gid; i < tensor_size; i += num_threads) {
     tensor[i] = (i / dim_stride) % dim;
-  }  
+  }
 }
 
 /** Set selected matrix entries to one.
@@ -152,7 +152,7 @@ __global__ void indicate_matrix_entries(El::Int k,
       }
       local_matrix[local_row + local_col * local_matrix_ldim] = DataType(1);
     }
-  }  
+  }
 }
 
 /** GPU implementation of in_top_k layer forward prop. */
@@ -180,7 +180,7 @@ void fp_gpu(lbann_comm& comm,
   } else if (local_width < 1) {
     return;
   }
-  
+
   // Column communicator
   auto&& col_comm = input.ColComm();
   const auto& col_comm_rank = El::mpi::Rank(col_comm);
@@ -240,7 +240,7 @@ void fp_gpu(lbann_comm& comm,
                     top_entries.size() * sizeof(entry),
                     reinterpret_cast<El::byte*>(global_top_entries.data().get()),
                     top_entries.size() * sizeof(entry),
-                    col_comm);
+                    col_comm, El::SyncInfo<El::Device::GPU>{stream, nullptr});
     fill_with_tensor_index<<<grid_dim, block_dim, 0, stream>>>(
       num_entries, local_width, k, global_top_entries_cols.data().get());
     thrust::sort_by_key(thrust::cuda::par(alloc).on(stream),

--- a/src/metrics/r2.cpp
+++ b/src/metrics/r2.cpp
@@ -36,14 +36,14 @@ EvalType r2_metric::evaluate_compute(const AbsDistMat& prediction,
   const int local_height = prediction.LocalHeight();
   const int local_width = prediction.LocalWidth();
   const int width = prediction.Width();
-  
+
   // Get local matrices
   const Mat& prediction_local = prediction.LockedMatrix();
   const Mat& ground_truth_local = ground_truth.LockedMatrix();
 
   DataType gt_mean, gt_std;
   // Entry-wise mean of ground truth
-  //@todo fix stat class not to compute stdev if not needed 
+  //@todo fix stat class not to compute stdev if not needed
   entrywise_mean_and_stdev(ground_truth, gt_mean, gt_std);
 
   // Compute residual sum of squares ss_res
@@ -63,12 +63,13 @@ EvalType r2_metric::evaluate_compute(const AbsDistMat& prediction,
   }
 
   EvalType res_tot[2] = {ss_res, ss_tot};  // Pack to do one allreduce.
-  El::mpi::AllReduce(res_tot, 2, prediction.DistComm());
+  El::mpi::AllReduce(res_tot, 2, prediction.DistComm(),
+                     El::SyncInfo<El::Device::CPU>{});
   //Keras and TF add epsilon (1e-07) to denominator to avoid inf score
   //We might actually need to do this here and other places too
   EvalType ss_tot_eps = res_tot[1] + 0.0000001;
   //Multiply by width because base class divide by mini-batch size
-  return ((1-(res_tot[0]/ss_tot_eps))*width); 
+  return ((1-(res_tot[0]/ss_tot_eps))*width);
 }
 
 }  // namespace lbann

--- a/src/utils/statistics.cpp
+++ b/src/utils/statistics.cpp
@@ -88,7 +88,8 @@ void entrywise_mean_and_stdev(const AbsDistMat& data,
     }
   }
   DataType sum_sqsum[2] = {sum, sqsum};  // Pack to do one allreduce.
-  El::mpi::AllReduce(sum_sqsum, 2, data.DistComm());
+  El::mpi::AllReduce(sum_sqsum, 2, data.DistComm(),
+                     El::SyncInfo<El::Device::CPU>{});
 
   // Compute mean and standard deviation
   mean = sum_sqsum[0] / size;


### PR DESCRIPTION
Integrates changes from [this PR](https://github.com/LLNL/Elemental/pull/44) on Hydrogen. This breaks backward compatibility with "pre-#44" hydrogen.

Changes are really minor, but the interface to `lbann::comm` is affected.

If built with Aluminum support in Hydrogen, this should resolve some of the collective issues that various users have been seeing (e.g., `MPI_Reduce_scatter_block`) by just avoiding the MPI calls entirely.