### PR TITLE
Always check CUDNN return values

### DIFF
--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -57,6 +57,19 @@
       LBANN_ERROR(err_CUDA_SYNC.str());                         \
     }                                                           \
   } while (0)
+#define LBANN_CUDA_CHECK_LAST_ERROR(async)                              \
+  do {                                                                  \
+    cudaError_t status = cudaGetLastError();                            \
+    if (status != cudaSuccess) {                                        \
+      cudaDeviceReset();                                                \
+      std::stringstream err_CUDA_CHECK_LAST_ERROR;                      \
+      if (async) { err_CUDA_CHECK_LAST_ERROR << "Asynchronous "; }      \
+      err_CUDA_CHECK_LAST_ERROR << "CUDA error ("                       \
+                                << cudaGetErrorString(status)           \
+                                << ")";                                 \
+      LBANN_ERROR(err_CUDA_CHECK_LAST_ERROR.str());                     \
+    }                                                                   \
+  } while (0)
 #define FORCE_CHECK_CUDA(cuda_call)                             \
   do {                                                          \
     /* Call CUDA API routine, synchronizing before and */       \

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -61,7 +61,6 @@
 #else
 #define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_NOSYNC(cudnn_call)
 #endif // #ifdef LBANN_DEBUG
-#define FORCE_CHECK_CUDNN(cudnn_call) CHECK_CUDNN(cudnn_call)
 
 namespace lbann {
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -38,11 +38,8 @@
 #include <cudnn.h>
 
 // Error utility macros
-#define FORCE_CHECK_CUDNN(cudnn_call)                           \
+#define CHECK_CUDNN_NOSYNC(cudnn_call)                          \
   do {                                                          \
-    /* Call cuDNN API routine, synchronizing before and */      \
-    /* after to check for errors. */                            \
-    LBANN_CUDA_SYNC(true);                                      \
     const cudnnStatus_t status_CHECK_CUDNN = (cudnn_call);      \
     if (status_CHECK_CUDNN != CUDNN_STATUS_SUCCESS) {           \
       cudaDeviceReset();                                        \
@@ -50,13 +47,21 @@
                   + cudnnGetErrorString(status_CHECK_CUDNN)     \
                   + std::string(")"));                          \
     }                                                           \
+  } while (0)
+#define CHECK_CUDNN_SYNC(cudnn_call)                            \
+  do {                                                          \
+    /* Call cuDNN API routine, synchronizing before and */      \
+    /* after to check for errors. */                            \
+    LBANN_CUDA_SYNC(true);                                      \
+    CHECK_CUDNN_NOSYNC(cudnn_call);                             \
     LBANN_CUDA_SYNC(false);                                     \
   } while (0)
 #ifdef LBANN_DEBUG
-#define CHECK_CUDNN(cudnn_call) FORCE_CHECK_CUDNN(cudnn_call);
+#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_SYNC(cudnn_call)
 #else
-#define CHECK_CUDNN(cudnn_call) (cudnn_call)
+#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_NOSYNC(cudnn_call)
 #endif // #ifdef LBANN_DEBUG
+#define FORCE_CHECK_CUDNN(cudnn_call) CHECK_CUDNN(cudnn_call)
 
 namespace lbann {
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -38,7 +38,7 @@
 #include <cudnn.h>
 
 // Error utility macros
-#define CHECK_CUDNN_NOSYNC(cudnn_call)                          \
+#define CHECK_CUDNN_NODEBUG(cudnn_call)                         \
   do {                                                          \
     const cudnnStatus_t status_CHECK_CUDNN = (cudnn_call);      \
     if (status_CHECK_CUDNN != CUDNN_STATUS_SUCCESS) {           \
@@ -48,18 +48,15 @@
                   + std::string(")"));                          \
     }                                                           \
   } while (0)
-#define CHECK_CUDNN_SYNC(cudnn_call)                            \
+#define CHECK_CUDNN_DEBUG(cudnn_call)                           \
   do {                                                          \
-    /* Call cuDNN API routine, synchronizing before and */      \
-    /* after to check for errors. */                            \
-    LBANN_CUDA_SYNC(true);                                      \
-    CHECK_CUDNN_NOSYNC(cudnn_call);                             \
-    LBANN_CUDA_SYNC(false);                                     \
+    LBANN_CUDA_CHECK_LAST_ERROR(true);                          \
+    CHECK_CUDNN_NODEBUG(cudnn_call);                            \
   } while (0)
 #ifdef LBANN_DEBUG
-#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_SYNC(cudnn_call)
+#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_DEBUG(cudnn_call)
 #else
-#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_NOSYNC(cudnn_call)
+#define CHECK_CUDNN(cudnn_call) CHECK_CUDNN_NODEBUG(cudnn_call)
 #endif // #ifdef LBANN_DEBUG
 
 namespace lbann {

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -48,7 +48,7 @@ struct handle_wrapper {
   cudnnHandle_t handle;
   handle_wrapper() : handle(nullptr) {
     CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    if (handle == nullptr) { FORCE_CHECK_CUDNN(cudnnCreate(&handle)); }
+    if (handle == nullptr) { CHECK_CUDNN(cudnnCreate(&handle)); }
     if (handle == nullptr) { LBANN_ERROR("failed to create cuDNN handle"); }
     CHECK_CUDNN(cudnnSetStream(handle, El::GPUManager::Stream()));
   }


### PR DESCRIPTION
Checking return values is not a performance concern, so it should always
be done. Previously, CHECK_CUDNN only checks errors with Debug build,
but that also introduces fairly heavy-weight device synchronizations
before and after error checking. FORCE_CHECK_CUDNN always checks return
values irrespective of the build mode, but due to the synchronizations
it is not only too costly but also can cause deadlocks.

This PR changes the behavior such that CUDNN return values are always
checked in any build mode. It still keeps the synchronizations for the
Debug build mode, but in my opinion we should also remove them as they
make the macro unusable.

FORCE_CHECK_CUDNN is not necessary anymore as CHECK_CUDNN always checks
errors. It is still there in order to make this PR minimal.

If this looks good, CUDA_CHECK and FORCE_CHECK_CUDA should be similarly
changed too.