### PR TITLE
Gather can accommodate arbitrary data types

### DIFF
--- a/src/layers/loss/categorical_accuracy.cpp
+++ b/src/layers/loss/categorical_accuracy.cpp
@@ -191,7 +191,7 @@ void fp_cpu(lbann_comm& comm,
                             DataType(1) : DataType(0));
     }
   }
-  
+
 }
 
 } // namespace

--- a/src/layers/loss/categorical_accuracy.cu
+++ b/src/layers/loss/categorical_accuracy.cu
@@ -49,7 +49,7 @@ __global__ void fill_indices_kernel(El::Int local_height,
     indices[row + col*local_height] = col_shift + row * col_stride;
   }
 }
-  
+
 /** Find largest entry within each CUDA block.
  *  Each block is assigned several entries from the same mini-batch
  *  sample and it finds the largest entry. Results are output to
@@ -73,7 +73,7 @@ __global__ void reduce_max_entries_kernel(El::Int height, El::Int width,
   const El::Int bidy = blockIdx.y;
   const El::Int nthreadsx = blockDim.x * gridDim.x;
   const El::Int nblocksx = gridDim.x;
-  
+
   // Reduce each matrix column independently
   for (El::Int col = bidy; col < width; col += gridDim.y) {
 
@@ -115,7 +115,7 @@ __global__ void reduce_max_entries_kernel(El::Int height, El::Int width,
     }
 
   }
-  
+
 }
 
 /** Compute sample-wise categorical accuracy.
@@ -137,7 +137,7 @@ __global__ void compute_accuracy_kernel(El::Int local_width,
                            DataType(1) : DataType(0));
   }
 }
-  
+
 /** GPU implementation of categorical accuracy layer forward prop. */
 void fp_gpu(lbann_comm& comm,
             const AbsDistMat& predictions,
@@ -154,7 +154,7 @@ void fp_gpu(lbann_comm& comm,
   const auto& local_height = local_predictions.Height();
   const auto& local_width = local_predictions.Width();
   if (local_width < 1) { return; }
-  
+
   // Column communicator
   auto&& col_comm = predictions.ColComm();
   const auto& col_comm_rank = El::mpi::Rank(col_comm);
@@ -272,7 +272,7 @@ void fp_gpu(lbann_comm& comm,
     if (col_comm_rank != col_comm_root) {
       comm.gather(label_vals.data().get(), label_vals.size(),
                   col_comm_root, col_comm, sync_info);
-      comm.gather(label_inds.data().get(), label_inds.size(),
+      comm.gather(label_inds.data().get(),label_inds.size(),
                   col_comm_root, col_comm, sync_info);
     } else {
       gathered_label_vals.resize(label_vals.size() * col_comm_size);
@@ -361,7 +361,7 @@ void fp_gpu(lbann_comm& comm,
       prediction_inds.data().get(), label_inds.data().get(),
       local_loss.Buffer(), local_loss.LDim());
   }
-  
+
 }
 
 } // namespace

--- a/src/layers/loss/top_k_categorical_accuracy.cpp
+++ b/src/layers/loss/top_k_categorical_accuracy.cpp
@@ -126,15 +126,13 @@ void fp_cpu(lbann_comm& comm,
   // Find top-k entries in each column of global prediction matrix
   if (col_comm_size > 1) {
     if (col_comm_rank != col_comm_root) {
-      comm.gather(reinterpret_cast<El::byte*>(top_entries.data()),
-                  top_entries.size() * sizeof(entry),
-                  col_comm_root,
-                  col_comm, El::SyncInfo<El::Device::CPU>{});
+      comm.gather(top_entries.data(), top_entries.size(),
+                  col_comm_root, col_comm,
+                  El::SyncInfo<El::Device::CPU>{});
     } else {
       std::vector<entry> global_top_entries(col_comm_size * local_width * k);
-      comm.gather(reinterpret_cast<El::byte*>(top_entries.data()),
-                  top_entries.size() * sizeof(entry),
-                  reinterpret_cast<El::byte*>(global_top_entries.data()),
+      comm.gather(top_entries.data(), top_entries.size(),
+                  global_top_entries.data(),
                   col_comm, El::SyncInfo<El::Device::CPU>{});
 #pragma omp parallel for
       for (El::Int col = 0; col < local_width; ++col) {


### PR DESCRIPTION
The LBANN communicator's gather function now reinterprets its data as `El::byte` (i.e.. `unsigned char`) before calling Hydrogen's MPI wrapper function. This allows it to easily handle custom structs, like those used in the top-k categorical accuracy layer. This approach can also be used for allgather, bcast, and scatter.

I've also made some changes for style conformity, mostly replacing camel case with underscores.