### PR TITLE
Reverting #548.

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -68,14 +68,7 @@ class Layer {
   Layer(lbann_comm *comm);
   Layer(const Layer& other);
   Layer& operator=(const Layer& other);
-#ifdef LBANN_HAS_GPU
-  virtual ~Layer() {
-    // Clean up the event (only needs to be done on LBANN exit).
-    cudaEventDestroy(m_async_HtoD_copy_event);
-  }
-#else
-   virtual ~Layer() = default;
-#endif // LBANN_HAS_GPU
+  virtual ~Layer() = default;
 
   /** Copy function.
    *  This function dynamically allocates memory for a layer instance
@@ -510,11 +503,6 @@ class Layer {
    */
   std::vector<std::unique_ptr<AbsDistMat>> m_gradient_wrt_inputs;
 
-#ifdef LBANN_HAS_GPU
-  // API reference: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__EVENT.html
-  cudaEvent_t m_async_HtoD_copy_event;
-  bool m_issue_async_HtoD_copy_event;
-#endif // LBANN_HAS_GPU
 };
 
 } // namespace lbann


### PR DESCRIPTION
PR #548 added some infrastructure to perform asynchronous CPU-to-GPU memory transfers when a CPU layer outputs to a GPU layer. This is advantageous since it allows us to overlap communication with computation. However, @ndryden has noted that we have a race condition since the parent layer may mess up its CPU data before the memory transfer has completed (or even started). We synchronize on a CUDA event before starting the memory transfer, but we are already in an error state if that synchronization is non-trivial.

For safety, I've disabled the asynchronous memory transfer. If anyone needs the speed and is willing to live dangerously, the asynchronous memory transfer can be reenabled by setting the `ASYNC_INPUT_MEMORY_TRANSFER` macro in src/layers/layer.cpp. The race condition introduced by this option is documented. We also perform asynchronous memory transfers in backprop as well as forward prop and we carefully check that the distributed matrices are aligned.

To properly implement this functionality, each CPU layer should synchronize w.r.t. their child layers' CUDA events before they do anything with their data. Things get more complicated if the child layer outputs a matrix view (e.g. the identity or dropout layers), in which case the layer must synchronize with the grandchild layers' CUDA events, ad infinitum. It's getting messy, so I think we should defer worrying about it until it becomes a performance bottleneck.