### PR TITLE
Refactoring CUDA utility header

### DIFF
--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -23,5 +23,8 @@ set_full_path(THIS_DIR_HEADERS
   timer.hpp
   )
 
+# Add the subdirectories
+add_subdirectory(impl)
+
 # Propagate the files up the tree
 set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -34,9 +34,6 @@
 #include <cuda.h>
 #include <thrust/memory.h>
 #include <thrust/detail/allocator/tagged_allocator.h>
-#ifdef __CUDACC__
-#include <cuda_fp16.hpp>
-#endif // __CUDACC__
 
 // -------------------------------------------------------------
 // Error utility macros
@@ -97,64 +94,28 @@ namespace cuda {
 // -------------------------------------------------------------
 #ifdef __CUDACC__
 
-// Atomic add functions
-#if __CUDA_ARCH__ >= 530
-__device__ __inline__ __half atomic_add(__half* address, __half val) {
-#if 0 // TODO: replace this once Nvidia implements atomicAdd for __half
-  return atomicAdd(address, val);
-#else
-  unsigned int* address_as_uint = (unsigned int*) address;
-  unsigned int old = *address_as_uint;
-  __half* old_as_half = (__half*) &old;
-  unsigned int assumed;
-  unsigned int updated;
-  __half* updated_as_half = (__half*) &updated;
-  do {
-    assumed = old;
-    updated = old;
-    *updated_as_half += val;
-    old = atomicCAS(address_as_uint, assumed, updated);
-  } while (assumed != old);
-  return *old_as_half;
-#endif // 0
-}
-#endif // __CUDA_ARCH__ >= 530
-__device__ __inline__ float atomic_add(float* address, float val) {
-  return atomicAdd(address, val);
-}
-__device__ __inline__ double atomic_add(double* address, double val) {
-#if __CUDA_ARCH__ >= 600
-  return atomicAdd(address, val);
-#else
-  unsigned long long int* address_as_ull =
-    (unsigned long long int*)address;
-  unsigned long long int old = *address_as_ull, assumed;
-  do {
-    assumed = old;
-    old = atomicCAS(address_as_ull, assumed,
-                    __double_as_longlong(val +
-                                         __longlong_as_double(assumed)));
-  } while (assumed != old);
-  return __longlong_as_double(old);
-#endif // __CUDA_ARCH__ < 600
-}
+// Atomic add
+template <typename T> __device__ __inline__
+T atomic_add(T* address, T val);
 
 // Min and max
 template <typename T> __device__ __inline__
 T min(const T& x, const T& y) { return x <= y ? x : y; }
 template <typename T> __device__ __inline__
 T max(const T& x, const T& y) { return x >= y ? x : y; }
-template <> __device__ __inline__
-float min<float>(const float& x, const float& y) { return fminf(x, y); }
-template <> __device__ __inline__
-double min<double>(const double& x, const double& y) { return fmin(x, y); }
-template <> __device__ __inline__
-float max<float>(const float& x, const float& y) { return fmaxf(x, y); }
-template <> __device__ __inline__
-double max<double>(const double& x, const double& y) { return fmax(x, y); }
+
+// Numeric limits
+template <typename T> constexpr __device__ __inline__ T min();
+template <typename T> constexpr __device__ __inline__ T max();
+template <typename T> constexpr __device__ __inline__ T epsilon();
+template <typename T> __device__ __inline__ T infinity();
   
 #endif // __CUDACC__
 
+// -------------------------------------------------------------
+// Utilities for CUDA events
+// -------------------------------------------------------------
+  
 /** Wrapper class for a CUDA event. */
 class event_wrapper {
 public:
@@ -186,96 +147,13 @@ private:
 // -------------------------------------------------------------
 #ifdef __CUDACC__
 
-/** CUDA kernel to apply an entry-wise unary operator. */
-template <typename UnaryOperator>
-__global__
-void entrywise_unary_operator_kernel(El::Int height, El::Int width,
-                                     const DataType* __restrict__ input,
-                                     El::Int input_ldim,
-                                     DataType* __restrict__ output,
-                                     El::Int output_ldim) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int size = height * width;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  UnaryOperator op;
-  for (El::Int pos = gid; pos < size; pos += num_threads) {
-    const auto& row = pos % height;
-    const auto& col = pos / height;
-    const auto& x = input[row + col * input_ldim];
-    auto& y = output[row + col * output_ldim];
-    y = op(x);
-  }
-}
-
-/** CUDA kernel to apply an entry-wise binary operator. */
-template <typename BinaryOperator>
-__global__
-void entrywise_binary_operator_kernel(El::Int height, El::Int width,
-                                     const DataType* __restrict__ input1,
-                                     El::Int input1_ldim,
-                                     const DataType* __restrict__ input2,
-                                     El::Int input2_ldim,
-                                     DataType* __restrict__ output,
-                                     El::Int output_ldim) {
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int size = height * width;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  BinaryOperator op;
-  for (El::Int pos = gid; pos < size; pos += num_threads) {
-    const auto& row = pos % height;
-    const auto& col = pos / height;
-    const auto& x1 = input1[row + col * input1_ldim];
-    const auto& x2 = input2[row + col * input2_ldim];
-    auto& y = output[row + col * output_ldim];
-    y = op(x1, x2);
-  }
-}
-
 /** Apply an entry-wise unary operator to GPU data.
  *  The input and output data must be on GPU and must have the same
  *  dimensions.
  */
 template <typename UnaryOperator>
 void apply_entrywise_unary_operator(const AbsMat& input,
-                                    AbsMat& output) {
-
-  // Check that input and output are valid
-  std::stringstream err;
-  if (input.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("input is not on GPU");
-  } else if (output.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("output is not on GPU");
-  } else if (input.Height() != output.Height()
-             || input.Width() != output.Width()) {
-    err << "input matrix dimensions "
-        << "(" << input.Height() << " x " << input.Width() << ")"
-        << "don't match output matrix dimensions "
-        << "(" << output.Height() << " x " << output.Width() << ")";
-    LBANN_ERROR(err.str());
-  }
-
-  // Get CUDA grid dimensions
-  // Note: Maximum CUDA grid dimension is 2^32-1
-  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
-  const El::Int height = input.Height();
-  const El::Int width = input.Width();
-  const El::Int block_dim = 256;
-  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
-  if (sizeof(El::Int) > sizeof(unsigned int)
-      && grid_dim > std::numeric_limits<uint32_t>::max()) {
-    grid_dim = std::numeric_limits<uint32_t>::max();
-  }
-
-  // Launch CUDA kernel
-  if (grid_dim > 0) {
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    entrywise_unary_operator_kernel<UnaryOperator>
-      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
-        height, width, input.LockedBuffer(), input.LDim(),
-        output.Buffer(), output.LDim());
-  }
-  
-}
+                                    AbsMat& output);
 
 /** Apply an entry-wise binary operator to GPU data.
  *  The input and output data must be on GPU and must have the same
@@ -284,74 +162,16 @@ void apply_entrywise_unary_operator(const AbsMat& input,
 template <typename BinaryOperator>
 void apply_entrywise_binary_operator(const AbsMat& input1,
                                      const AbsMat& input2,
-                                     AbsMat& output) {
-
-  // Check that input and output are valid
-  std::stringstream err;
-  if (input1.GetDevice() != El::Device::GPU
-      || input2.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("input is not on GPU");
-  } else if (output.GetDevice() != El::Device::GPU) {
-    LBANN_ERROR("output is not on GPU");
-  } else if (input1.Height() != input2.Height()
-             || input1.Width() != input2.Width()
-             || input1.Height() != output.Height()
-             || input1.Width() != output.Width()) {
-    err << "input matrix dimensions "
-        << "(" << input1.Height() << " x " << input1.Width() << ", "
-        << input2.Height() << " x " << input2.Width() << ")"
-        << "don't match output matrix dimensions "
-        << "(" << output.Height() << " x " << output.Width() << ")";
-    LBANN_ERROR(err.str());
-  }
-
-  // Get CUDA grid dimensions
-  // Note: Maximum CUDA grid dimension is 2^32-1
-  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
-  const El::Int height = input1.Height();
-  const El::Int width = input1.Width();
-  const El::Int block_dim = 256;
-  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
-  if (sizeof(El::Int) > sizeof(unsigned int)
-      && grid_dim > std::numeric_limits<uint32_t>::max()) {
-    grid_dim = std::numeric_limits<uint32_t>::max();
-  }
-
-  // Launch CUDA kernel
-  if (grid_dim > 0) {
-    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
-    entrywise_binary_operator_kernel<BinaryOperator>
-      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
-        height, width,
-        input1.LockedBuffer(), input1.LDim(),
-        input2.LockedBuffer(), input2.LDim(),
-        output.Buffer(), output.LDim());
-  }
+                                     AbsMat& output);
   
-}
 
-  
 /** Apply an entry-wise unary operator to GPU data.
  *  The input and output data must be on GPU, have the same
  *  dimensions, and be aligned.
  */
 template <typename UnaryOperator>
 void apply_entrywise_unary_operator(const AbsDistMat& input,
-                                    AbsDistMat& output) {
-  std::stringstream err;
-  if (input.Height() != output.Height()
-      || input.Width() != output.Width()) {
-    err << "input matrix dimensions "
-        << "(" << input.Height() << " x " << input.Width() << ")"
-        << "don't match output matrix dimensions "
-        << "(" << output.Height() << " x " << output.Width() << ")";
-    LBANN_ERROR(err.str());
-  } else if (input.DistData() != output.DistData()) {
-    LBANN_ERROR("input and output matrix distributions don't match");
-  }
-  apply_entrywise_unary_operator<UnaryOperator>(input.LockedMatrix(),
-                                                output.Matrix());
-}
+                                    AbsDistMat& output);
 
 /** Apply an entry-wise binary operator to GPU data.
  *  The input and output data must be on GPU, have the same
@@ -360,26 +180,7 @@ void apply_entrywise_unary_operator(const AbsDistMat& input,
 template <typename BinaryOperator>
 void apply_entrywise_binary_operator(const AbsDistMat& input1,
                                      const AbsDistMat& input2,
-                                     AbsDistMat& output) {
-  if (input1.Height() != input2.Height()
-      || input1.Width() != input2.Width()
-      || input1.Height() != output.Height()
-      || input1.Width() != output.Width()) {
-    std::stringstream err;
-    err << "input matrix dimensions "
-        << "(" << input1.Height() << " x " << input1.Width() << ", "
-        << input2.Height() << " x " << input2.Width() << ")"
-        << "don't match output matrix dimensions "
-        << "(" << output.Height() << " x " << output.Width() << ")";
-    LBANN_ERROR(err.str());
-  } else if (input1.DistData() != input2.DistData()
-             || input1.DistData() != output.DistData()) {
-    LBANN_ERROR("input and output matrix distributions don't match");
-  }
-  apply_entrywise_binary_operator<BinaryOperator>(input1.LockedMatrix(),
-                                                  input2.LockedMatrix(),
-                                                  output.Matrix());
-}
+                                     AbsDistMat& output);
   
 #endif // __CUDACC__
 
@@ -415,35 +216,12 @@ public:
     : m_stream(stream) {}
 
   /** Allocate GPU buffer. */
-  pointer allocate(size_type size) {
-    value_type* buffer = nullptr;
-    if (size > 0) {
-#ifdef HYDROGEN_HAVE_CUB
-      auto& memory_pool = El::cub::MemoryPool();
-      CHECK_CUDA(memory_pool.DeviceAllocate(reinterpret_cast<void**>(&buffer),
-                                            size * sizeof(value_type),
-                                            m_stream));
-#else
-      CHECK_CUDA(cudaMalloc(&buffer, size * sizeof(value_type)));
-#endif // HYDROGEN_HAVE_CUB
-    }
-    return pointer(buffer);
-  }
+  pointer allocate(size_type size);
 
   /** Deallocate GPU buffer.
    *  'size' is unused and maintained for compatibility with Thrust.
    */
-  void deallocate(pointer buffer, size_type size = 0) {
-    auto&& ptr = buffer.get();
-    if (ptr != nullptr) {
-#ifdef HYDROGEN_HAVE_CUB
-      auto& memory_pool = El::cub::MemoryPool();
-      CHECK_CUDA(memory_pool.DeviceFree(ptr));
-#else
-      CHECK_CUDA(cudaFree(ptr));
-#endif // HYDROGEN_HAVE_CUB
-    }
-  }
+  void deallocate(pointer buffer, size_type size = 0);
 
 };
 
@@ -451,6 +229,9 @@ public:
 
 } // namespace cuda
 } // namespace lbann
+
+// Template implementations
+#include "lbann/utils/impl/cuda.hpp"
 
 #endif // LBANN_HAS_GPU
 #endif // LBANN_UTILS_CUDA_HPP

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -95,20 +95,44 @@ namespace cuda {
 #ifdef __CUDACC__
 
 // Atomic add
-template <typename T> __device__ __inline__
+template <typename T> __device__ __forceinline__
 T atomic_add(T* address, T val);
 
-// Min and max
-template <typename T> __device__ __inline__
-T min(const T& x, const T& y) { return x <= y ? x : y; }
-template <typename T> __device__ __inline__
-T max(const T& x, const T& y) { return x >= y ? x : y; }
+// Unary math functions
+template <typename T> __device__ __forceinline__ T abs(const T& x);
+template <typename T> __device__ __forceinline__ T round(const T& x);
+template <typename T> __device__ __forceinline__ T ceil(const T& x);
+template <typename T> __device__ __forceinline__ T floor(const T& x);
+template <typename T> __device__ __forceinline__ T sqrt(const T& x);
+template <typename T> __device__ __forceinline__ T rsqrt(const T& x);
+template <typename T> __device__ __forceinline__ T exp(const T& x);
+template <typename T> __device__ __forceinline__ T expm1(const T& x);
+template <typename T> __device__ __forceinline__ T log(const T& x);
+template <typename T> __device__ __forceinline__ T log1p(const T& x);
+template <typename T> __device__ __forceinline__ T cos(const T& x);
+template <typename T> __device__ __forceinline__ T sin(const T& x);
+template <typename T> __device__ __forceinline__ T tan(const T& x);
+template <typename T> __device__ __forceinline__ T acos(const T& x);
+template <typename T> __device__ __forceinline__ T asin(const T& x);
+template <typename T> __device__ __forceinline__ T atan(const T& x);
+template <typename T> __device__ __forceinline__ T cosh(const T& x);
+template <typename T> __device__ __forceinline__ T sinh(const T& x);
+template <typename T> __device__ __forceinline__ T tanh(const T& x);
+template <typename T> __device__ __forceinline__ T acosh(const T& x);
+template <typename T> __device__ __forceinline__ T asinh(const T& x);
+template <typename T> __device__ __forceinline__ T atanh(const T& x);
 
+// Binary math functions
+template <typename T> __device__ __forceinline__ T min(const T& x, const T& y);
+template <typename T> __device__ __forceinline__ T max(const T& x, const T& y);
+template <typename T> __device__ __forceinline__ T mod(const T& x, const T& y);
+template <typename T> __device__ __forceinline__ T pow(const T& x, const T& y);
+  
 // Numeric limits
-template <typename T> constexpr __device__ __inline__ T min();
-template <typename T> constexpr __device__ __inline__ T max();
-template <typename T> constexpr __device__ __inline__ T epsilon();
-template <typename T> __device__ __inline__ T infinity();
+template <typename T> constexpr __device__ __forceinline__ T min();
+template <typename T> constexpr __device__ __forceinline__ T max();
+template <typename T> constexpr __device__ __forceinline__ T epsilon();
+template <typename T> __device__ __forceinline__ T infinity();
   
 #endif // __CUDACC__
 

--- a/include/lbann/utils/impl/CMakeLists.txt
+++ b/include/lbann/utils/impl/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Add the headers for this directory
+set_full_path(THIS_DIR_HEADERS
+  cuda.hpp
+  )
+
+# Propagate the files up the tree
+set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)

--- a/include/lbann/utils/impl/cuda.hpp
+++ b/include/lbann/utils/impl/cuda.hpp
@@ -1,0 +1,369 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifdef __CUDACC__
+#include <math_constants.h>
+#include <cuda_fp16.hpp>
+#endif // __CUDACC__
+
+namespace lbann {
+namespace cuda {
+
+// -------------------------------------------------------------
+// Device functions
+// -------------------------------------------------------------
+#ifdef __CUDACC__
+
+// Atomic add function
+#if __CUDA_ARCH__ >= 530
+template <> __device__ __inline__
+__half atomic_add<__half>(__half* address, __half val) {
+#if 0 // TODO: replace this once Nvidia implements atomicAdd for __half
+  return atomicAdd(address, val);
+#else
+  unsigned int* address_as_uint = (unsigned int*) address;
+  unsigned int old = *address_as_uint;
+  __half* old_as_half = (__half*) &old;
+  unsigned int assumed;
+  unsigned int updated;
+  __half* updated_as_half = (__half*) &updated;
+  do {
+    assumed = old;
+    updated = old;
+    *updated_as_half += val;
+    old = atomicCAS(address_as_uint, assumed, updated);
+  } while (assumed != old);
+  return *old_as_half;
+#endif // 0
+}
+#endif // __CUDA_ARCH__ >= 530
+template <> __device__ __inline__
+float atomic_add<float>(float* address, float val) {
+  return atomicAdd(address, val);
+}
+template <> __device__ __inline__
+double atomic_add<double>(double* address, double val) {
+#if __CUDA_ARCH__ >= 600
+  return atomicAdd(address, val);
+#else
+  unsigned long long int* address_as_ull =
+    (unsigned long long int*)address;
+  unsigned long long int old = *address_as_ull, assumed;
+  do {
+    assumed = old;
+    old = atomicCAS(address_as_ull, assumed,
+                    __double_as_longlong(val +
+                                         __longlong_as_double(assumed)));
+  } while (assumed != old);
+  return __longlong_as_double(old);
+#endif // __CUDA_ARCH__ < 600
+}
+
+// Min and max
+template <> __device__ __inline__
+float min<float>(const float& x, const float& y) { return fminf(x, y); }
+template <> __device__ __inline__
+double min<double>(const double& x, const double& y) { return fmin(x, y); }
+template <> __device__ __inline__
+float max<float>(const float& x, const float& y) { return fmaxf(x, y); }
+template <> __device__ __inline__
+double max<double>(const double& x, const double& y) { return fmax(x, y); }
+
+// Numeric limits
+#ifdef __CUDACC_RELAXED_CONSTEXPR__
+template <typename T> constexpr __device__ __inline__ T min() {
+  return std::numeric_limits<T>::min();
+}
+template <typename T> constexpr __device__ __inline__ T max() {
+  return std::numeric_limits<T>::min();
+}
+template <typename T> constexpr __device__ __inline__ T epsilon() {
+  return std::numeric_limits<T>::epsilon();
+}
+template <typename T> constexpr __device__ __inline__ T infinity() {
+  return std::numeric_limits<T>::infinity();
+}
+#else // __CUDACC_RELAXED_CONSTEXPR__
+#define SPECIFIERS template <> __device__ __inline__
+SPECIFIERS constexpr float min<float>()                 { return FLT_MIN;   }
+SPECIFIERS constexpr double min<double>()               { return DBL_MIN;   }
+SPECIFIERS constexpr int min<int>()                     { return INT_MIN;   }
+SPECIFIERS constexpr long int min<long int>()           { return LONG_MIN;  }
+SPECIFIERS constexpr long long int min<long long int>() { return LLONG_MIN; }
+SPECIFIERS constexpr float max<float>()                 { return FLT_MAX;   }
+SPECIFIERS constexpr double max<double>()               { return DBL_MAX;   }
+SPECIFIERS constexpr int max<int>()                     { return INT_MAX;   }
+SPECIFIERS constexpr long int max<long int>()           { return LONG_MAX;  }
+SPECIFIERS constexpr long long int max<long long int>() { return LLONG_MAX; }
+SPECIFIERS constexpr float epsilon<float>()   { return FLT_EPSILON; }
+SPECIFIERS constexpr double epsilon<double>() { return DBL_EPSILON; }
+SPECIFIERS float infinity<float>()   { return CUDART_INF_F; }
+SPECIFIERS double infinity<double>() { return CUDART_INF;   }
+#undef HEADER
+#endif // __CUDACC_RELAXED_CONSTEXPR__
+  
+#endif // __CUDACC__
+  
+// -------------------------------------------------------------
+// Helper functions for entrywise operations
+// -------------------------------------------------------------
+#ifdef __CUDACC__
+
+/** CUDA kernel to apply an entry-wise unary operator. */
+template <typename UnaryOperator>
+__global__
+void entrywise_unary_operator_kernel(El::Int height, El::Int width,
+                                     const DataType* __restrict__ input,
+                                     El::Int input_ldim,
+                                     DataType* __restrict__ output,
+                                     El::Int output_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  UnaryOperator op;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_ldim];
+    auto& y = output[row + col * output_ldim];
+    y = op(x);
+  }
+}
+
+/** CUDA kernel to apply an entry-wise binary operator. */
+template <typename BinaryOperator>
+__global__
+void entrywise_binary_operator_kernel(El::Int height, El::Int width,
+                                     const DataType* __restrict__ input1,
+                                     El::Int input1_ldim,
+                                     const DataType* __restrict__ input2,
+                                     El::Int input2_ldim,
+                                     DataType* __restrict__ output,
+                                     El::Int output_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  BinaryOperator op;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x1 = input1[row + col * input1_ldim];
+    const auto& x2 = input2[row + col * input2_ldim];
+    auto& y = output[row + col * output_ldim];
+    y = op(x1, x2);
+  }
+}
+
+/** Apply an entry-wise unary operator to GPU data.
+ *  The input and output data must be on GPU and must have the same
+ *  dimensions.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsMat& input,
+                                    AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("input is not on GPU");
+  } else if (output.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("output is not on GPU");
+  } else if (input.Height() != output.Height()
+             || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input.Height();
+  const El::Int width = input.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    entrywise_unary_operator_kernel<UnaryOperator>
+      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+        height, width, input.LockedBuffer(), input.LDim(),
+        output.Buffer(), output.LDim());
+  }
+  
+}
+
+/** Apply an entry-wise binary operator to GPU data.
+ *  The input and output data must be on GPU and must have the same
+ *  dimensions.
+ */
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsMat& input1,
+                                     const AbsMat& input2,
+                                     AbsMat& output) {
+
+  // Check that input and output are valid
+  std::stringstream err;
+  if (input1.GetDevice() != El::Device::GPU
+      || input2.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("input is not on GPU");
+  } else if (output.GetDevice() != El::Device::GPU) {
+    LBANN_ERROR("output is not on GPU");
+  } else if (input1.Height() != input2.Height()
+             || input1.Width() != input2.Width()
+             || input1.Height() != output.Height()
+             || input1.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  }
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input1.Height();
+  const El::Int width = input1.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    CHECK_CUDA(cudaSetDevice(El::GPUManager::Device()));
+    entrywise_binary_operator_kernel<BinaryOperator>
+      <<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+        height, width,
+        input1.LockedBuffer(), input1.LDim(),
+        input2.LockedBuffer(), input2.LDim(),
+        output.Buffer(), output.LDim());
+  }
+  
+}
+  
+/** Apply an entry-wise unary operator to GPU data.
+ *  The input and output data must be on GPU, have the same
+ *  dimensions, and be aligned.
+ */
+template <typename UnaryOperator>
+void apply_entrywise_unary_operator(const AbsDistMat& input,
+                                    AbsDistMat& output) {
+  std::stringstream err;
+  if (input.Height() != output.Height()
+      || input.Width() != output.Width()) {
+    err << "input matrix dimensions "
+        << "(" << input.Height() << " x " << input.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_unary_operator<UnaryOperator>(input.LockedMatrix(),
+                                                output.Matrix());
+}
+
+/** Apply an entry-wise binary operator to GPU data.
+ *  The input and output data must be on GPU, have the same
+ *  dimensions, and be aligned.
+ */
+template <typename BinaryOperator>
+void apply_entrywise_binary_operator(const AbsDistMat& input1,
+                                     const AbsDistMat& input2,
+                                     AbsDistMat& output) {
+  if (input1.Height() != input2.Height()
+      || input1.Width() != input2.Width()
+      || input1.Height() != output.Height()
+      || input1.Width() != output.Width()) {
+    std::stringstream err;
+    err << "input matrix dimensions "
+        << "(" << input1.Height() << " x " << input1.Width() << ", "
+        << input2.Height() << " x " << input2.Width() << ")"
+        << "don't match output matrix dimensions "
+        << "(" << output.Height() << " x " << output.Width() << ")";
+    LBANN_ERROR(err.str());
+  } else if (input1.DistData() != input2.DistData()
+             || input1.DistData() != output.DistData()) {
+    LBANN_ERROR("input and output matrix distributions don't match");
+  }
+  apply_entrywise_binary_operator<BinaryOperator>(input1.LockedMatrix(),
+                                                  input2.LockedMatrix(),
+                                                  output.Matrix());
+}
+  
+#endif // __CUDACC__
+
+// -------------------------------------------------------------
+// Utilities for Thrust
+// -------------------------------------------------------------
+namespace thrust {
+
+template <typename T>
+typename allocator<T>::pointer allocator<T>::allocate(allocator<T>::size_type size) {
+  value_type* buffer = nullptr;
+  if (size > 0) {
+#ifdef HYDROGEN_HAVE_CUB
+    auto& memory_pool = El::cub::MemoryPool();
+    CHECK_CUDA(memory_pool.DeviceAllocate(reinterpret_cast<void**>(&buffer),
+                                          size * sizeof(value_type),
+                                          m_stream));
+#else
+    CHECK_CUDA(cudaMalloc(&buffer, size * sizeof(value_type)));
+#endif // HYDROGEN_HAVE_CUB
+  }
+  return pointer(buffer);
+}
+
+template <typename T>
+void allocator<T>::deallocate(allocator<T>::pointer buffer,
+                              allocator<T>::size_type size) {
+  auto&& ptr = buffer.get();
+  if (ptr != nullptr) {
+#ifdef HYDROGEN_HAVE_CUB
+    auto& memory_pool = El::cub::MemoryPool();
+    CHECK_CUDA(memory_pool.DeviceFree(ptr));
+#else
+    CHECK_CUDA(cudaFree(ptr));
+#endif // HYDROGEN_HAVE_CUB
+  }
+}
+
+} // namespace thrust
+
+} // namespace cuda
+} // namespace lbann

--- a/src/layers/image/bilinear_resize.cu
+++ b/src/layers/image/bilinear_resize.cu
@@ -25,20 +25,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/layers/image/bilinear_resize.hpp"
+#include "lbann/utils/cuda.hpp"
 
 namespace lbann {
 
 namespace {
-
-// Wrapper for CUDA math API functions
-__device__ __forceinline__ float floor_(const float& x) {
-  static_cast<void>(static_cast<float (*)(const float&)>(floor_));
-  return floorf(x);
-}
-__device__ __forceinline__ double floor_(const double& x) {
-  static_cast<void>(static_cast<double (*)(const double&)>(floor_));
-  return floor(x);
-}
 
 template <int block_size>
 __global__ void fp_kernel(El::Int num_samples,
@@ -77,10 +68,10 @@ __global__ void fp_kernel(El::Int num_samples,
     const auto& y = (output_row + half) * y_stride;
 
     // Find input pixels near interpolation point
-    const auto input_col = static_cast<El::Int>(floor_(x - half));
+    const auto input_col = static_cast<El::Int>(cuda::floor(x - half));
     const auto& input_col0 = cuda::max(input_col, El::Int(0));
     const auto& input_col1 = cuda::min(input_col+1, input_width-1);
-    const auto input_row = static_cast<El::Int>(floor_(y - half));
+    const auto input_row = static_cast<El::Int>(cuda::floor(y - half));
     const auto& input_row0 = cuda::max(input_row, El::Int(0));
     const auto& input_row1 = cuda::min(input_row+1, input_height-1);
     

--- a/src/layers/loss/cross_entropy.cu
+++ b/src/layers/loss/cross_entropy.cu
@@ -32,48 +32,6 @@ namespace lbann {
 
 namespace {
 
-// Atomic add functions
-#if __CUDA_ARCH__ >= 530
-__device__ inline __half atomic_add(__half* address, __half val) {
-#if 0 // TODO: replace this once Nvidia implements atomicAdd for __half
-  return atomicAdd(address, val);
-#else
-  unsigned int* address_as_uint = (unsigned int*) address;
-  unsigned int old = *address_as_uint;
-  __half* old_as_half = (__half*) &old;
-  unsigned int assumed;
-  unsigned int updated;
-  __half* updated_as_half = (__half*) &updated;
-  do {
-    assumed = old;
-    updated = old;
-    *updated_as_half += value;
-    old = atomicCAS(address_as_uint, assumed, updated);
-  } while (assumed != old);
-  return *old_as_half;
-#endif // 0
-}
-#endif // __CUDA_ARCH__ >= 530
-__device__ inline float atomic_add(float* address, float val) {
-  return atomicAdd(address, val);
-}
-__device__ inline double atomic_add(double* address, double val) {
-#if __CUDA_ARCH__ >= 600
-  return atomicAdd(address, val);
-#else
-  unsigned long long int* address_as_ull =
-    (unsigned long long int*)address;
-  unsigned long long int old = *address_as_ull, assumed;
-  do {
-    assumed = old;
-    old = atomicCAS(address_as_ull, assumed,
-                    __double_as_longlong(val +
-                                         __longlong_as_double(assumed)));
-  } while (assumed != old);
-  return __longlong_as_double(old);
-#endif // __CUDA_ARCH__ < 600
-}
-
 template <int block_size>
 __global__ void fp_kernel(int height, int width,
                           const DataType* __restrict__ prediction,
@@ -112,7 +70,7 @@ __global__ void fp_kernel(int height, int width,
       }
     }
     if (tid == 0) {
-      atomic_add(&contribution[col], shared_contribution[0]);
+      cuda::atomic_add(&contribution[col], shared_contribution[0]);
     }
     
   }

--- a/src/layers/math/binary.cu
+++ b/src/layers/math/binary.cu
@@ -101,37 +101,6 @@ void apply_binary_backprop_operator(const AbsMat& x1,
   }
 
 }
-
-// Wrappers for CUDA math API functions
-// Note: For example, the CUDA math API provides the 'sqrtf' function
-// for floats and 'sqrt' function for doubles. We wrap these with the
-// overloaded function 'sqrt_'.
-#define WRAP_CUDA_MATH_UNARY_FUNCTION(func)                             \
-  __device__ __forceinline__ float func##_(const float& x) {            \
-    static_cast<void>(static_cast<float (*)(const float&)>(func##_));   \
-    return func##f(x);                                                  \
-  }                                                                     \
-  __device__ __forceinline__ double func##_(const double& x) {          \
-    static_cast<void>(static_cast<double (*)(const double&)>(func##_)); \
-    return func(x);                                                     \
-  }
-#define WRAP_CUDA_MATH_BINARY_FUNCTION(func)                            \
-  __device__ __forceinline__ float func##_(const float& x1,             \
-                                           const float& x2) {           \
-    static_cast<void>(static_cast<float (*)(const float&, const float&)>(func##_)); \
-    return func##f(x1, x2);                                             \
-  }                                                                     \
-  __device__ __forceinline__ double func##_(const double& x1,           \
-                                            const double& x2) {         \
-    static_cast<void>(static_cast<double (*)(const double&, const double&)>(func##_)); \
-    return func(x1, x2);                                                \
-  }
-WRAP_CUDA_MATH_UNARY_FUNCTION(floor)
-WRAP_CUDA_MATH_UNARY_FUNCTION(log)
-WRAP_CUDA_MATH_BINARY_FUNCTION(fmod)
-WRAP_CUDA_MATH_BINARY_FUNCTION(pow)
-WRAP_CUDA_MATH_BINARY_FUNCTION(fmax)
-WRAP_CUDA_MATH_BINARY_FUNCTION(fmin)
   
 // =========================================================
 // Operator objects for entry-wise binary layers
@@ -209,7 +178,7 @@ struct divide_op {
 struct mod_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
-    return fmod_(x1, x2);
+    return cuda::mod(x1, x2);
   }
   inline __device__ void operator()(const DataType& x1,
                                     const DataType& x2,
@@ -217,7 +186,7 @@ struct mod_op {
                                     DataType& dx1,
                                     DataType& dx2) const {
     dx1 = dy;
-    dx2 = -dy * floor_(x1 / x2);
+    dx2 = -dy * cuda::floor(x1 / x2);
   }
 };
 
@@ -225,7 +194,7 @@ struct mod_op {
 struct pow_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
-    return pow_(x1, x2);
+    return cuda::pow(x1, x2);
   }
   inline __device__ void operator()(const DataType& x1,
                                     const DataType& x2,
@@ -233,8 +202,8 @@ struct pow_op {
                                     DataType& dx1,
                                     DataType& dx2) const {
 
-    dx1 = dy * x2 * pow_(x1, x2 - DataType(1));
-    dx2 = dy * log_(x1) * pow_(x1, x2);
+    dx1 = dy * x2 * cuda::pow(x1, x2 - DataType(1));
+    dx2 = dy * cuda::log(x1) * cuda::pow(x1, x2);
   }
 };
 
@@ -269,7 +238,7 @@ struct safe_divide_op {
 struct max_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
-    return fmax_(x1, x2);
+    return cuda::max(x1, x2);
   }
   inline __device__ void operator()(const DataType& x1,
                                     const DataType& x2,
@@ -293,7 +262,7 @@ struct max_op {
 struct min_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
-    return fmin_(x1, x2);
+    return cuda::min(x1, x2);
   }
   inline __device__ void operator()(const DataType& x1,
                                     const DataType& x2,

--- a/src/layers/math/unary.cpp
+++ b/src/layers/math/unary.cpp
@@ -160,7 +160,7 @@ struct rsqrt_op {
   }
   inline DataType operator()(const DataType& x, const DataType& dy) const {
     const auto& s = std::sqrt(x);
-    return - dy / (2 * s*s*s);
+    return - dy / (2 * x * s);
   }
 };
 

--- a/src/layers/math/unary.cu
+++ b/src/layers/math/unary.cu
@@ -29,41 +29,6 @@
 namespace lbann {
 
 namespace {
-
-// Wrappers for CUDA math API functions
-// Note: For example, the CUDA math API provides the 'sqrtf' function
-// for floats and 'sqrt' function for doubles. We wrap these with the
-// overloaded function 'sqrt_'.
-#define WRAP_CUDA_MATH_FUNCTION(func)                                   \
-  __device__ __forceinline__ float func##_(const float& x) {            \
-    static_cast<void>(static_cast<float (*)(const float&)>(func##_));   \
-    return func##f(x);                                                  \
-  }                                                                     \
-  __device__ __forceinline__ double func##_(const double& x) {          \
-    static_cast<void>(static_cast<double (*)(const double&)>(func##_)); \
-    return func(x);                                                     \
-  }
-WRAP_CUDA_MATH_FUNCTION(fabs)
-WRAP_CUDA_MATH_FUNCTION(round)
-WRAP_CUDA_MATH_FUNCTION(ceil)
-WRAP_CUDA_MATH_FUNCTION(floor)
-WRAP_CUDA_MATH_FUNCTION(sqrt)
-WRAP_CUDA_MATH_FUNCTION(exp)
-WRAP_CUDA_MATH_FUNCTION(expm1)
-WRAP_CUDA_MATH_FUNCTION(log)
-WRAP_CUDA_MATH_FUNCTION(log1p)
-WRAP_CUDA_MATH_FUNCTION(cos)
-WRAP_CUDA_MATH_FUNCTION(sin)
-WRAP_CUDA_MATH_FUNCTION(tan)
-WRAP_CUDA_MATH_FUNCTION(acos)
-WRAP_CUDA_MATH_FUNCTION(asin)
-WRAP_CUDA_MATH_FUNCTION(atan)
-WRAP_CUDA_MATH_FUNCTION(cosh)
-WRAP_CUDA_MATH_FUNCTION(sinh)
-WRAP_CUDA_MATH_FUNCTION(tanh)
-WRAP_CUDA_MATH_FUNCTION(acosh)
-WRAP_CUDA_MATH_FUNCTION(asinh)
-WRAP_CUDA_MATH_FUNCTION(atanh)
   
 // =========================================================
 // Operator objects for entry-wise unary layers
@@ -87,7 +52,7 @@ struct not_op {
 /** Absolute value operator. */
 struct abs_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return fabs_(x);
+    return cuda::abs(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     constexpr DataType zero = 0;
@@ -124,7 +89,7 @@ struct sign_op {
 /** Round operator. */
 struct round_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return round_(x);
+    return cuda::round(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return DataType(0);
@@ -134,7 +99,7 @@ struct round_op {
 /** Ceiling operator. */
 struct ceil_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return ceil_(x);
+    return cuda::ceil(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return DataType(0);
@@ -144,7 +109,7 @@ struct ceil_op {
 /** Floor operator. */
 struct floor_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return floor_(x);
+    return cuda::floor(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return DataType(0);
@@ -177,21 +142,21 @@ struct square_op {
 /** Square root operator. */
 struct sqrt_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return sqrt_(x);
+    return cuda::sqrt(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy / (2 * sqrt_(x));
+    return dy / (2 * cuda::sqrt(x));
   }
 };
 
 /** Reciprocal square root operator. */
 struct rsqrt_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return 1 / sqrt_(x);
+    return cuda::rsqrt(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    const auto& s = sqrt_(x);
-    return - dy / (2 * s*s*s);
+    const auto& s = cuda::sqrt(x);
+    return - dy / (2 * x * s);
   }
 };
 
@@ -215,27 +180,27 @@ struct safe_reciprocal_op {
 /** Exponential operator. */
 struct exp_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return exp_(x);
+    return cuda::exp(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy * exp_(x);
+    return dy * cuda::exp(x);
   }
 };
 
 /** Exponential minus one operator. */
 struct expm1_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return expm1_(x);
+    return cuda::expm1(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy * exp_(x);
+    return dy * cuda::exp(x);
   }
 };
 
 /** Natural logarithm operator. */
 struct log_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return log_(x);
+    return cuda::log(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return dy / x;
@@ -245,7 +210,7 @@ struct log_op {
 /** Natural logarithm one plus operator. */
 struct log1p_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return log1p_(x);
+    return cuda::log1p(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return dy / (x + DataType(1));
@@ -255,30 +220,30 @@ struct log1p_op {
 /** Cosine operator. */
 struct cos_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return cos_(x);
+    return cuda::cos(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return -dy * sin_(x);
+    return -dy * cuda::sin(x);
   }
 };
 
 /** Sine operator. */
 struct sin_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return sin_(x);
+    return cuda::sin(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy * cos_(x);
+    return dy * cuda::cos(x);
   }
 };
 
 /** Tangent operator. */
 struct tan_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return tan_(x);
+    return cuda::tan(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    const auto& c = cos_(x);
+    const auto& c = cuda::cos(x);
     return dy / (c*c);
   }
 };
@@ -286,27 +251,27 @@ struct tan_op {
 /** Arccosine operator. */
 struct acos_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return acos_(x);
+    return cuda::acos(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return -dy / sqrt_(DataType(1) - x*x);
+    return -dy / cuda::sqrt(DataType(1) - x*x);
   }
 };
 
 /** Arcsine operator. */
 struct asin_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return asin_(x);
+    return cuda::asin(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy / sqrt_(DataType(1) - x*x);
+    return dy / cuda::sqrt(DataType(1) - x*x);
   }
 };
 
 /** Arctangent operator. */
 struct atan_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return atan_(x);
+    return cuda::atan(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return dy / (DataType(1) + x*x);
@@ -316,30 +281,30 @@ struct atan_op {
 /** Hyperbolic cosine operator. */
 struct cosh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return cosh_(x);
+    return cuda::cosh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy * sinh_(x);
+    return dy * cuda::sinh(x);
   }
 };
 
 /** Hyperbolic sine operator. */
 struct sinh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return sinh_(x);
+    return cuda::sinh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy * cosh_(x);
+    return dy * cuda::cosh(x);
   }
 };
 
 /** Hyperbolic tangent operator. */
 struct tanh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return tanh_(x);
+    return cuda::tanh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    const auto& c = cosh_(x);
+    const auto& c = cuda::cosh(x);
     return dy / (c*c);
   }
 };
@@ -347,27 +312,27 @@ struct tanh_op {
 /** Hyperbolic arccosine operator. */
 struct acosh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return acosh_(x);
+    return cuda::acosh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return -dy / (sqrt_(x - DataType(1)) * sqrt_(x + DataType(1)));
+    return -dy / (cuda::sqrt(x - DataType(1)) * cuda::sqrt(x + DataType(1)));
   }
 };
 
 /** Hyperbolic arcsine operator. */
 struct asinh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return asinh_(x);
+    return cuda::asinh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
-    return dy / sqrt_(DataType(1) + x*x);
+    return dy / cuda::sqrt(DataType(1) + x*x);
   }
 };
 
 /** Hyperbolic arctangent operator. */
 struct atanh_op {
   inline __device__ DataType operator()(const DataType& x) const {
-    return atanh_(x);
+    return cuda::atanh(x);
   }
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     return dy / (DataType(1) - x*x);

--- a/src/optimizers/adagrad.cu
+++ b/src/optimizers/adagrad.cu
@@ -30,19 +30,6 @@ namespace lbann {
 
 namespace {
 
-// Square root functions
-#if __CUDA_ARCH__ >= 530
-__device__ inline float sqrt_(__half x) {
-  return hsqrt(x);
-}
-#endif // __CUDA_ARCH__ >= 530
-__device__ inline float sqrt_(float x) {
-  return sqrtf(x);
-}
-__device__ inline double sqrt_(double x) {
-  return sqrt(x);
-}
-
 __global__ void adagrad_kernel(int height,
                                int width,
                                DataType learning_rate,
@@ -62,7 +49,7 @@ __global__ void adagrad_kernel(int height,
     const auto& g = gradient[i + j * gradient_ldim];
     auto& c = cache[i + j * cache_ldim];
     c += g * g;
-    x -= learning_rate * g / (sqrt_(c) + eps);
+    x -= learning_rate * g / (cuda::sqrt(c) + eps);
   }
 }
 

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -52,7 +52,7 @@ event_wrapper& event_wrapper::operator=(const event_wrapper& other) {
 }
   
 event_wrapper::~event_wrapper() {
-  CHECK_CUDA(cudaEventDestroy(m_event));
+  cudaEventDestroy(m_event);
 }
 
 void event_wrapper::record(cudaStream_t stream) {


### PR DESCRIPTION
This PR separates the implementations of templated functions in the CUDA utility header from the declarations. This made it easier to implement a bunch of templated device functions, mostly for math and for emulating `std::numeric_limits`.

This work is being used in my refactor of the top-k categorical accuracy layer.