### PR TITLE
some quick fixes for lbann versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,26 +37,45 @@ endif ()
 # Version setup
 #
 
-# Check to see if we are in a git repo
-execute_process(
-  COMMAND git rev-parse --is-inside-work-tree
-  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-  OUTPUT_VARIABLE GIT_REPO
-  OUTPUT_STRIP_TRAILING_WHITESPACE)
+set(LBANN_VERSION_MAJOR 0)
+set(LBANN_VERSION_MINOR 95)
 
-if (GIT_REPO)
-  # Get the git version so that we can embed it into the executable
+set(LBANN_VERSION "${LBANN_VERSION_MAJOR}.${LBANN_VERSION_MINOR}")
+
+# Check to see if we are in a git repo
+find_program(__GIT_EXECUTABLE git)
+mark_as_advanced(__GIT_EXECUTABLE)
+if (__GIT_EXECUTABLE)
+
   execute_process(
-    COMMAND git --git-dir .git describe --abbrev=7 --dirty --always --tags
-    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-    OUTPUT_VARIABLE GIT_VERSION
+    COMMAND ${__GIT_EXECUTABLE} rev-parse --is-inside-work-tree
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE __BUILDING_FROM_GIT_SOURCES
     OUTPUT_STRIP_TRAILING_WHITESPACE)
-  set(${UPPER_PROJECT_NAME}_VERSION ${GIT_VERSION}
-    CACHE STRING "LBANN's version string")
-else ()
-  set(${UPPER_PROJECT_NAME}_VERSION v0.95
-    CACHE STRING "LBANN's version string")
-endif (GIT_REPO)
+
+  if (__BUILDING_FROM_GIT_SOURCES)
+    # Get the git version so that we can embed it into the executable
+    execute_process(
+      COMMAND ${__GIT_EXECUTABLE} rev-parse --show-toplevel
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      OUTPUT_VARIABLE __GIT_TOPLEVEL_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${__GIT_EXECUTABLE} rev-parse --git-dir
+      WORKING_DIRECTORY "${__GIT_TOPLEVEL_DIR}"
+      OUTPUT_VARIABLE __GIT_GIT_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    execute_process(
+      COMMAND ${__GIT_EXECUTABLE} --git-dir "${__GIT_GIT_DIR}" describe
+      --abbrev=7 --always --dirty --tags
+      WORKING_DIRECTORY "${__GIT_TOPLEVEL_DIR}"
+      OUTPUT_VARIABLE __GIT_DESCRIBE_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    set(LBANN_GIT_VERSION "${__GIT_DESCRIBE_VERSION}"
+      CACHE STRING "LBANN's version string as told by git.")
+  endif (__BUILDING_FROM_GIT_SOURCES)
+endif (__GIT_EXECUTABLE)
 
 if (CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
   set(LBANN_GNU_LINUX TRUE)

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -9,6 +9,7 @@
 
 /* Version string for LBANN */
 #define LBANN_VERSION @LBANN_VERSION@
+#define LBANN_GIT_VERSION @LBANN_GIT_VERSION@
 
 /* Defined if LBANN is in debug mode */
 #cmakedefine LBANN_DEBUG

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -9,7 +9,7 @@
 
 /* Version string for LBANN */
 #define LBANN_VERSION @LBANN_VERSION@
-#define LBANN_GIT_VERSION @LBANN_GIT_VERSION@
+#cmakedefine LBANN_GIT_VERSION @LBANN_GIT_VERSION@
 
 /* Defined if LBANN is in debug mode */
 #cmakedefine LBANN_DEBUG

--- a/cmake/modules/SetupElemental.cmake
+++ b/cmake/modules/SetupElemental.cmake
@@ -8,39 +8,13 @@
 # Hydrogen, this file is no longer necessary as it's just one
 # find_package() line.
 
-find_package(Hydrogen NO_MODULE
+set(_MIN_H_VERSION 1.0.0)
+find_package(Hydrogen ${_MIN_H_VERSION} NO_MODULE
   HINTS ${Hydrogen_DIR} ${HYDROGEN_DIR} $ENV{Hydrogen_DIR} $ENV{HYDROGEN_DIR}
   PATH_SUFFIXES lib/cmake/hydrogen
-  NO_DEFUALT_PATH)
-find_package(Hydrogen NO_MODULE)
-
-if (Hydrogen_FOUND)
-  message(STATUS "Found Hydrogen: ${Hydrogen_DIR}")
-  set(LBANN_HAS_HYDROGEN TRUE)
-else ()
-  set(LBANN_HAS_HYDROGEN FALSE)
-
-  find_package(Elemental NO_MODULE
-    PATH_SUFFIXES lib/cmake/elemental)
-
-  if (Elemental_FOUND)
-    set(HYDROGEN_LIBRARIES "${Elemental_LIBRARIES}")
-    message(STATUS "Found Elemental: ${Elemental_DIR}")
-
-    if (TARGET El)
-      set_property(TARGET El PROPERTY
-        INTERFACE_INCLUDE_DIRECTORIES ${Elemental_INCLUDE_DIRS})
-    endif ()
-
-    set(LBANN_HAS_ELEMENTAL TRUE)
-  else ()
-    message(FATAL_ERROR "Neither Hydrogen nor Elemental was found! "
-      "Try setting Hydrogen_DIR or Elemental_DIR and try again!")
-
-    set(LBANN_HAS_ELEMENTAL FALSE)
-  endif (Elemental_FOUND)
-endif (Hydrogen_FOUND)
-
-if (NOT LBANN_HAS_HYDROGEN AND NOT LBANN_HAS_ELEMENTAL)
-  message(FATAL_ERROR "LBANN requires Hydrogen or Elemental.")
+  NO_DEFAULT_PATH)
+if (NOT Hydrogen_FOUND)
+  find_package(Hydrogen ${_MIN_H_VERSION} NO_MODULE REQUIRED)
 endif ()
+
+set(LBANN_HAS_HYDROGEN TRUE)

--- a/cmake/modules/SetupProtobuf.cmake
+++ b/cmake/modules/SetupProtobuf.cmake
@@ -14,7 +14,7 @@ if (${PROJECT_NAME}_USE_PROTOBUF_MODULE)
     list(APPEND CMAKE_INCLUDE_PATH ${PROTOBUF_DIR}/include)
     list(APPEND CMAKE_PREFIX_PATH ${PROTOBUF_DIR})
   endif ()
-  
+
   # At this point, throw an error if Protobuf is not found.
   find_package(Protobuf "${PROTOBUF_MIN_VERSION}" MODULE)
 
@@ -26,9 +26,19 @@ if (${PROJECT_NAME}_USE_PROTOBUF_MODULE)
   endif ()
 
 else ()
-  find_package(Protobuf "${PROTOBUF_MIN_VERSION}" CONFIG 
-    HINTS "${PROTOBUF_DIR}/lib64/cmake/protobuf" 
-    "${PROTOBUF_DIR}/lib/cmake/protobuf")
+  set(protobuf_MODULE_COMPATIBLE ON)
+  set(protobuf_BUILD_SHARED_LIBS ON)
+
+  find_package(Protobuf "${PROTOBUF_MIN_VERSION}" CONFIG
+    HINTS
+    "${Protobuf_DIR}/lib64/cmake/protobuf"
+    "${PROTOBUF_DIR}/lib64/cmake/protobuf"
+    "${Protobuf_DIR}/lib/cmake/protobuf"
+    "${PROTOBUF_DIR}/lib/cmake/protobuf"
+    "$ENV{Protobuf_DIR}/lib64/cmake/protobuf"
+    "$ENV{PROTOBUF_DIR}/lib64/cmake/protobuf"
+    "$ENV{Protobuf_DIR}/lib/cmake/protobuf"
+    "$ENV{PROTOBUF_DIR}/lib/cmake/protobuf")
 endif ()
 
 if(NOT PROTOBUF_FOUND AND NOT Protobuf_FOUND)


### PR DESCRIPTION
Also verifying Hydrogen's version, and using protobuf correctly.

This sets LBANN_VERSION to just be `0.95`. It also creates a version called "LBANN_GIT_STRING", which is the jumbly weird `git describe` output. This is omitted if `git` is not found or the source code is not in a git repo.

Moreover it explicitly requires `1.0` series of Hydrogen.

Finally it ensures that `protobuf_MODULE_COMPATIBILITY=ON` if using the `CONFIG` version of `find_package(protobuf)`.