### PR TITLE
Confusion matrix callback

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_HEADERS
   callback_check_reconstruction_error.hpp
   callback_checknan.hpp
   callback_checksmall.hpp
+  callback_confusion_matrix.hpp
   callback_debug.hpp
   callback_debug_io.hpp
   callback_dump_activations.hpp

--- a/include/lbann/callbacks/callback_confusion_matrix.hpp
+++ b/include/lbann/callbacks/callback_confusion_matrix.hpp
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_CONFUSION_MATRIX_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_CONFUSION_MATRIX_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+
+namespace lbann {
+
+/** Compute confusion matrix.
+ *  Confusion matrices are saved in CSV files of the form
+ *  "<prefix><mode>.csv". The (i,j)-entry is the proportion of samples
+ *  with prediction i and label j. The prediction and label layers are
+ *  assumed to output one-hot vectors for each mini-batch sample.
+ */
+class lbann_callback_confusion_matrix : public lbann_callback {
+public:
+
+  lbann_callback_confusion_matrix(std::string prediction_layer,
+                                  std::string label_layer,
+                                  std::string prefix);
+  lbann_callback_confusion_matrix(const lbann_callback_confusion_matrix&);
+  lbann_callback_confusion_matrix& operator=(const lbann_callback_confusion_matrix&);
+  lbann_callback_confusion_matrix* copy() const override {
+    return new lbann_callback_confusion_matrix(*this);
+  }
+  std::string name() const override { return "confusion matrix"; }
+
+  void setup(model *m) override;
+
+  void on_epoch_begin(model *m) override      { reset_counts(*m); }
+  void on_epoch_end(model *m) override        { save_confusion_matrix(*m); }
+  void on_validation_begin(model *m) override { reset_counts(*m); }
+  void on_validation_end(model *m) override   { save_confusion_matrix(*m); }
+  void on_test_begin(model *m) override       { reset_counts(*m); }
+  void on_test_end(model *m) override         { save_confusion_matrix(*m); }
+  void on_batch_end(model *m) override          { update_counts(*m); }
+  void on_batch_evaluate_end(model *m) override { update_counts(*m); }
+
+private:
+
+  /** Name of prediction layer.
+   *  This layer is assumed to output one-hot vectors.
+   */
+  std::string m_prediction_layer;
+  /** Name of label layer.
+   *  This layer is assumed to output one-hot vectors.
+   */
+  std::string m_label_layer;
+  /** Prefix for output files. */
+  std::string m_prefix;
+
+  /** Confusion matrix counts.
+   *  Each vector should be interpreted as a num_classes x num_classes
+   *  matrix in row-major order. The (i,j)-entry is the number of
+   *  samples with prediction i and label j.
+   */
+  std::map<execution_mode,std::vector<El::Int>> m_counts;
+
+  /** "View" into prediction matrix.
+   *  This is a CPU matrix. If the prediction layer keeps data on GPU,
+   *  then this will be a matrix copy rather than a matrix view.
+   */
+  std::unique_ptr<AbsDistMat> m_predictions_v;
+  /** "View" into label matrix.
+   *  This is a CPU matrix. If the label layer keeps data on GPU or in
+   *  a different distribution than the prediction layer, then this
+   *  will be a matrix copy rather than a matrix view.
+   */
+  std::unique_ptr<AbsDistMat> m_labels_v;
+
+  /** Get prediction matrix. */
+  const AbsDistMat& get_predictions(const model& m) const;
+  /** Get label matrix. */
+  const AbsDistMat& get_labels(const model& m) const;
+
+  /** Reset confusion matrix counts. */
+  void reset_counts(const model& m);
+  /** Update confusion matrix counts.
+   *  Counts are updated with current mini-batch predictions and
+   *  labels.
+   */
+  void update_counts(const model& m);
+  /** Output confusion matrix to file. */
+  void save_confusion_matrix(const model& m);
+
+};
+
+} // namespace lbann
+
+#endif  // LBANN_CALLBACKS_CALLBACK_CONFUSION_MATRIX_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -174,6 +174,7 @@
 #include "lbann/callbacks/callback_gpu_memory_usage.hpp"
 #include "lbann/callbacks/callback_sync_layers.hpp"
 #include "lbann/callbacks/callback_sync_selected.hpp"
+#include "lbann/callbacks/callback_confusion_matrix.hpp"
 
 /// Weights and weight initializers
 #include "lbann/weights/weights.hpp"

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
   callback_checknan.cpp
   callback_checkpoint.cpp
   callback_checksmall.cpp
+  callback_confusion_matrix.cpp
   callback_debug.cpp
   callback_debug_io.cpp
   callback_dump_activations.cpp

--- a/src/callbacks/callback_confusion_matrix.cpp
+++ b/src/callbacks/callback_confusion_matrix.cpp
@@ -1,0 +1,235 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+///////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_confusion_matrix.hpp"
+
+namespace lbann {
+
+// ---------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------
+
+lbann_callback_confusion_matrix::lbann_callback_confusion_matrix(std::string prediction_layer,
+                                                                 std::string label_layer,
+                                                                 std::string prefix)
+  : lbann_callback(1, nullptr),
+    m_prediction_layer(std::move(prediction_layer)),
+    m_label_layer(std::move(label_layer)),
+    m_prefix(std::move(prefix)) {}
+
+lbann_callback_confusion_matrix::lbann_callback_confusion_matrix(const lbann_callback_confusion_matrix& other)
+  : lbann_callback(other),
+    m_prediction_layer(other.m_prediction_layer),
+    m_label_layer(other.m_label_layer),
+    m_prefix(other.m_prefix),
+    m_counts(other.m_counts),
+    m_predictions_v(other.m_predictions_v ? other.m_predictions_v->Copy() : nullptr),
+    m_labels_v(other.m_labels_v ? other.m_labels_v->Copy() : nullptr) {}
+
+lbann_callback_confusion_matrix& lbann_callback_confusion_matrix::operator=(const lbann_callback_confusion_matrix& other) {
+  lbann_callback::operator=(other);
+  m_prediction_layer = other.m_prediction_layer;
+  m_label_layer = other.m_label_layer;
+  m_prefix = other.m_prefix;
+  m_counts = other.m_counts;
+  m_predictions_v.reset(other.m_predictions_v ? other.m_predictions_v->Copy() : nullptr);
+  m_labels_v.reset(other.m_labels_v ? other.m_labels_v->Copy() : nullptr);
+  return *this;
+}
+
+// ---------------------------------------------------------
+// Setup
+// ---------------------------------------------------------
+
+void lbann_callback_confusion_matrix::setup(model* m) {
+  lbann_callback::setup(m);
+
+  // Initialize matrix views/copies
+  const auto& predictions = get_predictions(*m);
+  const auto& labels = get_labels(*m);
+  auto dist_data = predictions.DistData();
+  dist_data.device = El::Device::CPU;
+  m_predictions_v.reset(AbsDistMat::Instantiate(dist_data));
+  m_labels_v.reset(AbsDistMat::Instantiate(dist_data));
+
+  // Check output dimensions of prediction and label layers
+  if (predictions.Height() != labels.Height()) {
+    std::stringstream err;
+    err << "callback \"" << name() << "\" "
+        << "has prediction and label layers with different dimensions "
+        << "(prediction layer \"" << m_prediction_layer << "\" "
+        << "outputs " << predictions.Height() << " entries, "
+        << "label layer \"" << m_label_layer << "\" "
+        << "outputs " << labels.Height() << " entries)";
+    LBANN_ERROR(err.str());
+  }
+
+}
+
+// ---------------------------------------------------------
+// Matrix access functions
+// ---------------------------------------------------------
+
+const AbsDistMat& lbann_callback_confusion_matrix::get_predictions(const model& m) const {
+  for (const auto* l : m.get_layers()) {
+    if (l->get_name() == m_prediction_layer) {
+      return l->get_activations();
+    }
+  }
+  std::stringstream err;
+  err << "callback \"" << name() << "\" could not find "
+      << "prediction layer \"" << m_prediction_layer << "\"";
+  LBANN_ERROR(err.str());
+  return m.get_layers()[0]->get_activations();
+}
+
+const AbsDistMat& lbann_callback_confusion_matrix::get_labels(const model& m) const {
+  for (const auto* l : m.get_layers()) {
+    if (l->get_name() == m_label_layer) {
+      return l->get_activations();
+    }
+  }
+  std::stringstream err;
+  err << "callback \"" << name() << "\" could not find "
+      << "label layer \"" << m_prediction_layer << "\"";
+  LBANN_ERROR(err.str());
+  return m.get_layers()[0]->get_activations();
+}
+
+// ---------------------------------------------------------
+// Count management functions
+// ---------------------------------------------------------
+
+void lbann_callback_confusion_matrix::reset_counts(const model& m) {
+  auto& counts = m_counts[m.get_execution_mode()];
+  const auto& num_classes = get_predictions(m).Height();
+  counts.assign(num_classes * num_classes, 0);
+}
+
+void lbann_callback_confusion_matrix::update_counts(const model& m) {
+  constexpr DataType zero = 0;
+
+  // Get predictions
+  const auto& predictions = get_predictions(m);
+  const auto& num_classes = predictions.Height();
+  m_predictions_v->Empty(false);
+  m_predictions_v->AlignWith(predictions);
+  if (m_predictions_v->DistData() == predictions.DistData()) {
+    El::LockedView(*m_predictions_v, predictions);
+  } else {
+    El::Copy(predictions, *m_predictions_v);
+  }
+  const auto& local_predictions = m_predictions_v->LockedMatrix();
+
+  // Get labels
+  const auto& labels = get_labels(m);
+  m_labels_v->Empty(false);
+  m_labels_v->AlignWith(predictions);
+  if (m_labels_v->DistData() == labels.DistData()) {
+    El::LockedView(*m_labels_v, labels);
+  } else {
+    El::Copy(labels, *m_labels_v);
+  }
+  const auto& local_labels = m_labels_v->LockedMatrix();
+
+  // Update counts
+  auto& counts = m_counts[m.get_execution_mode()];
+  const auto& local_height = local_predictions.Height();
+  const auto& local_width = local_predictions.Width();
+  for (El::Int local_col = 0; local_col < local_width; ++local_col) {
+    El::Int prediction_index = -1, label_index = -1;
+#pragma omp parallel for
+    for (El::Int local_row = 0; local_row < local_height; ++local_row) {
+      if (local_predictions(local_row, local_col) != zero) {
+        prediction_index = m_predictions_v->GlobalRow(local_row);
+      }
+      if (local_labels(local_row, local_col) != zero) {
+        label_index = m_labels_v->GlobalRow(local_row);
+      }
+    }
+    if (prediction_index >= 0 && label_index >= 0) {
+      counts[label_index + prediction_index * num_classes]++;
+    }
+  }
+
+}
+
+void lbann_callback_confusion_matrix::save_confusion_matrix(const model& m) {
+
+  // Get counts
+  const auto& mode = m.get_execution_mode();
+  auto& counts = m_counts[mode];
+
+  // Accumulate counts in master process
+  // Note: Counts in non-root processes are set to zero, so this can
+  // be called multiple times without affecting correctness.
+  auto&& comm = *m.get_comm();
+  if (comm.am_model_master()) {
+    comm.model_reduce(static_cast<El::Int*>(MPI_IN_PLACE),
+                      counts.size(),
+                      counts.data());
+  } else {
+    comm.model_reduce(counts.data(), counts.size(),
+                      comm.get_model_master());
+    counts.assign(counts.size(), 0);
+  }
+
+  // Save confusion matrix on master process
+  if (comm.am_model_master()) {
+    const auto& num_classes = get_predictions(m).Height();
+    const auto& total_count = std::accumulate(counts.begin(), counts.end(), 0);
+    const auto& scale = DataType(1) / total_count;
+
+    // Construct output file name
+    std::string mode_string;
+    switch (mode) {
+    case execution_mode::training:
+      mode_string = "train-epoch" + std::to_string(m.get_cur_epoch());
+      break;
+    case execution_mode::validation:
+      mode_string = "validation-epoch" + std::to_string(m.get_cur_epoch());
+      break;
+    case execution_mode::testing:
+      mode_string = "test";
+      break;
+    default: return; // Exit immediately if execution mode is unknown
+    }
+
+    // Write to file
+    std::ofstream fs(m_prefix + mode_string + ".csv");
+    for (El::Int i = 0; i < num_classes; ++i) {
+      for (El::Int j = 0; j < num_classes; ++j) {
+        fs << (j > 0 ? "," : "") << counts[j + i * num_classes] * scale;
+      }
+      fs << "\n";
+    }
+    fs.close();
+
+  }
+
+}
+
+}  // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -35,7 +35,7 @@ namespace {
 /** Select entries from a list based on names.
  *  Any entry in 'list' with a name found in 'names' (interpreted as a
  *  space-separated list) is added to the output list.
- */  
+ */
 template <typename T>
 std::vector<T*> select_from_list(std::string names,
                                         std::vector<T*> list) {
@@ -84,6 +84,12 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                           params.image_format(),
                                           params.image_prefix());
   }
+  if (proto_cb.has_confusion_matrix()) {
+    const auto& params = proto_cb.confusion_matrix();
+    return new lbann_callback_confusion_matrix(params.prediction(),
+                                               params.label(),
+                                               params.prefix());
+  }
 
   //////////////////////////////////////////////////////////////////
   // Inter-model communication
@@ -98,7 +104,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                    proto_cb.ltfb().increasing_metric_mode(),
                                    weight_names,
                                    summarizer);
-  }  
+  }
   /// @todo
   if (proto_cb.has_imcomm()) {
     const auto& params = proto_cb.imcomm();
@@ -391,7 +397,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
   if (proto_cb.has_gpu_memory_usage()) {
     return new lbann_callback_gpu_memory_usage();
   }
-  
+
   return nullptr;
 }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -473,6 +473,7 @@ message Callback {
    CallbackGPUMemoryUsage gpu_memory_usage = 32;
    CallbackSyncLayers sync_layers = 33;
    CallbackSyncSelected sync_selected = 34;
+   CallbackConfusionMatrix confusion_matrix = 36;
 }
 
 message CallbackLTFB {
@@ -683,6 +684,12 @@ message CallbackSyncSelected {
   bool async_mpi = 2;
   repeated LayerToSync layer_to_sync = 3;
   CudaProfilerSetup cuda_profiler_setup = 4;
+}
+
+message CallbackConfusionMatrix {
+  string prediction = 1; // Prediction layer
+  string label = 2;      // Label layer
+  string prefix = 3;     // Prefix for output files
 }
 
 //========================================================================


### PR DESCRIPTION
### Description
This PR adds a callback to compute confusion matrices and save them as CSV files (closing #49). It would be better to implement this as a metric, but that would require surgery in the base metric class to handle tensor-valued metrics. The CSV files can be parsed to compute the IOU metric (closing #479).

### Example usage
```
layer {
  parents: "input"
  name: "labels"
  identity {}
}
layer {
  parents: "softmax"
  name: "predictions"
  in_top_k { k: 1 } # Get one-hot prediction vectors
}
callback {
  confusion_matrix {
    prediction: "predictions"
    label: "labels"
    prefix: "experiment_dir/confusion-" # Files will look like "experiment_dir/confusion-train-epoch4.csv"
  }
}
```

### Example output
The following confusion matrix was obtained with LeNet on a validation set after one MNIST training epoch. Rows correspond to predictions and columns to labels.

![screenshot from 2018-11-20 17-01-00](https://user-images.githubusercontent.com/4406448/48812187-08daf280-ece6-11e8-8909-edb963c075dd.png)