### PR TITLE
Save image callback can accommodate any layer.

### DIFF
--- a/include/lbann/callbacks/callback_save_images.hpp
+++ b/include/lbann/callbacks/callback_save_images.hpp
@@ -22,36 +22,32 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_save_images .hpp .cpp - Callbacks to save images, currently used in autoencoder
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_CALLBACKS_CALLBACK_SAVE_IMAGES_HPP_INCLUDED
 #define LBANN_CALLBACKS_CALLBACK_SAVE_IMAGES_HPP_INCLUDED
 
-#include <utility>
-
+#include <string>
+#include <vector>
 #include "lbann/callbacks/callback.hpp"
-#include "lbann/data_readers/data_reader.hpp"
 
 namespace lbann {
 
-/**
- * Save images to file
+/** Save layer outputs as image files.
+ *  Image files are in the form
+ *  "<prefix><tag>-<layer name>.<extension>".
  */
 class lbann_callback_save_images : public lbann_callback {
- public:
-  /**
-   * @param data reader type e.g., imagenet, mnist, cifar10....
-   * @param image_dir directory to save image
-   * @param layer_names list of layers from which to save images 
-   * @param image extension e.g., jpg, png, pgm......
+public:
+
+  /** Constructor.
+   *  @param prefix      Prefix for saved image files.
+   *  @param layer_names List of layer names to save as images.
+   *  @param extension   Image file extension (e.g. jpg, png, pgm).
    */
-  lbann_callback_save_images(generic_data_reader *reader, std::string image_dir,
-                             std::vector<std::string> layer_names,
-                             std::string extension="jpg") :
-    lbann_callback(), m_image_dir(std::move(image_dir)), m_extension(std::move(extension)),
-    m_reader(reader), m_layer_names(layer_names) {}
+  lbann_callback_save_images(std::vector<std::string> layer_names,
+                             std::string extension = "",
+                             std::string prefix = "jpg");
   lbann_callback_save_images(const lbann_callback_save_images&) = default;
   lbann_callback_save_images& operator=(
     const lbann_callback_save_images&) = default;
@@ -62,15 +58,20 @@ class lbann_callback_save_images : public lbann_callback {
   void on_phase_end(model *m) override;
   void on_test_end(model *m) override;
   std::string name() const override { return "save images"; }
- private:
-  std::string m_image_dir; //directory to save images
-  std::string m_extension; //image extension; pgm, jpg, png etc
-  generic_data_reader *m_reader;
-  /** List of layers at which to save images*/
+
+private:
+
+  /** List of layer names to save as images. */
   std::vector<std::string> m_layer_names;
-  void save_image(model& m, std::string tag);
+  /** Image file extension.
+   *  Valid options: jpg, png, pgm.
+   */
+  std::string m_extension;
+  /** Prefix for saved image files. */
+  std::string m_prefix;
+
 };
 
-}  // namespace lbann
+} // namespace lbann
 
 #endif  // LBANN_CALLBACKS_CALLBACK_SAVE_IMAGES_HPP_INCLUDED

--- a/include/lbann/callbacks/callback_save_images.hpp
+++ b/include/lbann/callbacks/callback_save_images.hpp
@@ -35,19 +35,19 @@ namespace lbann {
 
 /** Save layer outputs as image files.
  *  Image files are in the form
- *  "<prefix><tag>-<layer name>.<extension>".
+ *  "<prefix><tag>-<layer name>.<format>".
  */
 class lbann_callback_save_images : public lbann_callback {
 public:
 
   /** Constructor.
-   *  @param prefix      Prefix for saved image files.
-   *  @param layer_names List of layer names to save as images.
-   *  @param extension   Image file extension (e.g. jpg, png, pgm).
+   *  @param layer_names  List of layer names to save as images.
+   *  @param image_format Image file format (e.g. jpg, png, pgm).
+   *  @param image_prefix Prefix for image file names.
    */
   lbann_callback_save_images(std::vector<std::string> layer_names,
-                             std::string extension = "",
-                             std::string prefix = "jpg");
+                             std::string image_format = "jpg",
+                             std::string image_prefix = "");
   lbann_callback_save_images(const lbann_callback_save_images&) = default;
   lbann_callback_save_images& operator=(
     const lbann_callback_save_images&) = default;
@@ -63,12 +63,12 @@ private:
 
   /** List of layer names to save as images. */
   std::vector<std::string> m_layer_names;
-  /** Image file extension.
+  /** Image file format.
    *  Valid options: jpg, png, pgm.
    */
-  std::string m_extension;
+  std::string m_image_format;
   /** Prefix for saved image files. */
-  std::string m_prefix;
+  std::string m_image_prefix;
 
 };
 

--- a/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_autoencoder_cifar10.prototext
@@ -33,8 +33,8 @@ model {
   }
   #callback {
   #  save_images {
-  #    image_dir: "images_"
-  #    extension: "pgm"
+  #    image_prefix: "images_"
+  #    image_format: "pgm"
   #  }
   #}
 

--- a/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
@@ -42,8 +42,8 @@ model {
   }
  # callback {
  #   save_images {
- #     image_dir: "images_"
- #     extension: "pgm"
+ #     image_prefix: "images_"
+ #     image_format: "pgm"
  #   }
  # }
 

--- a/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
+++ b/model_zoo/models/autoencoder_imagenet/model_conv_autoencoder_imagenet.prototext
@@ -32,8 +32,8 @@ model {
   }
   callback {
     save_images {
-      image_dir: "images_"
-      extension: "pgm"
+      image_prefix: "images_"
+      image_format: "pgm"
     }
   }
 

--- a/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
@@ -29,8 +29,8 @@ model {
 #  }
 #  callback {
 #    save_images {
-#      image_dir: "images_"
-#      extension: "pgm"
+#      image_prefix: "images_"
+#      image_format: "pgm"
 #    }
 #  }
 

--- a/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_conv_autoencoder_mnist.prototext
@@ -32,8 +32,8 @@ model {
   }
   callback {
     save_images {
-      image_dir: "images_"
-      extension: "pgm"
+      image_prefix: "images_"
+      image_format: "pgm"
     }
   }
 

--- a/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/vae_mnist.prototext
@@ -47,8 +47,8 @@ model {
   }
   callback {
     save_images {
-      image_dir: "images_"
-      extension: "png"
+      image_prefix: "images_"
+      image_format: "png"
     }
   }
 

--- a/model_zoo/models/gan/mnist/adversarial_model.prototext
+++ b/model_zoo/models/gan/mnist/adversarial_model.prototext
@@ -48,9 +48,9 @@ model {
   }
   callback {
     save_images {
-      image_dir: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dump_images_32mb/"
-      layer_names: "fc4_tanh sum"
-      extension: "png"
+      image_prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dump_images_32mb/"
+      layers: "fc4_tanh sum"
+      image_format: "png"
     }
   }
 

--- a/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
+++ b/model_zoo/models/greedy_layerwise_autoencoder_mnist/model_greedy_layerwise_autoencoder_mnist.prototext
@@ -35,8 +35,8 @@ model {
 #  }
 #  callback {
 #    save_images {
-#      image_dir: "images_"
-#      extension: "pgm"
+#      image_prefix: "images_"
+#      image_format: "pgm"
 #    }
 #  }
 

--- a/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
@@ -51,8 +51,8 @@ model {
   #}
   #callback {
   #  save_images {
-  #    image_dir: "vae_fcn_images_"
-  #    extension: "jpg"
+  #    image_prefix: "vae_fcn_images_"
+  #    image_format: "jpg"
   #  }
   #}
 

--- a/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
@@ -44,8 +44,8 @@ model {
   callback { timer {} }
  # callback {
  #   save_images {
- #     image_dir: "vae_fcn_images_"
- #     extension: "jpg"
+ #     image_prefix: "vae_fcn_images_"
+ #     image_format: "jpg"
  #   }
  # }
 

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -50,8 +50,8 @@ model {
   }
   callback {
     save_images {
-      image_dir: "vae_fcn_images_"
-      extension: "jpg"
+      image_prefix: "vae_fcn_images_"
+      image_format: "jpg"
     }
   }
 

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_autoencoder_pilot2.prototext
@@ -35,8 +35,8 @@ model {
   }
   # callback {
   #   save_images {
-  #     image_dir: "images_"
-  #     extension: "pgm"
+  #     image_prefix: "images_"
+  #     image_format: "pgm"
   #   }
   # }
 

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_conv_molecular_bead_autoencoder_pilot2.prototext
@@ -32,8 +32,8 @@ model {
   }
   # callback {
   #   save_images {
-  #     image_dir: "images_"
-  #     extension: "pgm"
+  #     image_prefix: "images_"
+  #     image_format: "pgm"
   #   }
   # }
 

--- a/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
+++ b/model_zoo/models/molecular_autoencoder_candle_pilot2/model_molecular_autoencoder_pilot2.prototext
@@ -32,8 +32,8 @@ model {
   }
   # callback {
   #   save_images {
-  #     image_dir: "images_"
-  #     extension: "pgm"
+  #     image_prefix: "images_"
+  #     image_format: "pgm"
   #   }
   # }
   ###################################################

--- a/src/callbacks/callback_save_images.cpp
+++ b/src/callbacks/callback_save_images.cpp
@@ -34,7 +34,7 @@ namespace lbann {
 namespace {
 
 void save_image(std::string prefix,
-                std::string extension,
+                std::string format,
                 const std::vector<Layer*>& layers,
                 const std::vector<std::string>& layer_names) {
 #ifdef LBANN_HAS_OPENCV
@@ -116,7 +116,7 @@ void save_image(std::string prefix,
       }
 
       // Write image to file
-      cv::imwrite(prefix + "-" + name + "." + extension, img);
+      cv::imwrite(prefix + "-" + name + "." + format, img);
         
     }
       
@@ -127,34 +127,34 @@ void save_image(std::string prefix,
 } // namespace
 
 lbann_callback_save_images::lbann_callback_save_images(std::vector<std::string> layer_names,
-                                                       std::string extension,
-                                                       std::string prefix)
+                                                       std::string image_format,
+                                                       std::string image_prefix)
   : lbann_callback(),
     m_layer_names(std::move(layer_names)),
-    m_extension(extension.empty() ? "jpg" : extension),
-    m_prefix(std::move(prefix)) {
+    m_image_format(image_format.empty() ? "jpg" : image_format),
+    m_image_prefix(std::move(image_prefix)) {
 #ifndef LBANN_HAS_OPENCV
   LBANN_ERROR("OpenCV not detected");
 #endif // LBANN_HAS_OPENCV
 }
 
 void lbann_callback_save_images::on_epoch_end(model *m) {
-  save_image(m_prefix + "epoch" + std::to_string(m->get_cur_epoch()),
-             m_extension,
+  save_image(m_image_prefix + "epoch" + std::to_string(m->get_cur_epoch()),
+             m_image_format,
              m->get_layers(),
              m_layer_names);
 }
 
 void lbann_callback_save_images::on_phase_end(model *m) {
-  save_image(m_prefix + "phase" + std::to_string(m->get_current_phase()),
-             m_extension,
+  save_image(m_image_prefix + "phase" + std::to_string(m->get_current_phase()),
+             m_image_format,
              m->get_layers(),
              m_layer_names);
 }
 
 void lbann_callback_save_images::on_test_end(model *m) {
-  save_image(m_prefix + "test",
-             m_extension,
+  save_image(m_image_prefix + "test",
+             m_image_format,
              m->get_layers(),
              m_layer_names);
 }

--- a/src/callbacks/callback_save_images.cpp
+++ b/src/callbacks/callback_save_images.cpp
@@ -81,9 +81,9 @@ void save_image(std::string prefix,
 
     // Export tensor as image
     if (circ_data.CrossRank() == circ_data.Root()) {
-      auto& data = circ_data.LockedMatrix();
+      const auto& data = circ_data.LockedMatrix();
 
-      // Data will be scaled to be in [0,255]
+      // Data will be scaled to be in [0,256]
       DataType lower = data(0, 0);
       DataType upper = data(0, 0);
       for (El::Int i = 1; i < data.Height(); ++i) {
@@ -91,7 +91,7 @@ void save_image(std::string prefix,
         upper = std::max(upper, data(i, 0));
       }
       const auto& scale = ((upper > lower) ?
-                           255 / (upper - lower) :
+                           256 / (upper - lower) :
                            DataType(1));
 
       // Copy data into OpenCV matrix
@@ -103,13 +103,13 @@ void save_image(std::string prefix,
         for (El::Int col = 0; col < width; ++col) {
           const auto& offset = row * width + col;
           if (num_channels == 1) {
-            img.at<unsigned char>(row, col)
-              = static_cast<unsigned char>(scale * (data(offset, 0) - lower));
+            img.at<uchar>(row, col)
+              = cv::saturate_cast<uchar>(scale * (data(offset, 0) - lower));
           } else if (num_channels == 3) {
             cv::Vec3b pixel;
-            pixel[0] = static_cast<unsigned char>(scale * (data(offset, 0) - lower));
-            pixel[1] = static_cast<unsigned char>(scale * (data(height*width + offset, 0) - lower));
-            pixel[2] = static_cast<unsigned char>(scale * (data(2*height*width + offset, 0) - lower));
+            pixel[0] = cv::saturate_cast<uchar>(scale * (data(offset, 0) - lower));
+            pixel[1] = cv::saturate_cast<uchar>(scale * (data(height*width + offset, 0) - lower));
+            pixel[2] = cv::saturate_cast<uchar>(scale * (data(2*height*width + offset, 0) - lower));
             img.at<cv::Vec3b>(row, col) = pixel;
           }
         }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -80,12 +80,9 @@ lbann_callback* construct_callback(lbann_comm* comm,
   }
   if (proto_cb.has_save_images()) {
     const auto& params = proto_cb.save_images();
-    auto&& reader = lbann::peek_map(data_readers, execution_mode::training);
-    const auto& layer_names = parse_list<>(params.layer_names());
-    return new lbann_callback_save_images(reader,
-                                          params.image_dir(),
-                                          layer_names,
-                                          params.extension());
+    return new lbann_callback_save_images(parse_list<>(params.layers()),
+                                          params.extension(),
+                                          params.prefix());
   }
 
   //////////////////////////////////////////////////////////////////

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -81,8 +81,8 @@ lbann_callback* construct_callback(lbann_comm* comm,
   if (proto_cb.has_save_images()) {
     const auto& params = proto_cb.save_images();
     return new lbann_callback_save_images(parse_list<>(params.layers()),
-                                          params.extension(),
-                                          params.prefix());
+                                          params.image_format(),
+                                          params.image_prefix());
   }
 
   //////////////////////////////////////////////////////////////////

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -473,9 +473,9 @@ message CallbackAdaptiveLearningRate {
 }
 
 message CallbackSaveImages {
-  string image_dir = 1;
-  string layer_names = 2; //layer(s) at which to save images  e.g., "input, reconstruction"
-  string extension = 3;
+  string layers    = 1; // Layer outputs to save as images
+  string extension = 2; // Image file extension (e.g. jpg, png, pgm)
+  string prefix    = 3; // Prefix for saved image files
 }
 
 message CallbackPrint {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -473,9 +473,9 @@ message CallbackAdaptiveLearningRate {
 }
 
 message CallbackSaveImages {
-  string layers    = 1; // Layer outputs to save as images
-  string extension = 2; // Image file extension (e.g. jpg, png, pgm)
-  string prefix    = 3; // Prefix for saved image files
+  string layers       = 1; // Layer outputs to save as images
+  string image_format = 2; // Image format (e.g. jpg, png, pgm)
+  string image_prefix = 3; // Prefix for saved image files
 }
 
 message CallbackPrint {

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -557,16 +557,6 @@ void get_cmdline_overrides(lbann::lbann_comm *comm, lbann_data::LbannPB& p)
     set_data_readers_percent(p);
   }
 
-  if (opts->has_string("image_dir")) {
-    int sz = model->callback_size();
-    for (int j=0; j<sz; j++) {
-      lbann_data::Callback *c = model->mutable_callback(j);
-      if (c->has_save_images()) {
-        lbann_data::CallbackSaveImages *i = c->mutable_save_images();
-        i->set_image_dir(opts->get_string("image_dir"));
-      }
-    }
-  }
   if (opts->has_bool("no_im_comm") and opts->get_bool("no_im_comm")) {
     int sz = model->callback_size();
     for (int j=0; j<sz; j++) {


### PR DESCRIPTION
The save image callback can now interface with any layer, not just input layers. It no longer interacts with a data reader, but calls OpenCV directly. I've (somewhat gratuitously) taken the liberty of reworking the prototext interface and updating all models in the model zoo, but this can be reverted if need be.

This PR closes #285.

Sample outputs:

| MNIST | ImageNet |
|--------|------------|
| ![test-data](https://user-images.githubusercontent.com/4406448/46565822-d9ecf680-c8c8-11e8-8a1a-cb10d40af5da.jpg) | ![imagenet-epoch1-images](https://user-images.githubusercontent.com/4406448/46565829-e4a78b80-c8c8-11e8-8418-d578ee86ff52.jpg) |
