### PR TITLE
Minor changes to entry-wise layers.

### DIFF
--- a/include/lbann/layers/loss/entrywise.hpp
+++ b/include/lbann/layers/loss/entrywise.hpp
@@ -24,34 +24,32 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_LOSS_ENTRYWISE_HPP_INCLUDED
-#define LBANN_LAYER_LOSS_ENTRYWISE_HPP_INCLUDED
+#ifndef LBANN_LAYERS_LOSS_ENTRYWISE_HPP_INCLUDED
+#define LBANN_LAYERS_LOSS_ENTRYWISE_HPP_INCLUDED
 
 #include "lbann/layers/math/binary.hpp"
 
 namespace lbann {
 
-// Convenience macro to define a binary math layer class
-// Note: Implementation of entrywise loss layers is identical to
-// binary math layers.
-#define LBANN_DEFINE_BINARY_MATH_LAYER(layer_name, layer_string) \
-  struct layer_name##_name_struct {                             \
-    inline operator std::string() { return layer_string; }      \
-  };                                                            \
-  template <data_layout Layout, El::Device Device>              \
-  using layer_name                                              \
-  = binary_math_layer<Layout, Device, layer_name##_name_struct>;
+// Convenience macro to define an entry-wise binary layer class
+#define DEFINE_ENTRYWISE_BINARY_LAYER(layer_name, layer_string)         \
+  struct layer_name##_name_struct {                                     \
+    inline operator std::string() { return layer_string; }              \
+  };                                                                    \
+  template <data_layout Layout, El::Device Device>                      \
+  using layer_name                                                      \
+  = entrywise_binary_layer<Layout, Device, layer_name##_name_struct>;
 
 // Cross entropy loss
-LBANN_DEFINE_BINARY_MATH_LAYER(binary_cross_entropy_layer, "binary cross entropy");
-LBANN_DEFINE_BINARY_MATH_LAYER(sigmoid_binary_cross_entropy_layer, "sigmoid binary cross entropy");
+DEFINE_ENTRYWISE_BINARY_LAYER(binary_cross_entropy_layer, "binary cross entropy");
+DEFINE_ENTRYWISE_BINARY_LAYER(sigmoid_binary_cross_entropy_layer, "sigmoid binary cross entropy");
 
 // Boolean loss functions
-LBANN_DEFINE_BINARY_MATH_LAYER(boolean_accuracy_layer, "Boolean accuracy");
-LBANN_DEFINE_BINARY_MATH_LAYER(boolean_false_negative_layer, "Boolean false negative rate");
-LBANN_DEFINE_BINARY_MATH_LAYER(boolean_false_positive_layer, "Boolean false positive rate");
+DEFINE_ENTRYWISE_BINARY_LAYER(boolean_accuracy_layer, "Boolean accuracy");
+DEFINE_ENTRYWISE_BINARY_LAYER(boolean_false_negative_layer, "Boolean false negative rate");
+DEFINE_ENTRYWISE_BINARY_LAYER(boolean_false_positive_layer, "Boolean false positive rate");
 
 } // namespace lbann
 
-#undef LBANN_DEFINE_BINARY_MATH_LAYER 
-#endif // LBANN_LAYER_LOSS_ENTRYWISE_HPP_INCLUDED
+#undef DEFINE_ENTRYWISE_BINARY_LAYER
+#endif // LBANN_LAYERS_LOSS_ENTRYWISE_HPP_INCLUDED

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -24,36 +24,36 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_MATH_BINARY_HPP_INCLUDED
-#define LBANN_LAYER_MATH_BINARY_HPP_INCLUDED
+#ifndef LBANN_LAYERS_MATH_BINARY_HPP_INCLUDED
+#define LBANN_LAYERS_MATH_BINARY_HPP_INCLUDED
 
 #include "lbann/layers/layer.hpp"
 
 namespace lbann {
 
-/** Base class for binary math layers.
+/** Templated class for entry-wise binary layers.
  *  'Name' should be a type such that Name() returns a human-readable
  *  layer name, e.g. an empty struct that can be converted to a
  *  string.
  */
 template <data_layout Layout, El::Device Device, typename Name>
-class binary_math_layer : public Layer {
+class entrywise_binary_layer : public Layer {
 public:
-  binary_math_layer(lbann_comm *comm) : Layer(comm) {
+  entrywise_binary_layer(lbann_comm *comm) : Layer(comm) {
     m_expected_num_parent_layers = 2;
   }
-  binary_math_layer* copy() const override {
-    return new binary_math_layer<Layout,Device,Name>(*this);
+  entrywise_binary_layer* copy() const override {
+    return new entrywise_binary_layer<Layout,Device,Name>(*this);
   }
   std::string get_type() const override { return Name(); }
   data_layout get_data_layout() const override { return Layout; }
   El::Device get_device_allocation() const override { return Device; }
-  
+
 protected:
-  
+
   void setup_dims() override {
-    set_output_dims(get_input_dims());
     Layer::setup_dims();
+    set_output_dims(get_input_dims());
 
     // Check that input dimensions match
     if (get_input_dims(0) != get_input_dims(1)) {
@@ -72,48 +72,48 @@ protected:
       err << ")";
       LBANN_ERROR(err.str());
     }
-    
+
   }
-  
+
   void fp_compute() override;
   void bp_compute() override;
-  
+
 };
 
-// Convenience macro to define a binary math layer class
-#define LBANN_DEFINE_BINARY_MATH_LAYER(layer_name, layer_string) \
-  struct layer_name##_name_struct {                             \
-    inline operator std::string() { return layer_string; }      \
-  };                                                            \
-  template <data_layout Layout, El::Device Device>              \
-  using layer_name                                              \
-  = binary_math_layer<Layout, Device, layer_name##_name_struct>;
+// Convenience macro to define an entry-wise binary layer class
+#define DEFINE_ENTRYWISE_BINARY_LAYER(layer_name, layer_string)         \
+  struct layer_name##_name_struct {                                     \
+    inline operator std::string() { return layer_string; }              \
+  };                                                                    \
+  template <data_layout Layout, El::Device Device>                      \
+  using layer_name                                                      \
+  = entrywise_binary_layer<Layout, Device, layer_name##_name_struct>;
 
 // Arithmetic operations
-LBANN_DEFINE_BINARY_MATH_LAYER(add_layer,         "add");
-LBANN_DEFINE_BINARY_MATH_LAYER(subtract_layer,    "subtract");
-LBANN_DEFINE_BINARY_MATH_LAYER(multiply_layer,    "multiply");
-LBANN_DEFINE_BINARY_MATH_LAYER(divide_layer,      "divide");
-LBANN_DEFINE_BINARY_MATH_LAYER(mod_layer,         "modulo");
-LBANN_DEFINE_BINARY_MATH_LAYER(pow_layer,         "power");
-LBANN_DEFINE_BINARY_MATH_LAYER(safe_divide_layer, "safe divide");
+DEFINE_ENTRYWISE_BINARY_LAYER(add_layer,         "add");
+DEFINE_ENTRYWISE_BINARY_LAYER(subtract_layer,    "subtract");
+DEFINE_ENTRYWISE_BINARY_LAYER(multiply_layer,    "multiply");
+DEFINE_ENTRYWISE_BINARY_LAYER(divide_layer,      "divide");
+DEFINE_ENTRYWISE_BINARY_LAYER(mod_layer,         "modulo");
+DEFINE_ENTRYWISE_BINARY_LAYER(pow_layer,         "power");
+DEFINE_ENTRYWISE_BINARY_LAYER(safe_divide_layer, "safe divide");
 
 // Comparison operations
-LBANN_DEFINE_BINARY_MATH_LAYER(max_layer,           "maximum");
-LBANN_DEFINE_BINARY_MATH_LAYER(min_layer,           "minimum");
-LBANN_DEFINE_BINARY_MATH_LAYER(equal_layer,         "equal");
-LBANN_DEFINE_BINARY_MATH_LAYER(not_equal_layer,     "not equal");
-LBANN_DEFINE_BINARY_MATH_LAYER(less_layer,          "less than");
-LBANN_DEFINE_BINARY_MATH_LAYER(less_equal_layer,    "less than or equal");
-LBANN_DEFINE_BINARY_MATH_LAYER(greater_layer,       "greater than");
-LBANN_DEFINE_BINARY_MATH_LAYER(greater_equal_layer, "greater than or equal");
-  
+DEFINE_ENTRYWISE_BINARY_LAYER(max_layer,           "maximum");
+DEFINE_ENTRYWISE_BINARY_LAYER(min_layer,           "minimum");
+DEFINE_ENTRYWISE_BINARY_LAYER(equal_layer,         "equal");
+DEFINE_ENTRYWISE_BINARY_LAYER(not_equal_layer,     "not equal");
+DEFINE_ENTRYWISE_BINARY_LAYER(less_layer,          "less than");
+DEFINE_ENTRYWISE_BINARY_LAYER(less_equal_layer,    "less than or equal");
+DEFINE_ENTRYWISE_BINARY_LAYER(greater_layer,       "greater than");
+DEFINE_ENTRYWISE_BINARY_LAYER(greater_equal_layer, "greater than or equal");
+
 // Logical operations
-LBANN_DEFINE_BINARY_MATH_LAYER(and_layer, "logical and");
-LBANN_DEFINE_BINARY_MATH_LAYER(or_layer,  "logical or");
-LBANN_DEFINE_BINARY_MATH_LAYER(xor_layer, "logical xor");
+DEFINE_ENTRYWISE_BINARY_LAYER(logical_and_layer, "logical and");
+DEFINE_ENTRYWISE_BINARY_LAYER(logical_or_layer,  "logical or");
+DEFINE_ENTRYWISE_BINARY_LAYER(logical_xor_layer, "logical xor");
 
 } // namespace lbann
 
-#undef LBANN_DEFINE_BINARY_MATH_LAYER 
-#endif // LBANN_LAYER_MATH_BINARY_HPP_INCLUDED
+#undef DEFINE_ENTRYWISE_BINARY_LAYER
+#endif // LBANN_LAYERS_MATH_BINARY_HPP_INCLUDED

--- a/include/lbann/layers/math/unary.hpp
+++ b/include/lbann/layers/math/unary.hpp
@@ -24,24 +24,24 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_MATH_UNARY_HPP_INCLUDED
-#define LBANN_LAYER_MATH_UNARY_HPP_INCLUDED
+#ifndef LBANN_LAYERS_MATH_UNARY_HPP_INCLUDED
+#define LBANN_LAYERS_MATH_UNARY_HPP_INCLUDED
 
 #include "lbann/layers/layer.hpp"
 
 namespace lbann {
 
-/** Base class for unary math layers.
+/** Templated class for entry-wise unary layers.
  *  'Name' should be a type such that Name() returns a human-readable
  *  layer name, e.g. an empty struct that can be converted to a
  *  string.
  */
 template <data_layout Layout, El::Device Device, typename Name>
-class unary_math_layer : public Layer {
+class entrywise_unary_layer : public Layer {
 public:
-  unary_math_layer(lbann_comm *comm) : Layer(comm) {}
-  unary_math_layer* copy() const override {
-    return new unary_math_layer<Layout,Device,Name>(*this);
+  entrywise_unary_layer(lbann_comm *comm) : Layer(comm) {}
+  entrywise_unary_layer* copy() const override {
+    return new entrywise_unary_layer<Layout,Device,Name>(*this);
   }
   std::string get_type() const override { return Name(); }
   data_layout get_data_layout() const override { return Layout; }
@@ -55,58 +55,58 @@ protected:
   void bp_compute() override;
 };
 
-// Convenience macro to define a unary math layer class
-#define LBANN_DEFINE_UNARY_MATH_LAYER(layer_name, layer_string) \
+// Convenience macro to define an entry-wise unary layer class
+#define DEFINE_ENTRYWISE_UNARY_LAYER(layer_name, layer_string)      \
   struct layer_name##_name_struct {                             \
     inline operator std::string() { return layer_string; }      \
   };                                                            \
   template <data_layout Layout, El::Device Device>              \
   using layer_name                                              \
-  = unary_math_layer<Layout, Device, layer_name##_name_struct>;
+  = entrywise_unary_layer<Layout, Device, layer_name##_name_struct>;
 
 // Logical operations
-LBANN_DEFINE_UNARY_MATH_LAYER(not_layer, "logical not");
-  
+DEFINE_ENTRYWISE_UNARY_LAYER(logical_not_layer, "logical not");
+
 // Sign operations
-LBANN_DEFINE_UNARY_MATH_LAYER(abs_layer,      "absolute value");
-LBANN_DEFINE_UNARY_MATH_LAYER(negative_layer, "negative");
-LBANN_DEFINE_UNARY_MATH_LAYER(sign_layer,     "sign");
+DEFINE_ENTRYWISE_UNARY_LAYER(abs_layer,      "absolute value");
+DEFINE_ENTRYWISE_UNARY_LAYER(negative_layer, "negative");
+DEFINE_ENTRYWISE_UNARY_LAYER(sign_layer,     "sign");
 
 // Rounding operations
-LBANN_DEFINE_UNARY_MATH_LAYER(round_layer, "round");
-LBANN_DEFINE_UNARY_MATH_LAYER(ceil_layer,  "ceil");
-LBANN_DEFINE_UNARY_MATH_LAYER(floor_layer, "floor");
+DEFINE_ENTRYWISE_UNARY_LAYER(round_layer, "round");
+DEFINE_ENTRYWISE_UNARY_LAYER(ceil_layer,  "ceil");
+DEFINE_ENTRYWISE_UNARY_LAYER(floor_layer, "floor");
 
 // Power operations
-LBANN_DEFINE_UNARY_MATH_LAYER(reciprocal_layer,      "reciprocal");
-LBANN_DEFINE_UNARY_MATH_LAYER(square_layer,          "square");
-LBANN_DEFINE_UNARY_MATH_LAYER(sqrt_layer,            "square root");
-LBANN_DEFINE_UNARY_MATH_LAYER(rsqrt_layer,           "reciprocal square root");
-LBANN_DEFINE_UNARY_MATH_LAYER(safe_reciprocal_layer, "safe reciprocal");
+DEFINE_ENTRYWISE_UNARY_LAYER(reciprocal_layer,      "reciprocal");
+DEFINE_ENTRYWISE_UNARY_LAYER(square_layer,          "square");
+DEFINE_ENTRYWISE_UNARY_LAYER(sqrt_layer,            "square root");
+DEFINE_ENTRYWISE_UNARY_LAYER(rsqrt_layer,           "reciprocal square root");
+DEFINE_ENTRYWISE_UNARY_LAYER(safe_reciprocal_layer, "safe reciprocal");
 
 // Exponential and logarithmic operations
-LBANN_DEFINE_UNARY_MATH_LAYER(exp_layer,   "exponential");
-LBANN_DEFINE_UNARY_MATH_LAYER(expm1_layer, "expm1");
-LBANN_DEFINE_UNARY_MATH_LAYER(log_layer,   "natural logarithm");
-LBANN_DEFINE_UNARY_MATH_LAYER(log1p_layer, "log1p");
+DEFINE_ENTRYWISE_UNARY_LAYER(exp_layer,   "exponential");
+DEFINE_ENTRYWISE_UNARY_LAYER(expm1_layer, "expm1");
+DEFINE_ENTRYWISE_UNARY_LAYER(log_layer,   "natural logarithm");
+DEFINE_ENTRYWISE_UNARY_LAYER(log1p_layer, "log1p");
 
 // Trigonometric operations
-LBANN_DEFINE_UNARY_MATH_LAYER(cos_layer,  "cosine");
-LBANN_DEFINE_UNARY_MATH_LAYER(sin_layer,  "sine");
-LBANN_DEFINE_UNARY_MATH_LAYER(tan_layer,  "tangent");
-LBANN_DEFINE_UNARY_MATH_LAYER(acos_layer, "arccosine");
-LBANN_DEFINE_UNARY_MATH_LAYER(asin_layer, "arcsine");
-LBANN_DEFINE_UNARY_MATH_LAYER(atan_layer, "arctangent");
+DEFINE_ENTRYWISE_UNARY_LAYER(cos_layer,  "cosine");
+DEFINE_ENTRYWISE_UNARY_LAYER(sin_layer,  "sine");
+DEFINE_ENTRYWISE_UNARY_LAYER(tan_layer,  "tangent");
+DEFINE_ENTRYWISE_UNARY_LAYER(acos_layer, "arccosine");
+DEFINE_ENTRYWISE_UNARY_LAYER(asin_layer, "arcsine");
+DEFINE_ENTRYWISE_UNARY_LAYER(atan_layer, "arctangent");
 
 // Hyperbolic operations
-LBANN_DEFINE_UNARY_MATH_LAYER(cosh_layer,  "hyperbolic cosine");
-LBANN_DEFINE_UNARY_MATH_LAYER(sinh_layer,  "hyperbolic sine");
-LBANN_DEFINE_UNARY_MATH_LAYER(tanh_layer,  "hyperbolic tangent");
-LBANN_DEFINE_UNARY_MATH_LAYER(acosh_layer, "hyperbolic arccosine");
-LBANN_DEFINE_UNARY_MATH_LAYER(asinh_layer, "hyperbolic arcsine");
-LBANN_DEFINE_UNARY_MATH_LAYER(atanh_layer, "hyperbolic arctangent");
+DEFINE_ENTRYWISE_UNARY_LAYER(cosh_layer,  "hyperbolic cosine");
+DEFINE_ENTRYWISE_UNARY_LAYER(sinh_layer,  "hyperbolic sine");
+DEFINE_ENTRYWISE_UNARY_LAYER(tanh_layer,  "hyperbolic tangent");
+DEFINE_ENTRYWISE_UNARY_LAYER(acosh_layer, "hyperbolic arccosine");
+DEFINE_ENTRYWISE_UNARY_LAYER(asinh_layer, "hyperbolic arcsine");
+DEFINE_ENTRYWISE_UNARY_LAYER(atanh_layer, "hyperbolic arctangent");
 
 } // namespace lbann
 
-#undef LBANN_DEFINE_UNARY_MATH_LAYER 
-#endif // LBANN_LAYER_MATH_UNARY_HPP_INCLUDED
+#undef DEFINE_ENTRYWISE_UNARY_LAYER
+#endif // LBANN_LAYERS_MATH_UNARY_HPP_INCLUDED

--- a/src/layers/math/binary.cpp
+++ b/src/layers/math/binary.cpp
@@ -355,7 +355,7 @@ struct greater_equal_op {
 };
 
 /** Logical and operator. */
-struct and_op {
+struct logical_and_op {
   inline DataType operator()(const DataType& x1,
                              const DataType& x2) const {
     const auto& b1 = x1 != zero && !std::isnan(x1);
@@ -373,7 +373,7 @@ struct and_op {
 };
 
 /** Logical or operator. */
-struct or_op {
+struct logical_or_op {
   inline DataType operator()(const DataType& x1,
                              const DataType& x2) const {
     const auto& b1 = x1 != zero && !std::isnan(x1);
@@ -391,7 +391,7 @@ struct or_op {
 };
 
 /** Logical xor operator. */
-struct xor_op {
+struct logical_xor_op {
   inline DataType operator()(const DataType& x1,
                              const DataType& x2) const {
     const auto& b1 = x1 != zero && !std::isnan(x1);
@@ -459,8 +459,8 @@ struct xor_op {
   INSTANTIATE(less_equal_layer, less_equal_op)
   INSTANTIATE(greater_layer, greater_op)
   INSTANTIATE(greater_equal_layer, greater_equal_op)
-  INSTANTIATE(and_layer, and_op)
-  INSTANTIATE(or_layer, or_op)
-  INSTANTIATE(xor_layer, xor_op)
+  INSTANTIATE(logical_and_layer, logical_and_op)
+  INSTANTIATE(logical_or_layer, logical_or_op)
+  INSTANTIATE(logical_xor_layer, logical_xor_op)
 
 } // namespace lbann

--- a/src/layers/math/binary.cu
+++ b/src/layers/math/binary.cu
@@ -59,7 +59,7 @@ void binary_backprop_operator_kernel(El::Int height, El::Int width,
   }
 }
 
-  
+
 /** Apply a binary backprop operator to CPU data.
  *  The input and output data must be on CPU and must have the same
  *  dimensions. Given a binary function \f$ y = f(x_1,x_2) \f$, the
@@ -101,7 +101,7 @@ void apply_binary_backprop_operator(const AbsMat& x1,
   }
 
 }
-  
+
 // =========================================================
 // Operator objects for entry-wise binary layers
 // =========================================================
@@ -141,7 +141,7 @@ struct subtract_op {
     dx2 = -dy;
   }
 };
-  
+
 /** Multiply operator. */
 struct multiply_op {
   inline __device__ DataType operator()(const DataType& x1,
@@ -173,7 +173,7 @@ struct divide_op {
     dx2 = -dy * x1 / (x2*x2);
   }
 };
-  
+
 /** Modulo operator. */
 struct mod_op {
   inline __device__ DataType operator()(const DataType& x1,
@@ -233,7 +233,7 @@ struct safe_divide_op {
     }
   }
 };
-  
+
 /** Maximum operator. */
 struct max_op {
   inline __device__ DataType operator()(const DataType& x1,
@@ -379,7 +379,7 @@ struct greater_equal_op {
 };
 
 /** Logical and operator. */
-struct and_op {
+struct logical_and_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
     const auto& b1 = x1 != DataType(0) && !isnan(x1);
@@ -397,7 +397,7 @@ struct and_op {
 };
 
 /** Logical or operator. */
-struct or_op {
+struct logical_or_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
     const auto& b1 = x1 != DataType(0) && !isnan(x1);
@@ -415,7 +415,7 @@ struct or_op {
 };
 
 /** Logical xor operator. */
-struct xor_op {
+struct logical_xor_op {
   inline __device__ DataType operator()(const DataType& x1,
                                         const DataType& x2) const {
     const auto& b1 = x1 != DataType(0) && !isnan(x1);
@@ -431,7 +431,7 @@ struct xor_op {
     dx2 = DataType(0);
   }
 };
-  
+
 } // namespace
 
 // Template instantiation
@@ -483,8 +483,8 @@ struct xor_op {
   INSTANTIATE(less_equal_layer, less_equal_op)
   INSTANTIATE(greater_layer, greater_op)
   INSTANTIATE(greater_equal_layer, greater_equal_op)
-  INSTANTIATE(and_layer, and_op)
-  INSTANTIATE(or_layer, or_op)
-  INSTANTIATE(xor_layer, xor_op)
-  
+  INSTANTIATE(logical_and_layer, logical_and_op)
+  INSTANTIATE(logical_or_layer, logical_or_op)
+  INSTANTIATE(logical_xor_layer, logical_xor_op)
+
 } // namespace lbann

--- a/src/layers/math/unary.cpp
+++ b/src/layers/math/unary.cpp
@@ -34,17 +34,17 @@ namespace {
 // Helpful constants
 constexpr DataType zero = 0;
 constexpr DataType one = 1;
-  
+
 // =========================================================
 // Operator objects for entry-wise unary layers
 // =========================================================
 // Note: Unary operator corresponds to forward prop step
-// (\f$ y = f(x) \f$) and binary operator corresponds to 
+// (\f$ y = f(x) \f$) and binary operator corresponds to
 // back prop step
 // (\f$ \frac{dL}{dx} = \frac{dL}{dy} f'(x) \f$).
 
 /** Logical not operator. */
-struct not_op {
+struct logical_not_op {
   inline DataType operator()(const DataType& x) const {
     const auto& b = x != zero && !std::isnan(x);
     return !b ? one : zero;
@@ -53,7 +53,7 @@ struct not_op {
     return zero;
   }
 };
-  
+
 /** Absolute value operator. */
 struct abs_op {
   inline DataType operator()(const DataType& x) const {
@@ -177,7 +177,7 @@ struct safe_reciprocal_op {
     else                  { return zero; }
   }
 };
-  
+
 /** Exponential operator. */
 struct exp_op {
   inline DataType operator()(const DataType& x) const {
@@ -339,7 +339,7 @@ struct atanh_op {
     return dy / (one - x*x);
   }
 };
-  
+
 } // namespace
 
 // Template instantiation
@@ -370,7 +370,7 @@ struct atanh_op {
                                         get_prev_error_signals(),       \
                                         get_error_signals());           \
   }
-  INSTANTIATE(not_layer, not_op)
+  INSTANTIATE(logical_not_layer, logical_not_op)
   INSTANTIATE(abs_layer, abs_op)
   INSTANTIATE(negative_layer, negative_op)
   INSTANTIATE(sign_layer, sign_op)
@@ -398,5 +398,5 @@ struct atanh_op {
   INSTANTIATE(acosh_layer, acosh_op)
   INSTANTIATE(asinh_layer, asinh_op)
   INSTANTIATE(atanh_layer, atanh_op)
-  
+
 } // namespace lbann

--- a/src/layers/math/unary.cu
+++ b/src/layers/math/unary.cu
@@ -29,17 +29,17 @@
 namespace lbann {
 
 namespace {
-  
+
 // =========================================================
 // Operator objects for entry-wise unary layers
 // =========================================================
 // Note: Unary operator corresponds to forward prop step
-// (\f$ y = f(x) \f$) and binary operator corresponds to 
+// (\f$ y = f(x) \f$) and binary operator corresponds to
 // back prop step
 // (\f$ \frac{dL}{dx} = \frac{dL}{dy} f'(x) \f$).
 
 /** Logical not operator. */
-struct not_op {
+struct logical_not_op {
   inline __device__ DataType operator()(const DataType& x) const {
     const auto& b = x != DataType(0) && !isnan(x);
     return !b ? DataType(1) : DataType(0);
@@ -48,7 +48,7 @@ struct not_op {
     return DataType(0);
   }
 };
-  
+
 /** Absolute value operator. */
 struct abs_op {
   inline __device__ DataType operator()(const DataType& x) const {
@@ -124,7 +124,7 @@ struct reciprocal_op {
   inline __device__ DataType operator()(const DataType& x, const DataType& dy) const {
     if (dy == DataType(0)) { return DataType(0); }
     else                   { return - dy / (x*x); }
-    
+
   }
 };
 
@@ -176,7 +176,7 @@ struct safe_reciprocal_op {
     else             { return DataType(0); }
   }
 };
-  
+
 /** Exponential operator. */
 struct exp_op {
   inline __device__ DataType operator()(const DataType& x) const {
@@ -338,7 +338,7 @@ struct atanh_op {
     return dy / (DataType(1) - x*x);
   }
 };
-  
+
 } // namespace
 
 // Template instantiation
@@ -369,7 +369,7 @@ struct atanh_op {
                                               get_prev_error_signals(), \
                                               get_error_signals());     \
   }
-  INSTANTIATE(not_layer, not_op)
+  INSTANTIATE(logical_not_layer, logical_not_op)
   INSTANTIATE(abs_layer, abs_op)
   INSTANTIATE(negative_layer, negative_op)
   INSTANTIATE(sign_layer, sign_op)
@@ -397,5 +397,5 @@ struct atanh_op {
   INSTANTIATE(acosh_layer, acosh_op)
   INSTANTIATE(asinh_layer, asinh_op)
   INSTANTIATE(atanh_layer, atanh_op)
-  
+
 } // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -492,7 +492,7 @@ Layer* construct_layer(lbann_comm* comm,
   }
 
   // Math layers
-  if (proto_layer.has_not_()) { return new not_layer<layout, Dev>(comm); }
+  CONSTRUCT_LAYER(logical_not);
   CONSTRUCT_LAYER(abs);
   CONSTRUCT_LAYER(negative);
   CONSTRUCT_LAYER(sign);
@@ -535,9 +535,9 @@ Layer* construct_layer(lbann_comm* comm,
   CONSTRUCT_LAYER(less_equal);
   CONSTRUCT_LAYER(greater);
   CONSTRUCT_LAYER(greater_equal);
-  if (proto_layer.has_and_()) { return new and_layer<layout, Dev>(comm); }
-  if (proto_layer.has_or_())  { return new or_layer<layout, Dev>(comm); }
-  if (proto_layer.has_xor_()) { return new xor_layer<layout, Dev>(comm); }
+  CONSTRUCT_LAYER(logical_and);
+  CONSTRUCT_LAYER(logical_or);
+  CONSTRUCT_LAYER(logical_xor);
 
   // Activation layers
   CONSTRUCT_LAYER(softmax);

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -866,7 +866,7 @@ message Layer {
    BooleanFalsePositive boolean_false_positive = 71;
 
    // Math layers
-   Not not = 401;
+   LogicalNot logical_not = 401;
    Abs abs = 402;
    Negative negative = 403;
    Sign sign = 404;
@@ -909,9 +909,9 @@ message Layer {
    LessEqual less_equal = 462;
    Greater greater = 463;
    GreaterEqual greater_equal = 464;
-   And and = 465;
-   Or or = 466;
-   Xor xor = 467;
+   LogicalAnd logical_and = 465;
+   LogicalOr logical_or = 466;
+   LogicalXor logical_xor = 467;
 
    // Target Layers
    Target target = 18;
@@ -957,7 +957,7 @@ message MotifLayer {
 ///////////////////////
 // Math Layers       //
 ///////////////////////
-message Not {}
+message LogicalNot {}
 message Abs {}
 message Negative {}
 message Sign {}
@@ -1000,9 +1000,9 @@ message Less {}
 message LessEqual {}
 message Greater {}
 message GreaterEqual {}
-message And {}
-message Or {}
-message Xor {}
+message LogicalAnd {}
+message LogicalOr {}
+message LogicalXor {}
 
 ///////////////////////
 // Activation Layers //


### PR DESCRIPTION
These are small, non-functional changes to the entry-wise math layers, mostly because I want to refactor some activation layers to use their functionality:
- Rename "not", "and", "or", and "xor" layers to "logical not", etc. It's a pain when the layer names are also common keywords.
- Rename `unary_math_layer` to `entrywise_unary_layer` and `binary_math_layer` to `entrywise_binary_layer`.
- Conforming header preprocessor guards to our style guide.