### PR TITLE
Tune host-transfer use for Sierra

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -165,11 +165,14 @@ void lbann_comm::allreduce(AbsMat& m,
     t = std::type_index(typeid(::Al::NCCLBackend));
     // If available, use the MPI-CUDA backend for small matrices.
 #ifdef AL_HAS_MPI_CUDA
-    // Based on runs on Pascal and Ray.
-    /*if ((El::mpi::Size(c) > 4 && local_size <= 8192) ||
-        (El::mpi::Size(c) >= 16 && local_size <= 32768)) {
+    // Tuned for Sierra.
+    if ((El::mpi::Size(c) >= 64 && local_size <= 4096) ||
+        (El::mpi::Size(c) >= 128 && local_size <= 8192) ||
+        (El::mpi::Size(c) >= 256 && local_size <= 32768) ||
+        (El::mpi::Size(c) >= 512 && local_size <= 65536) ||
+        (El::mpi::Size(c) >= 2048 && local_size <= 262144)) {
       t = std::type_index(typeid(::Al::MPICUDABackend));
-      }*/
+    }
 #endif  // AL_HAS_MPI_CUDA
 #elif defined(AL_HAS_MPI_CUDA)
     t = std::type_index(typeid(::Al::MPICUDABackend));
@@ -245,11 +248,14 @@ void lbann_comm::nb_allreduce(AbsMat& m,
     t = std::type_index(typeid(::Al::NCCLBackend));
     // If available, use the MPI-CUDA backend for small matrices.
 #ifdef AL_HAS_MPI_CUDA
-    // Based on runs on Pascal and Ray.
-    /*if ((El::mpi::Size(c) > 4 && local_size <= 8192) ||
-        (El::mpi::Size(c) >= 16 && local_size <= 32768)) {
+    // Tuned for Sierra.
+    if ((El::mpi::Size(c) >= 64 && local_size <= 4096) ||
+        (El::mpi::Size(c) >= 128 && local_size <= 8192) ||
+        (El::mpi::Size(c) >= 256 && local_size <= 32768) ||
+        (El::mpi::Size(c) >= 512 && local_size <= 65536) ||
+        (El::mpi::Size(c) >= 2048 && local_size <= 262144)) {
       t = std::type_index(typeid(::Al::MPICUDABackend));
-      }*/
+    }
 #endif  // AL_HAS_MPI_CUDA
 #elif defined(AL_HAS_MPI_CUDA)
     t = std::type_index(typeid(::Al::MPICUDABackend));


### PR DESCRIPTION
This updates the hard-coded tuning of the MPI-CUDA backend for Sierra and Lassen. (It had previously been disabled completely.)

Long-term we should have a unified interface for specifying such tuning parameters for a system without hard-coding them, but that's a bridge too far right now. 😉