### PR TITLE
CosmoFlow Prototype

### DIFF
--- a/model_zoo/data_readers/data_reader_synthetic_cosmoflow_128.prototext
+++ b/model_zoo/data_readers/data_reader_synthetic_cosmoflow_128.prototext
@@ -1,0 +1,27 @@
+data_reader {
+  reader {
+    name: "synthetic"
+    role: "train"
+    shuffle: true
+    # This is arbitrary.
+    num_samples: 10000
+    synth_dimensions: "1 128 128 128"
+    synth_response_dimensions: "3"
+    validation_percent: 0.01
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+    disable_responses: false
+  }
+
+  reader {
+    name: "synthetic"
+    role: "test"
+    shuffle: true
+    num_samples: 1000
+    synth_dimensions: "1 128 128 128"
+    synth_response_dimensions: "3"
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+    disable_responses: false
+  }
+}

--- a/model_zoo/models/cosmoflow/model_cosmoflow.prototext
+++ b/model_zoo/models/cosmoflow/model_cosmoflow.prototext
@@ -1,0 +1,306 @@
+model {
+  name: "directed_acyclic_graph_model"
+  data_layout: "data_parallel"
+  mini_batch_size: 64
+  block_size: 256
+  num_epochs: 18
+  num_parallel_readers: 0
+  procs_per_model: 0
+
+  objective_function {
+    layer_term { layer: "mean_absolute_error" }
+  }
+
+  # TODO: Metrics.
+
+  callback { print {} }
+  callback { timer {} }
+
+  # TODO: Polynomial learning rate decay.
+  # TOOD: LARC.
+
+  layer {
+    name: "data"
+    children: "DARK_MATTER SECRETS_OF_THE_UNIVERSE"
+    data_layout: "data_parallel"
+    input {
+      io_buffer: "partitioned"
+      target_mode: "regression"
+    }
+  }
+
+  layer {
+    name: "DARK_MATTER"
+    parents: "data"
+    data_layout: "data_parallel"
+    split {}
+  }
+  layer {
+    name: "SECRETS_OF_THE_UNIVERSE"
+    parents: "data"
+    data_layout: "data_parallel"
+    split {}
+  }
+
+  layer {
+    name: "conv1"
+    parents: "DARK_MATTER"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 16
+      conv_dims_i: 3
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act1"
+    parents: "conv1"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "pool1"
+    parents: "act1"
+    data_layout: "data_parallel"
+    pooling: {
+      num_dims: 3
+      pool_dims_i: 2
+      pool_pads_i: 0
+      pool_strides_i: 2
+      pool_mode: "average"
+    }
+  }
+
+  layer {
+    name: "conv2"
+    parents: "pool1"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 32
+      conv_dims_i: 4
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act2"
+    parents: "conv2"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "pool2"
+    parents: "act2"
+    data_layout: "data_parallel"
+    pooling: {
+      num_dims: 3
+      pool_dims_i: 2
+      pool_pads_i: 0
+      pool_strides_i: 2
+      pool_mode: "average"
+    }
+  }
+
+  layer {
+    name: "conv3"
+    parents: "pool2"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 64
+      conv_dims_i: 4
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act3"
+    parents: "conv3"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "pool3"
+    parents: "act3"
+    data_layout: "data_parallel"
+    pooling: {
+      num_dims: 3
+      pool_dims_i: 2
+      pool_pads_i: 0
+      pool_strides_i: 2
+      pool_mode: "average"
+    }
+  }
+
+  layer {
+    name: "conv4"
+    parents: "pool3"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 128
+      conv_dims_i: 3
+      conv_pads_i: 0
+      conv_strides_i: 2
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act4"
+    parents: "conv4"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "conv5"
+    parents: "act4"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 256
+      conv_dims_i: 3
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act5"
+    parents: "conv5"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "conv6"
+    parents: "act5"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 256
+      conv_dims_i: 2
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act6"
+    parents: "conv6"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "conv7"
+    parents: "act6"
+    data_layout: "data_parallel"
+    convolution {
+      num_dims: 3
+      num_output_channels: 256
+      conv_dims_i: 2
+      conv_pads_i: 0
+      conv_strides_i: 1
+      has_bias: true
+    }
+  }
+  layer {
+    name: "act7"
+    parents: "conv7"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "fc1"
+    parents: "act7"
+    data_layout: "model_parallel"
+    fully_connected {
+      num_neurons: 2048
+      has_bias: true
+    }
+  }
+  layer {
+    name: "drop1"
+    parents: "fc1"
+    data_layout: "model_parallel"
+    dropout {
+      keep_prob: 0.5
+    }
+  }
+  layer {
+    name: "fc_act1"
+    parents: "drop1"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "fc2"
+    parents: "fc_act1"
+    data_layout: "model_parallel"
+    fully_connected {
+      num_neurons: 256
+      has_bias: true
+    }
+  }
+  layer {
+    name: "drop2"
+    parents: "fc2"
+    data_layout: "model_parallel"
+    dropout {
+      keep_prob: 0.5
+    }
+  }
+  layer {
+    name: "fc_act2"
+    parents: "drop2"
+    data_layout: "data_parallel"
+    # Supposed to be leaky ReLU w/ leak=0.01, but not supported on GPU.
+    relu {}
+  }
+
+  layer {
+    name: "fc3"
+    parents: "fc_act2"
+    data_layout: "model_parallel"
+    fully_connected {
+      num_neurons: 3
+      has_bias: true
+    }
+  }
+  layer {
+    name: "drop3"
+    parents: "fc3"
+    data_layout: "model_parallel"
+    dropout {
+      keep_prob: 0.5
+    }
+  }
+
+  layer {
+    name: "mean_absolute_error"
+    parents: "drop3 SECRETS_OF_THE_UNIVERSE"
+    data_layout: "data_parallel"
+    mean_absolute_error {}
+  }
+
+}


### PR DESCRIPTION
Prototype CosmoFlow model for 128x128x128 data cubes. The main difference is that this uses ReLUs instead of leaky ReLUs as activations, since we do not have GPU support for the latter yet.

This is based on the [CosmoFlow paper](https://arxiv.org/pdf/1808.04728.pdf) (and [this prior work](https://arxiv.org/pdf/1711.02033.pdf)), as well as [this](https://github.com/NERSC/CosmoFlow) Github repo.