### PR TITLE
prevent insource builds for lbann and superbuild

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,15 @@ cmake_minimum_required(VERSION 3.8)
 
 project(LBANN CXX)
 
+# Prevent in-source builds
+if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(FATAL_ERROR
+    "In-source build attempted; please clean the CMake cache and then "
+    "switch to an out-of-source build, e.g.,\n"
+    "rm -rf CMakeCache.txt CMakeFiles/\nmkdir build && "
+    "cd build && cmake <options> ..\n")
+endif ()
+
 # Add CMake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -7,6 +7,27 @@ message("\nWelcome to the LBANN SuperBuild system.\n\n"
 # CXX is always required
 project(LBANN_SuperBuild CXX)
 
+if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(FATAL_ERROR
+    "You have attempted an in-source build of LBANN.\n"
+    "Please clean the CMake cache and switch to an out-of-source build.\n"
+    "Example:\n"
+    "rm -rf CMakeCache.txt CMakeFiles\n"
+    "mkdir build && cd build\n"
+    "cmake <lbann options> ..\n")
+endif ()
+
+get_filename_component(LBANN_SRC_DIR "${PROJECT_SOURCE_DIR}" PATH)
+if (LBANN_SRC_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(FATAL_ERROR
+    "You have attempted a superbuild in the LBANN source directory.\n"
+    "Please clean the CMake cache and switch to an out-of-source build.\n"
+    "Example:\n"
+    "rm -rf CMakeCache.txt CMakeFiles\n"
+    "mkdir build && cd build\n"
+    "cmake <superbuild options> ../superbuild\n")
+endif ()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 option(LBANN_SB_BUILD_ALUMINUM "Pull and build Aluminum from Github" OFF)


### PR DESCRIPTION
This prevents LBANN builds in LBANN_ROOT and it prevents superbuilds in LBANN_ROOT and LBANN_ROOT/superbuild.