### PR TITLE
GPU implementation of leaky ReLU layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_leaky_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(0, '../common_python')
+import tools
+import pytest
+import os
+
+def skeleton_layer_leaky_relu(cluster, executables, dir_name, compiler_name):
+    if compiler_name not in executables:
+      pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    output_file_name = '%s/bamboo/unit_tests/output/layer_leaky_relu_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/layer_leaky_relu_%s_error.txt' % (dir_name, compiler_name)
+    command = tools.get_command(
+        cluster=cluster, executable=executables[compiler_name], num_nodes=1, num_processes=2, dir_name=dir_name,
+        data_filedir_default='', data_reader_name='synthetic',
+        model_folder='tests/layer_tests', model_name='leaky_relu', optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
+    return_code = os.system(command)
+    assert return_code == 0
+
+def test_unit_layer_leaky_relu_clang4(cluster, exes, dirname):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'clang4')
+
+def test_unit_layer_leaky_relu_gcc4_check(cluster, exes, dirname):
+    if cluster in ['surface']:
+        pytest.skip('FIXME')
+        # Surface Errors:
+        # assert 34304 == 0
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc4')
+
+def test_unit_layer_leaky_relu_gcc7(cluster, exes, dirname):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc7')
+
+def test_unit_layer_leaky_relu_intel18(cluster, exes, dirname):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel18')
+
+# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_leaky_relu_exe' --exe=<executable>
+def test_unit_layer_leaky_relu_exe(cluster, dirname, exe):
+    if exe == None:
+        pytest.skip('Non-local testing')
+    exes = {'exe' : exe}
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'exe')

--- a/include/lbann/layers/activations/leaky_relu.hpp
+++ b/include/lbann/layers/activations/leaky_relu.hpp
@@ -24,43 +24,47 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LEAKY_RELU_HPP_INCLUDED
-#define LEAKY_RELU_HPP_INCLUDED
+#ifndef LBANN_LAYERS_ACTIVATIONS_LEAKY_RELU_HPP_INCLUDED
+#define LBANN_LAYERS_ACTIVATIONS_LEAKY_RELU_HPP_INCLUDED
 
-#include "lbann/layers/activations/activation.hpp"
+#include "lbann/layers/layer.hpp"
 
 namespace lbann {
 
-/** Leaky rectified linear unit activation function.
- *  This is a ReLU variant that avoids the dying ReLU problem where a
- *  ReLU neuron can stop updating. See:
- *  Maas, Andrew L., Awni Y. Hannun, and Andrew Y. Ng. "Rectifier
- *  nonlinearities improve neural network acoustic models."
- *  Proc. ICML. Vol. 30. No. 1. 2013.
+/** Leaky rectified linear unit layer.
+ *  \f[
+ *    \text{LeakyReLU}(x) =
+ *      \begin{cases}
+ *        x        & x > 0
+ *        \alpha x & x \leq 0
+ *      \end{cases}
+ *  \f]
+ *  See https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
  */
-template <data_layout T_layout, El::Device Dev>
-class leaky_relu_layer : public entrywise_activation_layer {
- public:
-  /** Leak is the amount of signal to permit for negative values. */
-  leaky_relu_layer(lbann_comm *comm,
-                   DataType leak = DataType(0.01))
-    : entrywise_activation_layer(comm), m_leak(leak) {}
+template <data_layout Layout, El::Device Device>
+class leaky_relu_layer : public Layer {
+public:
+  leaky_relu_layer(lbann_comm *comm, DataType negative_slope = 0.01)
+    : Layer(comm),
+      m_negative_slope(negative_slope) {}
   leaky_relu_layer* copy() const override { return new leaky_relu_layer(*this); }
-  std::string get_type() const override { return "leaky relu"; }
-  data_layout get_data_layout() const override { return T_layout; }
-  El::Device get_device_allocation() const override { return Dev; }
+  std::string get_type() const override { return "leaky ReLU"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
 
- protected:
-  DataType activation(DataType x) const override {
-    return std::max(m_leak * x, x);
+protected:
+  void setup_dims() override {
+    Layer::setup_dims();
+    set_output_dims(get_input_dims());
   }
-  DataType activation_derivative(DataType x) const override {
-    return (x > DataType(0)) ? DataType(1) : m_leak;
-  }
- private:
-  DataType m_leak;
+  void fp_compute() override;
+  void bp_compute() override;
+
+private:
+  DataType m_negative_slope;
+
 };
 
 } // namespace lbann
 
-#endif // LEAKY_RELU_HPP_INCLUDED
+#endif // LBANN_LAYERS_ACTIVATIONS_LEAKY_RELU_HPP_INCLUDED

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -31,8 +31,8 @@
 
 namespace lbann {
 
-/** Rectified linear unit activation function layer.
- *  \f[ ReLU(x) = \text{max}(x, 0) \f]
+/** Rectified linear unit layer.
+ *  \f[ \text{ReLU}(x) = \text{max}(x, 0) \f]
  *  See https://en.wikipedia.org/wiki/Rectifier_(neural_networks)
  */
 template <data_layout T_layout, El::Device Dev>

--- a/model_zoo/tests/layer_tests/model_leaky_relu.prototext
+++ b/model_zoo/tests/layer_tests/model_leaky_relu.prototext
@@ -1,0 +1,115 @@
+model {
+  data_layout: "data_parallel"
+  mini_batch_size: 11
+  block_size: 256
+  num_epochs: 0
+  num_parallel_readers: 0
+  procs_per_model: 0
+
+  ###################################################
+  # Objective function and metrics
+  ###################################################
+
+  objective_function {
+    layer_term { layer: "l2" }
+  }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
+
+  ###################################################
+  # Callbacks
+  ###################################################
+
+  callback { print {} }
+  callback { timer {} }
+  callback {
+    check_metric {
+      metric: "L2 norm" # Expected value: 6.946
+      lower_bound: 6.945
+      upper_bound: 6.947
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
+      verbose: false
+      error_on_failure: true
+    }
+  }
+
+  ###################################################
+  # Layers
+  ###################################################
+
+  layer {
+    name: "data"
+    data_layout: "data_parallel"
+    input {
+      io_buffer: "partitioned"
+    }
+  }
+
+  # Input data
+  layer {
+    name: "x"
+    weights_layer {
+      dims: "5"
+    }
+    data_layout: "model_parallel"
+    weights: "x_vals"
+  }
+  weights {
+    name: "x_vals"
+    value_initializer {
+      values: "-2 -1 -0.25 0.25 0.5"
+    }
+  }
+
+  # Variations of L1 norm layer
+  layer {
+    parents: "x"
+    name: "leaky_relu_slope_default_data_parallel"
+    leaky_relu {}
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "x"
+    name: "leaky_relu_slope_default_model_parallel"
+    leaky_relu {}
+    data_layout: "model_parallel"
+  }
+  layer {
+    parents: "x"
+    name: "leaky_relu_slope_03_data_parallel"
+    leaky_relu {
+      negative_slope: 0.3
+    }
+    data_layout: "data_parallel"
+  }
+  layer {
+    parents: "x"
+    name: "leaky_relu_slope_03_model_parallel"
+    leaky_relu {
+      negative_slope: 0.3
+    }
+    data_layout: "model_parallel"
+  }
+
+  # Combine into objective function
+  layer {
+    parents: "leaky_relu_slope_default_data_parallel leaky_relu_slope_default_model_parallel leaky_relu_slope_03_data_parallel leaky_relu_slope_03_model_parallel"
+    name: "sum"
+    sum {}
+  }
+  layer {
+    parents: "sum"
+    name: "l2"
+    l2_norm2 {}
+  }
+
+}

--- a/src/layers/activations/CMakeLists.txt
+++ b/src/layers/activations/CMakeLists.txt
@@ -1,18 +1,20 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  leaky_relu.cpp
+  log_softmax.cpp
   relu.cpp
   sigmoid.cpp
   softmax.cpp
-  log_softmax.cpp
   )
 
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
+    leaky_relu.cu
+    log_softmax.cu
     relu.cu
     sigmoid.cu
     softmax.cu
-    log_softmax.cu
     )
 endif ()
 

--- a/src/layers/activations/leaky_relu.cpp
+++ b/src/layers/activations/leaky_relu.cpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/activations/leaky_relu.hpp"
+
+namespace lbann {
+
+namespace {
+
+// Useful constants
+constexpr DataType zero = 0;
+
+/** Local forward prop computation. */
+void local_fp(DataType negative_slope,
+              const AbsMat& input,
+              AbsMat& output) {
+  const auto& height = input.Height();
+  const auto& width = input.Width();
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int col = 0; col < width; ++col) {
+    for (El::Int row = 0; row < height; ++row) {
+      const auto& x = input(row, col);
+      auto& y = output(row, col);
+      y = (x > zero) ? x : negative_slope * x;
+    }
+  }
+}
+
+/** Local backprop computation. */
+void local_bp(DataType negative_slope,
+              const AbsMat& input,
+              const AbsMat& gradient_wrt_output,
+              AbsMat& gradient_wrt_input) {
+  const auto& height = input.Height();
+  const auto& width = input.Width();
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int col = 0; col < width; ++col) {
+    for (El::Int row = 0; row < height; ++row) {
+      const auto& x = input(row, col);
+      const auto& dy = gradient_wrt_output(row, col);
+      auto& dx = gradient_wrt_input(row, col);
+      dx = (x > zero) ? dy : negative_slope * dy;
+    }
+  }
+}
+
+} // namespace
+
+template <>
+void leaky_relu_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+       ::fp_compute() {
+  local_fp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_activations());
+}
+template <>
+void leaky_relu_layer<data_layout::DATA_PARALLEL, El::Device::CPU>
+     ::bp_compute() {
+  local_bp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_prev_error_signals(),
+           get_local_error_signals());
+}
+template <>
+void leaky_relu_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
+       ::fp_compute() {
+  local_fp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_activations());
+}
+template <>
+void leaky_relu_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>
+     ::bp_compute() {
+  local_bp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_prev_error_signals(),
+           get_local_error_signals());
+}
+
+} // namespace lbann

--- a/src/layers/activations/leaky_relu.cu
+++ b/src/layers/activations/leaky_relu.cu
@@ -1,0 +1,165 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/activations/leaky_relu.hpp"
+
+namespace lbann {
+
+namespace {
+
+/** CUDA kernel for forward prop computation. */
+__global__ void fp_kernel(DataType negative_slope,
+                          El::Int height,
+                          El::Int width,
+                          const DataType* __restrict__ input,
+                          El::Int input_ldim,
+                          DataType* __restrict__ output,
+                          El::Int output_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_ldim];
+    auto& y = output[row + col * output_ldim];
+    y = (x > DataType(0)) ? x : negative_slope * x;
+  }
+}
+
+/** CUDA kernel for backprop computation. */
+__global__ void bp_kernel(DataType negative_slope,
+                          El::Int height,
+                          El::Int width,
+                          const DataType* __restrict__ input,
+                          El::Int input_ldim,
+                          const DataType* __restrict__ gradient_wrt_output,
+                          El::Int gradient_wrt_output_ldim,
+                          DataType* __restrict__ gradient_wrt_input,
+                          El::Int gradient_wrt_input_ldim) {
+  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const El::Int size = height * width;
+  const El::Int num_threads = blockDim.x * gridDim.x;
+  for (El::Int pos = gid; pos < size; pos += num_threads) {
+    const auto& row = pos % height;
+    const auto& col = pos / height;
+    const auto& x = input[row + col * input_ldim];
+    const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_ldim];
+    auto& dx = gradient_wrt_input[row + col * gradient_wrt_input_ldim];
+    dx = (x > DataType(0)) ? dy : negative_slope * dy;
+  }
+}
+
+/** Local forward prop computation. */
+void local_fp(DataType negative_slope,
+              const AbsMat& input,
+              AbsMat& output) {
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input.Height();
+  const El::Int width = input.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    fp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+      negative_slope, height, width,
+      input.LockedBuffer(), input.LDim(),
+      output.Buffer(), output.LDim());
+  }
+
+}
+
+/** Local backprop computation. */
+void local_bp(DataType negative_slope,
+              const AbsMat& input,
+              const AbsMat& gradient_wrt_output,
+              AbsMat& gradient_wrt_input) {
+
+  // Get CUDA grid dimensions
+  // Note: Maximum CUDA grid dimension is 2^32-1
+  // (https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#features-and-technical-specifications).
+  const El::Int height = input.Height();
+  const El::Int width = input.Width();
+  const El::Int block_dim = 256;
+  El::Int grid_dim = (height * width + block_dim - 1) / block_dim;
+  if (sizeof(El::Int) > sizeof(unsigned int)
+      && grid_dim > std::numeric_limits<uint32_t>::max()) {
+    grid_dim = std::numeric_limits<uint32_t>::max();
+  }
+
+  // Launch CUDA kernel
+  if (grid_dim > 0) {
+    bp_kernel<<<grid_dim, block_dim, 0, El::GPUManager::Stream()>>>(
+      negative_slope, height, width,
+      input.LockedBuffer(), input.LDim(),
+      gradient_wrt_output.LockedBuffer(), gradient_wrt_output.LDim(),
+      gradient_wrt_input.Buffer(), gradient_wrt_input.LDim());
+  }
+
+}
+
+} // namespace
+
+template <>
+void leaky_relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+       ::fp_compute() {
+  local_fp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_activations());
+}
+template <>
+void leaky_relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::bp_compute() {
+  local_bp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_prev_error_signals(),
+           get_local_error_signals());
+}
+template <>
+void leaky_relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
+       ::fp_compute() {
+  local_fp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_activations());
+}
+template <>
+void leaky_relu_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>
+     ::bp_compute() {
+  local_bp(m_negative_slope,
+           get_local_prev_activations(),
+           get_local_prev_error_signals(),
+           get_local_error_signals());
+}
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -548,7 +548,15 @@ Layer* construct_layer(lbann_comm* comm,
   CONSTRUCT_LAYER(bent_identity);
   CONSTRUCT_LAYER(softplus);
   CONSTRUCT_LAYER(smooth_relu);
-  CONSTRUCT_LAYER(leaky_relu);
+  if (proto_layer.has_leaky_relu()) {
+    const auto& params = proto_layer.leaky_relu();
+    const auto& negative_slope = params.negative_slope();
+    if (negative_slope != 0) {
+      return new leaky_relu_layer<layout, Dev>(comm, negative_slope);
+    } else {
+      return new leaky_relu_layer<layout, Dev>(comm);
+    }
+  }
   CONSTRUCT_LAYER(swish);
   if (proto_layer.has_elu()) {
     const auto& params = proto_layer.elu();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1015,7 +1015,7 @@ message Identity {
 }
 
 message LeakyRelu {
-  double leak = 2; //default: 0.01
+  double negative_slope = 1; //default: 0.01
 }
 
 message Relu {


### PR DESCRIPTION
This PR refactors the leaky ReLU layer and adds a GPU implementation. The Bamboo unit test passes, aside from issues with #717. It should help with #719.