### PR TITLE
Removing broken option for FC layers

### DIFF
--- a/model_zoo/models/alexnet/model_alexnet.prototext
+++ b/model_zoo/models/alexnet/model_alexnet.prototext
@@ -301,7 +301,7 @@ model {
     parents: "drop7"
     data_layout: "model_parallel"
     fully_connected {
-      num_neurons_is_num_labels: true
+      num_neurons: 1000
       has_bias: false
     }
   }
@@ -317,7 +317,7 @@ model {
     name: "cross_entropy"
     parents: "prob labels"
     data_layout: "data_parallel"
-    cross_entropy {}    
+    cross_entropy {}
   }
 
   layer {

--- a/model_zoo/models/siamese/finetune-cub/model_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub.prototext
@@ -545,7 +545,7 @@ model {
     fully_connected {
       # The number of outputs specific to the dataset used.
       # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
+      num_neurons: 200
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
@@ -688,7 +688,7 @@ model {
     fully_connected {
       # The number of outputs specific to the dataset used.
       # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
+      num_neurons: 200
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
@@ -940,7 +940,7 @@ model {
     fully_connected {
       # The number of outputs specific to the dataset used.
       # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
+      num_neurons: 200
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -1533,7 +1533,7 @@ model {
     children: "prob"
     data_layout: "data_parallel"
     fully_connected {
-      num_neurons_is_num_labels: true
+      num_neurons: 20
       has_bias: false
     }
     weights: "fc9_linearity fc9_bias"

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -60,39 +60,6 @@ void setup_parents_and_children(lbann_comm* comm,
   }
 }
 
-void setup_fc_num_neurons(
-  std::vector<Layer*>& layers,
-  const std::map<execution_mode, generic_data_reader *>& data_readers,
-  const lbann_data::Model& proto_model) {
-  std::stringstream err;
-  for (int i=0; i<proto_model.layer_size(); ++i) {
-    const auto& proto_layer = proto_model.layer(i);
-    Layer* l = layers[i];
-    if (proto_layer.has_fully_connected()) {
-      bool set_num_neurons = proto_layer.fully_connected().num_neurons_is_num_labels();
-      if (set_num_neurons) {
-        for (auto t : data_readers) {
-          if (t.second != nullptr && t.second->get_role() == "train") {
-            std::vector<int> dims(1, t.second->get_num_labels());
-            auto&& fc_dp_cpu = dynamic_cast<fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::CPU>*>(l);
-            auto&& fc_mp_cpu = dynamic_cast<fully_connected_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>*>(l);
-#ifdef LBANN_HAS_GPU
-            auto&& fc_dp_gpu = dynamic_cast<fully_connected_layer<data_layout::DATA_PARALLEL, El::Device::GPU>*>(l);
-            auto&& fc_mp_gpu = dynamic_cast<fully_connected_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>*>(l);
-#endif // LBANN_HAS_GPU
-            if (fc_dp_cpu != nullptr) { fc_dp_cpu->set_output_dims(dims); }
-            if (fc_mp_cpu != nullptr) { fc_mp_cpu->set_output_dims(dims); }
-#ifdef LBANN_HAS_GPU
-            if (fc_dp_gpu != nullptr) { fc_dp_gpu->set_output_dims(dims); }
-            if (fc_mp_gpu != nullptr) { fc_mp_gpu->set_output_dims(dims); }
-#endif // LBANN_HAS_GPU
-          }
-        }
-      }
-    }
-  }
-}
-
 /** Setup paired input layers for target layers. */
 void setup_target_pointers(lbann_comm* comm,
                            std::vector<Layer*>& layers,
@@ -274,9 +241,6 @@ std::vector<Layer*> construct_layer_graph(lbann_comm* comm,
   setup_parents_and_children(comm, layers, names_to_layers, proto_model);
   setup_target_pointers(comm, layers, names_to_layers, proto_model);
   setup_unpooling_pointers(comm, layers, names_to_layers, proto_model);
-
-  // Optionally Set num_neurons = num_labels
-  setup_fc_num_neurons(layers, data_readers, proto_model);
 
   // Return layer list
   return layers;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -98,9 +98,9 @@ message Reader {
   int32 num_image_srcs = 114; // data_reader_multi_images
 
   //------------- start of only for partitioned data sets ------------------
-  bool is_partitioned = 300; 
+  bool is_partitioned = 300;
   double partition_overlap = 301;
-  int32 partition_mode = 302;  
+  int32 partition_mode = 302;
        // 1 - share a portion of your data with two neighbors;
        // 2 - there's a set of overlap indices that are common to all models
   //------------- end of only for partitioned data sets ------------------
@@ -476,8 +476,8 @@ message Callback {
 }
 
 message CallbackLTFB {
-  int64 round_size = 1; 
-  bool increasing_metric_mode = 2; //Expectation for a good tournament metric: increasing (true) is default 
+  int64 round_size = 1;
+  bool increasing_metric_mode = 2; //Expectation for a good tournament metric: increasing (true) is default
   string eval_metrics = 3; //eval metrics to use for tournament, at least 1 metric has to be provided
   string weights_tosend = 4; //list of weights to transfer between model, default is all weights (classic LTFB)
 }
@@ -1219,7 +1219,6 @@ message FullyConnected {
   double l2_regularization_factor = 5; //default: 0
   double group_lasso_regularization_factor = 6; //default: 0
   bool transpose = 7;
-  bool num_neurons_is_num_labels = 8;
 
   bool get_input_dimension_from_reader = 9;
   bool get_image_and_scalar_dimension_from_reader = 10;
@@ -1285,7 +1284,7 @@ message Target {
 
 message TargetReconstruction {
 }
-  
+
 //////////////////
 // Image Layers //
 //////////////////


### PR DESCRIPTION
PR #685 adds a check to the prototext parser so that a fully-connected layer's output size must be known at instantiation time. This breaks the prototext option `num_neurons_is_num_labels`, which sets the output size based on the data reader's label size. We have two options:
- Remove the check (https://github.com/LLNL/lbann/blob/cabacb1a81b18795df617cac9b513ab01d3e9d66/src/proto/factories/layer_factory.cpp#L154).
- Remove the `num_neurons_is_num_labels` option.

This PR does the second, mostly because it was the fastest fix. There are still a few Siamese models that keep the `num_neurons_is_num_labels` option, but those are slated to be removed in PR #680.

In the future, I think it would be worthwhile implementing functionality so that we can provide any layer's output dimensions as a hint for any subsequent layer's output dimensions (see issue #320). This is more general and would be helpful for other layers that require user-specified output dimensions (like constant layers). It would also allow us to avoid messing around with data readers.
