### PR TITLE
LogSoftmax

### DIFF
--- a/include/lbann/layers/activations/CMakeLists.txt
+++ b/include/lbann/layers/activations/CMakeLists.txt
@@ -12,6 +12,7 @@ set_full_path(THIS_DIR_HEADERS
   sigmoid.hpp
   smooth_relu.hpp
   softmax.hpp
+  logsoftmax.hpp
   softplus.hpp
   swish.hpp
   tanh.hpp

--- a/include/lbann/layers/activations/logsoftmax.hpp
+++ b/include/lbann/layers/activations/logsoftmax.hpp
@@ -1,0 +1,313 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_LOGSOFTMAX_HPP_INCLUDED
+#define LBANN_LAYER_LOGSOFTMAX_HPP_INCLUDED
+
+#include "lbann/layers/activations/activation.hpp"
+#include "lbann/layers/layer.hpp"
+#include "lbann/io/file_io.hpp"
+#include "lbann/utils/random.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/cuda.hpp"
+#include "lbann/utils/cudnn.hpp"
+#include <unistd.h>
+#include <string>
+
+#include <cassert>
+
+namespace lbann {
+
+#ifdef LBANN_HAS_GPU
+namespace logsoftmax_cuda {
+/** Apply minimum cutoff to activation entries.
+ *  A minimum output value helps avoid denormalized floats. Data is
+ *  assumed to be on GPU.
+ */
+void fp_cutoff(int height, int width,
+               DataType* output,
+               int output_leading_dim,
+               DataType cutoff,
+               cudaStream_t stream);
+/** Error signal correction if activations have minimum cutoff.
+ *  Data is assumed to be on GPU.
+ */
+void bp_cutoff(int height, int width,
+               const DataType* output,
+               int output_leading_dim,
+               DataType* gradient_wrt_input,
+               int gradient_wrt_input_leading_dim,
+               DataType cutoff,
+               cudaStream_t stream);
+/** Compute the maximum entry in input for each column.
+ * Data is assumed to be on the GPU.
+ */
+void max_local_col_entry(int height, int width,
+                         const DataType * __restrict__ input,
+                         int input_ldim,
+                         DataType * __restrict__ workspace,
+                         cudaStream_t stream);
+/** Exponentiate the (shifted) input, and compute its sum.
+ * Data is assumed to be on the GPU.
+ */
+void exp_and_col_sum(int height, int width,
+                     const DataType * __restrict__ input,
+                     int intput_ldim,
+                     DataType * __restrict__ output,
+                     int output_ldim,
+                     DataType * __restrict__ workspace,
+                     cudaStream_t stream);
+/** Divide each entry in a column by the pre-computed sum of the column.
+ * Apply a minimum cutoff to the entries if needed.
+ * Data is assumed to be on the GPU.
+ */
+void div_by_col_sums_and_cutoff(int height, int width,
+                                DataType * __restrict__ output,
+                                int output_ldim,
+                                const DataType * __restrict__ workspace,
+                                const DataType cutoff,
+                                cudaStream_t stream);
+/** Compute the gradient w.r.t. the input and apply a cutoff if needed.
+ * Data is assumed to be on the GPU.
+ */
+void grad_wrt_input_and_cutoff(int height, int width,
+                               const DataType * __restrict__ output,
+                               int output_ldim,
+                               const DataType * __restrict__ workspace,
+                               const DataType * __restrict__ grad_wrt_output,
+                               int grad_wrt_output_ldim,
+                               DataType * __restrict__ grad_wrt_input,
+                               int grad_wrt_input_ldim,
+                               const DataType cutoff,
+                               cudaStream_t stream);
+}  // namespace logsoftmax_cuda
+#endif // LBANN_HAS_CUDA
+
+/** Softmax layer. */
+template <data_layout T_layout, El::Device Dev>
+class logsoftmax_layer : public activation_layer {
+
+ private:
+
+  /** Workspace for column-wise reductions. */
+  AbsDistMat *m_workspace;
+
+  /** Lower bound for outputs.
+   *  This should be sufficiently large to avoid denormalized
+   *  floats.
+   */
+  DataType m_min_output;
+
+#ifdef LBANN_HAS_CUDNN
+  /** Tensor cuDNN descriptors. */
+  cudnn::data_parallel_layer_tensor_manager m_tensors_cudnn_desc;
+#endif // LBANN_HAS_CUDNN
+
+ public:
+
+  logsoftmax_layer(lbann_comm *comm)
+    : activation_layer(comm),
+      m_workspace(nullptr),
+      m_min_output(std::sqrt(std::numeric_limits<DataType>::min()))
+#ifdef LBANN_HAS_CUDNN
+    , m_tensors_cudnn_desc(this)
+#endif // LBANN_HAS_CUDNN
+  {}
+
+  logsoftmax_layer(const logsoftmax_layer& other)
+    : activation_layer(other),
+      m_min_output(other.m_min_output)
+#ifdef LBANN_HAS_CUDNN
+    , m_tensors_cudnn_desc(other.m_tensors_cudnn_desc)
+#endif // LBANN_HAS_CUDNN
+  {
+
+    // Matrix deep copy
+    m_workspace = other.m_workspace;
+    if (m_workspace != nullptr) { m_workspace = m_workspace->Copy(); }
+
+#ifdef LBANN_HAS_CUDNN
+    m_tensors_cudnn_desc.set_layer(this);
+#endif // LBANN_HAS_CUDNN
+
+  }
+
+  logsoftmax_layer& operator=(const logsoftmax_layer& other) {
+    activation_layer::operator=(other);
+    m_min_output = other.m_min_output;
+
+    // Deep matrix copy
+    if (m_workspace != nullptr) { delete m_workspace; }
+    m_workspace = other.m_workspace;
+    if (m_workspace != nullptr) { m_workspace = m_workspace->Copy(); }
+
+#ifdef LBANN_HAS_CUDNN
+    // Copy cuDNN objects
+    m_tensors_cudnn_desc = other.m_tensors_cudnn_desc;
+    m_tensors_cudnn_desc.set_layer(this);
+#endif // LBANN_HAS_CUDNN
+
+  }
+
+  ~logsoftmax_layer() {
+    if (m_workspace != nullptr) { delete m_workspace; }
+  }
+
+  logsoftmax_layer* copy() const override { return new logsoftmax_layer(*this); }
+  std::string get_type() const override { return "logsoftmax"; }
+
+  std::string get_description() const override {
+    return std::string {} + " logsoftmax" + " dataLayout: "
+           + this->get_data_layout_string(get_data_layout());
+  }
+
+  data_layout get_data_layout() const override { return T_layout; }
+
+  El::Device get_device_allocation() const override { return Dev; }
+
+  void setup_matrices(const El::Grid& grid) override;
+
+  void setup_data() override {
+    activation_layer::setup_data();
+    const int mini_batch_size = this->m_model->get_max_mini_batch_size();
+    m_workspace->Resize(1, mini_batch_size);
+  }
+
+  void fp_setup_outputs(El::Int mini_batch_size) override {
+    activation_layer::fp_setup_outputs(mini_batch_size);
+    m_workspace->Resize(1, mini_batch_size);
+  }
+
+  void fp_compute() override;
+  void bp_compute() override;
+
+  virtual void fp_compute_cpu() {
+
+    // Local matrices
+    const auto& local_input = get_local_prev_activations();
+    auto& local_output = get_local_activations();
+    auto& shift_local_workspace = m_workspace->Matrix();
+    auto& sum_local_workspace = m_workspace->Matrix();
+
+    // Matrix parameters
+    const El::Int local_height = local_input.Height();
+    const El::Int local_width = local_input.Width();
+
+    // Find maximum entry in each column
+    if (local_height == 0) {
+      // When there's no local data, fill the workspace with a small value so
+      // the maximum across processors is still computed correctly.
+      El::Fill(shift_local_workspace, std::numeric_limits<DataType>::lowest());
+    } else {
+      #pragma omp parallel for
+      for (El::Int col = 0; col < local_width; ++col) {
+        DataType max_entry = local_input(0, col);
+        for (El::Int row = 1; row < local_height; ++row) {
+          max_entry = std::max(max_entry, local_input(row, col));
+        }
+        shift_local_workspace(0, col) = max_entry;
+      }
+    }
+    m_comm->allreduce(*m_workspace, m_workspace->RedundantComm(),
+                      El::mpi::MAX);
+
+    // Exponentiate activations and compute column sums
+    // Note: Subtracting by the column max prevents activations from
+    // blowing up. Large negative values underflow to 0.
+    // Save the max/shift value for the log-sum-exp trick.
+    #pragma omp parallel for
+    for (El::Int col = 0; col < local_width; ++col) {
+      const DataType shift = shift_local_workspace(0, col);
+      DataType sum = 0;
+      for (El::Int row = 0; row < local_height; ++row) {
+        const DataType x = local_input(row, col);
+        const DataType y = std::exp(x - shift);
+        sum += y;
+      }
+      sum_local_workspace(0, col) = sum;
+    }
+    m_comm->allreduce(*m_workspace, m_workspace->RedundantComm());
+
+    // Subtract log-sum-exp and shift value from input to get numerically stable output.
+    #pragma omp parallel for
+    for (El::Int col = 0; col < local_width; ++col) {
+      const DataType lse = std::log(sum_local_workspace(0, col));
+      const DataType shift = shift_local_workspace(0, col);
+      for (El::Int row = 0; row < local_height; ++row) {
+        const DataType x = local_input(row, col);
+        DataType& y = local_output(row, col);
+        y = x - lse - shift;
+      }
+    }
+
+  }
+
+  virtual void bp_compute_cpu() {
+
+    // Local matrices
+    const DMat<Dev>& local_output = get_local_activations();
+    const DMat<Dev>& local_gradient_wrt_output = get_local_prev_error_signals();
+    DMat<Dev>& local_gradient_wrt_input = get_local_error_signals();
+    DMat<Dev>& sum_local_workspace = m_workspace->Matrix();
+
+    // Matrix parameters
+    const El::Int local_height = local_output.Height();
+    const El::Int local_width = local_output.Width();
+
+    // Exponentiate activations and compute column sums
+    // Note: Subtracting by the column max prevents activations from
+    // blowing up. Large negative values underflow to 0.
+    // Save the max/shift value for the log-sum-exp trick.
+    #pragma omp parallel for
+    for (El::Int col = 0; col < local_width; ++col) {
+      DataType sum = 0;
+      for (El::Int row = 0; row < local_height; ++row) {
+        const DataType x = local_gradient_wrt_output(row, col);
+        sum += x;
+      }
+      sum_local_workspace(0, col) = sum;
+    }
+    m_comm->allreduce(*m_workspace, m_workspace->RedundantComm());
+
+    // Compute gradient w.r.t. input
+    #pragma omp parallel for
+    for (El::Int col = 0; col < local_width; ++col) {
+      const DataType sum = local_workspace(0, col);
+      for (El::Int row = 0; row < local_height; ++row) {
+        const DataType y = local_output(row, col);
+        const DataType dy = local_gradient_wrt_output(row, col);
+        DataType dx = dy - std::exp(y) * sum;
+        local_gradient_wrt_input(row, col) = dx;
+      }
+    }
+
+  }
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_LOGSOFTMAX_HPP_INCLUDED

--- a/include/lbann/layers/activations/logsoftmax.hpp
+++ b/include/lbann/layers/activations/logsoftmax.hpp
@@ -295,7 +295,7 @@ class logsoftmax_layer : public activation_layer {
     // Compute gradient w.r.t. input
     #pragma omp parallel for
     for (El::Int col = 0; col < local_width; ++col) {
-      const DataType sum = local_workspace(0, col);
+      const DataType sum = sum_local_workspace(0, col);
       for (El::Int row = 0; row < local_height; ++row) {
         const DataType y = local_output(row, col);
         const DataType dy = local_gradient_wrt_output(row, col);

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -51,6 +51,7 @@
 #include "lbann/layers/activations/sigmoid.hpp"
 #include "lbann/layers/activations/smooth_relu.hpp"
 #include "lbann/layers/activations/softmax.hpp"
+#include "lbann/layers/activations/logsoftmax.hpp"
 #include "lbann/layers/activations/softplus.hpp"
 #include "lbann/layers/activations/swish.hpp"
 #include "lbann/layers/activations/tanh.hpp"

--- a/src/layers/activations/CMakeLists.txt
+++ b/src/layers/activations/CMakeLists.txt
@@ -4,6 +4,7 @@ set_full_path(THIS_DIR_SOURCES
   tanh.cpp
   sigmoid.cpp
   softmax.cpp
+  logsoftmax.cpp
   )
 
 if (LBANN_HAS_CUDA)
@@ -13,6 +14,7 @@ if (LBANN_HAS_CUDA)
     relu.cu
     sigmoid.cu
     softmax.cu
+    logsoftmax.cu
     )
 endif ()
 

--- a/src/layers/activations/logsoftmax.cpp
+++ b/src/layers/activations/logsoftmax.cpp
@@ -1,0 +1,244 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/activations/logsoftmax.hpp"
+#ifdef LBANN_HAS_CUDNN
+#include "lbann/utils/cublas.hpp"
+#endif  // LBANN_HAS_CUDNN
+
+namespace lbann {
+
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
+  ::setup_matrices(const El::Grid& grid) {
+  activation_layer::setup_matrices(grid);
+  if (m_sum_workspace != nullptr) { delete m_sum_workspace; }
+  if (m_shift_workspace != nullptr) { delete m_shift_workspace; }
+  m_sum_workspace = new StarMRMat<El::Device::CPU>(grid);
+  m_shift_workspace = new StarMRMat<El::Device::CPU>(grid);
+}
+
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+  ::setup_matrices(const El::Grid& grid) {
+  activation_layer::setup_matrices(grid);
+  if (m_sum_workspace != nullptr) { delete m_sum_workspace; }
+  if (m_shift_workspace != nullptr) { delete m_shift_workspace; }
+  m_sum_workspace = new StarVCMat<El::Device::CPU>(grid);
+  m_shift_workspace = new StarVCMat<El::Device::CPU>(grid);
+}
+
+#ifdef LBANN_HAS_GPU
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
+  ::setup_matrices(const El::Grid& grid) {
+  activation_layer::setup_matrices(grid);
+  if (m_sum_workspace != nullptr) { delete m_sum_workspace; }
+  if (m_shift_workspace != nullptr) { delete m_shift_workspace; }
+  m_sum_workspace = new StarMRMat<El::Device::GPU>(grid);
+  m_shift_workspace = new StarMRMat<El::Device::GPU>(grid);
+}
+
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+  ::setup_matrices(const El::Grid& grid) {
+  activation_layer::setup_matrices(grid);
+  if (m_sum_workspace != nullptr) { delete m_sum_workspace; }
+  if (m_shift_workspace != nullptr) { delete m_shift_workspace; }
+  m_sum_workspace = new StarVCMat<El::Device::GPU>(grid);
+  m_shift_workspace = new StarVCMat<El::Device::GPU>(grid);
+}
+#endif // LBANN_HAS_GPU
+
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::fp_compute() {
+  fp_compute_cpu();
+}
+
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::bp_compute() {
+  bp_compute_cpu();
+}
+
+#ifdef LBANN_HAS_GPU
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
+
+  // Local matrices.
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+  auto& local_sum_workspace = m_sum_workspace->Matrix();
+  auto& local_shift_workspace = m_shift_workspace->Matrix();
+
+  const El::Int local_height = local_input.Height();
+  const El::Int local_width = local_input.Width();
+
+  // Find the maximum entry in each local column.
+  if (local_height == 0) {
+    // When there's no local data, fill the workspace with a small value so the
+    // maximum across processors is still computed correctly.
+    El::Fill(local_shift_workspace, std::numeric_limits<DataType>::lowest());
+  } else {
+    logsoftmax_cuda::max_local_col_entry(
+      local_height, local_width, local_input.LockedBuffer(),
+      local_input.LDim(), local_shift_workspace.Buffer(), El::GPUManager::Stream());
+  }
+  // Find the global max entry in each column.
+  m_comm->allreduce(*m_shift_workspace, m_shift_workspace->RedundantComm(), El::mpi::MAX);
+
+  // Exponentiate activations and compute column sums.
+  // This subtracts by the column max for stability.
+  if (local_height == 0) {
+    // Zero out so that we contribute nothing to the sum.
+    El::Zero(local_sum_workspace);
+  } else {
+    logsoftmax_cuda::exp_and_col_sum(
+      local_height, local_width, local_input.LockedBuffer(),
+      local_input.LDim(),
+      local_shift_workspace.Buffer(), 
+      local_sum_workspace.Buffer(), 
+      El::GPUManager::Stream());
+  }
+  // Compute the global sums for each column.
+  m_comm->allreduce(*m_sum_workspace, m_sum_workspace->RedundantComm(), El::mpi::SUM);
+
+  // Divide activations by the column sums.
+  // This rounds small values to avoid denormalization.
+  logsoftmax_cuda::sub_by_col_sums_and_shift(
+    local_height, local_width, 
+    local_input.LockedBuffer(), local_input.LDim(), 
+    local_output.Buffer(), local_output.LDim(), 
+    local_shift_workspace.LockedBuffer(), local_sum_workspace.LockedBuffer(), 
+    El::GPUManager::Stream());
+
+}
+
+template <>
+void logsoftmax_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
+
+  // Local matrices.
+  const auto& local_output = get_local_activations();
+  const auto& local_grad_wrt_output = get_local_prev_error_signals();
+  auto& local_grad_wrt_input = get_local_error_signals();
+  auto& local_sum_workspace = m_sum_workspace->Matrix();
+
+  const El::Int local_height = local_output.Height();
+  const El::Int local_width = local_output.Width();
+
+  // Compute dot products between output and gradient w.r.t. output.
+  auto&& handle = El::GPUManager::cuBLASHandle();
+  CHECK_CUBLAS(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE));
+  for (El::Int col = 0; col < local_width; ++col) {
+    cublas::dot(handle, local_height,
+                local_output.LockedBuffer(0, col), 1,
+                local_grad_wrt_output.LockedBuffer(0, col), 1,
+                local_sum_workspace.Buffer(0, col));
+  }
+  CHECK_CUBLAS(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST));
+  m_comm->allreduce(*m_sum_workspace, m_sum_workspace->RedundantComm(), El::mpi::SUM);
+
+  // Compute gradient w.r.t. input.
+  // Applies a cutoff if needed to avoid denormalized floats.
+  logsoftmax_cuda::grad_wrt_input(
+    local_height, local_width, local_output.LockedBuffer(),
+    local_output.LDim(), local_sum_workspace.LockedBuffer(),
+    local_grad_wrt_output.LockedBuffer(), local_grad_wrt_output.LDim(),
+    local_grad_wrt_input.Buffer(), local_grad_wrt_input.LDim(),
+    El::GPUManager::Stream());
+
+}
+#endif // LBANN_HAS_GPU
+
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
+  fp_compute_cpu();
+}
+
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
+  bp_compute_cpu();
+}
+
+#ifdef LBANN_HAS_GPU
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+#ifndef LBANN_HAS_CUDNN
+  LBANN_ERROR("cuDNN not detected");
+#else
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+  if (local_input.Height() > 0 && local_input.Width() > 0) {
+
+    // Useful constants
+    const DataType zero = DataType(0);
+    const DataType one = DataType(1);
+
+    // Apply logsoftmax
+    CHECK_CUDNN(cudnnSoftmaxForward(cudnn::get_handle(),
+                                    CUDNN_SOFTMAX_LOG,
+                                    CUDNN_SOFTMAX_MODE_INSTANCE,
+                                    &one,
+                                    m_tensors_cudnn_desc.get_prev_activations(),
+                                    local_input.LockedBuffer(),
+                                    &zero,
+                                    m_tensors_cudnn_desc.get_activations(),
+                                    local_output.Buffer()));
+  }
+#endif // LBANN_HAS_CUDNN
+}
+
+template <>
+void logsoftmax_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
+#ifndef LBANN_HAS_CUDNN
+  LBANN_ERROR("cuDNN not detected");
+#else
+  const auto& local_output = get_local_activations();
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+  if (local_output.Height() > 0 && local_output.Width() > 0) {
+
+    // Useful constants
+    const DataType zero = DataType(0);
+    const DataType one = DataType(1);
+    
+    // Perform backprop
+    CHECK_CUDNN(cudnnSoftmaxBackward(cudnn::get_handle(),
+                                     CUDNN_SOFTMAX_LOG,
+                                     CUDNN_SOFTMAX_MODE_INSTANCE,
+                                     &one,
+                                     m_tensors_cudnn_desc.get_activations(),
+                                     local_output.LockedBuffer(),
+                                     m_tensors_cudnn_desc.get_prev_error_signals(),
+                                     local_gradient_wrt_output.LockedBuffer(),
+                                     &zero,
+                                     m_tensors_cudnn_desc.get_error_signals(),
+                                     local_gradient_wrt_input.Buffer()));
+  }
+#endif // LBANN_HAS_CUDNN
+}
+#endif // LBANN_HAS_GPU
+
+} // namespace lbann

--- a/src/layers/activations/logsoftmax.cu
+++ b/src/layers/activations/logsoftmax.cu
@@ -1,0 +1,190 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// softmax_cuda.cu - GPU helper routines for softmax layer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/activations/logsoftmax.hpp"
+
+namespace {
+
+__global__ void max_local_col_entry_kernel(
+  int height, int width,
+  const lbann::DataType * __restrict__ input,
+  int input_ldim,
+  lbann::DataType * __restrict__ shift_workspace) {
+  const int tid = threadIdx.x + blockIdx.x*blockDim.x;
+  const int num_threads = blockDim.x * gridDim.x;
+  for (int col = tid; col < width; col += num_threads) {
+    const int col_offset = col*input_ldim;
+    lbann::DataType max_entry = input[col_offset];
+    for (int row = 1; row < height; ++row) {
+      max_entry = fmax(max_entry, input[row + col_offset]);
+    }
+    shift_workspace[col] = max_entry;
+  }
+}
+
+__global__ void exp_and_col_sum_kernel(
+  int height, int width,
+  const lbann::DataType * __restrict__ input,
+  int input_ldim,
+  lbann::DataType * __restrict__ shift_workspace,
+  lbann::DataType * __restrict__ sum_workspace) {
+  const int tid = threadIdx.x + blockIdx.x*blockDim.x;
+  const int num_threads = blockDim.x * gridDim.x;
+  for (int col = tid; col < width; col += num_threads) {
+    const int input_col_offset = col*input_ldim;
+    // Shift by the pre-computed maximum value for the column.
+    const lbann::DataType shift = shift_workspace[col];
+    lbann::DataType sum = lbann::DataType(0);
+    for (int row = 0; row < height; ++row) {
+      const lbann::DataType y = exp(input[row + input_col_offset] - shift);
+      sum += y;
+    }
+    sum_workspace[col] = sum;
+  }
+}
+
+__global__ void sub_by_col_sums_and_shift_kernel(
+  int height, int width,
+  const lbann::DataType * __restrict__ input,
+  int input_ldim,
+  lbann::DataType * __restrict__ output,
+  int output_ldim,
+  const lbann::DataType * __restrict__ shift_workspace,
+  const lbann::DataType * __restrict__ sum_workspace) {
+  const int tid = threadIdx.x + blockIdx.x*blockDim.x;
+  const int num_threads = blockDim.x * gridDim.x;
+  for (int col = tid; col < width; col += num_threads) {
+    const int input_col_offset = col*input_ldim;
+    const int output_col_offset = col*output_ldim;
+    const lbann::DataType shift = shift_workspace[col];
+    const lbann::DataType lse = log(sum_workspace[col]);
+    for (int row = 0; row < height; ++row) {
+      output[row + output_col_offset] = input[row + input_col_offset] - lse - shift;
+    }
+  }
+}
+
+__global__ void grad_wrt_input_kernel(
+  int height, int width,
+  const lbann::DataType * __restrict__ output,
+  int output_ldim,
+  const lbann::DataType * __restrict__ sum_workspace,
+  const lbann::DataType * __restrict__ grad_wrt_output,
+  int grad_wrt_output_ldim,
+  lbann::DataType * __restrict__ grad_wrt_input,
+  int grad_wrt_input_ldim) {
+  const int tid = threadIdx.x + blockIdx.x*blockDim.x;
+  const int num_threads = blockDim.x * gridDim.x;
+  for (int col = tid; col < width; col += num_threads) {
+    const lbann::DataType sum = sum_workspace[col];
+    const int output_col_offset = col * output_ldim;
+    const int grad_wrt_output_offset = col * grad_wrt_output_ldim;
+    const int grad_wrt_input_offset = col * grad_wrt_input_ldim;
+    for (int row = 0; row < height; ++row) {
+      const auto& y = output[row + output_col_offset];
+      auto& dx = grad_wrt_input[row + grad_wrt_input_offset];
+      {
+        const auto& dy = grad_wrt_output[row + grad_wrt_output_offset];
+        dx = dy - exp(y) * sum;
+      }
+    }
+  }
+}
+
+}  // anonymous namespace
+
+namespace lbann {
+namespace logsoftmax_cuda {
+
+void max_local_col_entry(int height, int width,
+                         const DataType * __restrict__ input,
+                         int input_ldim,
+                         DataType * __restrict__ shift_workspace,
+                         cudaStream_t stream) {
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  const int block_dim = 256;
+  const int grid_dim = (width + block_dim - 1) / block_dim;
+  max_local_col_entry_kernel<<<grid_dim, block_dim, 0, stream>>>(
+    height, width, input, input_ldim, shift_workspace);
+}
+
+void exp_and_col_sum(int height, int width,
+                     const DataType * __restrict__ input,
+                     int input_ldim,
+                     DataType * __restrict__ shift_workspace,
+                     DataType * __restrict__ sum_workspace,
+                     cudaStream_t stream) {
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  const int block_dim = 256;
+  const int grid_dim = (width + block_dim - 1) / block_dim;
+  exp_and_col_sum_kernel<<<grid_dim, block_dim, 0, stream>>>(
+    height, width, input, input_ldim, shift_workspace, sum_workspace);
+}
+
+void sub_by_col_sums_and_shift(int height, int width,
+                                const DataType * __restrict__ input,
+                                int input_ldim,
+                                DataType * __restrict__ output,
+                                int output_ldim,
+                                const DataType * __restrict__ shift_workspace,
+                                const DataType * __restrict__ sum_workspace,
+                                cudaStream_t stream) {
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  const int block_dim = 256;
+  const int grid_dim = (width + block_dim - 1) / block_dim;
+  sub_by_col_sums_and_shift_kernel<<<grid_dim, block_dim, 0, stream>>>(
+    height, width, input, input_ldim, output, output_ldim, shift_workspace, sum_workspace);
+}
+
+void grad_wrt_input(int height, int width,
+                               const DataType * __restrict__ output,
+                               int output_ldim,
+                               const DataType * __restrict__ sum_workspace,
+                               const DataType * __restrict__ grad_wrt_output,
+                               int grad_wrt_output_ldim,
+                               DataType * __restrict__ grad_wrt_input,
+                               int grad_wrt_input_ldim,
+                               cudaStream_t stream) {
+  if (width <= 0 || height <= 0) {
+    return;
+  }
+  const int block_dim = 256;
+  const int grid_dim = (width + block_dim - 1) / block_dim;
+  grad_wrt_input_kernel<<<grid_dim, block_dim, 0, stream>>>(
+    height, width, output, output_ldim, sum_workspace, grad_wrt_output,
+    grad_wrt_output_ldim, grad_wrt_input, grad_wrt_input_ldim);
+}
+
+} // namespace logsoftmax_cuda
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -367,6 +367,9 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_softmax()) {
     return new softmax_layer<layout, Dev>(comm);
   }
+  if (proto_layer.has_logsoftmax()) {
+    return new logsoftmax_layer<layout, Dev>(comm);
+  }
   if (proto_layer.has_relu()) {
     return new relu_layer<layout, Dev>(comm);
   }

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -819,6 +819,7 @@ message Layer {
 
    // activation Layers
    Softmax softmax = 200;
+   LogSoftmax logsoftmax = 203;
    ELU elu = 30;
    Identity identity = 31;
    LeakyRelu leaky_relu = 32;
@@ -894,6 +895,9 @@ message Selu {
 }
 
 message Softmax {
+}
+
+message LogSoftmax {
 }
 
 message Power {


### PR DESCRIPTION
This PR adds the "LogSoftmax" layer, which is numerically stable, unlike using a "Softmax" layer followed by a "Log" layer. This is done using the "log-sum-exp" trick, similar to the "exp-normalize" trick used in the Softmax implementation.

I tested the layer with all combinations of CPU/GPU model/data parallelism, and it seemed to work well in a test network, and produce values in the correct range: (-inf, 0]. I used the Softmax layer as a template so it is very similar.

I wasn't sure about the constant value to use in src/proto/lbann.proto, so I just picked a free value:
LogSoftmax logsoftmax = 203;

Let me know if this PR can be improved in any way.