### PR TITLE
Remove deprecated functionality in CANDLE Pilot1 models

### DIFF
--- a/model_zoo/models/autoencoder_candle_pilot1/README.md
+++ b/model_zoo/models/autoencoder_candle_pilot1/README.md
@@ -6,22 +6,21 @@ CANcer Distributed Learning Enviroment ([CANDLE](http://candle.cels.anl.gov/)) i
 [Autoencoder](https://en.wikipedia.org/wiki/Autoencoder) is one of deep learning techniques being explored in the **CANDLE** team. In this blog, I will explain how to build autoencoder of interest to **CANDLE** project within LBANN framework. Examples in this blog were taken from Tensorflow version of similar deep learning network architecture provided by the **CANDLE** research team.
 
 ## Autoencoder in LBANN
-A network architecture in LBANN is a collection of layers as a sequential list or graph. To build an autoencoder model in LBANN, the user simply describe how the layers are connected in a [model prototext file](https://github.com/LLNL/lbann/tree/develop/model_zoo/models/autoencoder_candle_pilot1), provide training optimization paratemers in the [optimizer prototext file](https://github.com/LLNL/lbann/tree/develop/model_zoo/optimizers), and input data (and labels in case of classification) in the [data reader prototext file ](https://github.com/LLNL/lbann/tree/develop/model_zoo/data_readers). The prototext files provide the flexibility for users to change a number of network and optimization hyperparameters at run time. For example, an LBANN fully connected (also known as linear or inner product in other deep learning toolkits) layer can be described as shown:
+A network architecture in LBANN is a collection of layers as a directed acyclic graph. To build an autoencoder model in LBANN, the user simply describe how the layers are connected in a [model prototext file](https://github.com/LLNL/lbann/tree/develop/model_zoo/models/autoencoder_candle_pilot1), provide training optimization paratemers in the [optimizer prototext file](https://github.com/LLNL/lbann/tree/develop/model_zoo/optimizers), and input data (and labels in case of classification) in the [data reader prototext file ](https://github.com/LLNL/lbann/tree/develop/model_zoo/data_readers). The prototext files provide the flexibility for users to change a number of network and optimization hyperparameters at run time. For example, an LBANN fully connected (also known as linear or inner product in other deep learning toolkits) layer can be described as shown:
  ```
 layer {
-    index: 8
-    parent: 7
+    name: "8"
+    parents: "7"
     data_layout: "data_parallel"
     fully_connected {
       num_neurons: 5000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
   
   ```
 
-Most of the attributes are self descriptive and some of them can be changed "on-the-fly". For instance, the glorot_uniform weight initialization scheme can be replaced with other schemes such as uniform, normal, he_normal, he_uniform, glorot_normal and so on.
+Most of the attributes are self descriptive and some of them can be changed "on-the-fly".
 
 
 ## Execute LBANN Autoencoder Example on LC

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -322,6 +322,7 @@ model {
   #####################
   # PEARSON CORRELATION
   #####################
+  # rho(x,y) = covariance(x,y) / sqrt( variance(x) * variance(y) )
   layer {
     parents: "reconstruction data"
     name: "pearson_r_cov"

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -2,7 +2,6 @@ model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
   ### This network description is anologous to AutoEncoder_Chem_ECFP
-  name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 128
   block_size: 256
@@ -15,7 +14,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mean_squared_error" }
   }
 
   ###################################################
@@ -23,7 +22,10 @@ model {
   ###################################################
 
   metric {
-    pearson_correlation {}
+    layer_metric {
+      name: "Pearson correlation"
+      layer: "pearson_r"
+    }
   }
 
   ###################################################
@@ -38,18 +40,6 @@ model {
     timer {
     }
   }
- # callback {
- #   summary {
- #     dir: "."
- #     batch_interval: 1
- #     mat_interval: 25
- #   }
- # }
-#  callback {
-#    debug {
-#      phase: "train"
-#    }
-#  }
 
   ###################################################
   # start of layers
@@ -59,24 +49,36 @@ model {
   # INPUT
   #######
   layer {
-    name: "data"
-    children: "encode1 reconstruction"
+    name: "data_input"
+    children: "data label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
       target_mode: "reconstruction"
     }
   }
+  layer {
+    parents: "data_input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "data_input"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
+  }
 
   #################
   # FULLY_CONNECTED encode1
   #################
   layer {
+    parents: "data"
     name: "encode1"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -85,21 +87,21 @@ model {
   # RELU relu1
   ######
   layer {
+    parents: "encode1"
     name: "relu1"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED encode2
   #################
   layer {
+    parents: "relu1"
     name: "encode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -108,21 +110,21 @@ model {
   # RELU relu2
   #######
   layer {
+    parents: "encode2"
     name: "relu2"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED encode3
   #################
   layer {
+    parents: "relu2"
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -131,21 +133,21 @@ model {
   # RELU relu3
   #######
   layer {
+    parents: "encode3"
     name: "relu3"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED encode4
   #################
   layer {
+    parents: "relu3"
     name: "encode4"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -154,21 +156,21 @@ model {
   # RELU relu4
   #######
   layer {
+    parents: "encode4"
     name: "relu4"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED encode5
   #################
   layer {
+    parents: "relu4'
     name: "encode5"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -177,16 +179,17 @@ model {
   # RELU relu5
   #######
   layer {
+    parents: "encode5"
     name: "relu5"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED decode5
   #################
   layer {
+    parents: "relu5"
     name: "decode5"
     data_layout: "model_parallel"
     fully_connected {
@@ -200,21 +203,21 @@ model {
   # RELU 6
   #######
   layer {
+    parents: "decode5"
     name: "relu6"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED decode4
   #################
   layer {
+    parents: "relu6"
     name: "decode4"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -224,21 +227,21 @@ model {
   # RELU relu7
   #######
   layer {
+    parents: "decode4"
     name: "relu7"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED decode3
   #################
   layer {
+    parents: "relu7"
     name: "decode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -247,21 +250,21 @@ model {
   # RELU relu8
   #######
   layer {
+    parents: "decode3"
     name: "relu8"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED decode2
   #################
   layer {
+    parents: "relu8"
     name: "decode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -270,21 +273,21 @@ model {
   # RELU relu9
   #######
   layer {
+    parents: "decode2"
     name: "relu9"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
   #################
   # FULLY_CONNECTED decode1
   #################
   layer {
+    parents: "relu9"
     name: "decode1"
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -293,10 +296,10 @@ model {
   # RELU relu10
   #######
   layer {
+    parents: "decode1"
     name: "relu10"
     data_layout: "model_parallel"
-    relu {
-    }
+    relu {}
   }
 
 
@@ -304,10 +307,56 @@ model {
   # RECONSTRUCTION
   #################
   layer {
+    parents: "relu10"
     name: "reconstruction"
-    parents: "relu10 data"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
+  }
+
+  #####################
+  # PEARSON CORRELATION
+  #####################
+  layer {
+    parents: "reconstruction data"
+    name: "pearson_r_cov"
+    data_layout: "model_parallel"
+    covariance {}
+  }
+  layer {
+    parents: "data"
+    name: "pearson_r_var1"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "reconstruction"
+    name: "pearson_r_var2"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "pearson_r_var1 pearson_r_var2"
+    name: "pearson_r_mult"
+    data_layout: "model_parallel"
+    multiply {}
+  }
+  layer {
+    parents: "pearson_r_mult"
+    name: "pearson_r_sqrt"
+    data_layout: "model_parallel"
+    sqrt {}
+  }
+  layer {
+    parents: "pearson_r_cov pearson_r_sqrt"
+    name: "pearson_r"
+    data_layout: "model_parallel"
+    divide {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
@@ -331,6 +331,7 @@ model {
   #####################
   # PEARSON CORRELATION
   #####################
+  # rho(x,y) = covariance(x,y) / sqrt( variance(x) * variance(y) )
   layer {
     parents: "reconstruction data"
     name: "pearson_r_cov"

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_200x150x100x100x100.prototext
@@ -2,7 +2,6 @@ model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
   ### This network description is anologous to AutoEncoder_Chem_ECFP
-  name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 1024
   block_size: 256
@@ -15,7 +14,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mean_squared_error" }
   }
 
   ###################################################
@@ -23,7 +22,10 @@ model {
   ###################################################
 
   metric {
-    pearson_correlation {}
+    layer_metric {
+      name: "Pearson correlation"
+      layer: "pearson_r"
+    }
   }
 
   ###################################################
@@ -38,18 +40,6 @@ model {
     timer {
     }
   }
- # callback {
- #   summary {
- #     dir: "."
- #     batch_interval: 1
- #     mat_interval: 25
- #   }
- # }
-#  callback {
-#    debug {
-#      phase: "train"
-#    }
-#  }
 
   ###################################################
   # start of layers
@@ -59,24 +49,36 @@ model {
   # INPUT
   #######
   layer {
-    name: "data"
-    children: "encode1 reconstruction"
+    name: "data_input"
+    children: "data label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
       target_mode: "reconstruction"
     }
   }
+  layer {
+    parents: "data_input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "data_input"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
+  }
 
   #################
   # FULLY_CONNECTED encode1
   #################
   layer {
+    parents: "data"
     name: "encode1"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 200
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -85,6 +87,7 @@ model {
   # RELU relu1
   ######
   layer {
+    parents: "encode1"
     name: "relu1"
     data_layout: "model_parallel"
     relu {
@@ -95,11 +98,11 @@ model {
   # FULLY_CONNECTED encode2
   #################
   layer {
+    parents: "relu1"
     name: "encode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 150
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -108,6 +111,7 @@ model {
   # RELU relu2
   #######
   layer {
+    parents: "encode2"
     name: "relu2"
     data_layout: "model_parallel"
     relu {
@@ -118,11 +122,11 @@ model {
   # FULLY_CONNECTED encode3
   #################
   layer {
+    parents: "relu2"
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -131,6 +135,7 @@ model {
   # RELU relu3
   #######
   layer {
+    parents: "encode3"
     name: "relu3"
     data_layout: "model_parallel"
     relu {
@@ -141,11 +146,11 @@ model {
   # FULLY_CONNECTED encode4
   #################
   layer {
+    parents: "relu3"
     name: "encode4"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -154,6 +159,7 @@ model {
   # RELU relu4
   #######
   layer {
+    parents: "encode4"
     name: "relu4"
     data_layout: "model_parallel"
     relu {
@@ -164,11 +170,11 @@ model {
   # FULLY_CONNECTED encode5
   #################
   layer {
+    parents: "relu4"
     name: "encode5"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -177,6 +183,7 @@ model {
   # RELU relu5
   #######
   layer {
+    parents: "encode5"
     name: "relu5"
     data_layout: "model_parallel"
     relu {
@@ -187,11 +194,11 @@ model {
   # FULLY_CONNECTED decode5
   #################
   layer {
+    parents: "relu5"
     name: "decode5"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -200,6 +207,7 @@ model {
   # RELU 6
   #######
   layer {
+    parents: "decode5"
     name: "relu6"
     data_layout: "model_parallel"
     relu {
@@ -210,11 +218,11 @@ model {
   # FULLY_CONNECTED decode4
   #################
   layer {
+    parents: "relu6"
     name: "decode4"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -224,6 +232,7 @@ model {
   # RELU relu7
   #######
   layer {
+    parents: "decode4"
     name: "relu7"
     data_layout: "model_parallel"
     relu {
@@ -234,11 +243,11 @@ model {
   # FULLY_CONNECTED decode3
   #################
   layer {
+    parents: "relu7"
     name: "decode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 150
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -247,6 +256,7 @@ model {
   # RELU relu8
   #######
   layer {
+    parents: "decode3"
     name: "relu8"
     data_layout: "model_parallel"
     relu {
@@ -257,11 +267,11 @@ model {
   # FULLY_CONNECTED decode2
   #################
   layer {
+    parents: "relu8"
     name: "decode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 200
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -270,6 +280,7 @@ model {
   # RELU relu9
   #######
   layer {
+    parents: "decode2"
     name: "relu9"
     data_layout: "model_parallel"
     relu {
@@ -280,11 +291,11 @@ model {
   # FULLY_CONNECTED decode1
   #################
   layer {
+    parents: "relu9"
     name: "decode1"
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -293,6 +304,7 @@ model {
   # RELU relu10
   #######
   layer {
+    parents: "decode1"
     name: "relu10"
     data_layout: "model_parallel"
     relu {
@@ -304,10 +316,56 @@ model {
   # RECONSTRUCTION
   #################
   layer {
+    parents: "relu10"
     name: "reconstruction"
-    parents: "relu10 data"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
+  }
+
+  #####################
+  # PEARSON CORRELATION
+  #####################
+  layer {
+    parents: "reconstruction data"
+    name: "pearson_r_cov"
+    data_layout: "model_parallel"
+    covariance {}
+  }
+  layer {
+    parents: "data"
+    name: "pearson_r_var1"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "reconstruction"
+    name: "pearson_r_var2"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "pearson_r_var1 pearson_r_var2"
+    name: "pearson_r_mult"
+    data_layout: "model_parallel"
+    multiply {}
+  }
+  layer {
+    parents: "pearson_r_mult"
+    name: "pearson_r_sqrt"
+    data_layout: "model_parallel"
+    sqrt {}
+  }
+  layer {
+    parents: "pearson_r_cov pearson_r_sqrt"
+    name: "pearson_r"
+    data_layout: "model_parallel"
+    divide {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
@@ -2,7 +2,6 @@ model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
   ### This network description is anologous to AutoEncoder_Chem_ECFP 
-  name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 1024
   block_size: 256
@@ -15,7 +14,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mean_squared_error" }
   }
 
   ###################################################
@@ -23,7 +22,10 @@ model {
   ###################################################
 
   metric {
-    pearson_correlation {}
+    layer_metric {
+      name: "Pearson correlation"
+      layer: "pearson_r"
+    }
   }
 
   ###################################################
@@ -38,18 +40,6 @@ model {
     timer {
     }
   }
- # callback {
- #   summary {
- #     dir: "."
- #     batch_interval: 1
- #     mat_interval: 25
- #   }
- # }
-#  callback {
-#    debug {
-#      phase: "train"
-#    }
-#  }
 
   ###################################################
   # start of layers
@@ -59,22 +49,35 @@ model {
   # INPUT
   #######
   layer {
-    name: "data"
+    name: "data_input"
+    children: "data label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
     }
+  }
+  layer {
+    parents: "data_input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "data_input"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
   }
 
   #################
   # FULLY_CONNECTED encode1
   #################
   layer {
+    parents: "data"
     name: "encode1"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -83,6 +86,7 @@ model {
   # SELU selu1
   ######
   layer {
+    parents: "encode1"
     name: "selu1"
     data_layout: "model_parallel"
     selu {
@@ -93,11 +97,11 @@ model {
   # FULLY_CONNECTED encode2
   #################
   layer {
+    parents: "selu1"
     name: "encode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -106,6 +110,7 @@ model {
   # SELU selu2
   #######
   layer {
+    parents: "encode2"
     name: "selu2"
     data_layout: "model_parallel"
     selu {
@@ -116,11 +121,11 @@ model {
   # FULLY_CONNECTED encode3
   #################
   layer {
+    parents: "selu2"
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100 
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -129,6 +134,7 @@ model {
   # SELU selu3
   #######
   layer {
+    parents: "encode3"
     name: "selu3"
     data_layout: "model_parallel"
     selu {
@@ -140,11 +146,11 @@ model {
   # FULLY_CONNECTED decode3
   #################
   layer {
+    parents: "selu3"
     name: "decode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -153,6 +159,7 @@ model {
   # SELU selu8
   #######
   layer {
+    parents: "decode3"
     name: "selu8"
     data_layout: "model_parallel"
     selu {
@@ -163,11 +170,11 @@ model {
   # FULLY_CONNECTED decode2
   #################
   layer {
+    parents: "selu8"
     name: "decode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -176,6 +183,7 @@ model {
   # SELU selu9
   #######
   layer {
+    parents: "decode2"
     name: "selu9"
     data_layout: "model_parallel"
     selu {
@@ -186,11 +194,11 @@ model {
   # FULLY_CONNECTED decode1
   #################
   layer {
+    parents: "selu9"
     name: "decode1"
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -199,6 +207,7 @@ model {
   # SELU selu10 
   #######
   layer {
+    parents: "decode1"
     name: "selu10"
     data_layout: "model_parallel"
     #selu {
@@ -211,11 +220,56 @@ model {
   # RECONSTRUCTION
   #################
   layer {
+    parents: "relu10"
     name: "reconstruction"
     data_layout: "model_parallel"
-    reconstruction {
-      original_layer: "data"
-    }
+    split {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
+  }
+
+  #####################
+  # PEARSON CORRELATION
+  #####################
+  layer {
+    parents: "reconstruction data"
+    name: "pearson_r_cov"
+    data_layout: "model_parallel"
+    covariance {}
+  }
+  layer {
+    parents: "data"
+    name: "pearson_r_var1"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "reconstruction"
+    name: "pearson_r_var2"
+    data_layout: "model_parallel"
+    variance {}
+  }
+  layer {
+    parents: "pearson_r_var1 pearson_r_var2"
+    name: "pearson_r_mult"
+    data_layout: "model_parallel"
+    multiply {}
+  }
+  layer {
+    parents: "pearson_r_mult"
+    name: "pearson_r_sqrt"
+    data_layout: "model_parallel"
+    sqrt {}
+  }
+  layer {
+    parents: "pearson_r_cov pearson_r_sqrt"
+    name: "pearson_r"
+    data_layout: "model_parallel"
+    divide {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp_500x250x100.prototext
@@ -235,6 +235,7 @@ model {
   #####################
   # PEARSON CORRELATION
   #####################
+  # rho(x,y) = covariance(x,y) / sqrt( variance(x) * variance(y) )
   layer {
     parents: "reconstruction data"
     name: "pearson_r_cov"

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_sigmoid.prototext
@@ -2,7 +2,6 @@ model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
   ### This network description is anologous to AutoEncoder_Chem_Sigmoid
-  name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 128
   block_size: 256
@@ -15,7 +14,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mean_squared_error" }
   }
 
   ###################################################
@@ -37,11 +36,6 @@ model {
       mat_interval: 25
     }
   }
-#  callback {
-#    debug {
-#      phase: "train"
-#    }
-#  }
 
   ###################################################
   # start of layers
@@ -51,24 +45,36 @@ model {
   # INPUT
   #######
   layer {
-    name: "data"
-    children: "encode1 reconstruction"
+    name: "data_input"
+    children: "data label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
       target_mode: "reconstruction"
     }
   }
+  layer {
+    parents: "data_input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "data_input"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
+  }
 
   #################
   # FULLY_CONNECTED encode1
   #################
   layer {
+    parents: "data"
     name: "encode1"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -77,6 +83,7 @@ model {
   # SIGMOID sigmoid1
   ######
   layer {
+    parents: "encode1"
     name: "sigmoid1"
     data_layout: "model_parallel"
     sigmoid {
@@ -87,11 +94,11 @@ model {
   # FULLY_CONNECTED encode2
   #################
   layer {
+    parents: "sigmoid1"
     name: "encode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -100,6 +107,7 @@ model {
   # SIGMOID sigmoid2
   #######
   layer {
+    parents: "encode2"
     name: "sigmoid2"
     data_layout: "model_parallel"
     sigmoid {
@@ -110,11 +118,11 @@ model {
   # FULLY_CONNECTED encode3
   #################
   layer {
+    parents: "sigmoid2"
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -123,6 +131,7 @@ model {
   # SIGMOID sigmoid3
   #######
   layer {
+    parents: "encode3"
     name: "sigmoid3"
     data_layout: "model_parallel"
     sigmoid {
@@ -134,11 +143,11 @@ model {
   # FULLY_CONNECTED decode3
   #################
   layer {
+    parents: "sigmoid3"
     name: "decode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -147,6 +156,7 @@ model {
   # SIGMOID sigmoid4
   #######
   layer {
+    parents: "decode3"
     name: "sigmoid4"
     data_layout: "model_parallel"
     sigmoid {
@@ -157,11 +167,11 @@ model {
   # FULLY_CONNECTED decode2
   #################
   layer {
+    parents: "sigmoid4"
     name: "decode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -171,6 +181,7 @@ model {
   # SIGMOID sigmoid5
   #######
   layer {
+    parents: "decode2"
     name: "sigmoid5"
     data_layout: "model_parallel"
     sigmoid {
@@ -181,11 +192,11 @@ model {
   # FULLY_CONNECTED decode1
   #################
   layer {
+    parents: "sigmoid5"
     name: "decode1"
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -194,6 +205,7 @@ model {
   # SIGMOID sigmoid6
   #######
   layer {
+    parents: "decode1"
     name: "sigmoid6"
     data_layout: "model_parallel"
     sigmoid {
@@ -205,10 +217,16 @@ model {
   # RECONSTRUCTION
   #################
   layer {
+    parents: "relu10"
     name: "reconstruction"
-    parents: "sigmoid6 data"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
   }
 
   ###################################################

--- a/model_zoo/models/autoencoder_candle_pilot1/model_dnn_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_dnn_chem_ecfp.prototext
@@ -2,7 +2,6 @@ model {
   ### Model description and network architecture taken from:
   ### https://lc.llnl.gov/bitbucket/projects/BIOM/repos/molresp/browse/tf_model.py?at=TensorFlow_chemClass
   ### This network description is anologous to AutoEncoder_Chem_ECFP
-  name: "sequential_model"
   data_layout: "model_parallel"
   mini_batch_size: 128
   block_size: 256
@@ -15,7 +14,7 @@ model {
   ###################################################
 
   objective_function {
-    cross_entropy {}
+    layer_term { layer: "cross_entropy" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -26,7 +25,10 @@ model {
   ###################################################
 
   metric {
-    categorical_accuracy {}
+    layer_metric {
+      name: "accuracy"
+      layer: "categorical_accuracy"
+    }
   }
 
 
@@ -42,18 +44,6 @@ model {
     timer {
     }
   }
- # callback {
- #   summary {
- #     dir: "."
- #     batch_interval: 1
- #     mat_interval: 25
- #   }
- # }
-#  callback {
-#    debug {
-#      phase: "train"
-#    }
-#  }
 
   ###################################################
   # start of layers
@@ -63,23 +53,35 @@ model {
   # INPUT
   #######
   layer {
-    name: "finetunedata"
-    children: "encode target"
+    name: "data"
+    children: "finetunedata label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
     }
+  }
+  layer {
+    parents: "data"
+    name: "finetunedata"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "data"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
   }
 
   #################
   # FULLY_CONNECTED encode1
   #################
   layer {
+    parents: "finetunedata"
     name: "encode1"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 2000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -88,6 +90,7 @@ model {
   # RELU relu1
   ######
   layer {
+    parents: "encode1"
     name: "relu1"
     data_layout: "model_parallel"
     relu {
@@ -98,11 +101,11 @@ model {
   # FULLY_CONNECTED encode2
   #################
   layer {
+    parents: "relu1"
     name: "encode2"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -111,6 +114,7 @@ model {
   # RELU relu2
   #######
   layer {
+    parents: "encode2"
     name: "relu2"
     data_layout: "model_parallel"
     relu {
@@ -121,11 +125,11 @@ model {
   # FULLY_CONNECTED encode3
   #################
   layer {
+    parents: "relu2"
     name: "encode3"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -134,6 +138,7 @@ model {
   # RELU relu3
   #######
   layer {
+    parents: "encode3"
     name: "relu3"
     data_layout: "model_parallel"
     relu {
@@ -144,11 +149,11 @@ model {
   # FULLY_CONNECTED encode4
   #################
   layer {
+    parents: "relu3"
     name: "encode4"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -157,6 +162,7 @@ model {
   # RELU relu4
   #######
   layer {
+    parents: "encode4"
     name: "relu4"
     data_layout: "model_parallel"
     relu {
@@ -167,11 +173,11 @@ model {
   # FULLY_CONNECTED encode5
   #################
   layer {
+    parents: "relu4"
     name: "encode5"
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 100
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -180,6 +186,7 @@ model {
   # RELU relu5
   #######
   layer {
+    parents: "encode5"
     name: "relu5"
     data_layout: "model_parallel"
     relu {
@@ -188,6 +195,7 @@ model {
 
 
   layer {
+    parents: "relu5"
     name: "ip2"
     data_layout: "model_parallel"
     fully_connected {
@@ -197,17 +205,26 @@ model {
   }
 
   layer {
+    parents: "ip2"
     name: "prob"
     data_layout: "model_parallel"
     softmax {}
   }
 
   layer {
-    name: "target"
-    parents: "prob finetunedata"
+    parents: "prob label"
+    name: "cross_entropy"
     data_layout: "model_parallel"
-    target {}
+    cross_entropy {}
   }
+
+  layer {
+    parents: "prob label"
+    name: "categorical_accuracy"
+    data_layout: "model_parallel"
+    categorical_accuracy {}
+  }
+  
   ###################################################
   # end of layers
   ###################################################

--- a/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
+++ b/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   mini_batch_size: 50
   block_size: 256

--- a/model_zoo/models/candle/pilot1/combo.prototext
+++ b/model_zoo/models/candle/pilot1/combo.prototext
@@ -1,7 +1,6 @@
 #Example taken from:https://github.com/ECP-CANDLE/Benchmarks/tree/frameworks/Pilot1/Combo
 #Timestamp 03/07/2018 8:30PM
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   mini_batch_size: 256
   block_size: 256
@@ -14,7 +13,7 @@ model {
   ###################################################
 
   objective_function {
-    mean_squared_error {}
+    layer_term { layer: "mean_squared_error" }
   }
 
   ###################################################
@@ -22,10 +21,16 @@ model {
   ###################################################
 
   metric {
-    mean_squared_error {}
+    layer_metric {
+      name: "mean squared error"
+      layer: "mean_squared_error"
+    }
   }
   metric {
-    r2{}
+    layer_metric {
+      name: "R2"
+      layer: "r2"
+    }
   }
 
   ###################################################
@@ -44,13 +49,25 @@ model {
 
   # INPUT (Merged Features)
   layer {
-    name: "data"
-    children: "slice_data target"
+    name: "data_input"
+    children: "data response"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
       target_mode: "regression"
     }
+  }
+  layer {
+    parents: "data_input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}    
+  }
+  layer {
+    parents: "data_input"
+    name: "response"
+    data_layout: "model_parallel"
+    split {}    
   }
 
   # SLICE
@@ -482,10 +499,39 @@ model {
 
   #TARGET
   layer {
-    parents: "fc data"
-    name: "target"
-    target {}
+    parents: "fc response"
+    name: "mean_squared_error"
     data_layout: "model_parallel"
+    mean_squared_error {}
+  }
+
+  layer {
+    parents: "fc"
+    name: "r2_var"
+    data_layout: "model_parallel"
+    variance {
+      biased: true
+    }
+  }
+  layer {
+    parents: "mean_squared_error r2_var"
+    name: "r2_div"
+    data_layout: "model_parallel"
+    divide {}
+  }
+  layer {
+    name: "r2_one"
+    data_layout: "model_parallel"
+    constant {
+      value: 1
+      num_neurons: "1"
+    }
+  }
+  layer {
+    parents: "r2_one r2_div"
+    name: "r2"
+    data_layout: "model_parallel"
+    subtract {}
   }
 
   ###################################################

--- a/model_zoo/models/candle/pilot1/combo.prototext
+++ b/model_zoo/models/candle/pilot1/combo.prototext
@@ -497,7 +497,7 @@ model {
     }
   }
 
-  #TARGET
+  #MEAN_SQUARED_ERROR
   layer {
     parents: "fc response"
     name: "mean_squared_error"
@@ -505,6 +505,7 @@ model {
     mean_squared_error {}
   }
 
+  # R2(x,y) = 1 - sum( (x-y)^2 ) / sum( (x-mean(x))^2 )
   layer {
     parents: "fc"
     name: "r2_var"


### PR DESCRIPTION
This is a followup to #667. It primarily removes target layers and reconstruction layers from the CANDLE Pilot1 models.