### PR TITLE
Updating run script to use raw ImageNet images.

### DIFF
--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -156,8 +156,8 @@ if [ -n "${IMAGENET_CLASSES}" ]; then
         catalyst|flash|quartz|surface|pascal)
             case ${IMAGENET_CLASSES} in
                 10|100|300|1000)
-                    IMAGENET_DIR=/p/lscratchf/brainusr/datasets/ILSVRC2012
-                    DATASET_TARBALLS="${IMAGENET_DIR}/resized_256x256/train.tar ${IMAGENET_DIR}/resized_256x256/val.tar ${IMAGENET_DIR}/labels.tar"
+                    IMAGENET_DIR=/p/lscratchh/brainusr/datasets/ILSVRC2012
+                    DATASET_TARBALLS="${IMAGENET_DIR}/original/train.tar ${IMAGENET_DIR}/original/val.tar ${IMAGENET_DIR}/labels.tar"
                     IMAGENET_SUFFIX=_c0-$((${IMAGENET_CLASSES}-1))
                     if [ "${IMAGENET_CLASSES}" -eq "1000" ]; then
                         IMAGENET_SUFFIX=
@@ -170,9 +170,9 @@ if [ -n "${IMAGENET_CLASSES}" ]; then
                             TEST_DATASET_LABELS=${CACHE_DIR}/labels/val${IMAGENET_SUFFIX}.txt
                             ;;
                         *)
-                            TRAIN_DATASET_DIR=${IMAGENET_DIR}/resized_256x256/train/
+                            TRAIN_DATASET_DIR=${IMAGENET_DIR}/original/train/
                             TRAIN_DATASET_LABELS=${IMAGENET_DIR}/labels/train${IMAGENET_SUFFIX}.txt
-                            TEST_DATASET_DIR=${IMAGENET_DIR}/resized_256x256/val/
+                            TEST_DATASET_DIR=${IMAGENET_DIR}/original/val/
                             TEST_DATASET_LABELS=${IMAGENET_DIR}/labels/val${IMAGENET_SUFFIX}.txt
                             ;;
                     esac
@@ -190,7 +190,7 @@ if [ -n "${IMAGENET_CLASSES}" ]; then
             ;;
         ray)
             IMAGENET_DIR=/p/gscratchr/brainusr/datasets/ILSVRC2012
-            DATASET_TARBALLS="${IMAGENET_DIR}/resized_256x256/train.tar ${IMAGENET_DIR}/resized_256x256/val.tar ${IMAGENET_DIR}/labels.tar"
+            DATASET_TARBALLS="${IMAGENET_DIR}/original/train.tar ${IMAGENET_DIR}/original/val.tar ${IMAGENET_DIR}/labels.tar"
             IMAGENET_SUFFIX=_c0-$((${IMAGENET_CLASSES}-1))
             if [ "${IMAGENET_CLASSES}" -eq "1000" ]; then
                 IMAGENET_SUFFIX=
@@ -203,9 +203,9 @@ if [ -n "${IMAGENET_CLASSES}" ]; then
                     TEST_DATASET_LABELS=${CACHE_DIR}/labels/val${IMAGENET_SUFFIX}.txt
                     ;;
                 *)
-                    TRAIN_DATASET_DIR=${IMAGENET_DIR}/resized_256x256/train/
+                    TRAIN_DATASET_DIR=${IMAGENET_DIR}/original/train/
                     TRAIN_DATASET_LABELS=${IMAGENET_DIR}/labels/train${IMAGENET_SUFFIX}.txt
-                    TEST_DATASET_DIR=${IMAGENET_DIR}/resized_256x256/val/
+                    TEST_DATASET_DIR=${IMAGENET_DIR}/original/val/
                     TEST_DATASET_LABELS=${IMAGENET_DIR}/labels/val${IMAGENET_SUFFIX}.txt
                     ;;
             esac


### PR DESCRIPTION
A while ago (865ac810dcea4eb96ba2eb5410606c428e520c44), we changed from using preprocessed ImageNet images to cropping raw images on the fly. If I remember correctly, the pre-resized images had some wonky aspect ratio issues. In any case, we forgot to the update experiment script with the correct dataset paths. It isn't a major problem since we only used the old dataset paths when debugging, e.g. when using ImageNet-10 or ImageNet-100, but we should handle it. I get similar results when I run AlexNet with ImageNet-10 on Pascal.