### PR TITLE
GPU evaluation layer no longer blocks host.

### DIFF
--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -66,6 +66,8 @@ private:
    *  The value may be stored in pinned memory.
    */
   CPUMat m_value;
+  /** Non-blocking allreduce request. */
+  Al::request m_allreduce_req;
 #ifdef LBANN_HAS_GPU
   /** CUDA event after a non-blocking GPU-CPU memory copy. */
   cuda::event_wrapper m_copy_event;

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -53,20 +53,23 @@ public:
                                               El::Device device);
   
 protected:
-
   abstract_evaluation_layer(lbann_comm *comm);
-
+  void setup_data() override;
   void fp_compute() override;
   void bp_compute() override;
 
 private:
 
   /** Scaling factor to apply to evaluated value. */
-  EvalType m_scale;
-  /** Evaluated value. */
-  DataType m_value;
-  /** Non-blocking allreduce request. */
-  Al::request m_allreduce_req;
+  EvalType m_scale = 0;
+  /** Evaluated value.
+   *  The value may be stored in pinned memory.
+   */
+  CPUMat m_value;
+#ifdef LBANN_HAS_GPU
+  /** CUDA event after a non-blocking GPU-CPU memory copy. */
+  cuda::event_wrapper m_copy_event;
+#endif // LBANN_HAS_GPU
   
 };
 
@@ -76,25 +79,14 @@ private:
  */
 template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
 class evaluation_layer : public abstract_evaluation_layer {
-
- public:
-
+public:
   evaluation_layer(lbann_comm *comm) : abstract_evaluation_layer(comm) {}
-
   evaluation_layer* copy() const override { return new evaluation_layer(*this); }
   std::string get_type() const override { return "evaluation"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-
-  /** Returns description. */
-  std::string get_description() const override {
-    std::stringstream s;
-     s << "evaluation_layer  dataLayout: " << this->get_data_layout_string(get_data_layout());
-     return s.str();
-  }
-
 };
-
+  
 } // namespace lbann
 
 #endif // LBANN_LAYER_EVALUATION_HPP_INCLUDED

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -88,7 +88,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
 };
-  
+
 } // namespace lbann
 
 #endif // LBANN_LAYER_EVALUATION_HPP_INCLUDED

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -127,16 +127,38 @@ __device__ __inline__ double atomic_add(double* address, double val) {
 }
 
 // Min and max
-__device__ __inline__ int min(int x, int y) { return x <= y ? x : y; }
-__device__ __inline__ El::Int min(El::Int x, El::Int y) { return x <= y ? x : y; }
-__device__ __inline__ float min(float x, float y) { return fminf(x, y); }
-__device__ __inline__ double min(double x, double y) { return fmin(x, y); }
-__device__ __inline__ int max(int x, int y) { return x >= y ? x : y; }
-__device__ __inline__ El::Int max(El::Int x, El::Int y) { return x >= y ? x : y; }
-__device__ __inline__ float max(float x, float y) { return fmaxf(x, y); }
-__device__ __inline__ double max(double x, double y) { return fmax(x, y); }
+template <typename T> __device__ __inline__
+T min(const T& x, const T& y) { return x <= y ? x : y; }
+template <typename T> __device__ __inline__
+T max(const T& x, const T& y) { return x >= y ? x : y; }
+template <> __device__ __inline__
+float min<float>(const float& x, const float& y) { return fminf(x, y); }
+template <> __device__ __inline__
+double min<double>(const double& x, const double& y) { return fmin(x, y); }
+template <> __device__ __inline__
+float max<float>(const float& x, const float& y) { return fmaxf(x, y); }
+template <> __device__ __inline__
+double max<double>(const double& x, const double& y) { return fmax(x, y); }
   
 #endif // __CUDACC__
+
+/** Wrapper class for a CUDA event. */
+class event_wrapper {
+public:
+  event_wrapper();
+  ~event_wrapper();
+  /** Enqueue CUDA event on a CUDA stream. */
+  void record(cudaStream_t stream);
+  /** Check whether CUDA event has completed. */
+  bool query() const;
+  /** Wait until CUDA event has completed. */
+  void synchronize();
+  /** Get CUDA event object. */
+  cudaEvent_t& get_event();
+private:
+  /** CUDA event object. */
+  cudaEvent_t m_event;
+};
   
 // -------------------------------------------------------------
 // Helper functions for entrywise operations

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -146,6 +146,8 @@ double max<double>(const double& x, const double& y) { return fmax(x, y); }
 class event_wrapper {
 public:
   event_wrapper();
+  event_wrapper(const event_wrapper& other);
+  event_wrapper& operator=(const event_wrapper& other);
   ~event_wrapper();
   /** Enqueue CUDA event on a CUDA stream. */
   void record(cudaStream_t stream);
@@ -156,8 +158,14 @@ public:
   /** Get CUDA event object. */
   cudaEvent_t& get_event();
 private:
-  /** CUDA event object. */
+  /** CUDA event object.
+   *  The event object lifetime is managed internally.
+   */
   cudaEvent_t m_event;
+  /** CUDA stream object.
+   *  The stream object lifetime is assumed to be managed externally.
+   */
+  cudaStream_t m_stream;
 };
   
 // -------------------------------------------------------------

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -37,13 +37,12 @@ namespace {
 /** CPU implementation of evaluation layer forward prop. */
 void fp_cpu(lbann_comm& comm,
             const AbsDistMat& input,
-            DataType& value,
-            Al::request& req) {
+            DataType& value) {
   const auto& local_input = input.LockedMatrix();
   const auto& local_height = local_input.Height();
   const auto& local_width = local_input.Width();
   const auto& mini_batch_size = input.Width();
-  value = DataType(0);
+  value = 0;
 #pragma omp parallel for reduction(+:value) collapse(2)
   for (El::Int col = 0; col < local_width; ++col) {
     for (El::Int row = 0; row < local_height; ++row) {
@@ -51,7 +50,7 @@ void fp_cpu(lbann_comm& comm,
     }
   }
   value = value / mini_batch_size;
-  comm.nb_allreduce(&value, 1, input.DistComm(), req);
+  comm.allreduce(&value, 1, input.DistComm());
 }
 
 #ifdef LBANN_HAS_GPU
@@ -59,8 +58,10 @@ void fp_cpu(lbann_comm& comm,
 void fp_gpu(lbann_comm& comm,
             const AbsDistMat& input,
             DataType& value,
-            Al::request& req) {
-
+            cuda::event_wrapper& copy_event) {
+  constexpr DataType zero = 0;
+  constexpr DataType one = 1;
+  
   // Local matrix
   const auto& local_input = input.LockedMatrix();
   const auto& local_height = local_input.Height();
@@ -70,57 +71,63 @@ void fp_gpu(lbann_comm& comm,
   // GPU objects
   GPUMat sum_d, ones_d;
 #ifdef HYDROGEN_HAVE_CUB
-  sum_d.SetMemoryMode(1);  // Use CUB GPU memory pool if possible
-  ones_d.SetMemoryMode(1); // Use CUB GPU memory pool if possible
+  sum_d.SetMemoryMode(1);  // Use CUB GPU memory pool
+  ones_d.SetMemoryMode(1); // Use CUB GPU memory pool
 #endif // HYDROGEN_HAVE_CUB
+  sum_d.Resize(1, 1);
   auto&& handle = El::GPUManager::cuBLASHandle();
+  auto&& stream = El::GPUManager::Stream();
   CHECK_CUBLAS(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE));
 
   // Compute sum of local input matrix entries
-  if (local_height < 1 || local_width < 1) {
-    El::Zeros(sum_d, 1, 1);
-  } else if (local_height == local_input.LDim() || local_width == 1) {
-    sum_d.Resize(1, 1);
+  if (local_input.IsEmpty()) {
+    El::Zero(sum_d);
+  } else if (local_input.Contiguous()) {
     ones_d.Resize(local_height * local_width, 1);
-    El::Fill(ones_d, DataType(1));
+    El::Fill(ones_d, one);
     cublas::dot(handle,
                 local_height * local_width,
                 local_input.LockedBuffer(), 1,
                 ones_d.LockedBuffer(), 1,
                 sum_d.Buffer());
   } else if (local_height == 1) {
-    sum_d.Resize(1, 1);
     ones_d.Resize(local_width, 1);
-    El::Fill(ones_d, DataType(1));
+    El::Fill(ones_d, one);
     cublas::dot(handle,
                 local_width,
                 local_input.LockedBuffer(), local_input.LDim(),
                 ones_d.LockedBuffer(), 1,
                 sum_d.Buffer());
   } else {
-    sum_d.Resize(local_width + 1, 1);
-    ones_d.Resize(std::max(local_height, local_width), 1);
-    El::Fill(ones_d, DataType(1));
-    for (El::Int col = 0; col < local_width; ++col) {
-      cublas::dot(handle,
-                  local_height,
-                  local_input.LockedBuffer(0, col), 1,
-                  ones_d.LockedBuffer(), 1,
-                  sum_d.Buffer(col+1, 0));
+    GPUMat col_sums_d;
+#ifdef HYDROGEN_HAVE_CUB
+    col_sums_d.SetMemoryMode(1);  // Use CUB GPU memory pool
+#endif // HYDROGEN_HAVE_CUB
+    col_sums_d.Resize(local_width, 1);
+    ones_d.Resize(local_height, 1);
+    El::Fill(ones_d, one);
+    El::Gemv(El::TRANSPOSE, one, local_input, ones_d, zero, col_sums_d);
+    if (local_width > local_height) {
+      ones_d.Resize(local_width, 1);
+      El::Fill(ones_d, one);
     }
     cublas::dot(handle,
                 local_width,
-                sum_d.LockedBuffer(1, 0), 1,
+                col_sums_d.LockedBuffer(), 1,
                 ones_d.LockedBuffer(), 1,
-                sum_d.Buffer(0, 0));
+                sum_d.Buffer());
   }
   CHECK_CUBLAS(cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_HOST));
 
   // Compute average value across mini-batch
-  CHECK_CUDA(cudaMemcpy(&value, sum_d.LockedBuffer(), sizeof(DataType),
-                        cudaMemcpyDeviceToHost));
-  value = value / mini_batch_size;
-  comm.nb_allreduce(&value, 1, input.DistComm(), req);
+  El::Scale(one / mini_batch_size, sum_d);
+  comm.allreduce(static_cast<AbsMat&>(sum_d), input.DistComm());
+  CHECK_CUDA(cudaMemcpyAsync(&value,
+                             sum_d.LockedBuffer(),
+                             sizeof(DataType),
+                             cudaMemcpyDeviceToHost,
+                             stream));
+  copy_event.record(stream);
 
 }
 #endif // LBANN_HAS_GPU
@@ -128,27 +135,37 @@ void fp_gpu(lbann_comm& comm,
 } // namespace
 
 EvalType abstract_evaluation_layer::get_value(bool scaled) {
-  get_comm()->wait(m_allreduce_req);
-  if (scaled) { return m_scale * m_value; }
-  else        { return m_value; }
+#ifdef LBANN_HAS_GPU
+  if (get_device_allocation() == El::Device::GPU) {
+    m_copy_event.synchronize();
+  }
+#endif // LBANN_HAS_GPU
+  if (scaled) { return m_scale * m_value(0, 0); }
+  else        { return m_value(0, 0); }
 }
 
 abstract_evaluation_layer::abstract_evaluation_layer(lbann_comm *comm)
-  : transform_layer(comm), m_scale(0), m_value(0) {
-
-  // Evaluation layer has no children
+  : transform_layer(comm) {
   m_expected_num_child_layers = 0;
-
 }
-
+  
+void abstract_evaluation_layer::setup_data() {
+  transform_layer::setup_data();
+#ifdef LBANN_HAS_GPU
+  m_value.SetMemoryMode(1); // Use pinned memory on host
+#endif // LBANN_HAS_GPU
+  El::Zeros(m_value, 1, 1);
+}
+  
 void abstract_evaluation_layer::fp_compute() {
   switch (get_device_allocation()) {
   case El::Device::CPU:
-    fp_cpu(*get_comm(), get_prev_activations(), m_value, m_allreduce_req);
+    fp_cpu(*get_comm(), get_prev_activations(), m_value(0, 0));
     break;
 #ifdef LBANN_HAS_GPU
   case El::Device::GPU:
-    fp_gpu(*get_comm(), get_prev_activations(), m_value, m_allreduce_req);
+    fp_gpu(*get_comm(), get_prev_activations(), m_value(0, 0),
+           m_copy_event);
     break;
 #endif // LBANN_HAS_GPU
   default: LBANN_ERROR("invalid device");

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -20,6 +20,13 @@ set_full_path(THIS_DIR_SOURCES
   summary.cpp
 )
 
+if (LBANN_HAS_CUDA)
+  # Add the CUDA source files for this directory
+  set_full_path(THIS_DIR_CU_SOURCES
+    cuda.cu
+    )
+endif ()
+
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)
 set(CUDA_SOURCES "${CUDA_SOURCES}" "${THIS_DIR_CU_SOURCES}" PARENT_SCOPE)

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -35,16 +35,29 @@ namespace cuda {
 // CUDA event wrapper
 ////////////////////////////////////////////////////////////
 
-event_wrapper::event_wrapper() : m_event(nullptr) {
+event_wrapper::event_wrapper() : m_event(nullptr), m_stream(0) {
   CHECK_CUDA(cudaEventCreate(&m_event));
 }
 
+event_wrapper::event_wrapper(const event_wrapper& other)
+  : m_event(nullptr), m_stream(other.m_stream) {
+  CHECK_CUDA(cudaEventCreate(&m_event));
+  if (!other.query()) { record(m_stream); }
+}
+
+event_wrapper& event_wrapper::operator=(const event_wrapper& other) {
+  m_stream = other.m_stream;
+  if (!other.query()) { record(m_stream); }
+  return *this;
+}
+  
 event_wrapper::~event_wrapper() {
   CHECK_CUDA(cudaEventDestroy(m_event));
 }
 
 void event_wrapper::record(cudaStream_t stream = 0) {
-  CHECK_CUDA(cudaEventRecord(m_event, stream));
+  m_stream = stream;
+  CHECK_CUDA(cudaEventRecord(m_event, m_stream));
 }
 
 bool event_wrapper::query() const {

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -36,12 +36,12 @@ namespace cuda {
 ////////////////////////////////////////////////////////////
 
 event_wrapper::event_wrapper() : m_event(nullptr), m_stream(0) {
-  CHECK_CUDA(cudaEventCreate(&m_event));
+  CHECK_CUDA(cudaEventCreateWithFlags(&m_event, cudaEventDisableTiming));
 }
 
 event_wrapper::event_wrapper(const event_wrapper& other)
   : m_event(nullptr), m_stream(other.m_stream) {
-  CHECK_CUDA(cudaEventCreate(&m_event));
+  CHECK_CUDA(cudaEventCreateWithFlags(&m_event, cudaEventDisableTiming));
   if (!other.query()) { record(m_stream); }
 }
 
@@ -55,7 +55,7 @@ event_wrapper::~event_wrapper() {
   CHECK_CUDA(cudaEventDestroy(m_event));
 }
 
-void event_wrapper::record(cudaStream_t stream = 0) {
+void event_wrapper::record(cudaStream_t stream) {
   m_stream = stream;
   CHECK_CUDA(cudaEventRecord(m_event, m_stream));
 }

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/cuda.hpp"
+
+#ifdef LBANN_HAS_GPU
+
+namespace lbann {
+namespace cuda {
+
+////////////////////////////////////////////////////////////
+// CUDA event wrapper
+////////////////////////////////////////////////////////////
+
+event_wrapper::event_wrapper() : m_event(nullptr) {
+  CHECK_CUDA(cudaEventCreate(&m_event));
+}
+
+event_wrapper::~event_wrapper() {
+  CHECK_CUDA(cudaEventDestroy(m_event));
+}
+
+void event_wrapper::record(cudaStream_t stream = 0) {
+  CHECK_CUDA(cudaEventRecord(m_event, stream));
+}
+
+bool event_wrapper::query() const {
+  const auto& status = cudaEventQuery(m_event);
+  switch (status) {
+  case cudaSuccess:       return true;
+  case cudaErrorNotReady: return false;
+  default:                CHECK_CUDA(status);
+  }
+  return false;
+}
+
+void event_wrapper::synchronize() {
+  CHECK_CUDA(cudaEventSynchronize(m_event));
+}
+
+cudaEvent_t& event_wrapper::get_event() { return m_event; }
+
+} // namespace cuda
+} // namespace lbann
+
+#endif // LBANN_HAS_GPU


### PR DESCRIPTION
The trade-off is that it now performs a blocking GPU allreduce. Gradient checking for model_zoo/tests/model_mnist_conv_graph.prototext with 2 Pascal nodes comes back clean. This is an experimental solution to #632, pending performance benchmark results.