### PR TITLE
flexible number of patches in Siamese model

### DIFF
--- a/include/lbann/data_readers/offline_patches_npz.hpp
+++ b/include/lbann/data_readers/offline_patches_npz.hpp
@@ -80,6 +80,10 @@ class offline_patches_npz {
   size_t get_num_patches() const {
     return m_num_patches;
   }
+  /// Set the number of patches per sample (the number of image data sources)
+  void set_num_patches(size_t n) {
+    m_num_patches = n;
+  }
   /// Reconsturct and return the meta-data (patch file names and the label) of idx-th sample
   sample_t get_sample(const size_t idx) const;
   /// Return the label of idx-th sample

--- a/src/data_readers/data_reader_triplet.cpp
+++ b/src/data_readers/data_reader_triplet.cpp
@@ -148,6 +148,8 @@ std::vector<data_reader_triplet::sample_t> data_reader_triplet::get_image_list()
 void data_reader_triplet::load() {
   const std::string data_filename = get_data_filename();
 
+  m_samples.set_num_patches(m_num_img_srcs);
+
   // To support m_first_n semantic, m_samples.load() takes m_first_n
   // as an argument and attempt to shrink the CNPY arrays loaded as needed
   if (!m_samples.load(data_filename, m_first_n)) {

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -519,7 +519,8 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const bool mast
   if (master) std::cout << reader->get_type() << " is set" << std::endl;
 
   // configure the data reader
-  if (name == "multi_images") {
+  if ((name == "multi_images") ||
+      ((name == "triplet") && (pb_readme.num_image_srcs() > 0))) {
     const int n_img_srcs = pb_readme.num_image_srcs();
     data_reader_multi_images* multi_image_dr_ptr
       = dynamic_cast<data_reader_multi_images*>(image_data_reader_ptr);


### PR DESCRIPTION
Allow different number of patches in triplet_data_readers via specifying the prototext variable 'num_image_srcs' in the data reader prototext.