### PR TITLE
Fix model_gather

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -357,7 +357,7 @@ class lbann_comm {
   /** Within-model scalar gather (for root processes). */
   template <typename T>
   void model_gather(T snd, T* rcv) {
-    gather(snd, get_model_master(), model_comm);
+    gather(snd, rcv, model_comm);
   }
   /** Within-model scalar-array gather (for non-root processes). */
   template <typename T>


### PR DESCRIPTION
There was a bug introduced into `lbann_comm::model_gather`, where the root version of the call did not correctly forward to `lbann_comm::gather`.