### PR TITLE
Channel-wise mean layer

### DIFF
--- a/include/lbann/layers/misc/CMakeLists.txt
+++ b/include/lbann/layers/misc/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
+  covariance.hpp
   variance.hpp
+  channelwise_mean.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/misc/channelwise_mean.hpp
+++ b/include/lbann/layers/misc/channelwise_mean.hpp
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_MISC_CHANNELWISE_MEAN_HPP_INCLUDED
+#define LBANN_LAYERS_MISC_CHANNELWISE_MEAN_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+
+namespace lbann {
+
+/** Channel-wise mean layer. */
+template <data_layout Layout = data_layout::DATA_PARALLEL, El::Device Device = El::Device::CPU>
+class channelwise_mean_layer : public Layer {
+public:
+
+  channelwise_mean_layer(lbann_comm *comm)
+    : Layer(comm) {
+    static_assert(Layout == data_layout::DATA_PARALLEL,
+                  "channelwise_mean_layer only supports "
+                  "data-parallel data layout");
+    if (comm->am_model_master()) {
+      LBANN_WARNING("channelwise_mean_layer is experimental "
+                    "and may be deprecated at any time");
+    }
+  }
+
+  channelwise_mean_layer* copy() const override { return new channelwise_mean_layer(*this); }
+  std::string get_type() const override { return "channel-wise mean"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
+
+protected:
+
+  void setup_dims() override {
+    Layer::setup_dims();
+    const auto& input_dims = get_input_dims();
+    set_output_dims({input_dims[0]});
+  }
+
+  void fp_compute() override;
+  void bp_compute() override;
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_MISC_CHANNELWISE_MEAN_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -113,6 +113,7 @@
 /// Miscellaneous Layers
 #include "lbann/layers/misc/covariance.hpp"
 #include "lbann/layers/misc/variance.hpp"
+#include "lbann/layers/misc/channelwise_mean.hpp"
 
 /// Data Readers
 #include "lbann/data_readers/data_reader_imagenet.hpp"

--- a/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
+++ b/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
@@ -1,0 +1,77 @@
+model {
+  data_layout: "data_parallel"
+  mini_batch_size: 11
+  block_size: 256
+  num_epochs: 0
+  num_parallel_readers: 0
+  procs_per_model: 0
+
+  ###################################################
+  # Objective function
+  ###################################################
+
+  objective_function {
+    layer_term { layer: "l2" }
+  }
+
+  ###################################################
+  # Callbacks
+  ###################################################
+  callback { print {} }
+  callback { timer {} }
+  callback {
+    gradient_check {
+      verbose: false
+      fail_on_error: true
+    }
+  }
+
+  ###################################################
+  # Layers
+  ###################################################
+
+  layer {
+    name: "data"
+    data_layout: "data_parallel"
+    input {
+      io_buffer: "partitioned"
+    }
+  }
+
+  # Input data
+  layer {
+    name: "x"
+    weights_layer {
+      dims: "2 3 2"
+    }
+    data_layout: "data_parallel"
+    weights: "x_vals"
+  }
+  weights {
+    name: "x_vals"
+    value_initializer {
+      values: "1.2 1 0.8 3.3 -0.2 -0.1 -0.9 -1.1 -2 -1.3 0.3 -1"
+    }
+  }
+
+  # Variations of channel-wise mean layer
+  layer {
+    parents: "x"
+    name: "channelwise_mean_data_parallel"
+    channelwise_mean {}
+    data_layout: "data_parallel"
+  }
+
+  # Combine into objective function
+  layer {
+    parents: "channelwise_mean_data_parallel"
+    name: "sum"
+    sum {}
+  }
+  layer {
+    parents: "sum"
+    name: "l2"
+    l2_norm2 {}
+  }
+
+}

--- a/src/layers/misc/CMakeLists.txt
+++ b/src/layers/misc/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_full_path(THIS_DIR_SOURCES
   covariance.cpp
   variance.cpp
+  channelwise_mean.cpp
   )
 
 if (LBANN_HAS_CUDA)
@@ -9,6 +10,7 @@ if (LBANN_HAS_CUDA)
   set_full_path(THIS_DIR_CU_SOURCES
     covariance.cu
     variance.cu
+    channelwise_mean.cu
     )
 endif ()
 

--- a/src/layers/misc/channelwise_mean.cpp
+++ b/src/layers/misc/channelwise_mean.cpp
@@ -37,6 +37,8 @@ void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
   auto& local_output = get_local_activations();
 
   // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
   const auto& input_dims = get_input_dims();
   const El::Int num_channels = input_dims[0];
   const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
@@ -67,6 +69,8 @@ void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
   auto& local_gradient_wrt_input = get_local_error_signals();
 
   // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
   const auto& input_dims = get_input_dims();
   const El::Int num_channels = input_dims[0];
   const El::Int channel_size = std::accumulate(input_dims.begin() + 1,

--- a/src/layers/misc/channelwise_mean.cpp
+++ b/src/layers/misc/channelwise_mean.cpp
@@ -1,0 +1,91 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/misc/channelwise_mean.hpp"
+
+namespace lbann {
+
+template <>
+void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+     ::fp_compute() {
+
+  // Local matrices
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const El::Int num_channels = input_dims[0];
+  const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
+                                               input_dims.end(),
+                                               1, std::multiplies<int>());
+  const auto& local_width = local_input.Width();
+
+  // Compute channel-wise mean
+#pragma omp parallel for collapse(2)
+  for (El::Int col = 0; col < local_width; ++col) {
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      DataType sum = 0;
+      for (El::Int i = 0; i < channel_size; ++i) {
+        sum += local_input(i + channel * channel_size, col);
+      }
+      local_output(channel, col) = sum / channel_size;
+    }
+  }
+
+}
+
+template <>
+void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+     ::bp_compute() {
+
+  // Local matrices
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const El::Int num_channels = input_dims[0];
+  const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
+                                               input_dims.end(),
+                                               1, std::multiplies<int>());
+  const auto& local_width = local_gradient_wrt_input.Width();
+
+  // Compute gradients
+#pragma omp parallel for collapse(2)
+  for (El::Int col = 0; col < local_width; ++col) {
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      const auto& dy = local_gradient_wrt_output(channel, col);
+      const auto& dx = dy / channel_size;
+      for (El::Int i = 0; i < channel_size; ++i) {
+        local_gradient_wrt_input(i + channel * channel_size, col) = dx;
+      }
+    }
+  }
+
+}
+
+} // namespace lbann

--- a/src/layers/misc/channelwise_mean.cu
+++ b/src/layers/misc/channelwise_mean.cu
@@ -119,6 +119,8 @@ void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
   auto& local_output = get_local_activations();
 
   // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
   const auto& input_dims = get_input_dims();
   const El::Int num_channels = input_dims[0];
   const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
@@ -152,6 +154,8 @@ void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
   auto& local_gradient_wrt_input = get_local_error_signals();
 
   // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
   const auto& input_dims = get_input_dims();
   const El::Int num_channels = input_dims[0];
   const El::Int channel_size = std::accumulate(input_dims.begin() + 1,

--- a/src/layers/misc/channelwise_mean.cu
+++ b/src/layers/misc/channelwise_mean.cu
@@ -1,0 +1,179 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/misc/channelwise_mean.hpp"
+
+namespace lbann {
+
+namespace {
+
+template <El::Int block_size>
+__global__ void mean_kernel(El::Int num_channels,
+                            El::Int channel_size,
+                            El::Int width,
+                            const DataType* __restrict__ input,
+                            El::Int input_ldim,
+                            DataType* __restrict__ output,
+                            El::Int output_ldim) {
+
+  // Indices
+  const El::Int tid = threadIdx.x;
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
+  const El::Int bidz = blockIdx.z;
+  const El::Int nthreadsx = blockDim.x * gridDim.x;
+  const El::Int nblocksy = gridDim.y;
+  const El::Int nblocksz = gridDim.z;
+
+  // Compute local contribution for each channel
+  for (El::Int col = bidz; col < width; col += nblocksz) {
+    for (El::Int channel = bidy; channel < num_channels; channel += nblocksy) {
+
+      // Sum for each thread
+      DataType private_sum = 0;
+      for (El::Int i = gidx; i < channel_size; i += nthreadsx) {
+        private_sum += input[i + channel*channel_size + col*input_ldim];
+      }
+
+      // Shared memory reduction to get sum for each block
+      /// @todo unroll loops
+      __shared__ DataType shared_sums[block_size];
+      shared_sums[tid] = private_sum;
+      for (El::Int stride = block_size / 2; stride > 0; stride /= 2) {
+        __syncthreads();
+        if (tid < stride) {
+          shared_sums[tid] += shared_sums[tid + stride];
+        }
+      }
+      if (tid == 0) {
+        cuda::atomic_add(&output[channel + col * output_ldim],
+                         shared_sums[0] / channel_size);
+      }
+
+    }
+  }
+
+}
+
+__global__ void backprop_kernel(El::Int num_channels,
+                                El::Int channel_size,
+                                El::Int width,
+                                const DataType* __restrict__ gradient_wrt_output,
+                                El::Int gradient_wrt_output_ldim,
+                                DataType* __restrict__ gradient_wrt_input,
+                                El::Int gradient_wrt_input_ldim) {
+
+  // Indices
+  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int bidy = blockIdx.y;
+  const El::Int bidz = blockIdx.z;
+  const El::Int nthreadsx = blockDim.x * gridDim.x;
+  const El::Int nblocksy = gridDim.y;
+  const El::Int nblocksz = gridDim.z;
+
+  // Compute local contribution for each channel
+  for (El::Int col = bidz; col < width; col += nblocksz) {
+    for (El::Int channel = bidy; channel < num_channels; channel += nblocksy) {
+      const auto& dy = gradient_wrt_output[channel + col * gradient_wrt_output_ldim];
+      const auto& dx = dy / channel_size;
+      for (El::Int i = gidx; i < channel_size; i += nthreadsx) {
+        gradient_wrt_input[i + channel*channel_size + col*gradient_wrt_input_ldim] = dx;
+      }
+    }
+  }
+
+}
+
+
+} // namespace
+
+template <>
+void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::fp_compute() {
+
+  // Local matrices
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const El::Int num_channels = input_dims[0];
+  const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
+                                               input_dims.end(),
+                                               1, std::multiplies<int>());
+  const auto& local_width = local_input.Width();
+
+  // Compute channel-wise mean
+  El::Zero(local_output);
+  if (!local_input.IsEmpty()) {
+    constexpr El::Int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_width;
+    mean_kernel<block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        num_channels, channel_size, local_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_output.Buffer(), local_output.LDim());
+  }
+
+}
+
+template <>
+void channelwise_mean_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::bp_compute() {
+  // Local matrices
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+
+  // Dimensions
+  const auto& input_dims = get_input_dims();
+  const El::Int num_channels = input_dims[0];
+  const El::Int channel_size = std::accumulate(input_dims.begin() + 1,
+                                               input_dims.end(),
+                                               1, std::multiplies<int>());
+  const auto& local_width = local_gradient_wrt_input.Width();
+
+  // Compute gradients
+  if (!local_gradient_wrt_input.IsEmpty()) {
+    constexpr El::Int block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_width;
+    backprop_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        num_channels, channel_size, local_width,
+        local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
+        local_gradient_wrt_input.Buffer(), local_gradient_wrt_input.LDim());
+  }
+
+}
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -599,6 +599,11 @@ Layer* construct_layer(lbann_comm* comm,
     const auto& params = proto_layer.variance();
     return new variance_layer<layout, Dev>(comm, params.biased());
   }
+  if (proto_layer.has_channelwise_mean()) {
+    if (layout == data_layout::DATA_PARALLEL) {
+      return new channelwise_mean_layer<data_layout::DATA_PARALLEL, Dev>(comm);
+    }
+  }
 
   // Throw exception if layer has not been constructed
   err << "could not construct layer " << proto_layer.name();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -926,6 +926,7 @@ message Layer {
    // Miscellaneous layers
    Covariance covariance = 600;
    Variance variance = 601;
+   ChannelwiseMean channelwise_mean = 602;
 
 }
 ///////////////////////
@@ -1309,3 +1310,4 @@ message Covariance {
 message Variance {
   bool biased = 1; //Whether to use a biased variance estimate
 }
+message ChannelwiseMean {}


### PR DESCRIPTION
This PR implements channel-wise mean reduction for data-parallel data, on both CPU and GPU. It is a temporary solution toward #474. At instantiation, the layer flashes a warning that its functionality may disappear at any time. Gradient checks come back clean.

The long-term goal is to replace it with a generic reduce_mean layer that can reduce tensors along arbitrary axes. A reduce_sum layer is the transpose of a broadcast layer, so this is on our pathway.