### PR TITLE
Remove deprecated functionality in JAG models

### DIFF
--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m1.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m1_template.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m1_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m2_template.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m2_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m3_template.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m3_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/gan/mnist/adversarial_model.prototext
+++ b/model_zoo/models/gan/mnist/adversarial_model.prototext
@@ -1,6 +1,5 @@
 #Adversarial Model
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   mini_batch_size: 32
   block_size: 256
@@ -14,7 +13,7 @@ model {
   ###################################################
 
   objective_function {
-    binary_cross_entropy {}
+    layer_term { layer: "binary_cross_entropy" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -25,7 +24,11 @@ model {
   ###################################################
 
   metric {
-    categorical_accuracy {}
+    layer_metric {
+      name: "categorical accuracy"
+      layer: "categorical_accuracy"
+      unit: "%"
+    }
   }
 
   ###################################################
@@ -61,12 +64,24 @@ model {
 
   # INPUT real data
   layer {
-    name: "data"
-    children: "zero_data target"
+    name: "input"
+    children: "input label"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
     }
+  }
+  layer {
+    parents: "input"
+    name: "data"
+    data_layout: "data_parallel"
+    split {}    
+  }
+  layer {
+    parents: "input"
+    name: "label"
+    data_layout: "data_parallel"
+    split {}    
   }
 
   #ZERO
@@ -109,7 +124,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -142,7 +156,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 512
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -175,7 +188,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 1024
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -208,7 +220,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 784
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -270,7 +281,6 @@ model {
     weights: "dis_flatten_weights"
     fully_connected {
       num_neurons: 784
-      #weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -287,7 +297,6 @@ model {
     weights: "dis_fc1_weights"
     fully_connected {
       num_neurons: 512
-      #weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -312,7 +321,6 @@ model {
     weights: "dis_fc2_weights"
     fully_connected {
       num_neurons: 256
-      #weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -338,7 +346,6 @@ model {
     weights: "dis_fc3_weights"
     fully_connected {
       num_neurons: 2
-      #weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -360,10 +367,16 @@ model {
   }
 
   layer {
-    parents: "prob data"
-    name: "target"
+    parents: "prob label"
+    name: "binary_cross_entropy"
     data_layout: "data_parallel"
-    target {}
+    binary_cross_entropy {}
+  }
+  layer {
+    parents: "prob label"
+    name: "categorical_accuracy"
+    data_layout: "data_parallel"
+    categorical_accuracy {}
   }
 
 }

--- a/model_zoo/models/gan/mnist/discriminator_model.prototext
+++ b/model_zoo/models/gan/mnist/discriminator_model.prototext
@@ -1,6 +1,5 @@
 #Discriminator Model
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   mini_batch_size: 32
   block_size: 256
@@ -14,7 +13,7 @@ model {
   ###################################################
 
   objective_function {
-    binary_cross_entropy {}
+    layer_term { layer: "binary_cross_entropy" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -25,7 +24,11 @@ model {
   ###################################################
 
   metric {
-    categorical_accuracy {}
+    layer_metric {
+      name: "categorical accuracy"
+      layer: "categorical_accuracy"
+      unit: "%"
+    }
   }
 
   ###################################################
@@ -54,14 +57,25 @@ model {
 
   # INPUT real data
   layer {
-    name: "data"
-    children: "zero_data target"
+    name: "input"
+    children: "input label"
     data_layout: "data_parallel"
     input {
       io_buffer: "partitioned"
     }
   }
-
+  layer {
+    parents: "input"
+    name: "data"
+    data_layout: "data_parallel"
+    split {}    
+  }
+  layer {
+    parents: "input"
+    name: "label"
+    data_layout: "data_parallel"
+    split {}    
+  }
 
   #ZERO
   layer {
@@ -102,7 +116,6 @@ model {
     weights: "gen_fc1_weights"
     fully_connected {
       num_neurons: 256
-     # weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -141,7 +154,6 @@ model {
     weights: "gen_fc2_weights"
     fully_connected {
       num_neurons: 512
-      #weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -180,7 +192,6 @@ model {
     weights: "gen_fc3_weights"
     fully_connected {
       num_neurons: 1024
-     # weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -219,7 +230,6 @@ model {
     weights: "gen_fc4_weights"
     fully_connected {
       num_neurons: 784
-      #weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -275,7 +285,6 @@ model {
     data_layout: "data_parallel"
     fully_connected {
       num_neurons: 784
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -287,7 +296,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 512
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -307,7 +315,6 @@ model {
     #weights: "gen_fc_weights"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -327,7 +334,6 @@ model {
     data_layout: "data_parallel"
     fully_connected {
       num_neurons: 2
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -349,10 +355,16 @@ model {
   }
 
   layer {
-    parents: "prob data"
-    name: "target"
+    parents: "prob label"
+    name: "binary_cross_entropy"
     data_layout: "data_parallel"
-    target {}
+    binary_cross_entropy {}
+  }
+  layer {
+    parents: "prob label"
+    name: "categorical_accuracy"
+    data_layout: "data_parallel"
+    categorical_accuracy {}
   }
 
 }

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m1.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001
@@ -86,7 +85,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -114,7 +112,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -141,7 +138,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -171,7 +167,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -182,7 +177,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001
@@ -61,7 +60,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -88,7 +86,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -115,7 +112,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -145,7 +141,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -156,7 +151,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001
@@ -61,7 +60,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -88,7 +86,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -115,7 +112,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -145,7 +141,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -156,7 +151,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
@@ -2,7 +2,6 @@
 #https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/run_vae.py
 #Timestamp 02/26/2018 8:45AM
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   #mini_batch_size: 128
   mini_batch_size: 100 #more last minibatch images to save
@@ -16,12 +15,8 @@ model {
   ###################################################
 
   objective_function {
-    binary_cross_entropy {}
-    #mean_squared_error {}
-    layer_term {
-      scale_factor: 1.0
-      layer: "kl_divergence"
-    }
+    layer_term { layer: "binary_cross_entropy" }
+    layer_term { layer: "kl_divergence" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -31,7 +26,12 @@ model {
   # Metrics
   ###################################################
 
-  metric { mean_squared_error {} }
+  metric {
+    layer_metric {
+      name: "mean squared error"
+      layer: "mean_squared_error"
+    }
+  }
 
   ###################################################
   # Callbacks
@@ -78,9 +78,21 @@ model {
       io_buffer: "partitioned"
       target_mode: "N/A"
     }
+    name: "input"
+    data_layout: "data_parallel"
+    children: "data label"
+  }
+  layer {
+    parents: "input"
     name: "data"
     data_layout: "data_parallel"
-    parents: " "
+    split {}
+  }
+  layer {
+    parents: "input"
+    name: "label"
+    data_layout: "data_parallel"
+    split {}
   }
   layer {
     name: "slice_data"
@@ -117,7 +129,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -144,7 +155,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -170,7 +180,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -199,7 +208,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -209,7 +217,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -315,7 +322,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -341,7 +347,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -367,7 +372,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -395,7 +399,6 @@ model {
     data_layout: "model_parallel"
     #num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_normal"
       num_neurons: 16384
       has_bias: true
     }
@@ -412,11 +415,22 @@ model {
   ######################
 
   layer {
-    #parents: "sigmoid data"
-    parents: "sigmoid image_data_dummy"
+    parents: "sigmoid"
     name: "reconstruction"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}    
+  }
+  layer {
+    parents: "reconstruction image_data_dummy"
+    name: "binary_cross_entropy"
+    data_layout: "model_parallel"
+    binary_cross_entropy {}
+  }
+  layer {
+    parents: "reconstruction image_data_dummy"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
   }
 
   ###################################################

--- a/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
@@ -2,7 +2,6 @@
 #https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/run_vae.py
 #Timestamp 02/26/2018 8:45AM
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   #mini_batch_size: 128
   mini_batch_size: 100 #more last minibatch images to save
@@ -16,12 +15,8 @@ model {
   ###################################################
 
   objective_function {
-    binary_cross_entropy {}
-    #mean_squared_error {}
-    layer_term {
-      scale_factor: 1.0
-      layer: "kl_divergence"
-    }
+    layer_term { layer: "binary_cross_entropy" }
+    layer_term { layer: "kl_divergence" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -31,7 +26,12 @@ model {
   # Metrics
   ###################################################
 
-  metric { mean_squared_error {} }
+  metric {
+    layer_metric {
+      name: "mean squared error"
+      layer: "mean_squared_error"
+    }
+  }
 
   ###################################################
   # Callbacks
@@ -62,9 +62,21 @@ model {
       io_buffer: "partitioned"
       target_mode: "N/A"
     }
+    name: "input"
+    data_layout: "data_parallel"
+    children: "data label"
+  }
+  layer {
+    parents: "input"
     name: "data"
     data_layout: "data_parallel"
-    parents: " "
+    split {}
+  }
+  layer {
+    parents: "input"
+    name: "label"
+    data_layout: "data_parallel"
+    split {}
   }
   layer {
     name: "slice_data"
@@ -193,7 +205,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -220,7 +231,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -246,36 +256,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
-      has_bias: true
-    }
-  }
-  layer {
-    parents: "encode3"
-    name: "encode3_tanh"
-    data_layout: "model_parallel"
-    tanh {}
-  }
-  layer {
-    parents: "encode3_tanh"
-    name: "encode3_dropout"
-    data_layout: "model_parallel"
-    dropout {
-      keep_prob: 0.95
-    }
-  }
-
-  ######################
-  # Latent space
-  ######################
-
-  layer {
-    parents: "encode3_dropout"
-    name: "z_mean"
-    data_layout: "model_parallel"
-    fully_connected {
-      num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -285,7 +265,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:20
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -393,7 +372,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -419,7 +397,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -445,7 +422,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -473,7 +449,6 @@ model {
     data_layout: "model_parallel"
     #num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_normal"
       num_neurons: 16384
       has_bias: true
     }
@@ -490,12 +465,22 @@ model {
   ######################
 
   layer {
-    #parents: "sigmoid data"
-    #parents: "sigmoid gen1fc4_1"
-    parents: "sigmoid image_data_id"
+    parents: "sigmoid"
     name: "reconstruction"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}    
+  }
+  layer {
+    parents: "reconstruction image_data_id"
+    name: "binary_cross_entropy"
+    data_layout: "model_parallel"
+    binary_cross_entropy {}
+  }
+  layer {
+    parents: "reconstruction image_data_id"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
   }
 
   ###################################################

--- a/model_zoo/models/jag/cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m1.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/jag/cycle_gan/cycgan_m1_template.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m1_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2_template.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3_template.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/jag/gan/cyclic/cyclic_gan_model.prototext
+++ b/model_zoo/models/jag/gan/cyclic/cyclic_gan_model.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   procs_per_model:0 
   objective_function {
     l2_weight_regularization {

--- a/model_zoo/models/jag/gan/cyclic/model_template.prototext
+++ b/model_zoo/models/jag/gan/cyclic/model_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/jag/gan/vanilla/gan.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   random_init_models_differently: true
   objective_function {
     l2_weight_regularization {

--- a/model_zoo/models/jag/gan/vanilla/gan_template.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan_template.prototext
@@ -1,5 +1,4 @@
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "data_parallel"
   mini_batch_size: 64 
   block_size: 256

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -2,7 +2,6 @@
 #https://lc.llnl.gov/bitbucket/users/jjayaram/repos/deep-latent-spaces/browse/codes/dev/VAE-FCN/run_vae.py
 #Timestamp 02/26/2018 8:45AM
 model {
-  name: "directed_acyclic_graph_model"
   data_layout: "model_parallel"
   #mini_batch_size: 128
   mini_batch_size: 100 #more last minibatch images to save
@@ -16,12 +15,8 @@ model {
   ###################################################
 
   objective_function {
-    binary_cross_entropy {}
-    #mean_squared_error {}
-    layer_term {
-      scale_factor: 1.0
-      layer: "kl_divergence"
-    }
+    layer_term { layer: "binary_cross_entropy" }
+    layer_term { layer: "kl_divergence" }
     l2_weight_regularization {
       scale_factor: 1e-4
     }
@@ -31,7 +26,12 @@ model {
   # Metrics
   ###################################################
 
-  metric { mean_squared_error {} }
+  metric {
+    layer_metric {
+      name: "mean squared error"
+      layer: "mean_squared_error"
+    }
+  }
 
   ###################################################
   # Callbacks
@@ -63,13 +63,25 @@ model {
   # Data
   ######################
   layer {
-    name: "data"
-    children: "encode1 reconstruction"
+    name: "input"
+    children: "data label"
     data_layout: "model_parallel"
     input {
       io_buffer: "distributed"
       target_mode: "reconstruction"
     }
+  }
+  layer {
+    parents: "input"
+    name: "data"
+    data_layout: "model_parallel"
+    split {}
+  }
+  layer {
+    parents: "input"
+    name: "label"
+    data_layout: "model_parallel"
+    split {}
   }
 
   ######################
@@ -83,7 +95,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -109,7 +120,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -135,7 +145,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -164,7 +173,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:5
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -174,7 +182,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons:5
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -213,17 +220,11 @@ model {
   }
   layer {
     parents: "kl_full"
-    name: "kl_sum"
+    name: "kl_divergence"
     data_layout: "data_parallel"
     reduction {
       mode: "sum"
     }
-  }
-  layer {
-    parents: "kl_sum"
-    name: "kl_divergence"
-    data_layout: "data_parallel"
-    evaluation {}
   }
 
   ######################
@@ -257,13 +258,13 @@ model {
     parents: "sample_exp sample_noise"
     name: "sample_exp_noise"
     data_layout: "model_parallel"
-    hadamard {}
+    multiply {}
   }
   layer {
     parents: "z_mean sample_exp_noise"
     name: "sample"
     data_layout: "model_parallel"
-    sum {}
+    add {}
   }
 
   ######################
@@ -277,7 +278,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -303,7 +303,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -329,7 +328,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 256
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -356,7 +354,6 @@ model {
     data_layout: "model_parallel"
     num_neurons_from_data_reader: true
     fully_connected {
-      weight_initialization: "glorot_normal"
       has_bias: true
     }
   }
@@ -372,10 +369,22 @@ model {
   ######################
 
   layer {
-    parents: "sigmoid data"
+    parents: "sigmoid"
     name: "reconstruction"
     data_layout: "model_parallel"
-    reconstruction {}
+    split {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "mean_squared_error"
+    data_layout: "model_parallel"
+    mean_squared_error {}
+  }
+  layer {
+    parents: "reconstruction data"
+    name: "binary_cross_entropy"
+    data_layout: "model_parallel"
+    binary_cross_entropy {}
   }
 
   ###################################################


### PR DESCRIPTION
This is a followup to #667. It primarily removes target layers and reconstruction layers from the JAG models.