### PR TITLE
Fix dropout when input local matrix is empty

### DIFF
--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -224,7 +224,7 @@ protected:
       El::Copy(input, output);
       return;
     }
-    if (local_input.Height() < 1 && local_input.Width() < 1) { return; }
+    if (local_input.Height() < 1 || local_input.Width() < 1) { return; }
 
     // Initialize cuDNN objects
     auto&& input_desc = m_tensors_cudnn_desc.get_prev_activations();


### PR DESCRIPTION
An empty matrix was not correctly detected. This caused CUDNN returned a random value at `cudnnDropoutGetReserveSpaceSize`, which was then used as the parameter for `Resize` of Hydrogen, sometimes resizing a matrix to an extremely large size. This is likely what happened with Sam's experiments.