### PR TITLE
Update Aluminum algorithm name

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -670,9 +670,9 @@ class lbann_comm {
     bytes_sent += count * sizeof(T);
 #ifdef LBANN_HAS_ALUMINUM
 #ifdef LBANN_ALUMINUM_MPI_PASSTHROUGH
-    ::Al::AllreduceAlgorithm algo = ::Al::AllreduceAlgorithm::mpi_passthrough;
+    ::Al::MPIAllreduceAlgorithm algo = ::Al::MPIAllreduceAlgorithm::mpi_passthrough;
 #else
-    ::Al::AllreduceAlgorithm algo = ::Al::AllreduceAlgorithm::automatic;
+    ::Al::MPIAllreduceAlgorithm algo = ::Al::MPIAllreduceAlgorithm::automatic;
 #endif
     ::Al::Allreduce<::Al::MPIBackend>(
       snd, rcv, count, mpi_op_to_al_op(op), c.template GetComm<::Al::MPIBackend>(), algo);
@@ -689,9 +689,9 @@ class lbann_comm {
     bytes_sent += count * sizeof(T);
 #ifdef LBANN_HAS_ALUMINUM
 #ifdef LBANN_ALUMINUM_MPI_PASSTHROUGH
-    ::Al::AllreduceAlgorithm algo = ::Al::AllreduceAlgorithm::mpi_passthrough;
+    ::Al::MPIAllreduceAlgorithm algo = ::Al::MPIAllreduceAlgorithm::mpi_passthrough;
 #else
-    ::Al::AllreduceAlgorithm algo = ::Al::AllreduceAlgorithm::automatic;
+    ::Al::MPIAllreduceAlgorithm algo = ::Al::MPIAllreduceAlgorithm::automatic;
 #endif
     ::Al::Allreduce<::Al::MPIBackend>(
       data, count, mpi_op_to_al_op(op), c.template GetComm<::Al::MPIBackend>(), algo);


### PR DESCRIPTION
This corresponds to [this](https://github.com/LLNL/Aluminum/pull/25) PR on Aluminum, which renames `Al::AllreduceAlgorithm` to `Al::MPIAllreduceAlgorithm`.