### PR TITLE
Batch norm refactor

### DIFF
--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -28,62 +28,9 @@
 #define LBANN_LAYER_REGULARIZER_BATCH_NORMALIZATION_HPP_INCLUDED
 
 #include "lbann/layers/regularizers/regularizer.hpp"
-#include "lbann/utils/cuda.hpp"
+#include "lbann/models/model.hpp"
 
 namespace lbann {
-
-#ifdef LBANN_HAS_GPU
-namespace batch_normalization_cuda {
-/** Compute channel sums.
- *  Sums and squares of sums are used to compute mean and variance.
- */
-void channel_sums(int num_channels,
-                  const AbsMat& data,
-                  AbsMat& sums,
-                  AbsMat& sqsums);
-/** Compute statistics from sums.
- *  On input, mean and var are assumed to contain sums and squares
- *  of sums, respectively.
- */
-void compute_statistics(int num_per_sum,
-                        DataType epsilon,
-                        DataType decay,
-                        AbsMat& mean,
-                        AbsMat& var,
-                        AbsMat& running_mean,
-                        AbsMat& running_var);  
-/** Apply batch normalization. */
-void batch_normalization(const AbsMat& input,
-                         const AbsMat& mean,
-                         const AbsMat& var,
-                         DataType epsilon,
-                         const AbsMat& scale,
-                         const AbsMat& bias,
-                         AbsMat& output);
-/** Compute gradients w.r.t. batch norm parameters. */
-void backprop1(const AbsMat& input,
-               const AbsMat& gradient_wrt_output,
-               const AbsMat& mean,
-               const AbsMat& var,
-               DataType epsilon,
-               const AbsMat& scale,
-               AbsMat& dscale,
-               AbsMat& dbias,
-               AbsMat& dmean,
-               AbsMat& dvar);
-/** Compute gradients w.r.t. inputs. */
-void backprop2(int global_width,
-               const AbsMat& input,
-               const AbsMat& gradient_wrt_output,
-               const AbsMat& mean,
-               const AbsMat& var,
-               DataType epsilon,
-               const AbsMat& scale,
-               const AbsMat& dmean,
-               const AbsMat& dvar,
-               AbsMat& gradient_wrt_input);
-}
-#endif // LBANN_HAS_GPU
 
 /** Batch normalization layer.
  *  Each input channel is normalized across the mini-batch to have
@@ -98,7 +45,7 @@ void backprop2(int global_width,
  *    https://cthorey.github.io/backpropagation/
  */
 template <data_layout T_layout, El::Device Dev>
-class batch_normalization : public regularizer_layer {
+class batch_normalization_layer : public regularizer_layer {
 
  private:
 
@@ -131,10 +78,10 @@ class batch_normalization : public regularizer_layer {
    * @param use_global_stats Whether to use global statistics when
    * training.
    */
-  batch_normalization(lbann_comm *comm,
-                      DataType decay=0.9,
-                      DataType epsilon=1e-5,
-                      bool use_global_stats = false)
+  batch_normalization_layer(lbann_comm *comm,
+                            DataType decay=0.9,
+                            DataType epsilon=1e-5,
+                            bool use_global_stats = false)
     : regularizer_layer(comm),
       m_decay(decay),
       m_epsilon(epsilon),
@@ -147,7 +94,7 @@ class batch_normalization : public regularizer_layer {
 #endif
   }
 
-  batch_normalization(const batch_normalization& other)
+  batch_normalization_layer(const batch_normalization_layer& other)
     : regularizer_layer(other),
       m_decay(other.m_decay),
       m_epsilon(other.m_epsilon),
@@ -163,7 +110,7 @@ class batch_normalization : public regularizer_layer {
       m_bias_gradient(other.m_bias_gradient ?
                       other.m_bias_gradient->Copy() : nullptr) {}
 
-  batch_normalization& operator=(const batch_normalization& other) {
+  batch_normalization_layer& operator=(const batch_normalization_layer& other) {
     regularizer_layer::operator=(other);
     m_decay = other.m_decay;
     m_epsilon = other.m_epsilon;
@@ -194,7 +141,7 @@ class batch_normalization : public regularizer_layer {
     return ss.str();
   }
 
-  batch_normalization* copy() const override { return new batch_normalization(*this); }
+  batch_normalization_layer* copy() const override { return new batch_normalization_layer(*this); }
 
   std::string get_type() const override { return "batch normalization"; }
 
@@ -322,400 +269,8 @@ class batch_normalization : public regularizer_layer {
 
   }
 
-  void fp_compute() override {
-    if (this->using_gpus()) {
-      fp_compute_gpu();
-    } else {
-      fp_compute_cpu();
-    }
-  }
-
-  void bp_compute() override {
-    if (this->using_gpus()) {
-      bp_compute_gpu();
-    } else {
-      bp_compute_cpu();
-    }
-  }
-
-  void fp_compute_gpu() {
-#ifndef LBANN_HAS_GPU
-    LBANN_ERROR("CUDA not detected");
-#else
-
-    // Matrices
-    const auto& input = get_prev_activations();
-    const auto& local_input = input.LockedMatrix();
-    auto& local_output = get_local_activations();
-
-    // Compute statistics during training
-    const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
-    if (is_training) {
-      const auto& output_dims = get_output_dims();
-      const int num_channels = output_dims[0];
-      const int channel_size = get_output_size() / num_channels;
-      batch_normalization_cuda::channel_sums(num_channels,
-                                             local_input,
-                                             m_mean->Matrix(),
-                                             m_var->Matrix());
-      int num_per_sum = channel_size * input.LocalWidth();
-      if (m_use_global_stats) {
-        m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
-        m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
-        num_per_sum = channel_size * input.Width();
-      }
-      batch_normalization_cuda::compute_statistics(
-        num_per_sum,
-        m_epsilon,
-        m_decay,
-        m_mean->Matrix(),
-        m_var->Matrix(),
-        m_weights[2]->get_values().Matrix(),
-        m_weights[3]->get_values().Matrix());
-    }
-
-    // Perform batch normalization
-    const auto& mean = (is_training ?
-                        m_mean->LockedMatrix() :
-                        m_weights[2]->get_values().Matrix());
-    const auto& var = (is_training ?
-                       m_var->LockedMatrix() :
-                       m_weights[3]->get_values().Matrix());
-    batch_normalization_cuda::batch_normalization(
-      local_input,
-      mean, var, m_epsilon,
-      m_weights[0]->get_values().Matrix(),
-      m_weights[1]->get_values().Matrix(),
-      local_output);
-
-#endif // LBANN_HAS_GPU
-  }
-
-  void bp_compute_gpu() {
-#ifndef LBANN_HAS_GPU
-    LBANN_ERROR("CUDA not detected");
-#else
-    const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
-    const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
-
-    // GPU matrices
-    const auto& input = get_prev_activations();
-    const auto& local_input = input.LockedMatrix();
-    const auto& local_gradient_wrt_output = get_local_prev_error_signals();
-    auto& local_gradient_wrt_input = get_local_error_signals();
-    const auto& mean = (is_training ?
-                        m_mean->LockedMatrix() :
-                        m_weights[2]->get_values().Matrix());
-    const auto& var = (is_training ?
-                       m_var->LockedMatrix() :
-                       m_weights[3]->get_values().Matrix());
-
-    // Compute gradients w.r.t. batch norm parameters
-    batch_normalization_cuda::backprop1(local_input,
-                                        local_gradient_wrt_output,
-                                        mean, var, m_epsilon,
-                                        m_weights[0]->get_values().Matrix(),
-                                        m_scale_gradient->Matrix(),
-                                        m_bias_gradient->Matrix(),
-                                        m_mean_gradient->Matrix(),
-                                        m_var_gradient->Matrix());
-
-    // Accumulate gradients
-    if (is_training) {
-      if (m_use_global_stats) {
-        m_comm->allreduce(*m_mean_gradient,
-                          m_mean_gradient->RedundantComm(),
-                          El::mpi::SUM);
-        m_comm->allreduce(*m_var_gradient,
-                          m_var_gradient->RedundantComm(),
-                          El::mpi::SUM);
-      }
-    } else {
-      El::Zero(*m_mean_gradient);
-      El::Zero(*m_var_gradient);
-    }
-    auto* scale_optimizer = m_weights[0]->get_optimizer();
-    if (scale_optimizer != nullptr) {
-      scale_optimizer->add_to_gradient_staging(
-        *m_scale_gradient,
-        DataType(1) / effective_mini_batch_size);
-    }
-    auto* bias_optimizer = m_weights[1]->get_optimizer();
-    if (bias_optimizer != nullptr) {
-      bias_optimizer->add_to_gradient_staging(
-        *m_bias_gradient,
-        DataType(1) / effective_mini_batch_size);
-    }
-
-    // Compute gradient w.r.t. input
-    batch_normalization_cuda::backprop2(m_use_global_stats ? input.Width() : input.LocalWidth(),
-                                        local_input,
-                                        local_gradient_wrt_output,
-                                        mean, var, m_epsilon,
-                                        m_weights[0]->get_values().Matrix(),
-                                        m_mean_gradient->LockedMatrix(),
-                                        m_var_gradient->LockedMatrix(),
-                                        local_gradient_wrt_input);
-
-#endif // LBANN_HAS_GPU
-  }
-
-  void fp_compute_cpu() {
-    const DataType zero = DataType(0);
-    const DataType one = DataType(1);
-
-    // Check execution mode
-    const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
-
-    // Matrices
-    const auto& input = get_prev_activations();
-    const auto& local_input = input.LockedMatrix();
-    auto& local_output = get_local_activations();
-
-    // Matrix parameters
-    const int width = input.Width();
-    const El::Int local_width = local_input.Width();
-    const auto& output_dims = get_output_dims();
-    const int num_channels = output_dims[0];
-    const int channel_size = get_output_size() / num_channels;
-
-    // Compute statistics
-    if (is_training) {
-
-      // Local matrices
-      // Note: local_new_running_mean and local_new_running_var are
-      // stored in m_mean_gradient and m_var_gradient.
-      auto& local_mean = m_mean->Matrix();
-      auto& local_var = m_var->Matrix();
-      const auto& local_running_mean = this->m_weights[2]->get_values().LockedMatrix();
-      const auto& local_running_var = this->m_weights[3]->get_values().LockedMatrix();
-      auto& local_new_running_mean = m_mean_gradient->Matrix();
-      auto& local_new_running_var = m_var_gradient->Matrix();
-
-      // Compute sums and sums of squares
-      #pragma omp parallel for
-      for (int channel = 0; channel < num_channels; ++channel) {
-        DataType sum = zero;
-        DataType sqsum = zero;
-        const El::Int row_start = channel * channel_size;
-        const El::Int row_end = (channel+1) * channel_size;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
-            const DataType x = local_input(row, col);
-            sum += x;
-            sqsum += x * x;
-          }
-        }
-        local_mean(channel, 0) = sum;
-        local_var(channel, 0) = sqsum;
-      }
-      DataType num_per_sum;
-      if (m_use_global_stats) {
-        m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
-        m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
-        num_per_sum = channel_size * width;
-      } else {
-        num_per_sum = channel_size * local_width;
-      }
-
-      // Compute minibatch statistics
-      // Note: local_new_running_mean and local_new_running_var are
-      // stored in m_mean_gradient and m_var_gradient.
-      if (num_per_sum <= 1) {
-        El::Fill(local_var, one);
-      } else {
-        #pragma omp parallel for
-        for (int channel = 0; channel < num_channels; ++channel) {
-          const DataType mean = local_mean(channel, 0) / num_per_sum;
-          const DataType sqmean = local_var(channel, 0) / num_per_sum;
-          const DataType var = num_per_sum / (num_per_sum - one) * std::max(sqmean - mean * mean, m_epsilon);
-          const DataType old_running_mean = local_running_mean(channel, 0);
-          const DataType old_running_var = local_running_var(channel, 0);
-          const DataType new_running_mean = m_decay * old_running_mean + (one - m_decay) * mean;
-          const DataType new_running_var = m_decay * old_running_var + (one - m_decay) * var;
-          local_mean(channel, 0) = mean;
-          local_var(channel, 0) = var;
-          local_new_running_mean(channel, 0) = new_running_mean;
-          local_new_running_var(channel, 0) = new_running_var;
-        }
-        m_weights[2]->set_values(*m_mean_gradient);
-        m_weights[3]->set_values(*m_var_gradient);
-      }
-
-    }
-
-    // Get matrices
-    const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
-    const auto& local_bias = this->m_weights[1]->get_values().LockedMatrix();
-    const auto& local_mean = (is_training ?
-                              m_mean->LockedMatrix() :
-                              this->m_weights[2]->get_values().LockedMatrix());
-    const auto& local_var = (is_training ?
-                             m_var->LockedMatrix() :
-                             this->m_weights[3]->get_values().LockedMatrix());
-
-    // Iterate through channels
-    #pragma omp parallel for
-    for (int channel = 0; channel < num_channels; ++channel) {
-
-      // Get channel parameters
-      const DataType mean = local_mean(channel, 0);
-      const DataType var = local_var(channel, 0);
-      const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
-      const DataType scale = local_scale(channel, 0);
-      const DataType bias = local_bias(channel, 0);
-
-      // Apply batch normalization to inputs in channel
-      const El::Int row_start = channel * channel_size;
-      const El::Int row_end = (channel+1) * channel_size;
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = row_start; row < row_end; ++row) {
-          const DataType x = local_input(row, col);
-          const DataType xhat = (x - mean) * inv_stdev;
-          const DataType y = scale * xhat + bias;
-          local_output(row, col) = y;
-        }
-      }
-
-    }
-
-  }
-
-  void bp_compute_cpu() {
-
-    // Check execution mode
-    const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
-
-    // Matrices
-    const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
-    const auto& local_mean = (is_training ?
-                              m_mean->LockedMatrix() :
-                              this->m_weights[2]->get_values().LockedMatrix());
-    const auto& local_var = (is_training ?
-                             m_var->LockedMatrix() :
-                             this->m_weights[3]->get_values().LockedMatrix());
-    const auto& input = get_prev_activations();
-    const auto& local_input = input.LockedMatrix();
-    const auto& local_gradient_wrt_output = get_local_prev_error_signals();
-    auto& local_gradient_wrt_input = get_local_error_signals();
-    auto& local_mean_gradient = m_mean_gradient->Matrix();
-    auto& local_var_gradient = m_var_gradient->Matrix();
-    auto& local_scale_gradient = m_scale_gradient->Matrix();
-    auto& local_bias_gradient = m_bias_gradient->Matrix();
-
-    // Matrix parameters
-    const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
-    const int width = input.Width();
-    const El::Int local_width = local_input.Width();
-    const auto& output_dims = get_output_dims();
-    const int num_channels = output_dims[0];
-    const int channel_size = get_output_size() / num_channels;
-
-    // Compute local gradients
-    #pragma omp parallel for
-    for (int channel = 0; channel < num_channels; ++channel) {
-
-      // Initialize channel parameters and gradients
-      const DataType mean = local_mean(channel, 0);
-      const DataType var = local_var(channel, 0);
-      const DataType scale = local_scale(channel, 0);
-      const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
-      const DataType dvar_factor = inv_stdev * inv_stdev * inv_stdev / 2;
-      DataType dmean = DataType(0);
-      DataType dvar = DataType(0);
-      DataType dscale = DataType(0);
-      DataType dbias = DataType(0);
-
-      // Compute gradient contributions from local entries
-      const El::Int row_start = channel * channel_size;
-      const El::Int row_end = (channel+1) * channel_size;
-      for (El::Int col = 0; col < local_width; ++col) {
-        for (El::Int row = row_start; row < row_end; ++row) {
-          const DataType x = local_input(row, col);
-          const DataType xhat = (x - mean) * inv_stdev;
-          const DataType dy = local_gradient_wrt_output(row, col);
-          dscale += dy * xhat;
-          dbias += dy;
-          const DataType dxhat = dy * scale;
-          dmean += - dxhat * inv_stdev;
-          dvar += - dxhat * (x - mean) * dvar_factor;
-        }
-      }
-      local_mean_gradient(channel, 0) = dmean;
-      local_var_gradient(channel, 0) = dvar;
-      local_scale_gradient(channel, 0) = dscale;
-      local_bias_gradient(channel, 0) = dbias;
-
-    }
-
-    // Accumulate gradients
-    if (is_training) {
-      if (m_use_global_stats) {
-        m_comm->allreduce(*m_mean_gradient,
-                          m_mean_gradient->RedundantComm(),
-                          El::mpi::SUM);
-        m_comm->allreduce(*m_var_gradient,
-                          m_var_gradient->RedundantComm(),
-                          El::mpi::SUM);
-      }
-    } else {
-      El::Zero(*m_mean_gradient);
-      El::Zero(*m_var_gradient);
-    }
-    optimizer* scale_optimizer = m_weights[0]->get_optimizer();
-    if (scale_optimizer != nullptr) {
-      scale_optimizer->add_to_gradient_staging(
-        *m_scale_gradient,
-        DataType(1) / effective_mini_batch_size);
-    }
-    optimizer* bias_optimizer = m_weights[1]->get_optimizer();
-    if (bias_optimizer != nullptr) {
-      bias_optimizer->add_to_gradient_staging(
-        *m_bias_gradient,
-        DataType(1) / effective_mini_batch_size);
-    }
-
-    // Compute error signal
-    const int num_per_sum = (m_use_global_stats ?
-                             width * channel_size :
-                             local_width * channel_size);
-    if (num_per_sum <= 1) {
-      El::Zero(local_gradient_wrt_input);
-    } else {
-      #pragma omp parallel for
-      for (int channel = 0; channel < num_channels; ++channel) {
-
-        // Initialize channel parameters and gradients
-        const auto& mean = local_mean(channel, 0);
-        const auto& var = local_var(channel, 0);
-        const auto& scale = local_scale(channel, 0);
-        const auto& dmean = local_mean_gradient(channel, 0);
-        const auto& dvar = local_var_gradient(channel, 0);
-
-        // Compute useful constants
-        const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
-        const auto& dmean_term = dmean / num_per_sum;
-        const auto& dvar_term = dvar * 2 / (num_per_sum - 1);
-
-        // Compute error signal for current channel
-        const El::Int row_start = channel * channel_size;
-        const El::Int row_end = (channel+1) * channel_size;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
-            const auto& x = local_input(row, col);
-            const auto& dy = local_gradient_wrt_output(row, col);
-            const auto& dxhat = dy * scale;
-            auto dx = dxhat * inv_stdev;
-            dx += dmean_term;
-            dx += dvar_term * (x - mean);
-            local_gradient_wrt_input(row, col) = dx;
-          }
-        }
-
-      }
-    }
-
-  }
+  void fp_compute() override;
+  void bp_compute() override;
 
 };
 

--- a/src/layers/regularizers/CMakeLists.txt
+++ b/src/layers/regularizers/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Add the source files for this directory
+set_full_path(THIS_DIR_SOURCES
+  batch_normalization.cpp
+  )
+
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
@@ -6,4 +11,5 @@ if (LBANN_HAS_CUDA)
 endif ()
 
 # Propagate the files up the tree
+set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)
 set(CUDA_SOURCES "${CUDA_SOURCES}" "${THIS_DIR_CU_SOURCES}" PARENT_SCOPE)

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -1,0 +1,274 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/regularizers/batch_normalization.hpp"
+
+namespace lbann {
+
+template <>
+void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
+  constexpr DataType zero = 0;
+  constexpr DataType one = 1;
+  const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
+
+  // Matrices
+  const auto& input = get_prev_activations();
+  const auto& local_input = input.LockedMatrix();
+  auto& local_output = get_local_activations();
+
+  // Matrix parameters
+  const auto& width = input.Width();
+  const auto& local_width = local_input.Width();
+  const auto& output_dims = get_output_dims();
+  const auto& num_channels = output_dims[0];
+  const auto& channel_size = get_output_size() / num_channels;
+
+  // Compute statistics
+  if (is_training) {
+
+    // Local matrices
+    auto& local_mean = m_mean->Matrix();
+    auto& local_var = m_var->Matrix();
+    auto& local_running_mean = this->m_weights[2]->get_values().Matrix();
+    auto& local_running_var = this->m_weights[3]->get_values().Matrix();
+
+    // Compute sums and sums of squares
+#pragma omp parallel for
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      DataType sum = zero;
+      DataType sqsum = zero;
+      const auto& row_start = channel * channel_size;
+      const auto& row_end = (channel+1) * channel_size;
+      for (El::Int col = 0; col < local_width; ++col) {
+        for (El::Int row = row_start; row < row_end; ++row) {
+          const auto& x = local_input(row, col);
+          sum += x;
+          sqsum += x * x;
+        }
+      }
+      local_mean(channel, 0) = sum;
+      local_var(channel, 0) = sqsum;
+    }
+    El::Int num_per_sum;
+    if (m_use_global_stats) {
+      m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
+      m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
+      num_per_sum = channel_size * width;
+    } else {
+      num_per_sum = channel_size * local_width;
+    }
+
+    // Compute minibatch statistics
+    if (num_per_sum <= 1) {
+      El::Fill(local_var, one);
+    } else {
+#pragma omp parallel for
+      for (El::Int channel = 0; channel < num_channels; ++channel) {
+        const auto& mean = local_mean(channel, 0) / num_per_sum;
+        const auto& sqmean = local_var(channel, 0) / num_per_sum;
+        auto var = num_per_sum * (sqmean - mean * mean) / (num_per_sum - 1);
+        var = std::max(var, m_epsilon);
+        local_mean(channel, 0) = mean;
+        local_var(channel, 0) = var;
+        auto& running_mean = local_running_mean(channel, 0);
+        auto& running_var = local_running_var(channel, 0);
+        running_mean = m_decay * running_mean + (one - m_decay) * mean;
+        running_var = m_decay * running_var + (one - m_decay) * var;
+      }
+    }
+
+  }
+
+  // Get matrices
+  const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
+  const auto& local_bias = this->m_weights[1]->get_values().LockedMatrix();
+  const auto& local_mean = (is_training ?
+                            m_mean->LockedMatrix() :
+                            this->m_weights[2]->get_values().LockedMatrix());
+  const auto& local_var = (is_training ?
+                           m_var->LockedMatrix() :
+                           this->m_weights[3]->get_values().LockedMatrix());
+
+  // Iterate through channels
+#pragma omp parallel for
+  for (El::Int channel = 0; channel < num_channels; ++channel) {
+
+    // Get channel parameters
+    const auto& mean = local_mean(channel, 0);
+    const auto& var = local_var(channel, 0);
+    const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
+    const auto& scale = local_scale(channel, 0);
+    const auto& bias = local_bias(channel, 0);
+
+    // Apply batch normalization to inputs in channel
+    const auto& row_start = channel * channel_size;
+    const auto& row_end = (channel+1) * channel_size;
+    for (El::Int col = 0; col < local_width; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& x = local_input(row, col);
+        const auto& xhat = (x - mean) * inv_stdev;
+        auto& y = local_output(row, col);
+        y = scale * xhat + bias;
+      }
+    }
+
+  }
+    
+}
+
+template <>
+void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
+  constexpr DataType one = 1;
+  const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
+
+  // Matrices
+  const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
+  const auto& local_mean = (is_training ?
+                            m_mean->LockedMatrix() :
+                            this->m_weights[2]->get_values().LockedMatrix());
+  const auto& local_var = (is_training ?
+                           m_var->LockedMatrix() :
+                           this->m_weights[3]->get_values().LockedMatrix());
+  const auto& input = get_prev_activations();
+  const auto& local_input = input.LockedMatrix();
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+  auto& local_mean_gradient = m_mean_gradient->Matrix();
+  auto& local_var_gradient = m_var_gradient->Matrix();
+  auto& local_scale_gradient = m_scale_gradient->Matrix();
+  auto& local_bias_gradient = m_bias_gradient->Matrix();
+
+  // Matrix parameters
+  const El::Int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
+  const auto& width = input.Width();
+  const auto& local_width = local_input.Width();
+  const auto& output_dims = get_output_dims();
+  const auto& num_channels = output_dims[0];
+  const auto& channel_size = get_output_size() / num_channels;
+
+  // Compute local gradients
+#pragma omp parallel for
+  for (El::Int channel = 0; channel < num_channels; ++channel) {
+
+    // Initialize channel parameters and gradients
+    const auto& mean = local_mean(channel, 0);
+    const auto& var = local_var(channel, 0);
+    const auto& scale = local_scale(channel, 0);
+    const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
+    const auto& dvar_factor = inv_stdev * inv_stdev * inv_stdev / 2;
+    DataType dmean = 0;
+    DataType dvar = 0;
+    DataType dscale = 0;
+    DataType dbias = 0;
+
+    // Compute gradient contributions from local entries
+    const auto& row_start = channel * channel_size;
+    const auto& row_end = (channel+1) * channel_size;
+    for (El::Int col = 0; col < local_width; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& x = local_input(row, col);
+        const auto& xhat = (x - mean) * inv_stdev;
+        const auto& dy = local_gradient_wrt_output(row, col);
+        dscale += dy * xhat;
+        dbias += dy;
+        const auto& dxhat = dy * scale;
+        dmean += - dxhat * inv_stdev;
+        dvar += - dxhat * (x - mean) * dvar_factor;
+      }
+    }
+    local_mean_gradient(channel, 0) = dmean;
+    local_var_gradient(channel, 0) = dvar;
+    local_scale_gradient(channel, 0) = dscale;
+    local_bias_gradient(channel, 0) = dbias;
+
+  }
+
+  // Accumulate gradients
+  if (is_training) {
+    if (m_use_global_stats) {
+      m_comm->allreduce(*m_mean_gradient,
+                        m_mean_gradient->RedundantComm(),
+                        El::mpi::SUM);
+      m_comm->allreduce(*m_var_gradient,
+                        m_var_gradient->RedundantComm(),
+                        El::mpi::SUM);
+    }
+  } else {
+    El::Zero(*m_mean_gradient);
+    El::Zero(*m_var_gradient);
+  }
+  optimizer* scale_optimizer = m_weights[0]->get_optimizer();
+  if (scale_optimizer != nullptr) {
+    scale_optimizer->add_to_gradient_staging(*m_scale_gradient,
+                                             one / effective_mini_batch_size);
+  }
+  optimizer* bias_optimizer = m_weights[1]->get_optimizer();
+  if (bias_optimizer != nullptr) {
+    bias_optimizer->add_to_gradient_staging(*m_bias_gradient,
+                                            one / effective_mini_batch_size);
+  }
+
+  // Compute error signal
+  const auto& num_per_sum = (m_use_global_stats ?
+                             width * channel_size :
+                             local_width * channel_size);
+  if (num_per_sum <= 1) {
+    El::Zero(local_gradient_wrt_input);
+  } else {
+#pragma omp parallel for
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+
+      // Initialize channel parameters and gradients
+      const auto& mean = local_mean(channel, 0);
+      const auto& var = local_var(channel, 0);
+      const auto& scale = local_scale(channel, 0);
+      const auto& dmean = local_mean_gradient(channel, 0);
+      const auto& dvar = local_var_gradient(channel, 0);
+
+      // Compute useful constants
+      const DataType inv_stdev = 1 / std::sqrt(var + m_epsilon);
+      const auto& dmean_term = dmean / num_per_sum;
+      const auto& dvar_term = dvar * 2 / (num_per_sum - 1);
+
+      // Compute error signal for current channel
+      const auto& row_start = channel * channel_size;
+      const auto& row_end = (channel+1) * channel_size;
+      for (El::Int col = 0; col < local_width; ++col) {
+        for (El::Int row = row_start; row < row_end; ++row) {
+          const auto& x = local_input(row, col);
+          const auto& dy = local_gradient_wrt_output(row, col);
+          const auto& dxhat = dy * scale;
+          auto& dx = local_gradient_wrt_input(row, col);
+          dx = dxhat * inv_stdev + dmean_term + dvar_term * (x - mean);
+        }
+      }
+
+    }
+  }
+  
+}
+  
+} // namespace lbann

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -24,9 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "math.h"
-#include "lbann/base.hpp"
-#include "lbann/utils/exception.hpp"
+#include "lbann/layers/regularizers/batch_normalization.hpp"
 #include "lbann/utils/cuda.hpp"
 
 namespace lbann {
@@ -36,6 +34,7 @@ namespace {
 // Atomic add functions
 #if __CUDA_ARCH__ >= 530
 __device__ inline __half atomic_add(__half* address, __half val) {
+  static_cast<void>(static_cast<__half (*)(__half*, __half)>(atomic_add)); // Suppress "unused function" warning
 #if 0 // TODO: replace this once Nvidia implements atomicAdd for __half
   return atomicAdd(address, val);
 #else
@@ -56,9 +55,11 @@ __device__ inline __half atomic_add(__half* address, __half val) {
 }
 #endif // __CUDA_ARCH__ >= 530
 __device__ inline float atomic_add(float* address, float val) {
+  static_cast<void>(static_cast<float (*)(float*, float)>(atomic_add)); // Suppress "unused function" warning
   return atomicAdd(address, val);
 }
 __device__ inline double atomic_add(double* address, double val) {
+  static_cast<void>(static_cast<double (*)(double*, double)>(atomic_add)); // Suppress "unused function" warning
 #if __CUDA_ARCH__ >= 600
   return atomicAdd(address, val);
 #else
@@ -78,42 +79,45 @@ __device__ inline double atomic_add(double* address, double val) {
 // Reciprocal square root functions
 #if __CUDA_ARCH__ >= 530
 __device__ inline float rsqrt_(__half x) {
+  static_cast<void>(static_cast<__half (*)(__half)>(rsqrt_)); // Suppress "unused function" warning
   return hrsqrt(x);
 }
 #endif // __CUDA_ARCH__ >= 530
 __device__ inline float rsqrt_(float x) {
+  static_cast<void>(static_cast<float (*)(float)>(rsqrt_)); // Suppress "unused function" warning
   return rsqrtf(x);
 }
 __device__ inline double rsqrt_(double x) {
+  static_cast<void>(static_cast<double (*)(double)>(rsqrt_)); // Suppress "unused function" warning
   return rsqrt(x);
 }
 
 /** CUDA kernel to compute channel sums.
  *  Sums and squares of sums are used to compute mean and variance.
  */
-template <int block_size>
+template <El::Int block_size>
 __global__ void channel_sums_kernel(
-  int channel_height,
-  int width,
-  const DataType * __restrict__ data, int data_ldim,
+  El::Int channel_height,
+  El::Int width,
+  const DataType * __restrict__ data, El::Int data_ldim,
         DataType * __restrict__ sums,
         DataType * __restrict__ sqsums) {
 
   // Indices
-  const int tid = threadIdx.x;
-  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const int bidy = blockIdx.y;
+  const El::Int tid = threadIdx.x;
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
 
   // Initialize shared memory
   __shared__ DataType shared_sums[block_size];
- __shared__ DataType shared_sqsums[block_size];
+  __shared__ DataType shared_sqsums[block_size];
 
   // Compute row sums in shared memory
-  DataType private_sum = DataType(0);
-  DataType private_sqsum = DataType(0);
+  DataType private_sum = 0;
+  DataType private_sqsum = 0;
   if (gidx < channel_height) {
-    const int row = gidx + bidy * channel_height;
-    for (int col = 0; col < width; ++col) {
+    const auto& row = gidx + bidy * channel_height;
+    for (El::Int col = 0; col < width; ++col) {
       const auto& x = data[row + col * data_ldim];
       private_sum += x;
       private_sqsum += x * x;
@@ -124,7 +128,7 @@ __global__ void channel_sums_kernel(
 
   // Compute channel sum with shared memory reduction
   /// @todo unroll loops
-  for (int stride = block_size / 2; stride > 0; stride /= 2) {
+  for (El::Int stride = block_size / 2; stride > 0; stride /= 2) {
     __syncthreads();
     if(tid < stride) {
       shared_sums[tid] += shared_sums[tid + stride];
@@ -145,18 +149,18 @@ __global__ void channel_sums_kernel(
  *  and squares of sums, respectively.
  */
 __global__ void compute_statistics_kernel(
-  int num_sums,
-  int num_per_sum,
+  El::Int num_sums,
+  El::Int num_per_sum,
   DataType epsilon,
   DataType decay,
   DataType * __restrict__ global_mean,
   DataType * __restrict__ global_var,
   DataType * __restrict__ global_running_mean,
   DataType * __restrict__ global_running_var) {
-  const DataType one = DataType(1);
-  const int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const int num_threads = blockDim.x * gridDim.x;
-  for (int i = gid; i < num_sums; i += num_threads) {
+  constexpr DataType one = 1;
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  for (El::Int i = gid; i < num_sums; i += num_threads) {
 
     // Compute mean and variance
     const auto& mean = global_mean[i] / num_per_sum;
@@ -177,21 +181,21 @@ __global__ void compute_statistics_kernel(
 }
 
 /** CUDA kernel to apply batch normalization. */
-template <int block_size>
+template <El::Int block_size>
 __global__ void batch_normalization_kernel(
-  int channel_height,
-  int width,
-  const DataType * __restrict__ global_input, int input_ldim,
+  El::Int channel_height,
+  El::Int width,
+  const DataType * __restrict__ global_input, El::Int input_ldim,
   const DataType * __restrict__ global_mean,
   const DataType * __restrict__ global_var,
   DataType epsilon,
   const DataType * __restrict__ global_scale,
   const DataType * __restrict__ global_bias,
-        DataType * __restrict__ global_output, int output_ldim) {
+        DataType * __restrict__ global_output, El::Int output_ldim) {
 
   // Indices
-  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const int bidy = blockIdx.y;
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
 
   // Copy batch normalization parameters to private memory
   const auto& mean = global_mean[bidy];
@@ -204,8 +208,8 @@ __global__ void batch_normalization_kernel(
 
   // Apply batch normalization
   if (gidx < channel_height) {
-    const int row = gidx + bidy * channel_height;
-    for (int col = 0; col < width; ++col) {
+    const auto& row = gidx + bidy * channel_height;
+    for (El::Int col = 0; col < width; ++col) {
       const auto& x = global_input[row + col * input_ldim];
       const auto& xhat = (x - mean) * inv_stdev;
       const auto& y = scale * xhat + bias;
@@ -216,14 +220,14 @@ __global__ void batch_normalization_kernel(
 }
 
 /** CUDA kernel to compute gradients w.r.t. batch norm parameters. */
-template <int block_size>
+template <El::Int block_size>
 __global__ void backprop1_kernel(
-  int channel_height,
-  int width,
+  El::Int channel_height,
+  El::Int width,
   const DataType * __restrict__ global_input,
-  int input_ldim,
+  El::Int input_ldim,
   const DataType * __restrict__ global_gradient_wrt_output,
-  int gradient_wrt_output_ldim,
+  El::Int gradient_wrt_output_ldim,
   const DataType * __restrict__ global_mean,
   const DataType * __restrict__ global_var,
   DataType epsilon,
@@ -234,9 +238,9 @@ __global__ void backprop1_kernel(
         DataType * __restrict__ global_dvar) {
 
   // Indices
-  const int tid = threadIdx.x;
-  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const int bidy = blockIdx.y;
+  const El::Int tid = threadIdx.x;
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
 
   // Initialize shared memory
   __shared__ DataType shared_dscale[block_size];
@@ -250,7 +254,7 @@ __global__ void backprop1_kernel(
   const auto& scale = global_scale[bidy];
 
   // Compute useful constants
-  const DataType zero = DataType(0);
+  constexpr DataType zero = 0;
   const auto& inv_stdev = rsqrt_(var + epsilon);
   const auto& dvar_factor = inv_stdev * inv_stdev * inv_stdev / 2;
 
@@ -260,8 +264,8 @@ __global__ void backprop1_kernel(
   auto dmean = zero;
   auto dvar = zero;
   if (gidx < channel_height) {
-    const int row = gidx + bidy * channel_height;
-    for(int col = 0; col < width; ++col) {
+    const auto& row = gidx + bidy * channel_height;
+    for(El::Int col = 0; col < width; ++col) {
       const auto& x = global_input[row + col * input_ldim];
       const auto& xhat = (x - mean) * inv_stdev;
       const auto& dy = global_gradient_wrt_output[row + col * gradient_wrt_output_ldim];
@@ -279,7 +283,7 @@ __global__ void backprop1_kernel(
 
   // Compute gradients with shared memory reduction
   // @todo unroll loops
-  for (int stride = block_size / 2; stride > 0; stride /= 2) {
+  for (El::Int stride = block_size / 2; stride > 0; stride /= 2) {
     __syncthreads();
     if (tid < stride) {
       shared_dscale[tid] += shared_dscale[tid + stride];
@@ -300,15 +304,15 @@ __global__ void backprop1_kernel(
 }
 
 /** CUDA kernel to compute gradients w.r.t. input. */
-template <int block_size>
+template <El::Int block_size>
 __global__ void backprop2_kernel(
-  int channel_height,
-  int local_width,
-  int global_width,
+  El::Int channel_height,
+  El::Int local_width,
+  El::Int num_per_sum,
   const DataType * __restrict__ global_input,
-  int input_ldim,
+  El::Int input_ldim,
   const DataType * __restrict__ global_gradient_wrt_output,
-  int gradient_wrt_output_ldim,
+  El::Int gradient_wrt_output_ldim,
   const DataType * __restrict__ global_mean,
   const DataType * __restrict__ global_var,
   DataType epsilon,
@@ -316,11 +320,11 @@ __global__ void backprop2_kernel(
   const DataType * __restrict__ global_dmean,
   const DataType * __restrict__ global_dvar,
         DataType * __restrict__ global_gradient_wrt_input,
-  int gradient_wrt_input_ldim) {
+  El::Int gradient_wrt_input_ldim) {
 
   // Indices
-  const int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const int bidy = blockIdx.y;
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
 
   // Copy batch normalization parameters to private memory
   const auto& mean = global_mean[bidy];
@@ -331,290 +335,225 @@ __global__ void backprop2_kernel(
 
   // Compute useful constants
   const auto& inv_stdev = rsqrt_(var + epsilon);
-  const auto& dmean_term = dmean / (global_width * channel_height);
-  const auto& dvar_term = dvar * 2 / (global_width * channel_height - 1);
+  const auto& dmean_term = dmean / num_per_sum;
+  const auto& dvar_term = dvar * 2 / (num_per_sum - 1);
 
   // Apply batch normalization
   if (gidx < channel_height) {
-    const int row = gidx + bidy * channel_height;
-    for (int col = 0; col < local_width; ++col) {
+    const auto& row = gidx + bidy * channel_height;
+    for (El::Int col = 0; col < local_width; ++col) {
       const auto& x = global_input[row + col * input_ldim];
       const auto& dy = global_gradient_wrt_output[row + col * gradient_wrt_output_ldim];
       const auto& dxhat = dy * scale;
-      auto dx = dxhat * inv_stdev;
-      dx += dmean_term;
-      dx += dvar_term * (x - mean);
-      global_gradient_wrt_input[row + col * gradient_wrt_input_ldim] = dx;
+      auto& dx = global_gradient_wrt_input[row + col * gradient_wrt_input_ldim];
+      dx = dxhat * inv_stdev + dmean_term + dvar_term * (x - mean);
     }
   }
 
 }
 
 } // namespace
+  
+template <>
+void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+  constexpr DataType one = 1;
+  const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
 
-namespace batch_normalization_cuda {
+  // CUDA objects
+  CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+  auto&& stream = El::GPUManager::Stream();
+  
+  // Matrices
+  const auto& input = get_prev_activations();
+  const auto& local_input = input.LockedMatrix();
+  auto& local_output = get_local_activations();
 
-void channel_sums(int num_channels,
-                  const AbsMat& data,
-                  AbsMat& sums,
-                  AbsMat& sqsums) {
+  // Matrix parameters
+  const auto& width = input.Width();
+  const auto& local_width = local_input.Width();
+  const auto& output_dims = get_output_dims();
+  const auto& num_channels = output_dims[0];
+  const auto& channel_size = get_output_size() / num_channels;
 
-#ifdef LBANN_DEBUG
-  // Check that inputs are valid
-  if (num_channels < 1) { LBANN_ERROR("non-positive number of channels"); }
-  if (data.Height() % num_channels != 0) {
-    LBANN_ERROR("number of channels does not divide input matrix height"); 
-  }
-  if (data.GetDevice() != El::Device::GPU
-      || sums.GetDevice() != El::Device::GPU
-      || sqsums.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("matrices do not reside on GPU");
-  }
-#endif // LBANN_DEBUG  
+  // Compute statistics
+  if (is_training) {
 
-  // Compute channel sums and squares of sums
-  El::Zeros(sums, num_channels, 1);
-  El::Zeros(sqsums, num_channels, 1);
-  if (data.Height() > 0 && data.Width() > 0) {
-    const int channel_height = data.Height() / num_channels;
-    const int block_size = 256;
-    dim3 block_dims, grid_dims;
-    block_dims.x = block_size;
-    grid_dims.x = (channel_height + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    channel_sums_kernel<block_size>
-      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
-        channel_height, data.Width(),
-        data.LockedBuffer(), data.LDim(),
-        sums.Buffer(), sqsums.Buffer());
-  }
-}
+    // Local matrices
+    auto& local_mean = m_mean->Matrix();
+    auto& local_var = m_var->Matrix();
+    auto& local_running_mean = this->m_weights[2]->get_values().Matrix();
+    auto& local_running_var = this->m_weights[3]->get_values().Matrix();
 
-void compute_statistics(int num_per_sum,
-                        DataType epsilon,
-                        DataType decay,
-                        AbsMat& mean,
-                        AbsMat& var,
-                        AbsMat& running_mean,
-                        AbsMat& running_var) {
-
-#ifdef LBANN_DEBUG
-  // Check that inputs are valid
-  if (mean.Height() != var.Height()
-      || mean.Height() != running_mean.Height()
-      || mean.Height() != running_var.Height()
-      || mean.Width() != 1 || var.Width() != 1
-      || running_mean.Width() != 1 || running_var.Width() != 1) {
-    LBANN_ERROR("invalid matrix dimensions");
-  }
-  if (mean.GetDevice() != El::Device::GPU
-      || var.GetDevice() != El::Device::GPU
-      || running_mean.GetDevice() != El::Device::GPU
-      || running_var.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("matrices do not reside on GPU");
-  }
-#endif // LBANN_DEBUG  
-
-  // Compute statistics from sums
-  const int block_dim = 256;
-  const int grid_dim = (mean.Height() + block_dim - 1) / block_dim;
-  if (num_per_sum > 1) {
-    if (grid_dim > 0) {
-      CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-      compute_statistics_kernel
-        <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
-          mean.Height(), num_per_sum, epsilon, decay,
-          mean.Buffer(), var.Buffer(),
-          running_mean.Buffer(), running_var.Buffer());
-    }
-  } else {
-    El::Fill(var, DataType(1));
-  }
-
-}
-
-void batch_normalization(const AbsMat& input,
-                         const AbsMat& mean,
-                         const AbsMat& var,
-                         DataType epsilon,
-                         const AbsMat& scale,
-                         const AbsMat& bias,
-                         AbsMat& output) {
-  const int num_channels = mean.Height();
-
-#ifdef LBANN_DEBUG
-  // Check that inputs are valid
-  if (num_channels < 1) { LBANN_ERROR("non-positive number of channels"); }
-  if (input.Height() % num_channels != 0) {
-    LBANN_ERROR("number of channels does not divide input matrix height"); 
-  }
-  if (mean.Height() != num_channels || var.Height() != num_channels
-      || scale.Height() != num_channels || bias.Height() != num_channels
-      || mean.Width() != 1 || var.Width() != 1
-      || scale.Width() != 1 || bias.Width() != 1
-      || input.Height() != output.Height()
-      || input.Width() != output.Width()) {
-    LBANN_ERROR("invalid matrix dimensions");
-  }
-  if (input.GetDevice() != El::Device::GPU
-      || mean.GetDevice() != El::Device::GPU
-      || var.GetDevice() != El::Device::GPU
-      || scale.GetDevice() != El::Device::GPU
-      || bias.GetDevice() != El::Device::GPU
-      || output.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("matrices do not reside on GPU");
-  }
-#endif // LBANN_DEBUG  
-
-  // Apply batch normalization
-  if (input.Height() > 0 && input.Width() > 0) {
-    const int channel_height = input.Height() / num_channels;
-    const int block_size = 256;
-    dim3 block_dims, grid_dims;
-    block_dims.x = block_size;
-    grid_dims.x = (channel_height + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    batch_normalization_kernel<block_size>
-      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
-        channel_height, input.Width(),
-        input.LockedBuffer(), input.LDim(),
-        mean.LockedBuffer(), var.LockedBuffer(), epsilon,
-        scale.LockedBuffer(), bias.LockedBuffer(),
-        output.Buffer(), output.LDim());
-  }
-
-}
-
-void backprop1(const AbsMat& input,
-               const AbsMat& gradient_wrt_output,
-               const AbsMat& mean,
-               const AbsMat& var,
-               DataType epsilon,
-               const AbsMat& scale,
-               AbsMat& dscale,
-               AbsMat& dbias,
-               AbsMat& dmean,
-               AbsMat& dvar) {
-  const int num_channels = mean.Height();
-
-#ifdef LBANN_DEBUG
-  // Check that inputs are valid
-  if (num_channels < 1) { LBANN_ERROR("non-positive number of channels"); }
-  if (input.Height() % num_channels != 0) {
-    LBANN_ERROR("number of channels does not divide input matrix height"); 
-  }
-  if (mean.Height() != num_channels || var.Height() != num_channels
-      || scale.Height() != num_channels
-      || mean.Width() != 1 || var.Width() != 1 || scale.Width() != 1
-      || input.Height() != gradient_wrt_output.Height()
-      || input.Width() != gradient_wrt_output.Width()) {
-    LBANN_ERROR("invalid matrix dimensions");
-  }
-  if (input.GetDevice() != El::Device::GPU
-      || gradient_wrt_output.GetDevice() != El::Device::GPU
-      || mean.GetDevice() != El::Device::GPU
-      || var.GetDevice() != El::Device::GPU
-      || scale.GetDevice() != El::Device::GPU
-      || dscale.GetDevice() != El::Device::GPU
-      || dbias.GetDevice() != El::Device::GPU
-      || dmean.GetDevice() != El::Device::GPU
-      || dvar.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("matrices do not reside on GPU");
-  }
-#endif // LBANN_DEBUG  
-
-  // Compute gradients w.r.t. batch norm parameters
-  El::Zeros(dscale, num_channels, 1);
-  El::Zeros(dbias, num_channels, 1);
-  El::Zeros(dmean, num_channels, 1);
-  El::Zeros(dvar, num_channels, 1);
-  if (input.Height() > 0 && input.Width() > 0) {
-    const int channel_height = input.Height() / num_channels;
-    const int block_size = 256;
-    dim3 block_dims, grid_dims;
-    block_dims.x = block_size;
-    grid_dims.x = (channel_height + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    backprop1_kernel<block_size>
-      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
-        channel_height, input.Width(),
-        input.LockedBuffer(), input.LDim(),
-        gradient_wrt_output.LockedBuffer(), gradient_wrt_output.LDim(),
-        mean.LockedBuffer(), var.LockedBuffer(), epsilon,
-        scale.LockedBuffer(), dscale.Buffer(), dbias.Buffer(),
-        dmean.Buffer(), dvar.Buffer());
-  }
-
-}
-
-void backprop2(int global_width,
-               const AbsMat& input,
-               const AbsMat& gradient_wrt_output,
-               const AbsMat& mean,
-               const AbsMat& var,
-               DataType epsilon,
-               const AbsMat& scale,
-               const AbsMat& dmean,
-               const AbsMat& dvar,
-               AbsMat& gradient_wrt_input) {
-  const int num_channels = mean.Height();
-
-#ifdef LBANN_DEBUG
-  // Check that inputs are valid
-  if (num_channels < 1) { LBANN_ERROR("non-positive number of channels"); }
-  if (input.Height() % num_channels != 0) {
-    LBANN_ERROR("number of channels does not divide input matrix height"); 
-  }
-  if (mean.Height() != num_channels || var.Height() != num_channels
-      || scale.Height() != num_channels
-      || dmean.Height() != num_channels || dvar.Height() != num_channels
-      || mean.Width() != 1 || var.Width() != 1 || scale.Width() != 1
-      || dmean.Width() != 1 || dvar.Width() != 1
-      || input.Height() != gradient_wrt_output.Height()
-      || input.Height() != gradient_wrt_input.Height()
-      || input.Width() != gradient_wrt_output.Width()
-      || input.Width() != gradient_wrt_input.Width()) {
-    LBANN_ERROR("invalid matrix dimensions");
-  }
-  if (input.GetDevice() != El::Device::GPU
-      || gradient_wrt_output.GetDevice() != El::Device::GPU
-      || mean.GetDevice() != El::Device::GPU
-      || var.GetDevice() != El::Device::GPU
-      || scale.GetDevice() != El::Device::GPU
-      || dmean.GetDevice() != El::Device::GPU
-      || dvar.GetDevice() != El::Device::GPU
-      || gradient_wrt_input.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("matrices do not reside on GPU");
-  }
-#endif // LBANN_DEBUG  
-
-  // Compute gradient w.r.t. input
-  const int channel_height = input.Height() / num_channels;
-  if (channel_height * global_width <= 1) {
-    // El::Zero(gradient_wrt_input);
-  } else {
-    if (input.Height() > 0 && input.Width() > 0) {
-      const int block_size = 256;
+    // Compute sums and sums of squares
+    El::Zero(local_mean);
+    El::Zero(local_var);
+    if (!local_input.IsEmpty()) {
+      const El::Int block_size = 256;
       dim3 block_dims, grid_dims;
       block_dims.x = block_size;
-      grid_dims.x = (channel_height + block_size - 1) / block_size;
+      grid_dims.x = (channel_size + block_size - 1) / block_size;
       grid_dims.y = num_channels;
-      CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-      backprop2_kernel<block_size>
-        <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
-          channel_height, input.Width(), global_width,
-          input.LockedBuffer(), input.LDim(),
-          gradient_wrt_output.LockedBuffer(), gradient_wrt_output.LDim(),
-          mean.LockedBuffer(), var.LockedBuffer(), epsilon,
-          scale.LockedBuffer(), dmean.LockedBuffer(), dvar.LockedBuffer(),
-          gradient_wrt_input.Buffer(), gradient_wrt_input.LDim());
+      channel_sums_kernel<block_size>
+        <<<grid_dims, block_dims, 0, stream>>>(
+          channel_size, local_width,
+          local_input.LockedBuffer(), local_input.LDim(),
+          local_mean.Buffer(), local_var.Buffer());
     }
+    El::Int num_per_sum;
+    if (m_use_global_stats) {
+      m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
+      m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
+      num_per_sum = channel_size * width;
+    } else {
+      num_per_sum = channel_size * local_width;
+    }
+
+    // Compute minibatch statistics
+    if (num_per_sum <= 1) {
+      El::Fill(local_var, one);
+    } else if (num_channels > 0) {
+      const El::Int block_dim = 256;
+      const El::Int grid_dim = (num_channels + block_dim - 1) / block_dim;
+      compute_statistics_kernel
+        <<<grid_dim, block_dim, 0, stream>>>(
+          num_channels, num_per_sum, m_epsilon, m_decay,
+          local_mean.Buffer(), local_var.Buffer(),
+          local_running_mean.Buffer(), local_running_var.Buffer());
+    }
+
   }
 
+  // Apply batch normalization
+  const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
+  const auto& local_bias = this->m_weights[1]->get_values().LockedMatrix();
+  const auto& local_mean = (is_training ?
+                            m_mean->LockedMatrix() :
+                            this->m_weights[2]->get_values().LockedMatrix());
+  const auto& local_var = (is_training ?
+                           m_var->LockedMatrix() :
+                           this->m_weights[3]->get_values().LockedMatrix());
+  if (!local_input.IsEmpty()) {
+    const El::Int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    batch_normalization_kernel<block_size>
+      <<<grid_dims, block_dims, 0, stream>>>(
+        channel_size, local_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_mean.LockedBuffer(), local_var.LockedBuffer(), m_epsilon,
+        local_scale.LockedBuffer(), local_bias.LockedBuffer(),
+        local_output.Buffer(), local_output.LDim());
+  }
+  
 }
 
-} // namespace batch_normalization
+template <>
+void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
+  constexpr DataType one = 1;
+  const bool is_training = this->m_model->get_execution_mode() == execution_mode::training;
+
+  // CUDA objects
+  CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+  auto&& stream = El::GPUManager::Stream();
+
+  // Matrices
+  const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
+  const auto& local_mean = (is_training ?
+                            m_mean->LockedMatrix() :
+                            this->m_weights[2]->get_values().LockedMatrix());
+  const auto& local_var = (is_training ?
+                           m_var->LockedMatrix() :
+                           this->m_weights[3]->get_values().LockedMatrix());
+  const auto& input = get_prev_activations();
+  const auto& local_input = input.LockedMatrix();
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+  auto& local_mean_gradient = m_mean_gradient->Matrix();
+  auto& local_var_gradient = m_var_gradient->Matrix();
+  auto& local_scale_gradient = m_scale_gradient->Matrix();
+  auto& local_bias_gradient = m_bias_gradient->Matrix();
+
+  // Matrix parameters
+  const El::Int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
+  const auto& width = input.Width();
+  const auto& local_width = local_input.Width();
+  const auto& output_dims = get_output_dims();
+  const auto& num_channels = output_dims[0];
+  const auto& channel_size = get_output_size() / num_channels;
+
+  // Compute local gradients
+  // Compute gradients w.r.t. batch norm parameters
+  El::Zero(local_scale_gradient);
+  El::Zero(local_bias_gradient);
+  El::Zero(local_mean_gradient);
+  El::Zero(local_var_gradient);
+  if (!local_input.IsEmpty()) {
+    const El::Int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    backprop1_kernel<block_size>
+      <<<grid_dims, block_dims, 0, stream>>>(
+        channel_size, local_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
+        local_mean.LockedBuffer(), local_var.LockedBuffer(), m_epsilon,
+        local_scale.LockedBuffer(),
+        local_scale_gradient.Buffer(), local_bias_gradient.Buffer(),
+        local_mean_gradient.Buffer(), local_var_gradient.Buffer());
+  }
+
+  // Accumulate gradients
+  if (is_training) {
+    if (m_use_global_stats) {
+      m_comm->allreduce(*m_mean_gradient,
+                        m_mean_gradient->RedundantComm(),
+                        El::mpi::SUM);
+      m_comm->allreduce(*m_var_gradient,
+                        m_var_gradient->RedundantComm(),
+                        El::mpi::SUM);
+    }
+  } else {
+    El::Zero(*m_mean_gradient);
+    El::Zero(*m_var_gradient);
+  }
+  optimizer* scale_optimizer = m_weights[0]->get_optimizer();
+  if (scale_optimizer != nullptr) {
+    scale_optimizer->add_to_gradient_staging(*m_scale_gradient,
+                                             one / effective_mini_batch_size);
+  }
+  optimizer* bias_optimizer = m_weights[1]->get_optimizer();
+  if (bias_optimizer != nullptr) {
+    bias_optimizer->add_to_gradient_staging(*m_bias_gradient,
+                                            one / effective_mini_batch_size);
+  }
+
+  // Compute error signal
+  const auto& num_per_sum = (m_use_global_stats ?
+                             width * channel_size :
+                             local_width * channel_size);
+  if (num_per_sum <= 1) {
+    El::Zero(local_gradient_wrt_input);
+  } else if (!local_input.IsEmpty()) {
+    const El::Int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    backprop2_kernel<block_size>
+      <<<grid_dims, block_dims, 0, stream>>>(
+        channel_size, local_width, num_per_sum,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
+        local_mean.LockedBuffer(), local_var.LockedBuffer(), m_epsilon,
+        local_scale.LockedBuffer(),
+        local_mean_gradient.LockedBuffer(), local_var_gradient.LockedBuffer(),
+        local_gradient_wrt_input.Buffer(), local_gradient_wrt_input.LDim());
+  }
+  
+}
+  
 } // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -331,10 +331,12 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_batch_normalization()) {
     const auto& params = proto_layer.batch_normalization();
     if (layout == data_layout::DATA_PARALLEL) {
-      return new batch_normalization<data_layout::DATA_PARALLEL, Dev>(comm,
-                                                                      params.decay(),
-                                                                      params.epsilon(),
-                                                                      params.global_stats());
+      return new batch_normalization_layer<data_layout::DATA_PARALLEL, Dev>(comm,
+                                                                            params.decay(),
+                                                                            params.epsilon(),
+                                                                            params.global_stats());
+    } else {
+      LBANN_ERROR("batch normalization is only supported in a data-parallel layout");
     }
   }
   if (proto_layer.has_dropout()) {


### PR DESCRIPTION
### Description
This PR makes several stylistic changes to make the batch norm layer easier to maintain:
- Private matrices are stored in `unique_ptr`s (see #155).
- The CPU and GPU implementations are moved out of the header file and into template specializations.
- The layer is renamed from `batch_normalization` to `batch_normalization_layer`, which better matches our naming scheme.
- `El::Int` is used consistently as the integer type (see #91).

No substantive changes have been made to the prototext interface or to computation. This is intended as preparatory work for #618.

### Validation
- Gradient checks on model_zoo/tests/model_mnist_conv_graph.prototext come back clean. (bbde260)
- Reasonable results with Resnet-50 on ImageNet-10 (7.25 epoch 0 training objective, 7.11 epoch 0 validation objective, 5.59 epoch 4 training objective, 5.68 epoch 4 validation objective, 10.5s epoch 4 runtime on 4 Pascal nodes) (bbde260).
  - For comparison, a similar run on 9/10 got 7.06 epoch 0 training objective, 6.49 epoch 0 validation objective, 5.51 epoch 4 training objective, 5.72 epoch 4 validation objective, 11.6s epoch 4 runtime (110cef2).

