### PR TITLE
Tweak the way loop bounds are passed in omp collapse

### DIFF
--- a/include/lbann/utils/entrywise_operator.hpp
+++ b/include/lbann/utils/entrywise_operator.hpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/exception.hpp"
 
 namespace lbann {
-  
+
 /** Apply an entry-wise unary operator to CPU data.
  *  The input and output data must be on CPU and must have the same
  *  dimensions.
@@ -66,15 +66,17 @@ void apply_entrywise_unary_operator(const AbsMat& input,
       output_buffer[i] = op(input_buffer[i]);
     }
   } else {
+    auto const width = input.Width();
+    auto const height = input.Height();
 #pragma omp parallel for collapse(2)
-    for (El::Int col = 0; col < input.Width(); ++col) {
-      for (El::Int row = 0; row < input.Height(); ++row) {
+    for (El::Int col = 0; col < width; ++col) {
+      for (El::Int row = 0; row < height; ++row) {
         UnaryOperator op;
         output(row, col) = op(input(row, col));
       }
     }
   }
-  
+
 }
 
 /** Apply an entry-wise binary operator to CPU data.
@@ -118,9 +120,11 @@ void apply_entrywise_binary_operator(const AbsMat& input1,
       output_buffer[i] = op(input1_buffer[i], input2_buffer[i]);
     }
   } else {
+    auto const width = input1.Width();
+    auto const height = input1.Height();
 #pragma omp parallel for collapse(2)
-    for (El::Int col = 0; col < input1.Width(); ++col) {
-      for (El::Int row = 0; row < input1.Height(); ++row) {
+    for (El::Int col = 0; col < width; ++col) {
+      for (El::Int row = 0; row < height; ++row) {
         BinaryOperator op;
         output(row, col) = op(input1(row, col), input2(row, col));
       }

--- a/src/layers/loss/entrywise.cpp
+++ b/src/layers/loss/entrywise.cpp
@@ -34,7 +34,7 @@ namespace {
 // Helpful constants
 constexpr DataType zero = 0;
 constexpr DataType one = 1;
-  
+
 /** Apply a binary backprop operator to CPU data.
  *  The input and output data must be on CPU and must have the same
  *  dimensions. Given a binary function \f$ y = f(x_1,x_2) \f$, the
@@ -64,9 +64,11 @@ void apply_binary_backprop_operator(const AbsMat& x1,
          dx1_buffer[i], dx2_buffer[i]);
     }
   } else {
+    auto const width = x1.Width();
+    auto const height = x2.Height();
 #pragma omp parallel for collapse(2)
-    for (El::Int col = 0; col < x1.Width(); ++col) {
-      for (El::Int row = 0; row < x2.Height(); ++row) {
+    for (El::Int col = 0; col < width; ++col) {
+      for (El::Int row = 0; row < height; ++row) {
         BinaryBackPropOperator op;
         op(x1(row, col), x2(row, col), dy(row, col),
            dx1(row, col), dx2(row, col));
@@ -75,7 +77,7 @@ void apply_binary_backprop_operator(const AbsMat& x1,
   }
 
 }
-  
+
 // =========================================================
 // Operator objects for entry-wise binary layers
 // =========================================================
@@ -143,7 +145,7 @@ struct sigmoid_binary_cross_entropy_op {
     dx2 = (x2 == z) ? -x1 * dy : zero;
   }
 };
-  
+
 /** Boolean accuracy operator. */
 struct boolean_accuracy_op {
   inline DataType operator()(const DataType& x1,
@@ -197,7 +199,7 @@ struct boolean_false_positive_op {
     dx2 = zero;
   }
 };
-  
+
 } // namespace
 
 // Template instantiation
@@ -239,5 +241,5 @@ struct boolean_false_positive_op {
   INSTANTIATE(boolean_accuracy_layer, boolean_accuracy_op)
   INSTANTIATE(boolean_false_negative_layer, boolean_false_negative_op)
   INSTANTIATE(boolean_false_positive_layer, boolean_false_positive_op)
-  
+
 } // namespace lbann

--- a/src/layers/loss/entrywise.cpp
+++ b/src/layers/loss/entrywise.cpp
@@ -65,7 +65,7 @@ void apply_binary_backprop_operator(const AbsMat& x1,
     }
   } else {
     auto const width = x1.Width();
-    auto const height = x2.Height();
+    auto const height = x1.Height();
 #pragma omp parallel for collapse(2)
     for (El::Int col = 0; col < width; ++col) {
       for (El::Int row = 0; row < height; ++row) {

--- a/src/layers/loss/l2_norm2.cpp
+++ b/src/layers/loss/l2_norm2.cpp
@@ -46,9 +46,11 @@ void local_fp_cpu(const AbsMat& local_input,
 void local_bp_cpu(const AbsMat& local_input,
                   const AbsMat& local_gradient_wrt_output,
                   AbsMat& local_gradient_wrt_input) {
+  auto const width = local_input.Width();
+  auto const height = local_input.Height();
 #pragma omp parallel for collapse(2)
-  for (El::Int col = 0; col < local_input.Width(); ++col) {
-    for (El::Int row = 0; row < local_input.Height(); ++row) {
+  for (El::Int col = 0; col < width; ++col) {
+    for (El::Int row = 0; row < height; ++row) {
       const auto& x = local_input(row, col);
       const auto& dy = local_gradient_wrt_output(0, col);
       auto& dx = local_gradient_wrt_input(row, col);

--- a/src/layers/math/binary.cpp
+++ b/src/layers/math/binary.cpp
@@ -64,9 +64,11 @@ void apply_binary_backprop_operator(const AbsMat& x1,
          dx1_buffer[i], dx2_buffer[i]);
     }
   } else {
+    auto const width = x1.Width();
+    auto const height = x2.Height();
 #pragma omp parallel for collapse(2)
-    for (El::Int col = 0; col < x1.Width(); ++col) {
-      for (El::Int row = 0; row < x2.Height(); ++row) {
+    for (El::Int col = 0; col < width; ++col) {
+      for (El::Int row = 0; row < height; ++row) {
         BinaryBackPropOperator op;
         op(x1(row, col), x2(row, col), dy(row, col),
            dx1(row, col), dx2(row, col));
@@ -75,7 +77,7 @@ void apply_binary_backprop_operator(const AbsMat& x1,
   }
 
 }
-  
+
 // =========================================================
 // Operator objects for entry-wise binary layers
 // =========================================================
@@ -115,7 +117,7 @@ struct subtract_op {
     dx2 = -dy;
   }
 };
-  
+
 /** Multiply operator. */
 struct multiply_op {
   inline DataType operator()(const DataType& x1,
@@ -147,7 +149,7 @@ struct divide_op {
     dx2 = -dy * x1 / (x2*x2);
   }
 };
-  
+
 /** Modulo operator. */
 struct mod_op {
   inline DataType operator()(const DataType& x1,
@@ -207,7 +209,7 @@ struct safe_divide_op {
     }
   }
 };
-  
+
 /** Maximum operator. */
 struct max_op {
   inline DataType operator()(const DataType& x1,
@@ -405,7 +407,7 @@ struct xor_op {
     dx2 = zero;
   }
 };
-  
+
 } // namespace
 
 // Template instantiation
@@ -460,5 +462,5 @@ struct xor_op {
   INSTANTIATE(and_layer, and_op)
   INSTANTIATE(or_layer, or_op)
   INSTANTIATE(xor_layer, xor_op)
-  
+
 } // namespace lbann

--- a/src/layers/math/binary.cpp
+++ b/src/layers/math/binary.cpp
@@ -65,7 +65,7 @@ void apply_binary_backprop_operator(const AbsMat& x1,
     }
   } else {
     auto const width = x1.Width();
-    auto const height = x2.Height();
+    auto const height = x1.Height();
 #pragma omp parallel for collapse(2)
     for (El::Int col = 0; col < width; ++col) {
       for (El::Int row = 0; row < height; ++row) {

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -60,9 +60,11 @@ void value_initializer::fill(AbsDistMat& matrix) {
   } else {
     matrix_cpu.Resize(matrix.LocalHeight(), matrix.LocalWidth());
   }
+  auto const width = matrix.LocalWidth();
+  auto const height = matrix.LocalHeight();
 #pragma omp parallel for collapse(2)
-  for (El::Int local_col = 0; local_col < matrix.LocalWidth(); ++local_col) {
-    for (El::Int local_row = 0; local_row < matrix.LocalHeight(); ++local_row) {
+  for (El::Int local_col = 0; local_col < width; ++local_col) {
+    for (El::Int local_row = 0; local_row < height; ++local_row) {
       const auto& global_row = matrix.GlobalRow(local_row);
       const auto& global_col = matrix.GlobalCol(local_col);
       const auto& global_pos = global_row + matrix.Height() * global_col;
@@ -75,16 +77,16 @@ void value_initializer::fill(AbsDistMat& matrix) {
     El::GPUManager::SynchronizeStream(); /// @todo Use new Hydrogen synchronization semantics when available
 #endif // HYDROGEN_HAVE_CUDA
   }
-  
+
 }
-  
+
 void uniform_initializer::fill(AbsDistMat& matrix) {
-  uniform_fill(matrix, matrix.Height(), matrix.Width(), 
+  uniform_fill(matrix, matrix.Height(), matrix.Width(),
                (m_max + m_min) / 2, (m_max - m_min) / 2);
 }
 
 void normal_initializer::fill(AbsDistMat& matrix) {
-  gaussian_fill(matrix, matrix.Height(), matrix.Width(), 
+  gaussian_fill(matrix, matrix.Height(), matrix.Width(),
                 m_mean, m_standard_deviation);
 }
 


### PR DESCRIPTION
Intel was fussing about this. No other compiler seems to care all that much.