### PR TITLE
Disabling CUDA-aware MVAPICH2 in experiment script

### DIFF
--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -366,7 +366,6 @@ echo "${MPIRUN} hostname > ${NODE_LIST}"                >> ${BATCH_SCRIPT}
 echo "sort --unique --output=${NODE_LIST} ${NODE_LIST}" >> ${BATCH_SCRIPT}
 case ${USE_GPU} in
     YES|yes|TRUE|true|ON|on|1)
-        echo "export MV2_USE_CUDA=1"                    >> ${BATCH_SCRIPT}
         echo "export MV2_CUDA_ALLGATHER_FGP=0"          >> ${BATCH_SCRIPT}
         ;;
 esac


### PR DESCRIPTION
CUDA-aware MPI is no longer the build script default, so we shouldn't enable it in our experiment script. This should close #595 (for future reference, that issue includes discussion on the advantages/disadvantages of CUDA-aware MPI and Aluminum's CUDA-MPI backend).