### PR TITLE
Follow-up refactoring for PR #715.

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -76,7 +76,7 @@ def get_command(cluster,
         command_allocate = ''
         # Allocate a node if we don't have one already
         # Running the tests manually allows for already having a node allocated
-        if os.getenv('SLURM_NNODES') == None:
+        if os.getenv('SLURM_JOB_NUM_NODES') == None:
             command_allocate = 'salloc'
             option_num_nodes = ''
             option_partition = ''

--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_full_path(THIS_DIR_HEADERS
   callback.hpp
   callback_check_dataset.hpp
+  callback_check_gradients.hpp
   callback_check_init.hpp
   callback_check_metric.hpp
   callback_checknan.hpp
@@ -15,7 +16,6 @@ set_full_path(THIS_DIR_HEADERS
   callback_dump_minibatch_sample_indices.hpp
   callback_dump_weights.hpp
   callback_early_stopping.hpp
-  callback_gradient_check.hpp
   callback_hang.hpp
   callback_imcomm.hpp
   callback_io.hpp

--- a/include/lbann/callbacks/callback_check_gradients.hpp
+++ b/include/lbann/callbacks/callback_check_gradients.hpp
@@ -22,34 +22,44 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_gradient_check .hpp .cpp - Callback hooks for gradient check
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_CALLBACKS_CALLBACK_GRADIENT_CHECK_HPP_INCLUDED
-#define LBANN_CALLBACKS_CALLBACK_GRADIENT_CHECK_HPP_INCLUDED
+#ifndef LBANN_CALLBACKS_CALLBACK_CHECK_GRADIENTS_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_CHECK_GRADIENTS_HPP_INCLUDED
 
 #include "lbann/callbacks/callback.hpp"
 
 namespace lbann {
 
-/** Callback hooks for gradient check. */
-class lbann_callback_gradient_check : public lbann_callback {
- public:
-  
-  /** Constructor.
-   *  @param step_size  Step size for numerical differentiation.
-   *  @param verbose    Whether to print results for each parameter.
-   */
-  lbann_callback_gradient_check(DataType step_size = DataType(0),
-                                bool verbose = false,
-                                bool fail_on_error = false);
+/** Gradient checking callback.
+ *  Gradient checking is performed at the beginning of the test
+ *  phase. Using a fourth-order finite difference scheme, a numerical
+ *  partial derivative is computed for every weight parameter. If the
+ *  numerical derivative differs signifcantly from the analytical
+ *  derivative computed during backprop, the gradient check has
+ *  failed.
+ */
+class lbann_callback_check_gradients : public lbann_callback {
+public:
 
-  lbann_callback_gradient_check(const lbann_callback_gradient_check&) = default;
-  lbann_callback_gradient_check& operator=(const lbann_callback_gradient_check&) = default;
-  lbann_callback_gradient_check* copy() const override { return new lbann_callback_gradient_check(*this); }
+  /** Constructor.
+   *  @param step_size          Step size for numerical
+   *                            differentiation (with a step size of
+   *                            zero, the step size is chosen to
+   *                            minimize the numerical error).
+   *  @param verbose            Whether to print results for each
+   *                            parameter.
+   *  @param error_on_failure   Whether to throw an exception for
+   *                            large gradient errors.
+   */
+  lbann_callback_check_gradients(DataType step_size = DataType(0),
+                                 bool verbose = false,
+                                 bool error_on_failure = false);
+  lbann_callback_check_gradients* copy() const override {
+    return new lbann_callback_check_gradients(*this);
+  }
   void on_test_begin(model *m) override;
-  std::string name() const override { return "gradient check"; }
+  std::string name() const override { return "check gradients"; }
 
   /** Compute objective function value.
    *  It is assumed that input data has already been loaded into the
@@ -58,15 +68,16 @@ class lbann_callback_gradient_check : public lbann_callback {
   DataType compute_objective_function(model *m);
 
 private:
+
   /** Step size for numerical differentiation. */
   DataType m_step_size;
   /** Whether to print results for each parameter. */
   bool m_verbose;
   /** Whether to throw an exception for large gradient errors. */
-  bool m_fail_on_error;
+  bool m_error_on_failure;
 
 };
 
 }  // namespace lbann
 
-#endif  // LBANN_CALLBACKS_CALLBACK_GRADIENT_CHECK_HPP_INCLUDED
+#endif  // LBANN_CALLBACKS_CALLBACK_CHECK_GRADIENTS_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -165,7 +165,6 @@
 #include "lbann/callbacks/profiler.hpp"
 #include "lbann/callbacks/callback_hang.hpp"
 #include "lbann/callbacks/callback_variable_minibatch.hpp"
-#include "lbann/callbacks/callback_gradient_check.hpp"
 #include "lbann/callbacks/callback_timeline.hpp"
 #include "lbann/callbacks/callback_checkpoint.hpp"
 #include "lbann/callbacks/callback_save_model.hpp"
@@ -174,6 +173,7 @@
 #include "lbann/callbacks/callback_sync_layers.hpp"
 #include "lbann/callbacks/callback_sync_selected.hpp"
 #include "lbann/callbacks/callback_confusion_matrix.hpp"
+#include "lbann/callbacks/callback_check_gradients.hpp"
 #include "lbann/callbacks/callback_check_metric.hpp"
 
 /// Weights and weight initializers

--- a/model_zoo/models/lenet_mnist/model_lenet_mnist.prototext
+++ b/model_zoo/models/lenet_mnist/model_lenet_mnist.prototext
@@ -83,12 +83,6 @@ model {
   #     layers: "data"
   #   }
   # }
-  # callback {
-  #   gradient_check {
-  #     verbose: false
-  #     fail_on_error: false
-  #   }
-  # }
 
   ###################################################
   # Layers

--- a/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
+++ b/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
@@ -7,22 +7,38 @@ model {
   procs_per_model: 0
 
   ###################################################
-  # Objective function
+  # Objective function and metrics
   ###################################################
 
   objective_function {
     layer_term { layer: "l2" }
   }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
 
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_metric {
+      metric: "L2 norm" # Expected value: 2
+      lower_bound: 1.999
+      upper_bound: 2.001
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/layer_tests/model_covariance.prototext
+++ b/model_zoo/tests/layer_tests/model_covariance.prototext
@@ -7,22 +7,38 @@ model {
   procs_per_model: 0
 
   ###################################################
-  # Objective function
+  # Objective function and metrics
   ###################################################
 
   objective_function {
     layer_term { layer: "l2" }
   }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
 
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_metric {
+      metric: "L2 norm" # Expected value: 0.08365
+      lower_bound: 0.08364
+      upper_bound: 0.08366
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/layer_tests/model_l2_norm2.prototext
+++ b/model_zoo/tests/layer_tests/model_l2_norm2.prototext
@@ -23,6 +23,7 @@ model {
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
@@ -35,9 +36,9 @@ model {
     }
   }
   callback {
-    gradient_check {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/layer_tests/model_log_softmax.prototext
+++ b/model_zoo/tests/layer_tests/model_log_softmax.prototext
@@ -7,22 +7,38 @@ model {
   procs_per_model: 0
 
   ###################################################
-  # Objective function
+  # Objective function and metric
   ###################################################
 
   objective_function {
     layer_term { layer: "l2" }
   }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
 
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_metric {
+      metric: "L2 norm" # Expected value: 275.4
+      lower_bound: 275.3
+      upper_bound: 275.5
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/layer_tests/model_softmax.prototext
+++ b/model_zoo/tests/layer_tests/model_softmax.prototext
@@ -7,22 +7,38 @@ model {
   procs_per_model: 0
 
   ###################################################
-  # Objective function
+  # Objective function and metric
   ###################################################
 
   objective_function {
     layer_term { layer: "l2" }
   }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
 
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_metric {
+      metric: "L2 norm" # Expected value: 1.987
+      lower_bound: 1.986
+      upper_bound: 1.988
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/layer_tests/model_variance.prototext
+++ b/model_zoo/tests/layer_tests/model_variance.prototext
@@ -7,22 +7,38 @@ model {
   procs_per_model: 0
 
   ###################################################
-  # Objective function
+  # Objective function and metrics
   ###################################################
 
   objective_function {
     layer_term { layer: "l2" }
   }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
 
   ###################################################
   # Callbacks
   ###################################################
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_metric {
+      metric: "L2 norm" # Expected value: 1.239
+      lower_bound: 1.238
+      upper_bound: 1.240
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/model_mnist_conv_graph.prototext
+++ b/model_zoo/tests/model_mnist_conv_graph.prototext
@@ -17,13 +17,13 @@ model {
   ###################################################
   # Callbacks
   ###################################################
-  
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/model_mnist_ridge_regression.prototext
+++ b/model_zoo/tests/model_mnist_ridge_regression.prototext
@@ -29,9 +29,9 @@ model {
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/model_zoo/tests/model_mnist_softmax_classifier.prototext
+++ b/model_zoo/tests/model_mnist_softmax_classifier.prototext
@@ -17,19 +17,19 @@ model {
   ###################################################
   # Metrics
   ###################################################
-  
+
   metric { layer_metric { layer: "accuracy" } }
 
   ###################################################
   # Callbacks
   ###################################################
-  
+
   callback { print {} }
   callback { timer {} }
   callback {
-    gradient_check {
+    check_gradients {
       verbose: false
-      fail_on_error: true
+      error_on_failure: true
     }
   }
 

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   callback_check_dataset.cpp
+  callback_check_gradients.cpp
   callback_check_init.cpp
   callback_check_metric.cpp
   callback_checknan.cpp
@@ -15,7 +16,6 @@ set_full_path(THIS_DIR_SOURCES
   callback_dump_minibatch_sample_indices.cpp
   callback_dump_weights.cpp
   callback_early_stopping.cpp
-  callback_gradient_check.cpp
   callback_imcomm.cpp
   callback_io.cpp
   callback_learning_rate.cpp

--- a/src/callbacks/callback_check_gradients.cpp
+++ b/src/callbacks/callback_check_gradients.cpp
@@ -22,22 +22,21 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
-// lbann_callback_gradient_check .hpp .cpp - Callback hooks for gradient check
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann/callbacks/callback_gradient_check.hpp"
+#include "lbann/callbacks/callback_check_gradients.hpp"
 
 namespace lbann {
 
-lbann_callback_gradient_check::lbann_callback_gradient_check(DataType step_size,
-                                                             bool verbose,
-                                                             bool fail_on_error)
+lbann_callback_check_gradients
+  ::lbann_callback_check_gradients(DataType step_size,
+                                   bool verbose,
+                                   bool error_on_failure)
   : m_step_size(step_size),
     m_verbose(verbose),
-    m_fail_on_error(fail_on_error) {}
+    m_error_on_failure(error_on_failure) {}
 
-void lbann_callback_gradient_check::on_test_begin(model *m) {
+void lbann_callback_check_gradients::on_test_begin(model *m) {
 
   // Get model members
   lbann_comm *comm = m->get_comm();
@@ -141,7 +140,7 @@ void lbann_callback_gradient_check::on_test_begin(model *m) {
             relative_error = error / std::max(std::fabs(analytical_gradient),
                                               std::fabs(numerical_gradient));
           }
-        
+
           // Print warning if relative error is large
           if (error > expected_error || std::isnan(error) || std::isinf(error)) {
             std::cout << "  GRADIENT ERROR: " << w->get_name() << ", "
@@ -151,8 +150,8 @@ void lbann_callback_gradient_check::on_test_begin(model *m) {
                       << "    Numerical gradient  = " << numerical_gradient << std::endl
                       << "    Error               = " << error << std::endl
                       << "    Relative error      = " << relative_error << std::endl;
-            if (m_fail_on_error) {
-              throw lbann_exception("callback_gradient_check: found large error in gradient");
+            if (m_error_on_failure) {
+              throw lbann_exception("callback_check_gradients: found large error in gradient");
             }
           } else if (m_verbose) {
             std::cout << "  " << w->get_name() << ", "
@@ -176,7 +175,7 @@ void lbann_callback_gradient_check::on_test_begin(model *m) {
 
 }
 
-DataType lbann_callback_gradient_check::compute_objective_function(model *m) {
+DataType lbann_callback_check_gradients::compute_objective_function(model *m) {
   const std::vector<Layer*>& layers = m->get_layers();
   objective_function* obj_fn = m->get_objective_function();
   for (size_t l = 1; l < layers.size(); l++) {

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -389,11 +389,11 @@ lbann_callback* construct_callback(lbann_comm* comm,
     }
     return new lbann_callback_hang(rank_to_hang);
   }
-  if (proto_cb.has_gradient_check()) {
-    const auto& params = proto_cb.gradient_check();
-    return new lbann_callback_gradient_check(params.step_size(),
-                                             params.verbose(),
-                                             params.fail_on_error());
+  if (proto_cb.has_check_gradients()) {
+    const auto& params = proto_cb.check_gradients();
+    return new lbann_callback_check_gradients(params.step_size(),
+                                              params.verbose(),
+                                              params.error_on_failure());
   }
   if (proto_cb.has_check_metric()) {
     const auto& params = proto_cb.check_metric();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -461,7 +461,7 @@ message Callback {
    CallbackLinearGrowthLearningRate linear_growth_learning_rate = 20;
    CallbackProfiler profiler = 21;
    CallbackStepMinibatch step_minibatch = 22;
-   CallbackGradientCheck gradient_check = 23;
+   CallbackCheckGradients check_gradients = 23;
    CallbackLTFB ltfb = 24;
    CallbackDebugIO debug_io = 25;
    CallbackMinibatchSchedule minibatch_schedule = 26;
@@ -622,10 +622,10 @@ message CallbackMinibatchSchedule {
   repeated MinibatchScheduleStep step = 2;
 }
 
-message CallbackGradientCheck {
+message CallbackCheckGradients {
   double step_size = 1;
   bool verbose = 2;
-  bool fail_on_error = 3; // Throw error if gradient check fails
+  bool error_on_failure = 3; // Throw error if gradient check fails
 }
 
 message CallbackCheckMetric {


### PR DESCRIPTION
Changes:
- Rename "gradient_check" callback to "check_gradients" for consistency with other callback names.
- Rename "fail_on_error" option in gradient checking callback to "error_on_failure" for consistency with metric checking callback.
- Add metric checking callbacks to all layer unit tests.