### PR TITLE
Bilinear resize layer

### DIFF
--- a/include/lbann/layers/CMakeLists.txt
+++ b/include/lbann/layers/CMakeLists.txt
@@ -5,10 +5,11 @@ set_full_path(THIS_DIR_HEADERS
 
 # Add the subdirectories
 add_subdirectory(activations)
+add_subdirectory(image)
 add_subdirectory(io)
-add_subdirectory(math)
 add_subdirectory(learning)
 add_subdirectory(loss)
+add_subdirectory(math)
 add_subdirectory(regularizers)
 add_subdirectory(transform)
 

--- a/include/lbann/layers/image/CMakeLists.txt
+++ b/include/lbann/layers/image/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Add the headers for this directory
+set_full_path(THIS_DIR_HEADERS
+  bilinear_resize.hpp
+  )
+
+# Propagate the files up the tree
+set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)

--- a/include/lbann/layers/image/bilinear_resize.hpp
+++ b/include/lbann/layers/image/bilinear_resize.hpp
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_IMAGE_BILINEAR_RESIZE_HPP_INCLUDED
+#define LBANN_LAYERS_IMAGE_BILINEAR_RESIZE_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+
+namespace lbann {
+
+/** Bilinear resize layer.
+ *  Tensors are assumed to be image data in CHW format. Gradients are
+ *  not propagated during backprop.
+ */
+template <data_layout Layout, El::Device Device>
+class bilinear_resize_layer : public Layer {
+public:
+
+  bilinear_resize_layer(lbann_comm *comm, El::Int height, El::Int width)
+    : Layer(comm), m_height(height), m_width(width) {
+    static_assert(Layout == data_layout::DATA_PARALLEL,
+                  "bilinear_resize_layer only supports DATA_PARALLEL");
+    static_assert(Device == El::Device::CPU,
+                  "bilinear_resize_layer only supports CPU");
+  }
+
+  bilinear_resize_layer* copy() const override {
+    return new bilinear_resize_layer(*this);
+  }
+  std::string get_type() const override { return "bilinear resize"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
+
+  void fp_compute() override;
+
+protected:
+
+  void setup_dims() override {
+    Layer::setup_dims();
+
+    // Get input dimensions
+    auto dims = get_input_dims();
+    const auto& num_dims = dims.size();
+
+    // Check that dimensions are valid
+    std::stringstream err;
+    if (num_dims < 2) {
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "expects input with at least two dimensions, "
+          << "but input dimensions are ";
+      for (size_t i = 0; i < num_dims; ++i) {
+        err << (i > 0 ? " x " : "") << dims[i];
+      }
+      LBANN_ERROR(err.str());
+    } else if (m_height <= 0) {
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "attempted to resize with "
+          << "negative height (" << m_height << ")";
+      LBANN_ERROR(err.str());
+    } else if (m_width <= 0) {
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "attempted to resize with "
+          << "negative width (" << m_width << ")";
+      LBANN_ERROR(err.str());
+    }
+
+    // Resize output tensor
+    dims[num_dims-2] = m_height;
+    dims[num_dims-1] = m_width;
+    set_output_dims(dims);
+    
+  }
+
+private:
+
+  /** Output image height.
+   *  Data is assumed to be in CHW format.
+   */
+  El::Int m_height;
+  /** Output image width.
+   *  Data is assumed to be in CHW format.
+   */
+  El::Int m_width;
+  
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_IMAGE_BILINEAR_RESIZE_HPP_INCLUDED

--- a/include/lbann/layers/image/bilinear_resize.hpp
+++ b/include/lbann/layers/image/bilinear_resize.hpp
@@ -43,8 +43,6 @@ public:
     : Layer(comm), m_height(height), m_width(width) {
     static_assert(Layout == data_layout::DATA_PARALLEL,
                   "bilinear_resize_layer only supports DATA_PARALLEL");
-    static_assert(Device == El::Device::CPU,
-                  "bilinear_resize_layer only supports CPU");
   }
 
   bilinear_resize_layer* copy() const override {

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -52,6 +52,9 @@
 #include "lbann/layers/activations/swish.hpp"
 #include "lbann/layers/activations/sigmoid_bce_with_logits.hpp"
 
+/// Image Layers
+#include "lbann/layers/image/bilinear_resize.hpp"
+
 /// Learning Layers
 #include "lbann/layers/learning/fully_connected.hpp"
 #include "lbann/layers/learning/convolution.hpp"

--- a/src/layers/image/CMakeLists.txt
+++ b/src/layers/image/CMakeLists.txt
@@ -1,16 +1,13 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
-  layer.cpp
+  bilinear_resize.cpp
   )
 
-# Add the subdirectories
-add_subdirectory(activations)
-add_subdirectory(image)
-add_subdirectory(learning)
-add_subdirectory(loss)
-add_subdirectory(math)
-add_subdirectory(regularizers)
-add_subdirectory(transform)
+if (LBANN_HAS_CUDA)
+  # Add the CUDA source files for this directory
+  set_full_path(THIS_DIR_CU_SOURCES
+    )
+endif ()
 
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/layers/image/CMakeLists.txt
+++ b/src/layers/image/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
+    bilinear_resize.cu
     )
 endif ()
 

--- a/src/layers/image/bilinear_resize.cpp
+++ b/src/layers/image/bilinear_resize.cpp
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/image/bilinear_resize.hpp"
+
+namespace lbann {
+
+template <>
+void bilinear_resize_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
+
+  // Useful constants
+  constexpr DataType half = 0.5;
+  constexpr DataType one = 1;
+  
+  // Matrices
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const auto& num_dims = input_dims.size();
+  const auto& num_samples = local_input.Width();
+  const El::Int num_channels = std::accumulate(input_dims.begin(),
+                                               input_dims.end()-2,
+                                               1,
+                                               std::multiplies<int>());
+  const El::Int input_height = input_dims[num_dims-2];
+  const El::Int input_width = input_dims[num_dims-1];
+
+  // Perform bilinear interpolation for each output pixel
+  const auto& x_stride = static_cast<DataType>(input_width) / m_width;
+  const auto& y_stride = static_cast<DataType>(input_height) / m_height;
+#pragma omp parallel for collapse(4)
+  for (El::Int sample = 0; sample < num_samples; ++sample) {
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      for (El::Int output_row = 0; output_row < m_height; ++output_row) {
+        for (El::Int output_col = 0; output_col < m_width; ++output_col) {
+
+          // Interpolation point
+          const auto& x = (output_col + half) * x_stride;
+          const auto& y = (output_row + half) * y_stride;
+
+          // Find input pixels near interpolation point
+          const auto input_col = static_cast<El::Int>(std::floor(x - half));
+          const auto& input_col0 = std::max(input_col, El::Int(0));
+          const auto& input_col1 = std::min(input_col+1, input_width-1);
+          const auto input_row = static_cast<El::Int>(std::floor(y - half));
+          const auto& input_row0 = std::max(input_row, El::Int(0));
+          const auto& input_row1 = std::min(input_row+1, input_height-1);
+
+          // Interpolation point relative to input pixel centers
+          const auto& unit_x = x - (input_col + half);
+          const auto& unit_y = y - (input_row + half);
+
+          // Input and output pixels
+          const auto& pixel00 = local_input(channel * input_height * input_width
+                                            + input_row0 * input_width
+                                            + input_col0,
+                                            sample);
+          const auto& pixel01 = local_input(channel * input_height * input_width
+                                            + input_row0 * input_width
+                                            + input_col1,
+                                            sample);
+          const auto& pixel10 = local_input(channel * input_height * input_width
+                                            + input_row1 * input_width
+                                            + input_col0,
+                                            sample);
+          const auto& pixel11 = local_input(channel * input_height * input_width
+                                            + input_row1 * input_width
+                                            + input_col1,
+                                            sample);
+          auto& result = local_output(channel * m_height * m_width
+                                      + output_row * m_width
+                                      + output_col,
+                                      sample);
+
+          // Bilinear interpolation
+          result = (pixel00 * (one - unit_x) * (one - unit_y)
+                    + pixel01 * unit_x * (one - unit_y)
+                    + pixel10 * (one - unit_x) * unit_y
+                    + pixel11 * unit_x * unit_y);
+          
+        }
+      }
+    }
+  }
+  
+}
+  
+} // namespace lbann

--- a/src/layers/image/bilinear_resize.cu
+++ b/src/layers/image/bilinear_resize.cu
@@ -1,0 +1,168 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/image/bilinear_resize.hpp"
+
+namespace lbann {
+
+namespace {
+
+// Wrapper for CUDA math API functions
+__device__ __forceinline__ float floor_(const float& x) {
+  static_cast<void>(static_cast<float (*)(const float&)>(floor_));
+  return floorf(x);
+}
+__device__ __forceinline__ double floor_(const double& x) {
+  static_cast<void>(static_cast<double (*)(const double&)>(floor_));
+  return floor(x);
+}
+
+template <int block_size>
+__global__ void fp_kernel(El::Int num_samples,
+                          El::Int num_channels,
+                          El::Int input_height,
+                          El::Int input_width,
+                          const DataType* __restrict__ input,
+                          El::Int input_ldim,
+                          El::Int output_height,
+                          El::Int output_width,
+                          DataType* __restrict__ output,
+                          El::Int output_ldim) {
+
+  // Useful constants
+  constexpr DataType half = 0.5;
+  constexpr DataType one = 1;
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  
+  // Stride between interpolation points
+  const auto& x_stride = static_cast<DataType>(input_width) / output_width;
+  const auto& y_stride = static_cast<DataType>(input_height) / output_height;
+
+  const auto& size = (num_samples * num_channels
+                      * output_height * output_width);
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+
+    // Indices
+    const auto& sample = pos / (num_channels * output_height * output_width);
+    const auto& channel = (pos / (output_height * output_width)) % num_channels;
+    const auto& output_row = (pos / output_width) % output_height;
+    const auto& output_col = pos % output_width;
+
+    // Interpolation point
+    const auto& x = (output_col + half) * x_stride;
+    const auto& y = (output_row + half) * y_stride;
+
+    // Find input pixels near interpolation point
+    const auto input_col = static_cast<El::Int>(floor_(x - half));
+    const auto& input_col0 = cuda::max(input_col, El::Int(0));
+    const auto& input_col1 = cuda::min(input_col+1, input_width-1);
+    const auto input_row = static_cast<El::Int>(floor_(y - half));
+    const auto& input_row0 = cuda::max(input_row, El::Int(0));
+    const auto& input_row1 = cuda::min(input_row+1, input_height-1);
+    
+    // Interpolation point relative to input pixel centers
+    const auto& unit_x = x - (input_col + half);
+    const auto& unit_y = y - (input_row + half);
+
+    // Input and output pixels
+    const auto& pixel00 = input[sample * input_ldim
+                                + channel * input_height * input_width
+                                + input_row0 * input_width
+                                + input_col0];
+    const auto& pixel01 = input[sample * input_ldim
+                                + channel * input_height * input_width
+                                + input_row0 * input_width
+                                + input_col1];
+    const auto& pixel10 = input[sample * input_ldim
+                                + channel * input_height * input_width
+                                + input_row1 * input_width
+                                + input_col0];
+    const auto& pixel11 = input[sample * input_ldim
+                                + channel * input_height * input_width
+                                + input_row1 * input_width
+                                + input_col1];
+    auto& result = output[sample * output_ldim
+                          + channel * output_height * output_width
+                          + output_row * output_width
+                          + output_col];
+
+    // Bilinear interpolation
+    result = (pixel00 * (one - unit_x) * (one - unit_y)
+              + pixel01 * unit_x * (one - unit_y)
+              + pixel10 * (one - unit_x) * unit_y
+              + pixel11 * unit_x * unit_y);
+    
+  }
+  
+}  
+  
+}
+
+  
+template <>
+void bilinear_resize_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+
+  // Matrices
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const auto& num_dims = input_dims.size();
+  const auto& num_samples = local_input.Width();
+  const El::Int num_channels = std::accumulate(input_dims.begin(),
+                                               input_dims.end()-2,
+                                               1,
+                                               std::multiplies<int>());
+  const El::Int input_height = input_dims[num_dims-2];
+  const El::Int input_width = input_dims[num_dims-1];
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int size = local_output.Height() * local_output.Width();
+  constexpr El::Int block_dim = 256;
+  El::Int grid_dim = (size + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(uint32_t)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    fp_kernel<block_dim>
+      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+        num_samples, num_channels,
+        input_height, input_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        m_height, m_width,
+        local_output.Buffer(), local_output.LDim());
+  }
+  
+}
+  
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -553,11 +553,10 @@ Layer* construct_layer(lbann_comm* comm,
   // Image layers
   if (proto_layer.has_bilinear_resize()) {
     const auto& params = proto_layer.bilinear_resize();
-    if (layout == data_layout::DATA_PARALLEL
-        && Dev == El::Device::CPU) {
-      return new bilinear_resize_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(comm,
-                                                                                    params.height(),
-                                                                                    params.width());
+    if (layout == data_layout::DATA_PARALLEL) {
+      return new bilinear_resize_layer<data_layout::DATA_PARALLEL, Dev>(comm,
+                                                                        params.height(),
+                                                                        params.width());
     }
   }
   

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -549,6 +549,18 @@ Layer* construct_layer(lbann_comm* comm,
     return new sigmoid_bce_with_logits_layer<layout, Dev>(comm, params.true_label());
   }
 
+  
+  // Image layers
+  if (proto_layer.has_bilinear_resize()) {
+    const auto& params = proto_layer.bilinear_resize();
+    if (layout == data_layout::DATA_PARALLEL
+        && Dev == El::Device::CPU) {
+      return new bilinear_resize_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(comm,
+                                                                                    params.height(),
+                                                                                    params.width());
+    }
+  }
+  
   // Throw exception if layer has not been constructed
   err << "could not construct layer " << proto_layer.name();
   LBANN_ERROR(err.str());

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -890,6 +890,9 @@ message Layer {
    Swish swish = 42;
    Sigmoid_Binary_Cross_Entropy_With_Logits bce_with_logits = 47;
 
+   // Image layers
+   BilinearResize bilinear_resize = 500;
+
 }
 ///////////////////////
 // MotifLayer //
@@ -1246,4 +1249,12 @@ message Target {
 }
 
 message TargetReconstruction {
+}
+
+//////////////////
+// Image Layers //
+//////////////////
+message BilinearResize {
+  int64 height = 1;
+  int64 width = 2;
 }


### PR DESCRIPTION
This PR implements a layer to resize image data with bilinear interpolation. We have naive implementations for both CPU and GPU and we may want to explore using OpenCV's implementation in the future. This closes #478. I should note that bicubic implementation is preferred within the graphic design folklore, especially for upsampling, so we may want to implement that in the future.

Sample images generated on Pascal:

<details>
<summary> MNIST </summary>

![epoch1-resize28x28](https://user-images.githubusercontent.com/4406448/46985045-445a1f80-d09d-11e8-95b9-e7c26a790005.jpg) ![epoch1-resize11x11](https://user-images.githubusercontent.com/4406448/46985049-48863d00-d09d-11e8-873c-469ce46bca9c.jpg) ![epoch1-resize263x263](https://user-images.githubusercontent.com/4406448/46985059-4f14b480-d09d-11e8-9ed3-6a0b4c3ecb8b.jpg) ![epoch1-resize40x60](https://user-images.githubusercontent.com/4406448/46985066-589e1c80-d09d-11e8-8b40-114e9162f3c2.jpg) ![epoch1-resize50x20](https://user-images.githubusercontent.com/4406448/46985070-5d62d080-d09d-11e8-944b-f9fd48c88af6.jpg)

</details>

<details>
<summary> ImageNet </summary>

![epoch1-resize224x224](https://user-images.githubusercontent.com/4406448/46985086-681d6580-d09d-11e8-9796-06ad7d409613.jpg) ![epoch1-resize53x53](https://user-images.githubusercontent.com/4406448/46985092-6c498300-d09d-11e8-91e3-c325f6e1f07e.jpg) ![epoch1-resize691x691](https://user-images.githubusercontent.com/4406448/46985097-710e3700-d09d-11e8-8b9f-16c950063ea8.jpg) ![epoch1-resize](https://user-images.githubusercontent.com/4406448/46985102-779cae80-d09d-11e8-917c-5d8dff32ce08.jpg) ![epoch1-resize500x200](https://user-images.githubusercontent.com/4406448/46985112-7cf9f900-d09d-11e8-87f6-ab83cafc354a.jpg)

</details>
