### PR TITLE
Flexible number of patches in the Siamese model

### DIFF
--- a/include/lbann/data_readers/offline_patches_npz.hpp
+++ b/include/lbann/data_readers/offline_patches_npz.hpp
@@ -80,6 +80,10 @@ class offline_patches_npz {
   size_t get_num_patches() const {
     return m_num_patches;
   }
+  /// Set the number of patches per sample (the number of image data sources)
+  void set_num_patches(size_t n) {
+    m_num_patches = n;
+  }
   /// Reconsturct and return the meta-data (patch file names and the label) of idx-th sample
   sample_t get_sample(const size_t idx) const;
   /// Return the label of idx-th sample

--- a/src/data_readers/data_reader_triplet.cpp
+++ b/src/data_readers/data_reader_triplet.cpp
@@ -148,6 +148,8 @@ std::vector<data_reader_triplet::sample_t> data_reader_triplet::get_image_list()
 void data_reader_triplet::load() {
   const std::string data_filename = get_data_filename();
 
+  m_samples.set_num_patches(m_num_img_srcs);
+
   // To support m_first_n semantic, m_samples.load() takes m_first_n
   // as an argument and attempt to shrink the CNPY arrays loaded as needed
   if (!m_samples.load(data_filename, m_first_n)) {

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -519,7 +519,8 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
   if (master) std::cout << reader->get_type() << " is set" << std::endl;
 
   // configure the data reader
-  if (name == "multi_images") {
+  if ((name == "multi_images") ||
+      ((name == "triplet") && (pb_readme.num_image_srcs() > 0))) {
     const int n_img_srcs = pb_readme.num_image_srcs();
     data_reader_multi_images* multi_image_dr_ptr
       = dynamic_cast<data_reader_multi_images*>(image_data_reader_ptr);

--- a/tools/filelist/CMakeLists.txt
+++ b/tools/filelist/CMakeLists.txt
@@ -1,0 +1,107 @@
+project(conduit_load)
+cmake_minimum_required(VERSION 2.8)
+cmake_policy(SET CMP0015 NEW)
+cmake_policy(SET CMP0054 NEW)
+
+set(COMPILER "gnu")
+#set(COMPILER "clang")
+#set(CLUSTER "catalyst")
+set(CLUSTER "surface")
+#set(CLUSTER "quartz")
+#set(CLUSTER "sierra")
+
+set(LBANN_DIR ../..)
+set(LBANN_INSTALL_DIR ${LBANN_DIR}/build/${COMPILER}.Release.${CLUSTER}.llnl.gov/install)
+include(${LBANN_DIR}/cmake/modules/SetupMPI.cmake)
+include(${LBANN_DIR}/cmake/modules/SetupOpenMP.cmake)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+if (NOT OpenMP_CXX_LIBRARIES)
+  message("  Set OpenMP_CXX_LIBRARIES manually")
+  set(OpenMP_CXX_LIBRARIES "-fopenmp")
+endif()
+
+set(CONDUIT_LOAD_EXE conduit_load)
+set(CONDUIT_LOAD_SRCS conduit_load.cpp)
+set(WITH_OPENCL OFF)
+
+add_definitions(-Wall)
+add_definitions(-O2)
+add_definitions(-fopenmp)
+add_definitions(-g)
+add_definitions(-std=c++11)
+add_definitions(-D_JAG_OFFLINE_TOOL_MODE_)
+add_definitions(-DLBANN_HAS_OPENCV)
+add_definitions(-DLBANN_HAS_CONDUIT)
+add_definitions(-DLBANN_NO_OMP_FOR_DATA_READERS)
+
+
+#list(APPEND OpenCV_DIR /usr/local/tools/opencv-3.0.0)
+list(APPEND OpenCV_DIR ${LBANN_INSTALL_DIR}/../opencv/build)
+list(APPEND OpenCV_DIR /usr)
+find_package(OpenCV QUIET HINTS ${OpenCV_DIR})
+message(STATUS "OpenCV_DIR: ${OpenCV_DIR}")
+
+if(NOT OpenCV_FOUND)
+  set(OpenCV_DIR ${LBANN_INSTALL_DIR})
+  set(OpenCV_LIBS "libopencv_highgui.so;libopencv_imgproc.so;libopencv_imgcodecs.so;libopencv_core.so")
+  set(OpenCV_INCLUDE_DIRS "${OpenCV_DIR}/include")
+  set(OpenCV_LIB_DIR "${OpenCV_DIR}/lib")
+  message(STATUS "OpenCV_DIR: ${OpenCV_DIR}")
+endif()
+
+include_directories(SYSTEM ${OpenCV_INCLUDE_DIRS})
+link_directories(${OpenCV_LIB_DIR})
+
+
+#set(CONDUIT_DIR /p/lscratchh/brainusr/conduit/conduit-${CLUSTER})
+set(CONDUIT_DIR /usr/workspace/wsb/icfsi/conduit/install-toss3-dev)
+#set(CONDUIT_DIR /usr/workspace/wsb/icfsi/conduit/install-blueos-dev)
+#set(HDF5_DIR /usr/workspace/wsb/icfsi/conduit-helpers/hdf5-${CLUSTER}/hdf5)
+set(HDF5_DIR /usr/workspace/wsb/icfsi/conduit-helpers/hdf5-quartz/hdf5)
+
+message(STATUS "CONDUIT_DIR: ${CONDUIT_DIR}")
+set(CONDUIT_LIB_DIR "${CONDUIT_DIR}/lib")
+set(CONDUIT_LIBRARIES "libconduit.so;libconduit_relay.so")
+link_directories(${CONDUIT_LIB_DIR})
+set(CONDUIT_INCLUDE_DIRS "${CONDUIT_DIR}/include")
+
+if(HDF5_DIR)
+  message(STATUS "HDF5_DIR: ${HDF5_DIR}")
+  set(HDF5_LIB_DIR "${HDF5_DIR}/lib")
+  set(HDF5_LIBRARIES "libhdf5.so")
+  link_directories(${HDF5_LIB_DIR})
+  set(HDF5_INCLUDE_DIRS "${HDF5_DIR}/include")
+endif()
+
+include_directories(SYSTEM ${CONDUIT_INCLUDE_DIRS} ${HDF5_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+
+
+find_package(MPI REQUIRED)
+message(STATUS "Found MPI: ${MPI_CXX_COMPILER} ${MPI_C_COMPILER} ${MPI_Fortran_COMPILER}")
+include_directories(${MPI_CXX_INCLUDE_PATH})
+
+
+file(GLOB CONDUIT_LOAD_DEPEND_SRCS
+     data_reader_jag_conduit.cpp
+     lbann/utils/random.cpp
+     ${LBANN_DIR}/src//utils/file_utils.cpp
+     ${LBANN_DIR}/src/data_readers/image_utils.cpp
+     ${LBANN_DIR}/src/data_readers/cv_utils.cpp
+     ${LBANN_DIR}/src/data_readers/cv_augmenter.cpp
+     ${LBANN_DIR}/src/data_readers/cv_colorizer.cpp
+     ${LBANN_DIR}/src/data_readers/cv_cropper.cpp
+     ${LBANN_DIR}/src/data_readers/cv_decolorizer.cpp
+     ${LBANN_DIR}/src/data_readers/cv_mean_extractor.cpp
+     ${LBANN_DIR}/src/data_readers/cv_normalizer.cpp
+     ${LBANN_DIR}/src/data_readers/cv_process.cpp
+     ${LBANN_DIR}/src/data_readers/cv_process_patches.cpp
+     ${LBANN_DIR}/src/data_readers/cv_subtractor.cpp
+     ${LBANN_DIR}/src/data_readers/cv_transform.cpp
+     ${LBANN_DIR}/src/data_readers/patchworks/patchworks.cpp
+     ${LBANN_DIR}/src/data_readers/patchworks/patchworks_patch_descriptor.cpp
+     ${LBANN_DIR}/src/data_readers/patchworks/patchworks_ROI.cpp
+     ${LBANN_DIR}/src/data_readers/patchworks/patchworks_stats.cpp)
+
+add_executable(${CONDUIT_LOAD_EXE} ${CONDUIT_LOAD_SRCS} ${CONDUIT_LOAD_DEPEND_SRCS})
+target_link_libraries(${CONDUIT_LOAD_EXE} ${OpenCV_LIBS} ${CONDUIT_LIBRARIES} ${HDF5_LIBRARIES} ${MPI_CXX_LIBRARIES} ${OpenMP_CXX_LIBRARIES})

--- a/tools/filelist/Makefile
+++ b/tools/filelist/Makefile
@@ -1,8 +1,8 @@
 MPICXX = mpic++
 
 all: sample_list.hpp sample_list_impl.hpp main.cpp
-	${CXX} -std=c++11 -Wall -o test main.cpp
-	${MPICXX} -std=c++11 -Wall -lmpi -o test_mpi main_mpi.cpp
+	${CXX} -std=c++11 -Wall -O3 -fopenmp -o test main.cpp
+	${MPICXX} -std=c++11 -Wall -lmpi -O3 -o test_mpi main_mpi.cpp
 
 clean:
 	rm -f *.o test test_mpi

--- a/tools/filelist/Makefile
+++ b/tools/filelist/Makefile
@@ -1,0 +1,8 @@
+MPICXX = mpic++
+
+all: sample_list.hpp sample_list_impl.hpp main.cpp
+	${CXX} -std=c++11 -Wall -o test main.cpp
+	${MPICXX} -std=c++11 -Wall -lmpi -o test_mpi main_mpi.cpp
+
+clean:
+	rm -f *.o test test_mpi

--- a/tools/filelist/Mat.hpp
+++ b/tools/filelist/Mat.hpp
@@ -1,0 +1,1 @@
+../compute_mean/Mat.hpp

--- a/tools/filelist/conduit_load.cpp
+++ b/tools/filelist/conduit_load.cpp
@@ -1,0 +1,688 @@
+#include <iostream>
+#include <cstdio>
+#include <string>
+#include <set>
+#include <vector>
+#include <map>
+#include "data_reader_jag_conduit.hpp"
+#include "lbann/utils/glob.hpp"
+#include <chrono>
+#include <cstdio>
+#include <algorithm>
+
+// The number of channels in a JAG image
+const int num_channels = 4;
+using variable_t = lbann::data_reader_jag_conduit::variable_t;
+
+struct stats_t {
+  std::vector<double> m_sum;
+  std::vector<double> m_min;
+  std::vector<double> m_max;
+  size_t m_num_bins;
+  std::vector< std::vector<size_t> > m_histo;
+
+  bool set_num_bins(size_t n) {
+    m_num_bins = n;
+    return (n > 0u);
+  }
+
+  void init(size_t num_variables) {
+    m_sum.assign(num_variables, 0.0);
+    m_min.assign(num_variables, std::numeric_limits<double>::max());
+    m_max.assign(num_variables, std::numeric_limits<double>::lowest());
+    std::vector<size_t> empty_bins(m_num_bins, 0u);
+    m_histo.assign(num_variables, empty_bins);
+  }
+
+  void add_to_bin(size_t idx_var, double value) {
+    int bin = static_cast<int>(value * m_num_bins);
+    bin = std::min(bin, static_cast<int>(m_num_bins-1));
+    bin = std::max(bin, 0);
+    (m_histo.at(idx_var))[bin] ++;
+  }
+};
+
+inline double get_time() {
+  using namespace std::chrono;
+  return duration_cast<duration<double>>(
+           steady_clock::now().time_since_epoch()).count();
+}
+
+std::string to_string(const variable_t vt);
+
+void show_help(int argc, char** argv);
+
+void configuration(lbann::data_reader_jag_conduit& dreader, const bool use_all, const bool do_normalize, variable_t response_t);
+
+template <typename T>
+std::ostream& print(const std::vector<T>& keys, std::ostream& os);
+void print_keys(const std::vector<std::string>& keys);
+
+void show_details(const lbann::data_reader_jag_conduit& dreader);
+
+void fetch_iteration(const bool wrt_response,
+                     const bool stat_response,
+                     const size_t mb_size,
+                     lbann::data_reader_jag_conduit& dreader,
+                     stats_t& response_stats);
+
+void report_summary_stats(const lbann::data_reader_jag_conduit& dreader,
+                     stats_t& response_stats);
+
+
+int main(int argc, char** argv)
+{
+
+  if (argc != 10) {
+    show_help(argc, argv);
+    return 0;
+  }
+
+  const std::string file_path_pattern = std::string(argv[1]);
+  std::vector<std::string> filenames = lbann::glob(file_path_pattern);
+  if (filenames.size() < 1u) {
+    std::cerr << "Failed to get data filenames from: " + file_path_pattern << std::endl;
+    return 0;
+  }
+
+
+  bool use_all = (atoi(argv[2]) > 0);
+  bool write_schema = (atoi(argv[3]) > 0);
+  bool write_images = (atoi(argv[4]) > 0);
+  bool measure_time = (atoi(argv[5]) > 0);
+  bool do_normalize = (atoi(argv[6]) > 0);
+  bool wrt_response = (atoi(argv[7]) > 0);
+  bool stat_response = (atoi(argv[8]) > 0);
+  variable_t response_type = static_cast<variable_t>(atoi(argv[9]));
+
+  std::cout << "use_all_vars : " << use_all << std::endl;
+  std::cout << "write_schema : " << write_schema << std::endl;
+  std::cout << "write_images : " << write_images << std::endl;
+  std::cout << "measure_time : " << measure_time << std::endl;
+  std::cout << "do_normalize : " << do_normalize << std::endl;
+  std::cout << "wrt_response : " << wrt_response << std::endl;
+  std::cout << "stat_response : " << stat_response << std::endl;
+  std::cout << "response_type : " << to_string(response_type) << std::endl;
+  if (stat_response && wrt_response) {
+    std::cerr << "Both wrt_response and stat_response cannot be set simultaneously" << std::endl;
+    return 0;
+  }
+
+  using namespace lbann;
+
+  std::shared_ptr<cv_process> pp;
+  pp = std::make_shared<cv_process>();
+
+#ifdef LBANN_HAS_CONDUIT
+  using namespace std;
+  data_reader_jag_conduit dreader(pp);
+
+  configuration(dreader, use_all, do_normalize, response_type);
+
+  double t_load =  get_time();
+  for (const auto& data_file: filenames) {
+    std::cout << "loading " << data_file << std::endl;
+    size_t num_valid_samples = 0ul;
+
+    dreader.load_conduit(data_file, num_valid_samples);
+  }
+  std::cout << "time to load consuit file: " << get_time() - t_load << " (sec)" << std::endl;
+
+  dreader.check_image_data();
+
+  show_details(dreader);
+
+  const size_t n = dreader.get_num_valid_local_samples();
+  // prepare the fake base data reader class (generic_data_reader) for mini batch data accesses
+  const size_t mb_size = 64u;
+  dreader.set_num_samples(n);
+  dreader.set_mini_batch_size(mb_size);
+  dreader.init();
+  dreader.check_image_data();
+
+  if (measure_time) {
+    double t =  get_time();
+    stats_t response_stats;
+    response_stats.set_num_bins(10u);
+
+    fetch_iteration(wrt_response, stat_response, mb_size, dreader, response_stats);
+
+    std::cout << "time to read all the samples: " << get_time() - t << " (sec)" << std::endl;
+
+    if (stat_response) {
+      std::cout << "Statistics of the response variables:" << std::endl;
+      report_summary_stats(dreader, response_stats);
+    }
+  } else if (stat_response) {
+    stats_t response_stats;
+    response_stats.set_num_bins(10u);
+
+    fetch_iteration(wrt_response, stat_response, mb_size, dreader, response_stats);
+
+    std::cout << "Statistics of the response variables:" << std::endl;
+    report_summary_stats(dreader, response_stats);
+  }
+
+  if (write_schema) { // print schemas
+    for (size_t s = 0u; s < n; ++s) {
+      std::ofstream schema_out("schema." + std::to_string(s) + ".txt");
+      std::streambuf *org_buf = std::cout.rdbuf(); // save old buf
+      std::cout.rdbuf(schema_out.rdbuf()); // redirect std::cout to schema_out
+      dreader.print_schema(s);
+      std::cout.rdbuf(org_buf);
+    }
+  }
+
+  if (write_images) { // dump image files
+    for (size_t s = 0u; s < n; ++s) {
+      std::vector<cv::Mat> images = dreader.get_cv_images(s);
+      for (size_t i = 0u; i < images.size(); ++i) {
+        if (dreader.check_split_image_channels()) {
+          cv::normalize(images[i], images[i], 0, 256, cv::NORM_MINMAX);
+          cv::imwrite("image." + std::to_string(s) + '.' + std::to_string(i/num_channels)
+                      + '.' + std::to_string(i%num_channels) + ".png", images[i]);
+        } else {
+          cv::Mat ch[num_channels];
+          cv::split(images[i], ch);
+          for(int c=0; c < num_channels; ++c) {
+            cv::normalize(ch[c], ch[c], 0, 256, cv::NORM_MINMAX);
+            cv::imwrite("image." + std::to_string(s) + '.' + std::to_string(i)
+                        + '.' + std::to_string(c) + ".png", ch[c]);
+          }
+        }
+      }
+    }
+  }
+
+/*
+  dreader.get_scalars(0);
+  double t =  get_time();
+  for (size_t s = 0u; s < n; ++s) {
+    dreader.get_inputs(s);
+  }
+  std::cout << "time to load input data: " << get_time() - t << std::endl;
+*/
+#endif // LBANN_HAS_CONDUIT
+
+  return 0;
+}
+
+
+
+void show_help(int argc, char** argv) {
+  std::cout << "Uasge: > " << argv[0] << " conduit_file use_all_vars write_schema write_images measure_time do_normalize wrt_response stat_response response_type" << std::endl;
+  std::cout << "         - use_all_vars (1|0): whether to use all the variables or only those selected." << std::endl;
+  std::cout << "         - write_schema (1|0): whether to write schema files." << std::endl;
+  std::cout << "         - write_images (1|0): whether to write image files." << std::endl;
+  std::cout << "         - measure_time (1|0): whether to measure the time to read all the samples." << std::endl;
+  std::cout << "         - do_normalize (1|0): whether to use normalization." << std::endl;
+  std::cout << "         - wrt_response (1|0): whether to print out response variables." << std::endl;
+  std::cout << "         - stat_response (1|0): whether to summarize the statistics of response variables." << std::endl;
+  std::cout << "           Both wrt_response and stat_response cannot be set simultaneously" << std::endl;
+  std::cout << "         - response_type (2|3): type of the response variable: 2 for JAG_Scalar, and 3 for JAG_Input." << std::endl;
+}
+
+
+void set_normalization(lbann::data_reader_jag_conduit& dreader) {
+
+  const auto& image_keys = dreader.get_image_choices();
+  const auto& scalar_keys = dreader.get_scalar_choices();
+  const auto& input_keys = dreader.get_input_choices();
+
+  using linear_transform_t = lbann::data_reader_jag_conduit::linear_transform_t;
+
+  dreader.clear_image_normalization_params();
+  dreader.clear_scalar_normalization_params();
+  dreader.clear_input_normalization_params();
+
+  for (const auto& key: image_keys) { // TODO: use unique set of values per key
+    std::cout << " - define image normalization for " << key << std::endl;
+    dreader.add_image_normalization_param(linear_transform_t(28.128928461, 0.0)); // ch0
+    dreader.add_image_normalization_param(linear_transform_t(817.362315273, 0.0)); // ch1
+    dreader.add_image_normalization_param(linear_transform_t(93066.843470244, 0.0)); // ch2
+    dreader.add_image_normalization_param(linear_transform_t(4360735.362407147, 0.0)); // ch3
+  }
+
+  for (const auto& key: scalar_keys) {
+    std::cout << " - define scalar normalization for " << key << std::endl;
+  #if 0 // 10K
+    if (key == "BWx")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.660399380e+01, -8.914478521e-01)); // BWx
+    else if (key == "BT")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.499062171e+00, -3.529513015e+00)); // BT
+    else if (key == "tMAXt")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.530702521e+00, -3.599429878e+00)); // tMAXt
+    else if (key == "BWn")
+      dreader.add_scalar_normalization_param(linear_transform_t(4.644040100e+01, -1.703187287e+00)); // BWn
+    else if (key == "MAXpressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.795164343e-06, -5.849243445e-01)); // MAXpressure
+    else if (key == "BAte")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.807222136e-01, -1.042499360e+00)); // BAte
+    else if (key == "MAXtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.571981124e-01, -1.050431705e+00)); // MAXtion
+    else if (key == "tMAXpressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.468048973e+00, -3.447884539e+00)); // tMAXpressure
+    else if (key == "BAt")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.807222136e-01, -1.042499360e+00)); // BAt
+    else if (key == "Yn")
+      dreader.add_scalar_normalization_param(linear_transform_t(8.210767783e-18, -2.182660862e-02)); // Yn
+    else if (key == "Ye")
+      dreader.add_scalar_normalization_param(linear_transform_t(3.634574711e-03, -2.182660596e-02)); // Ye
+    else if (key == "Yx")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.242376030e-02, -3.376249820e-01)); // Yx
+    else if (key == "tMAXte")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.530702521e+00, -3.599429878e+00)); // tMAXte
+    else if (key == "BAtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.807222136e-01, -1.042499360e+00)); // BAtion
+    else if (key == "MAXte")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.571981124e-01, -1.050431705e+00)); // MAXte
+    else if (key == "tMAXtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.530702521e+00, -3.599429878e+00)); // tMAXtion
+    else if (key == "BTx")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.461374463e+00, -3.414620490e+00)); // BTx
+    else if (key == "MAXt")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.571981124e-01, -1.050431705e+00)); // MAXt
+    else if (key == "BTn")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.499062171e+00, -3.529513015e+00)); // BTn
+    else if (key == "BApressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.240009139e-06, -5.837354616e-01)); // BApressure
+    else if (key == "tMINradius")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.427286973e+00, -3.328267524e+00)); // tMINradius
+    else if (key == "MINradius")
+      dreader.add_scalar_normalization_param(linear_transform_t(6.404465614e-02, -1.418863592e+00)); // MINradius
+  #else
+    if (key == "BWx")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.5420795e+01, -8.313582e-01)); // BWx
+    else if (key == "BT")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4593427e+00, -3.426026e+00)); // BT
+    else if (key == "tMAXt")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4901131e+00, -3.493689e+00)); // tMAXt
+    else if (key == "BWn")
+      dreader.add_scalar_normalization_param(linear_transform_t(4.4250137e+01, -1.623055e+00)); // BWn
+    else if (key == "MAXpressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.4432852e-06, -7.724349e-01)); // MAXpressure
+    else if (key == "BAte")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.6368040e-01, -9.765773e-01)); // BAte
+    else if (key == "MAXtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.4198603e-01, -9.856284e-01)); // MAXtion
+    else if (key == "tMAXpressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4302059e+00, -3.349900e+00)); // tMAXpressure
+    else if (key == "BAt")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.6368040e-01, -9.765773e-01)); // BAt
+    else if (key == "Yn")
+      dreader.add_scalar_normalization_param(linear_transform_t(7.1544386e-18, -1.869906e-02)); // Yn
+    else if (key == "Ye")
+      dreader.add_scalar_normalization_param(linear_transform_t(3.1669860e-03, -1.869906e-02)); // Ye
+    else if (key == "Yx")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.1041247e-02, -3.084058e-01)); // Yx
+    else if (key == "tMAXte")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4901131e+00, -3.493689e+00)); // tMAXte
+    else if (key == "BAtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.6368040e-01, -9.765773e-01)); // BAtion
+    else if (key == "MAXte")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.4198603e-01, -9.856284e-01)); // MAXte
+    else if (key == "tMAXtion")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4901131e+00, -3.493689e+00)); // tMAXtion
+    else if (key == "BTx")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.3456596e+00, -3.116023e+00)); // BTx
+    else if (key == "MAXt")
+      dreader.add_scalar_normalization_param(linear_transform_t(2.4198603e-01, -9.856284e-01)); // MAXt
+    else if (key == "BTn")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.4593427e+00, -3.426026e+00)); // BTn
+    else if (key == "BApressure")
+      dreader.add_scalar_normalization_param(linear_transform_t(3.0520000e-06, -7.714907e-01)); // BApressure
+    else if (key == "tMINradius")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.3925443e+00, -3.239921e+00)); // tMINradius
+    else if (key == "MINradius")
+      dreader.add_scalar_normalization_param(linear_transform_t(1.0023756e-01, -2.815272e+00)); // MINradius
+  #endif
+  }
+
+  for (const auto& key: input_keys) {
+    std::cout << " - define input normalization for " << key << std::endl;
+  #if 0
+    if (key == "shape_model_initial_modes:(4,3)")
+      dreader.add_input_normalization_param(linear_transform_t(1.667587753e+00, 4.997824968e-01)); // shape_model_initial_modes:(4,3)
+    else if (key == "betti_prl15_trans_u")
+      dreader.add_input_normalization_param(linear_transform_t(1.000245480e+00, -8.438836401e-05)); // betti_prl15_trans_u
+    else if (key == "betti_prl15_trans_v")
+      dreader.add_input_normalization_param(linear_transform_t(1.000870539e+00, -7.346414236e-04)); // betti_prl15_trans_v
+    else if (key == "shape_model_initial_modes:(2,1)")
+      dreader.add_input_normalization_param(linear_transform_t(1.668835219e+00, 4.997744013e-01)); // shape_model_initial_modes:(2,1)
+    else if (key == "shape_model_initial_modes:(1,0)")
+      dreader.add_input_normalization_param(linear_transform_t(1.667992865e+00, 4.999102733e-01)); // shape_model_initial_modes:(1,0)
+  #else
+    if (key == "shape_model_initial_modes:(4,3)")
+      dreader.add_input_normalization_param(linear_transform_t(1.666721654e+01, 5.000145788e+00)); // shape_model_initial_modes:(4,3)
+    else if (key == "betti_prl15_trans_u")
+      dreader.add_input_normalization_param(linear_transform_t(1.000025133e+01, -1.603520955e-06)); // betti_prl15_trans_u
+    else if (key == "betti_prl15_trans_v")
+      dreader.add_input_normalization_param(linear_transform_t(1.000001645e+00, -1.406676728e-06)); // betti_prl15_trans_v
+    else if (key == "shape_model_initial_modes:(2,1)")
+      dreader.add_input_normalization_param(linear_transform_t(1.666672975e+00, 4.999989818e-01)); // shape_model_initial_modes:(2,1)
+    else if (key == "shape_model_initial_modes:(1,0)")
+      dreader.add_input_normalization_param(linear_transform_t(1.666668753e+00, 5.000004967e-01)); // shape_model_initial_modes:(1,0)
+  #endif
+  }
+}
+
+
+void configuration(lbann::data_reader_jag_conduit& dreader,
+  const bool use_all_vars,
+  const bool do_normalize,
+  const variable_t response_t) {
+
+  using namespace lbann;
+
+  if (!((response_t == data_reader_jag_conduit::JAG_Image) ||
+      (response_t == data_reader_jag_conduit::JAG_Scalar) ||
+      (response_t == data_reader_jag_conduit::JAG_Input))) {
+    std::cerr << "unknown response type: " << static_cast<int>(response_t) << std::endl;
+    exit(0);
+  }
+
+  const std::vector< std::vector<variable_t> > independent
+    = {{data_reader_jag_conduit::JAG_Image, data_reader_jag_conduit::JAG_Scalar}, {data_reader_jag_conduit::JAG_Input} };
+  dreader.set_independent_variable_type(independent);
+
+  const std::vector< std::vector<variable_t> > dependent = {{response_t}};
+  dreader.set_dependent_variable_type(dependent);
+
+  const std::vector<std::string> image_keys_manual = {
+    "(0.0, 0.0)/0.0",
+    "(90.0, 0.0)/-0.01",
+    "(90.0, 78.0)/-0.03"
+  };
+
+  const std::vector<std::string> scalar_keys_manual = {
+    "BWx",
+    "BT",
+    "tMAXt",
+    "BWn",
+    "MAXpressure",
+    "BAte",
+    "MAXtion",
+    "tMAXpressure",
+    "BAt",
+    "Yn",
+    "Ye",
+    "Yx",
+    "tMAXte",
+    "BAtion",
+    "MAXte",
+    "tMAXtion",
+    "BTx",
+    "MAXt",
+    "BTn",
+    "BApressure",
+    "tMINradius",
+    "MINradius"
+  };
+
+  const std::vector<std::string> input_keys_manual = {
+    "shape_model_initial_modes:(4,3)",
+    "betti_prl15_trans_u",
+    "betti_prl15_trans_v",
+    "shape_model_initial_modes:(2,1)",
+    "shape_model_initial_modes:(1,0)"
+  };
+
+  if (use_all_vars) {
+    dreader.set_all_scalar_choices();
+    dreader.set_all_input_choices();
+    dreader.add_scalar_prefix_filter(std::make_pair("image_(", 26));
+    dreader.add_scalar_filter("iBT");
+  } else {
+    dreader.set_scalar_choices(scalar_keys_manual);
+    dreader.set_input_choices(input_keys_manual);
+  }
+
+  dreader.set_image_dims(64, 64, num_channels);
+  dreader.set_image_choices(image_keys_manual);
+  dreader.set_split_image_channels();
+
+  if (do_normalize) {
+    set_normalization(dreader);
+  }
+}
+
+std::string to_string(const variable_t vt) {
+  using namespace lbann;
+  switch(vt) {
+    case data_reader_jag_conduit::JAG_Image:
+      return "Jag_Image";
+      break;
+    case data_reader_jag_conduit::JAG_Scalar:
+      return "JAG_Scalar";
+      break;
+    case data_reader_jag_conduit::JAG_Input:
+      return "JAG_Input";
+      break;
+    default: return "Undefined";
+  }
+  return "Undefined";
+}
+
+template <typename T>
+std::ostream& print(const std::vector<T>& keys, std::ostream& os) {
+  for(const auto& key: keys) {
+    os << ' ' << key;
+  }
+  return (os << ' ');
+}
+
+void print_keys(const std::vector<std::string>& keys) {
+  std::cout << "==========================" << std::endl;
+  print(keys, std::cout);
+  std::cout << std::endl;
+  std::cout << "==========================" << std::endl;
+}
+
+void show_details(const lbann::data_reader_jag_conduit& dreader) {
+  std::cout << "- number_of_samples: " << dreader.get_num_valid_local_samples() << std::endl;
+  std::cout << "- linearized image size: " << dreader.get_linearized_image_size() << std::endl;
+  std::cout << "- linearized scalar size: " << dreader.get_linearized_scalar_size() << std::endl;
+  std::cout << "- linearized input size: " << dreader.get_linearized_input_size() << std::endl;
+  std::cout << "- linearized data size: " << dreader.get_linearized_data_size() << std::endl;
+  std::cout << "- linearized response size: " << dreader.get_linearized_response_size() << std::endl;
+
+  std::cout << "- linearized data sizes:";
+  for (const auto& sz: dreader.get_linearized_data_sizes()) {
+    std::cout << ' ' << sz;
+  }
+  std::cout << std::endl;
+
+  std::cout << "- slice points for independent vars: ";
+  print(dreader.get_slice_points_independent(), std::cout);
+  std::cout << std::endl;
+  std::cout << "- slice points for dependent vars: " ;
+  print(dreader.get_slice_points_dependent(), std::cout);
+  std::cout << std::endl;
+
+  print_keys(dreader.get_scalar_choices());
+  print_keys(dreader.get_input_choices());
+  std::cout << dreader.get_description() << std::endl;
+}
+
+
+void fetch_iteration(const bool wrt_response, const bool stat_response,
+                     const size_t mb_size,
+                     lbann::data_reader_jag_conduit& dreader,
+                     stats_t& stats) {
+
+  const size_t n = dreader.get_num_valid_local_samples();
+  const size_t nd = dreader.get_linearized_data_size();
+  const size_t nr = dreader.get_linearized_response_size();
+  const size_t n_full = (n / mb_size) * mb_size; // total number of samples in full mini batches
+  const size_t n_rem  = n - n_full; // number of samples in the last partial mini batch (0 if the last one is full)
+
+  CPUMat X;
+  CPUMat Y;
+
+  X.Resize(nd, mb_size);
+  Y.Resize(nr, mb_size);
+
+  stats.init(nr);
+
+  if (wrt_response) {
+    for (size_t s = 0u; s < n_full; s += mb_size) {
+      std::cout << "samples [" << s << ' ' << s+mb_size << ")" << std::endl;
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+
+      for (size_t c = 0; c < mb_size; ++c) {
+        for(size_t r = 0; r < nr ; ++r) {
+          printf("\t%e", Y(r, c));
+        }
+        std::cout << std::endl;
+      }
+      std::cout << std::endl;
+
+      dreader.update();
+    }
+    if (n_rem > 0u) {
+      X.Resize(X.Height(), n_rem);
+      Y.Resize(Y.Height(), n_rem);
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+
+      for (size_t c = 0; c < n_rem; ++c) {
+        for(size_t r = 0; r < nr ; ++r) {
+          printf("\t%e", Y(r, c));
+        }
+        std::cout << std::endl;
+      }
+      std::cout << std::endl;
+
+      dreader.update();
+    }
+  } else if (stat_response) {
+    for (size_t s = 0u; s < n_full; s += mb_size) {
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+
+      for (size_t c = 0; c < mb_size; ++c) {
+        for(size_t r = 0; r < nr ; ++r) {
+          const double val = Y(r,c);
+          if (val < stats.m_min[r]) {
+            stats.m_min[r] = val;
+          }
+          if (val > stats.m_max[r]) {
+            stats.m_max[r] = val;
+          }
+          
+          stats.m_sum[r] += val;
+          stats.add_to_bin(r, val);
+        }
+      }
+
+      dreader.update();
+    }
+    if (n_rem > 0u) {
+      X.Resize(X.Height(), n_rem);
+      Y.Resize(Y.Height(), n_rem);
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+
+      for (size_t c = 0; c < n_rem; ++c) {
+        for(size_t r = 0; r < nr ; ++r) {
+          const double val = Y(r,c);
+          if (val < stats.m_min[r]) {
+            stats.m_min[r] = val;
+          }
+          if (val > stats.m_max[r]) {
+            stats.m_max[r] = val;
+          }
+          stats.m_sum[r] += val;
+          stats.add_to_bin(r, val);
+        }
+      }
+
+      dreader.update();
+    }
+  } else {
+    for (size_t s = 0u; s < n_full; s += mb_size) {
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+      dreader.update();
+    }
+    if (n_rem > 0u) {
+      X.Resize(X.Height(), n_rem);
+      Y.Resize(Y.Height(), n_rem);
+      dreader.fetch_data(X);
+      dreader.fetch_responses(Y);
+      dreader.update();
+    }
+  }
+}
+
+
+void report_summary_stats(const  lbann::data_reader_jag_conduit& dreader,
+                          stats_t& stats) {
+
+  const size_t n = dreader.get_num_valid_local_samples();
+  const auto response_types = dreader.get_dependent_variable_type();
+
+  if (response_types.size() != 1u) {
+    std::cerr << "Not able to handle composite responses. Use only one type." << std::endl;
+    return;
+  }
+
+  const auto& image_keys = dreader.get_image_choices();
+  const auto& scalar_keys = dreader.get_scalar_choices();
+  const auto& input_keys = dreader.get_input_choices();
+
+  using namespace lbann;
+  using variable_t = lbann::data_reader_jag_conduit::variable_t;
+
+  const std::map<variable_t, const std::vector<std::string>*> keys = {
+    std::make_pair(data_reader_jag_conduit::JAG_Image, &image_keys),
+    std::make_pair(data_reader_jag_conduit::JAG_Scalar, &scalar_keys),
+    std::make_pair(data_reader_jag_conduit::JAG_Input, &input_keys),
+  };
+
+  const auto it_keys = keys.find(response_types[0]);
+  if (it_keys == keys.cend() || (it_keys->second == nullptr)) {
+    std::cerr << "Unknown dependent variable keys." << std::endl;
+    return;
+  }
+  const std::vector<std::string> response_keys = *(it_keys->second);
+
+  const size_t nr = dreader.get_linearized_response_size();
+
+  std::cout << "min: ";
+  for (size_t r = 0u; r < nr; ++r) {
+    std::cout << '\t' << stats.m_min[r];
+  }
+  std::cout << std::endl;
+  std::cout << "max: ";
+  for (size_t r = 0u; r < nr; ++r) {
+    std::cout << '\t' << stats.m_max[r];
+  }
+  std::cout << std::endl;
+  std::cout << "mean: ";
+  for (size_t r = 0u; r < nr; ++r) {
+    std::cout << '\t' << stats.m_sum[r]/n;
+  }
+  std::cout << std::endl;
+  std::cout << "histo: \n";
+  for (size_t r = 0u; r < nr; ++r) {
+    for (size_t b = 0u; b < stats.m_num_bins; ++b) {
+      std::cout << '\t' << stats.m_histo[r][b];
+    }
+    std::cout << std::endl;
+  }
+  std::cout << std::endl;
+
+  std::cout << "linear transform parameters: " << std::endl;
+  std::vector<double> alpha(nr);
+  std::vector<double> beta(nr);
+
+  for (size_t r = 0u; r < nr; ++r) {
+    alpha[r] = 1.0/(stats.m_max[r] - stats.m_min[r]);
+    beta[r] = -stats.m_min[r]/(stats.m_max[r] - stats.m_min[r]);
+    const char comma = (r + 1u == nr)? ' '  : ',';
+    printf("      { scale: %.9e \tbias: %.9e}%c \t# %s\n", alpha[r], beta[r], comma, response_keys[r].c_str());
+  }
+  std::cout << std::endl;
+}

--- a/tools/filelist/data_reader.hpp
+++ b/tools/filelist/data_reader.hpp
@@ -1,0 +1,131 @@
+#ifndef _DATA_READER_HPP_
+#define _DATA_READER_HPP_
+
+#include <string>
+#include <vector>
+#include "lbann/base.hpp"
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/omp_pragma.hpp"
+#include <omp.h>
+
+namespace lbann {
+
+class generic_data_reader {
+ public:
+  generic_data_reader(bool);
+  generic_data_reader(const generic_data_reader&) = default;
+  generic_data_reader& operator=(const generic_data_reader&) = default;
+  virtual generic_data_reader* copy() const { return nullptr; }
+  virtual ~generic_data_reader() {}
+
+  virtual std::string get_type() const = 0;
+
+  bool is_master() const { return m_master; }
+
+  /// Set the mini batch size
+  void set_mini_batch_size(const int s) {
+    m_mini_batch_size = s;
+  }
+  virtual int get_linearized_data_size() const = 0;
+  virtual int get_linearized_response_size() const = 0;
+  virtual int get_linearized_label_size() const = 0;
+  virtual int get_num_labels() const = 0;
+  virtual int get_linearized_size(const std::string& desc) const { return 0; }
+  virtual const std::vector<int> get_data_dims() const = 0;
+  virtual void save_image(Mat& pixels, const std::string filename, bool do_scale = true) = 0;
+
+  virtual int fetch_data(CPUMat& X);
+  virtual int fetch_responses(CPUMat& Y);
+  virtual int fetch_labels(CPUMat& Y);
+
+  void set_num_samples(size_t ns) { m_num_samples = ns; }
+  virtual bool init();
+  virtual void update();
+  int get_cur_mini_batch_size() const;
+  virtual void load() { init(); }
+
+ protected:
+  virtual bool fetch_datum(CPUMat& X, int data_id, int mb_idx, int tid) = 0;
+  virtual bool fetch_response(CPUMat& Y, int data_id, int mb_idx, int tid) = 0;
+  virtual bool fetch_label(CPUMat& Y, int data_id, int mb_idx, int tid) = 0;
+  int get_current_mini_batch_size() const { return 128; }
+
+  bool m_master;
+  bool m_gan_labelling = false;
+  int m_gan_label_value = 0;
+  std::string m_role;
+  int m_mini_batch_size;
+
+  int m_sid; // sample index
+  int m_num_samples;
+  int m_current_mini_batch_idx;
+  int m_num_full_mbs;
+  int m_num_rem_samples;
+};
+
+inline generic_data_reader::generic_data_reader(bool b)
+ : m_master(true), m_role("offline"), m_mini_batch_size(8), m_sid(0),
+   m_num_samples(0), m_current_mini_batch_idx(0),
+   m_num_full_mbs(0), m_num_rem_samples(0)
+{}
+
+template<typename T>
+inline void set_minibatch_item(CPUMat& M, const int mb_idx, const T* const ptr, const size_t count) {
+  if ((count > 0u) && (ptr == nullptr)) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
+                          " :: attempt to dereference a nullptr ");
+  }
+  for (size_t i = 0u; i < count; ++i) {
+    M.Set(static_cast<El::Int>(i), static_cast<El::Int>(mb_idx), static_cast<DataType>(ptr[i]));
+  }
+}
+
+inline int generic_data_reader::fetch_data(CPUMat& X) {
+  const int mbsz = get_cur_mini_batch_size();
+  LBANN_DATA_FETCH_OMP_FOR (int s = 0; s < mbsz; s++) {
+    fetch_datum(X, static_cast<int>(m_sid + s), static_cast<int>(s), LBANN_OMP_THREAD_NUM);
+  }
+  return mbsz;
+}
+
+inline int generic_data_reader::fetch_responses(CPUMat& X) {
+  const int mbsz = get_cur_mini_batch_size();
+  LBANN_DATA_FETCH_OMP_FOR (int s = 0; s < mbsz; s++) {
+    fetch_response(X, static_cast<int>(m_sid + s), static_cast<int>(s), LBANN_OMP_THREAD_NUM);
+  }
+  return mbsz;
+}
+
+inline int generic_data_reader::fetch_labels(CPUMat& X) {
+  const int mbsz = get_cur_mini_batch_size();
+  LBANN_DATA_FETCH_OMP_FOR (int s = 0; s < mbsz; s++) {
+    fetch_label(X, static_cast<int>(m_sid + s), static_cast<int>(s), LBANN_OMP_THREAD_NUM);
+  }
+  return mbsz;
+}
+
+inline int generic_data_reader::get_cur_mini_batch_size() const {
+  return (m_current_mini_batch_idx >= m_num_full_mbs)? m_num_rem_samples : m_mini_batch_size;
+}
+
+inline bool generic_data_reader::init() {
+  if (m_num_samples == 0 || m_mini_batch_size == 0) {
+    return false;
+  }
+  m_num_full_mbs = (m_num_samples / m_mini_batch_size) ;
+  m_num_rem_samples = m_num_samples - m_num_full_mbs * m_mini_batch_size;
+  m_sid = 0;
+  m_current_mini_batch_idx = 0;
+  std::cout << "m_num_full_mbs " << m_num_full_mbs << " m_num_rem_samples " << m_num_rem_samples << std::endl;
+  return true;
+}
+
+inline void generic_data_reader::update() {
+  m_sid += get_cur_mini_batch_size();
+  m_current_mini_batch_idx ++;
+  std::cout << "m_current_mini_batch_idx: " << m_current_mini_batch_idx << " m_sid" << m_sid << std::endl;
+}
+
+} // namespace lbann
+
+#endif // _DATA_READER_HPP_

--- a/tools/filelist/data_reader_jag_conduit.cpp
+++ b/tools/filelist/data_reader_jag_conduit.cpp
@@ -1,0 +1,1 @@
+../../src/data_readers/data_reader_jag_conduit.cpp

--- a/tools/filelist/data_reader_jag_conduit.hpp
+++ b/tools/filelist/data_reader_jag_conduit.hpp
@@ -1,0 +1,1 @@
+../../include/lbann/data_readers/data_reader_jag_conduit.hpp

--- a/tools/filelist/gentest.sh
+++ b/tools/filelist/gentest.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+for i in `seq 1 1000`
+do
+  str=file$i
+  for j in `seq 0 999`
+  do
+     str=$str' sample_'$i'_'$j
+  done
+  echo $str
+done

--- a/tools/filelist/lbann
+++ b/tools/filelist/lbann
@@ -1,0 +1,1 @@
+../compute_mean/lbann

--- a/tools/filelist/lbann_config.hpp
+++ b/tools/filelist/lbann_config.hpp
@@ -1,0 +1,1 @@
+../compute_mean/lbann_config.hpp

--- a/tools/filelist/main.cpp
+++ b/tools/filelist/main.cpp
@@ -1,0 +1,34 @@
+#include "sample_list.hpp"
+
+using namespace lbann;
+
+int main(int argc, char** argv)
+{
+  if (argc != 3) {
+    std::cout << "usage : > " << argv[0] << " sample_list_file num_ranks" << std::endl;
+    return 0;
+  }
+
+  // The file name of the sample file list
+  std::string sample_list_file(argv[1]);
+
+  // The number of ranks to divide samples with
+  int num_ranks = atoi(argv[2]);
+
+  sample_list<> sn;
+  sn.set_num_partitions(num_ranks);
+  sn.load(sample_list_file);
+
+  // Create a copy of the sample file list read for verification
+  sn.write("copy_of_" + sample_list_file);
+
+
+  for(int i = 0; i < num_ranks; ++i) {
+    std::string sstr;
+    sn.to_string(static_cast<size_t>(i), sstr);
+    std::cout << sstr;
+  }
+  return 0;
+}
+
+

--- a/tools/filelist/main_mpi.cpp
+++ b/tools/filelist/main_mpi.cpp
@@ -1,0 +1,173 @@
+#include "sample_list.hpp"
+#include <deque>
+#include <memory>
+#include <mpi.h>
+#include <cstdio>
+
+using namespace lbann;
+
+MPI_Status status;
+
+struct send_request {
+  int m_receiver;
+  MPI_Request m_mpi_request;
+  std::shared_ptr<std::string> m_data;
+  unsigned long m_buf_size;
+
+  send_request() {
+    m_data = std::make_shared<std::string>();
+  }
+
+  void set_receiver(int recv) {
+    m_receiver = recv;
+  }
+
+  int get_receiver() const {
+    return m_receiver;
+  }
+
+  MPI_Request& request() {
+    return m_mpi_request;
+  }
+
+  std::string* data() const {
+    return m_data.get();
+  }
+
+  unsigned long& size() {
+    m_buf_size = static_cast<unsigned long>(m_data->size());
+    return m_buf_size;
+  }
+};
+
+
+void handle_mpi_error(int ierr) {
+  int errclass, resultlen;;
+  char err_buffer[MPI_MAX_ERROR_STRING];
+ 
+  if (ierr != MPI_SUCCESS) {
+    MPI_Error_class(ierr, &errclass);
+    if (errclass == MPI_ERR_RANK) {
+      fprintf(stderr, "Invalid rank used in MPI send call\n");
+      MPI_Error_string(ierr, err_buffer, &resultlen);
+      fprintf(stderr,err_buffer);
+      MPI_Finalize();             /* abort*/
+    }
+  }
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::cout << "usage : > " << argv[0] << " sample_list_file num_ranks" << std::endl;
+    return 0;
+  }
+
+  std::string my_samples;
+
+  // The number of ranks to divide samples with
+  int num_ranks = 1;
+  int my_rank = 0;
+  int ierr;
+  int root_rank = 0;
+  int size_tag = 0;
+  int data_tag = 1;
+  MPI_Comm comm = MPI_COMM_WORLD;
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(comm, &my_rank);
+  MPI_Comm_size(comm, &num_ranks);
+  MPI_Errhandler_set(MPI_COMM_WORLD,MPI_ERRORS_RETURN);
+  
+  if (my_rank == root_rank) {
+    // The file name of the sample file list
+    std::string sample_list_file(argv[1]);
+
+    sample_list<> sn;
+    sn.set_num_partitions(num_ranks);
+    sn.load(sample_list_file);
+    std::deque< send_request > send_requests;
+
+    // Start of serialization and transmission
+    MPI_Barrier(comm);
+
+    for(int i = 0; i < num_ranks; ++i) {
+      if (i == root_rank) {
+        sn.to_string(static_cast<size_t>(root_rank), my_samples);
+        continue;
+      }
+
+      send_requests.emplace_back();
+      auto& req0 = send_requests.back();
+      send_requests.emplace_back();
+      auto& req1 = send_requests.back();
+      req0.set_receiver(i);
+      req1.set_receiver(i);
+      std::string& sstr = *(req1.data());
+
+      sn.to_string(static_cast<size_t>(i), sstr);
+      unsigned long& bufsize = req1.size();
+
+      ierr = MPI_Isend(reinterpret_cast<void*>(&bufsize), 1,
+                       MPI_UNSIGNED_LONG, i, size_tag, comm, &(req0.request())); 
+      handle_mpi_error(ierr);
+
+      ierr = MPI_Isend(reinterpret_cast<void*>(const_cast<char*>(sstr.data())), static_cast<int>(sstr.size()),
+                       MPI_BYTE, i, data_tag, comm, &(req1.request())); 
+      handle_mpi_error(ierr);
+
+      const int n_prev_reqs = static_cast<int>(send_requests.size() - 2);
+
+      for (int j = 0; j < n_prev_reqs; ++j) {
+        MPI_Status status;
+        int flag;
+        auto& req = send_requests.front();
+
+        MPI_Test(&(req.request()), &flag, &status);
+
+        if (!flag) {
+          break;
+        }
+        std::cout << "completnig Isend for recv by rank " << req.get_receiver() << std::endl;
+        send_requests.pop_front();
+      }
+    }
+
+    for (auto& req: send_requests) {
+      MPI_Status status;
+      MPI_Wait(&(req.request()), &status);
+      std::cout << "finally completnig Isend for recv by rank " << req.get_receiver() << std::endl;
+    }
+
+    send_requests.clear();
+  } else {
+    // Start of serialization and transmission
+    MPI_Barrier(comm);
+    MPI_Status status;
+    unsigned long bufsize = 0u;
+    ierr = MPI_Recv(reinterpret_cast<void*>(&bufsize), 1,
+                    MPI_UNSIGNED_LONG, root_rank, size_tag, comm, &status);
+    handle_mpi_error(ierr);
+
+    my_samples.resize(bufsize);
+
+    ierr = MPI_Recv(reinterpret_cast<void*>(&my_samples[0]), static_cast<int>(bufsize),
+                    MPI_BYTE, root_rank, data_tag, comm, &status);
+    handle_mpi_error(ierr);
+  }
+
+  // End of serialization and transmission
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  for(int i = 0; i < num_ranks; ++i) {
+    if (i == my_rank) {
+      std::cout << my_samples;
+    }
+    MPI_Barrier(MPI_COMM_WORLD);
+  }
+  MPI_Finalize();
+
+  return 0;
+}
+
+

--- a/tools/filelist/sample_list.hpp
+++ b/tools/filelist/sample_list.hpp
@@ -1,6 +1,7 @@
 #ifndef __SAMPLE_LIST_HPP__
 #define __SAMPLE_LIST_HPP__
 
+#include <iostream>
 #include <string>
 #include <vector>
 #include <list>
@@ -30,6 +31,9 @@ class sample_list {
   /// Load a sample list from a file
   bool load(const std::string& samplelist_file);
 
+  /// Extract a sample list from a serialized sample list in a string
+  bool load_from_string(const std::string& samplelist);
+
   /// Write the current sample list into a file
   bool write(const std::string& out_filename) const;
 
@@ -41,8 +45,11 @@ class sample_list {
 
  protected:
 
-  /// Populate m_samples_per_file and m_filenames by reading samplelist_file
-  size_t get_samples_per_file(const std::string& samplelist_file);
+  /// Populate m_samples_per_file and m_filenames by reading from input stream
+  size_t get_samples_per_file(std::istream& istr);
+
+  /// Extract m_samples_per_file and m_filenames by parsing a serialized string
+  size_t get_samples_per_file(const std::string& samplelist);
 
   /// Populate the list of starting sample id for each sample file
   bool get_sample_range_per_file();

--- a/tools/filelist/sample_list.hpp
+++ b/tools/filelist/sample_list.hpp
@@ -1,0 +1,86 @@
+#ifndef __SAMPLE_LIST_HPP__
+#define __SAMPLE_LIST_HPP__
+
+#include <string>
+#include <vector>
+#include <list>
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+template <typename SN = std::string>
+class sample_list {
+ public:
+  /// The type of the native identifier of a sample rather than an arbitrarily assigned index
+  using sample_name_t = SN;
+  /// The type for arbitrarily assigned index
+  using sample_id_t = size_t;
+  /// Type for list of sample names in a sample file
+  using samples_t = std::template list<sample_name_t>;
+  /// Type for list where an element is the list of samples in a sample file
+  using sample_files_t = std::template list<samples_t>;
+  /// Type for list of sample file names
+  using file_name_list_t = std::list<std::string>;
+
+  sample_list() : m_num_partitions(1u) {}
+
+  /// Set the number of partitions and clear internal states
+  bool set_num_partitions(size_t n);
+
+  /// Load a sample list from a file
+  bool load(const std::string& samplelist_file);
+
+  /// Write the current sample list into a file
+  bool write(const std::string& out_filename) const;
+
+  /// Clear internal states
+  void clear();
+
+  /// Serialize sample list for a partition
+  bool to_string(size_t p, std::string& sstr);
+
+ protected:
+
+  /// Populate m_samples_per_file and m_filenames by reading samplelist_file
+  size_t get_samples_per_file(const std::string& samplelist_file);
+
+  /// Populate the list of starting sample id for each sample file
+  bool get_sample_range_per_file();
+
+  /// Populate the list of starting sample id for each partition
+  bool get_sample_range_per_part();
+
+  /// Find the range of sample files that covers the range of samples of a partition
+  bool find_sample_files_of_part(size_t p, size_t& sf_begin, size_t& sf_end) const;
+
+  std::string to_string(const std::string& s);
+
+  template <typename T>
+  std::string to_string(const T v);
+
+ protected:
+
+  /// The number of partitions to divide samples into
+  size_t m_num_partitions;
+
+  /// The sample file names
+  file_name_list_t m_filenames;
+
+  /** In a sample file list, each line begins with a sample file name
+   * that is followed by the names of the samples in the file.
+   */
+  sample_files_t m_samples_per_file;
+
+  /// Contains starting sample id of each file
+  std::vector<sample_id_t> m_sample_range_per_file;
+
+  /// Contains starting sample id of each partition
+  std::vector<sample_id_t> m_sample_range_per_part;
+};
+
+
+} // end of namespace
+
+#include "sample_list_impl.hpp"
+
+#endif // __SAMPLE_LIST_HPP__

--- a/tools/filelist/sample_list.hpp
+++ b/tools/filelist/sample_list.hpp
@@ -19,9 +19,7 @@ class sample_list {
   /// Type for list of sample names in a sample file
   using samples_t = std::template list<sample_name_t>;
   /// Type for list where an element is the list of samples in a sample file
-  using sample_files_t = std::template list<samples_t>;
-  /// Type for list of sample file names
-  using file_name_list_t = std::list<std::string>;
+  using sample_files_t = std::template list< std::pair<std::string, samples_t> >;
 
   sample_list() : m_num_partitions(1u) {}
 
@@ -45,10 +43,10 @@ class sample_list {
 
  protected:
 
-  /// Populate m_samples_per_file and m_filenames by reading from input stream
+  /// Populate m_samples_per_file by reading from input stream
   size_t get_samples_per_file(std::istream& istr);
 
-  /// Extract m_samples_per_file and m_filenames by parsing a serialized string
+  /// Extract m_samples_per_file by parsing a serialized string
   size_t get_samples_per_file(const std::string& samplelist);
 
   /// Populate the list of starting sample id for each sample file
@@ -69,9 +67,6 @@ class sample_list {
 
   /// The number of partitions to divide samples into
   size_t m_num_partitions;
-
-  /// The sample file names
-  file_name_list_t m_filenames;
 
   /** In a sample file list, each line begins with a sample file name
    * that is followed by the names of the samples in the file.

--- a/tools/filelist/sample_list_impl.hpp
+++ b/tools/filelist/sample_list_impl.hpp
@@ -1,0 +1,273 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <vector>
+#include <list>
+#include <algorithm>
+#include "sample_list.hpp"
+
+namespace lbann {
+
+template <typename SN>
+std::string sample_list<SN>::to_string(const std::string& s) {
+  return s;
+}
+
+template <typename SN>
+template <typename T>
+std::string sample_list<SN>::to_string(const T v) {
+  return std::to_string(v);
+}
+
+
+template <typename SN>
+inline bool sample_list<SN>::set_num_partitions(size_t n) {
+  if (n == 0) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+                          + " :: number of partitions must be a positive number ("
+                          + std::to_string(n) + ")");
+    return false;
+  }
+  clear();
+  m_num_partitions = n;
+  return true;
+}
+
+template <typename SN>
+inline bool sample_list<SN>::load(const std::string& samplelist_file) {
+  bool ok = true;
+  ok = get_samples_per_file(samplelist_file);
+  ok = ok && get_sample_range_per_file();
+  ok = ok && get_sample_range_per_part();
+  return ok;
+}
+
+template <typename SN>
+inline size_t sample_list<SN>::get_samples_per_file(const std::string& samplelist_file)
+{
+  std::ifstream ifstr(samplelist_file);
+  if (!ifstr.good()) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+                          + " :: failed to open " + samplelist_file + " for reading");
+  }
+
+  std::string line;
+
+  size_t total_num_samples = 0u;
+  m_filenames.clear();
+
+  while (getline(ifstr, line)) {
+    std::stringstream sstr(line);
+    std::string filename;
+
+    sstr >> filename;
+    m_filenames.emplace_back(filename);
+
+    m_samples_per_file.emplace_back();
+    auto& samples_of_current_file = m_samples_per_file.back();
+
+    sample_name_t sample_name;
+
+    while (sstr >> sample_name) {
+      samples_of_current_file.emplace_back(sample_name);
+    }
+
+    const size_t num_samples_of_current_file = samples_of_current_file.size();
+    total_num_samples += num_samples_of_current_file;
+  }
+
+  ifstr.close();
+
+  return total_num_samples;
+}
+
+
+/**
+ * Reads through m_samples_per_file, and populate m_sample_range_per_file
+ * by the sequential id of the first sample in each sample file.
+ * The last element of m_sample_range_per_file is the total number of samples.
+ */
+template <typename SN>
+inline bool sample_list<SN>::get_sample_range_per_file()
+{
+  if (m_samples_per_file.empty()) {
+    return false;
+  }
+
+  m_sample_range_per_file.clear();
+  m_sample_range_per_file.reserve(m_samples_per_file.size()+1u);
+  m_sample_range_per_file.push_back(0u);
+
+  size_t total_so_far = 0u;
+
+  for (const auto slist: m_samples_per_file) {
+    total_so_far += slist.size();
+    m_sample_range_per_file.push_back(total_so_far);
+  }
+  return true;
+}
+
+
+template <typename SN>
+inline bool sample_list<SN>::get_sample_range_per_part()
+{
+  const size_t total = static_cast<size_t>(m_sample_range_per_file.back());
+  const size_t one_more = total % m_num_partitions;
+  const size_t min_per_partition = total/m_num_partitions;
+
+  if (min_per_partition == 0u) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+          + " :: insufficient number of samples for each partition to have at least one.");
+    return false;
+  }
+
+  m_sample_range_per_part.clear();
+  m_sample_range_per_part.resize(m_num_partitions+1u);
+
+  #pragma omp parallel for
+  for (size_t p = 0u; p < m_num_partitions; ++p) {
+    const size_t r_start = min_per_partition * p + ((p >= one_more)? one_more : p);
+    const size_t r_end = r_start + min_per_partition + ((p < one_more)? 1u : 0u);
+    m_sample_range_per_part[p+1] = r_end;
+  }
+
+  return true;
+}
+
+
+template <typename SN>
+inline bool sample_list<SN>::find_sample_files_of_part(size_t p, size_t& sf_begin, size_t& sf_end) const
+{
+  if (p+1 >= m_sample_range_per_part.size()) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+                          + " :: invalid partition id or uninitialized m_sample_range_per_part.");
+    return false;
+  }
+  const sample_id_t sample_start = m_sample_range_per_part[p];
+  const sample_id_t sample_end = m_sample_range_per_part[p+1];
+
+  std::vector<sample_id_t>::const_iterator i_begin
+    = std::upper_bound(m_sample_range_per_file.cbegin(), m_sample_range_per_file.cend(), sample_start);
+  std::vector<sample_id_t>::const_iterator i_end
+    = std::lower_bound(m_sample_range_per_file.cbegin(), m_sample_range_per_file.cend(), sample_end);
+
+  sf_begin = std::distance(m_sample_range_per_file.cbegin(), i_begin) - 1u;
+  sf_end = std::distance(m_sample_range_per_file.cbegin(), i_end) - 1u;
+
+  if ((sample_start > sample_end) || (sf_begin > sf_end)) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+                          + " :: invalid sample or sample file range.");
+    return false;
+  }
+  return true;
+}
+
+
+template <typename SN>
+inline bool sample_list<SN>::write(const std::string& out_filename) const
+{
+  const size_t num_files = m_filenames.size();
+  std::ofstream ofstr(out_filename);
+
+  if (!ofstr.good() || (m_samples_per_file.size() != num_files)) {
+    return false;
+  }
+
+  file_name_list_t::const_iterator it_filename = m_filenames.cbegin();
+  typename sample_files_t::const_iterator it_samples = m_samples_per_file.cbegin();
+
+  for (size_t i = 0u; i < num_files; ++i, ++it_filename, ++it_samples) {
+    const auto& samples_of_current_file = *it_samples;
+    ofstr << *it_filename;
+    for (const auto& sample : samples_of_current_file) {
+      ofstr << ' ' << sample;
+    }
+    ofstr << std::endl;
+  }
+
+  ofstr.close();
+  return true;
+}
+
+
+template <typename SN>
+inline void sample_list<SN>::clear() {
+  m_num_partitions = 1u;
+  m_filenames.clear();
+  m_samples_per_file.clear();
+  m_sample_range_per_file.clear();
+  m_sample_range_per_part.clear();
+}
+
+
+template <typename SN>
+inline bool sample_list<SN>::to_string(size_t p, std::string& sstr)
+{
+  const size_t num_local_samples = m_sample_range_per_part[p+1] - m_sample_range_per_part[p];
+
+  size_t sf_begin;
+  size_t sf_end;
+
+  // Find the range of sample files that covers the range of samples of the partition.
+  find_sample_files_of_part(p, sf_begin, sf_end);
+
+  file_name_list_t::const_iterator it_fl_begin = m_filenames.cbegin();
+  file_name_list_t::const_iterator it_fl_end = m_filenames.cbegin();
+  std::advance(it_fl_begin, sf_begin);
+  std::advance(it_fl_end, sf_end);
+  file_name_list_t::const_iterator it_fl = it_fl_begin; // filenmae iterator
+
+  typename sample_files_t::const_iterator it_sfl_begin = m_samples_per_file.cbegin();
+  typename sample_files_t::const_iterator it_sfl_end = m_samples_per_file.cbegin();
+  std::advance(it_sfl_begin, sf_begin);
+  std::advance(it_sfl_end, sf_end);
+
+  size_t s_begin = m_sample_range_per_part[p] - m_sample_range_per_file[sf_begin];
+  size_t s_end = m_sample_range_per_part[p+1] - m_sample_range_per_file[sf_end];
+
+  if (s_begin >= it_sfl_begin->size() || s_end > it_sfl_end->size()) {
+    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
+                          + " :: incorrect sample indices.");
+    return false;
+  }
+
+  typename sample_files_t::const_iterator it_sfl = it_sfl_begin;
+  typename samples_t::const_iterator it_s = it_sfl->cbegin(); // sample name iterator
+  std::advance(it_s, s_begin);
+  const size_t b_s_begin = std::min(it_sfl_begin->size(), num_local_samples + s_begin);
+
+  const size_t estimated_len = (sf_end - sf_begin) * it_fl->size() +
+    ((to_string(*it_s)).size() + 1u) * static_cast<size_t>(num_local_samples * 1.2);
+  sstr.reserve(estimated_len);
+
+  sstr += *(it_fl++);
+  for (size_t s = s_begin; s < b_s_begin; ++s, ++it_s) {
+    sstr += ' ' + to_string(*it_s);
+  }
+  sstr += '\n';
+
+  if (sf_begin < sf_end) {
+    for (size_t sf = sf_begin+1; sf < sf_end; ++sf) {
+      sstr += *(it_fl++);
+      for (const auto& s : *(++it_sfl)) {
+        sstr += ' ' + to_string(s);
+      }
+      sstr += '\n';
+    }
+
+    typename samples_t::const_iterator it_s = (++it_sfl)->cbegin();
+    sstr += *(it_fl++);
+    for (size_t s = 0u; s < s_end; ++s, ++it_s) {
+      sstr += ' ' + to_string(*it_s);
+    }
+    sstr += '\n';
+  }
+
+  std::cerr << "estimated size vs actual size: " << estimated_len << ' ' << sstr.size() << std::endl;
+  std::cerr << "num samples: " << num_local_samples << " samples of rank " << p << std::endl;
+  return true;
+}
+
+
+} // end of namespace lbann


### PR DESCRIPTION
Allow different number of patches to use in data_reader_triplet via the prototext variable num_image_srcs of the data reader.