### PR TITLE
update data reader prototexts to explicitly set raw_num_channels.

### DIFF
--- a/model_zoo/models/jag/data_reader_jag_conduit.prototext
+++ b/model_zoo/models/jag/data_reader_jag_conduit.prototext
@@ -15,9 +15,9 @@ data_reader {
 
     split_jag_image_channels: true
 
-    # 1: JAG_Image,  2: JAG_Scalar,  3: JAG_Input
-    independent: [ { pieces: [ JAG_Image, JAG_Scalar ] }, { pieces: JAG_Input } ]
-    dependent: [ { pieces: JAG_Input } ]
+    # JAG_Image, JAG_Scalar, JAG_Input
+    independent: [ { pieces: [ JAG_Image, JAG_Scalar ] }, { pieces: [ JAG_Input ] } ]
+    dependent: [ { pieces: [ JAG_Input ] } ]
 
     jag_image_keys: ["(0.0, 0.0)/0.0", "(90.0, 0.0)/0.0", "(90.0, 78.0)/0.0"]
 

--- a/model_zoo/models/siamese/finetune-cub/data_reader_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/data_reader_cub.prototext
@@ -14,6 +14,7 @@ data_reader {
     image_preprocessor {
       raw_width: 256
       raw_height: 256
+      raw_num_channels: 3
 
       cropper {
         disable: false
@@ -57,6 +58,7 @@ data_reader {
     image_preprocessor {
       raw_width: 256
       raw_height: 256
+      raw_num_channels: 3
 
       cropper {
         disable: false

--- a/model_zoo/models/siamese/triplet/data_reader_triplet.prototext
+++ b/model_zoo/models/siamese/triplet/data_reader_triplet.prototext
@@ -14,6 +14,7 @@ data_reader {
     image_preprocessor {
       raw_width: 110
       raw_height: 110
+      raw_num_channels: 3
 
       cropper {
         disable: false
@@ -61,6 +62,7 @@ data_reader {
     image_preprocessor {
       raw_width: 110
       raw_height: 110
+      raw_num_channels: 3
 
       cropper {
         disable: false


### PR DESCRIPTION
The the default of raw_num_channels is now 1 (It was change a while back from 3). Therefore, it is necessary to set it if expecting multi-channel images especially when no colorizer or decolorizer is set as with Siamese data readers.