### PR TITLE
Dilated and grouped convolutions

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -57,6 +57,14 @@ class base_convolution_layer : public learning_layer {
   std::vector<int> m_pads;
   /** Convolution strides. */
   std::vector<int> m_strides;
+  /** Convolution dilations. */
+  std::vector<int> m_dilations;
+  /** Convolution groups.
+   *  The channels are split into this many independent groups when performing
+   *  convolution. The default convolution operation has one group, and a
+   *  depthwise convolution has as many groups as there are input channels.
+   */
+  int m_num_groups;
 
   /** Scaling factor for bias term.
    *  If the scaling factor is zero, bias is not applied.
@@ -95,12 +103,16 @@ class base_convolution_layer : public learning_layer {
                          const std::vector<int> conv_dims,
                          const std::vector<int> pads,
                          const std::vector<int> strides,
+                         const std::vector<int> dilations,
+                         int groups,
                          bool has_bias)
     : learning_layer(comm),
       m_kernel_dims(conv_dims),
       m_kernel_size(0),
       m_pads(pads),
       m_strides(strides),
+      m_dilations(dilations),
+      m_num_groups(groups),
       m_bias_scaling_factor(has_bias ? DataType(1) : DataType(0)),
       m_kernel_gradient(this->m_comm->get_model_grid()),
       m_bias_gradient(this->m_comm->get_model_grid())
@@ -112,17 +124,40 @@ class base_convolution_layer : public learning_layer {
 #endif // LBANN_HAS_CUDNN
   {
 
+    bool nonunit_dilation = false;
+    for (const auto& d : m_dilations) {
+      if (d != 1) {
+        nonunit_dilation = true;
+        break;
+      }
+    }
+    if (Dev != El::Device::GPU && nonunit_dilation) {
+      std::stringstream err;
+      err << "layer \"" << get_name() << "\" "
+          << "has nonunit dilation which is only supported on GPUs";
+      LBANN_ERROR(err.str());
+    }
+    if (Dev != El::Device::GPU && m_num_groups > 1) {
+      std::stringstream err;
+      err << "layer \"" << get_name() << "\" "
+          << "has nonunit groups " << m_num_groups
+          << " which is only supported on GPUs";
+      LBANN_ERROR(err.str());
+    }
+
     // Check dimensions of convolution parameters
     if ((int) m_kernel_dims.size() != num_data_dims
         || (int) m_pads.size() != num_data_dims
-        || (int) m_strides.size() != num_data_dims) {
+        || (int) m_strides.size() != num_data_dims
+        || (int) m_dilations.size() != num_data_dims) {
       std::stringstream err;
       err << "layer \"" << get_name() << "\" "
           << "has an invalid number of convolution parameters "
           << "(expected " << num_data_dims << " parameters, "
           << "conv_dims has " << m_kernel_dims.size() << ", "
           << "pads has " << m_pads.size() << ", "
-          << "strides has " << m_strides.size() << ")";
+          << "strides has " << m_strides.size() << ", "
+          << "dilations has " << m_dilations.size() << ")";
       LBANN_ERROR(err.str());
     }
 
@@ -137,6 +172,8 @@ class base_convolution_layer : public learning_layer {
       m_kernel_size(other.m_kernel_size),
       m_pads(other.m_pads),
       m_strides(other.m_strides),
+      m_dilations(other.m_dilations),
+      m_num_groups(other.m_num_groups),
       m_bias_scaling_factor(other.m_bias_scaling_factor),
       m_kernel_gradient(other.m_kernel_gradient),
       m_bias_gradient(other.m_bias_gradient)
@@ -164,6 +201,8 @@ class base_convolution_layer : public learning_layer {
     m_kernel_size = other.m_kernel_size;
     m_pads = other.m_pads;
     m_strides = other.m_strides;
+    m_dilations = other.m_dilations;
+    m_num_groups = other.m_num_groups;
     m_bias_scaling_factor = other.m_bias_scaling_factor;
     m_kernel_gradient = other.m_kernel_gradient;
     m_bias_gradient = other.m_bias_gradient;
@@ -300,16 +339,16 @@ class base_convolution_layer : public learning_layer {
                                            m_kernel_dims.data()));
 
     // Set convolution descriptor
-    // Note: upscales are not supported as of cuDNN v5.1
     CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&m_convolution_cudnn_desc));
-    std::vector<int> upscales(output_dims.size() - 1, 1);
     CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(m_convolution_cudnn_desc,
                                                 m_pads.size(),
                                                 m_pads.data(),
                                                 m_strides.data(),
-                                                upscales.data(),
+                                                m_dilations.data(),
                                                 CUDNN_CROSS_CORRELATION,
                                                 cudnn::get_data_type()));
+    CHECK_CUDNN(cudnnSetConvolutionGroupCount(m_convolution_cudnn_desc,
+                                              m_num_groups));
 
     // Set bias tensor descriptor
     std::vector<int> bias_dims(output_dims.size() + 1, 1);
@@ -956,22 +995,27 @@ class base_convolution_layer : public learning_layer {
                                                   nullptr,
                                                   &mode,
                                                   &data_type));
-      std::vector<int> pads(num_dims), strides(num_dims), upscales(num_dims);
+      std::vector<int> pads(num_dims), strides(num_dims), dilations(num_dims);
       CHECK_CUDNN(cudnnGetConvolutionNdDescriptor(src,
                                                   num_dims,
                                                   &num_dims,
                                                   pads.data(),
                                                   strides.data(),
-                                                  upscales.data(),
+                                                  dilations.data(),
                                                   &mode,
                                                   &data_type));
+      int num_groups;
+      CHECK_CUDNN(cudnnGetConvolutionGroupCount(src,
+                                                &num_groups));
       CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(dst,
                                                   num_dims,
                                                   pads.data(),
                                                   strides.data(),
-                                                  upscales.data(),
+                                                  dilations.data(),
                                                   mode,
                                                   data_type));
+      CHECK_CUDNN(cudnnSetConvolutionGroupCount(dst,
+                                                num_groups));
     }
 
   }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -172,14 +172,22 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& params = proto_layer.convolution();
     const auto& num_output_channels = params.num_output_channels();
     const auto& bias = params.has_bias();
+    int num_groups = params.num_groups();
+    if (num_groups == 0) {
+      num_groups = 1;
+    }
     if (params.has_vectors()) {
       const auto& dims = parse_list<int>(params.conv_dims());
       const auto& pads = parse_list<int>(params.conv_pads());
       const auto& strides = parse_list<int>(params.conv_strides());
+      std::vector<int> dilations = parse_list<int>(params.conv_dilations());
+      if (dilations.empty()) {
+        dilations.resize(dims.size(), 1);
+      }
       if (layout == data_layout::DATA_PARALLEL) {
         return new convolution_layer<data_layout::DATA_PARALLEL, Dev>(
                      comm, dims.size(), num_output_channels,
-                     dims, pads, strides, bias
+                     dims, pads, strides, dilations, num_groups, bias
                    );
       }
     } else {
@@ -187,10 +195,14 @@ Layer* construct_layer(lbann_comm* comm,
       const auto& dim = params.conv_dims_i();
       const auto& pad = params.conv_pads_i();
       const auto& stride = params.conv_strides_i();
+      int dilation = params.conv_dilations_i();
+      if (dilation == 0) {
+        dilation = 1;
+      }
       if (layout == data_layout::DATA_PARALLEL) {
         return new convolution_layer<data_layout::DATA_PARALLEL, Dev>(
                      comm, num_dims, num_output_channels,
-                     dim, pad, stride, bias
+                     dim, pad, stride, dilation, num_groups, bias
                    );
       }
     }
@@ -199,6 +211,10 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& params = proto_layer.deconvolution();
     const auto& bias = params.has_bias();
     int num_output_channels = params.num_output_channels();
+    int num_groups = params.num_groups();
+    if (num_groups == 0) {
+      num_groups = 1;
+    }
     if (proto_layer.num_neurons_from_data_reader()) {
       const auto dr  = lbann::peek_map(data_readers, execution_mode::training);
       if (!dr) {
@@ -210,10 +226,14 @@ Layer* construct_layer(lbann_comm* comm,
       const auto& dims = parse_list<int>(params.conv_dims());
       const auto& pads = parse_list<int>(params.conv_pads());
       const auto& strides = parse_list<int>(params.conv_strides());
+      std::vector<int> dilations = parse_list<int>(params.conv_dilations());
+      if (dilations.empty()) {
+        dilations.resize(dims.size(), 1);
+      }
       if (layout == data_layout::DATA_PARALLEL) {
         return new deconvolution_layer<data_layout::DATA_PARALLEL, Dev>(
                      comm, dims.size(), num_output_channels,
-                     dims, pads, strides, bias
+                     dims, pads, strides, dilations, num_groups, bias
                    );
       }
     } else {
@@ -221,10 +241,14 @@ Layer* construct_layer(lbann_comm* comm,
       const auto& dim = params.conv_dims_i();
       const auto& pad = params.conv_pads_i();
       const auto& stride = params.conv_strides_i();
+      int dilation = params.conv_dilations_i();
+      if (dilation == 0) {
+        dilation = 1;
+      }
       if (layout == data_layout::DATA_PARALLEL) {
         return new deconvolution_layer<data_layout::DATA_PARALLEL, Dev>(
                      comm, num_dims, num_output_channels,
-                     dim, pad, stride, bias
+                     dim, pad, stride, dilation, num_groups, bias
                    );
       }
     }

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1232,6 +1232,7 @@ message FullyConnected {
 message Convolution {
   int64 num_dims = 1;
   int64 num_output_channels = 4;
+  int64 num_groups = 3;
 
   bool has_vectors = 2;
 
@@ -1239,11 +1240,13 @@ message Convolution {
   string conv_dims = 5; //should be space-separated list, e.g, "2 2 3"
   string conv_pads = 6;  //should be space-separated list, e.g, "2 2 3"
   string conv_strides = 7; //should be space-separated list, e.g, "2 2 3"
+  string conv_dilations = 8;  //should be space-separated list, e.g. "2 3 3"
 
   // these are used if has_vector = false
   int64 conv_dims_i = 50;
   int64 conv_pads_i = 60;
   int64 conv_strides_i = 70;
+  int64 conv_dilations_i = 80;
 
   string weight_initialization = 9;     //DEPRECATED
   bool has_bias = 10;                   //default: true
@@ -1254,6 +1257,7 @@ message Convolution {
 message Deconvolution {
   int64 num_dims = 1;
   int64 num_output_channels = 4;
+  int64 num_groups = 3;
 
   bool has_vectors = 2;
 
@@ -1261,11 +1265,13 @@ message Deconvolution {
   string conv_dims = 5; //should be space-separated list, e.g, "2 2 3"
   string conv_pads = 6;  //should be space-separated list, e.g, "2 2 3"
   string conv_strides = 7; //should be space-separated list, e.g, "2 2 3"
+  string conv_dilations = 8;  //should be space-separated list, e.g. "2 3 3"
 
   // these are used if has_vector = false
   int64 conv_dims_i = 50;
   int64 conv_pads_i = 60;
   int64 conv_strides_i = 70;
+  int64 conv_dilations_i = 80;
 
   string weight_initialization = 9;     //DEPRECATED
   bool has_bias = 10;                   //default: true


### PR DESCRIPTION
This adds support for dilated (atrous) and grouped (depthwise) convolutions to GPU convolution layers. Deconvolution and CPU convolution/deconvolution are not currently supported.

I did some quick tests with a modified ResNet-50 and didn't notice any issues on Sierra.

Depthwise-separable convolution can be implemented in the usual way by doing a depthwise convolution (with groups equal to the number of input channels) followed by a 1x1 convolution to mix.

Closes #475 and #476.