### PR TITLE
Squared difference layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_squared_difference.py
+++ b/bamboo/unit_tests/test_unit_layer_squared_difference.py
@@ -1,0 +1,41 @@
+import sys
+sys.path.insert(0, '../common_python')
+import tools
+import pytest
+import os
+
+def skeleton_layer_squared_difference(cluster, executables, dir_name, compiler_name):
+    if compiler_name not in executables:
+      pytest.skip('default_exes[%s] does not exist' % compiler_name)
+    output_file_name = '%s/bamboo/unit_tests/output/layer_squared_difference_%s_output.txt' % (dir_name, compiler_name)
+    error_file_name  = '%s/bamboo/unit_tests/error/layer_squared_difference_%s_error.txt' % (dir_name, compiler_name)
+    command = tools.get_command(
+        cluster=cluster, executable=executables[compiler_name], num_nodes=1, num_processes=2, dir_name=dir_name,
+        data_filedir_default='', data_reader_name='synthetic',
+        model_folder='tests/layer_tests', model_name='squared_difference', optimizer_name='sgd',
+        output_file_name=output_file_name, error_file_name=error_file_name)
+    return_code = os.system(command)
+    assert return_code == 0
+
+def test_unit_layer_squared_difference_clang4(cluster, exes, dirname):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'clang4')
+
+def test_unit_layer_squared_difference_gcc4_check(cluster, exes, dirname):
+    if cluster in ['surface']:
+        pytest.skip('FIXME')
+        # Surface Errors:
+        # assert 34304 == 0
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc4')
+
+def test_unit_layer_squared_difference_gcc7(cluster, exes, dirname):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc7')
+
+def test_unit_layer_squared_difference_intel18(cluster, exes, dirname):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'intel18')
+
+# Run with python -m pytest -s test_unit_layer_squared_difference.py -k 'test_unit_layer_squared_difference_exe' --exe=<executable>
+def test_unit_layer_squared_difference_exe(cluster, dirname, exe):
+    if exe == None:
+        pytest.skip('Non-local testing')
+    exes = {'exe' : exe}
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'exe')

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -91,13 +91,14 @@ protected:
   = entrywise_binary_layer<Layout, Device, layer_name##_name_struct>;
 
 // Arithmetic operations
-DEFINE_ENTRYWISE_BINARY_LAYER(add_layer,         "add");
-DEFINE_ENTRYWISE_BINARY_LAYER(subtract_layer,    "subtract");
-DEFINE_ENTRYWISE_BINARY_LAYER(multiply_layer,    "multiply");
-DEFINE_ENTRYWISE_BINARY_LAYER(divide_layer,      "divide");
-DEFINE_ENTRYWISE_BINARY_LAYER(mod_layer,         "modulo");
-DEFINE_ENTRYWISE_BINARY_LAYER(pow_layer,         "power");
-DEFINE_ENTRYWISE_BINARY_LAYER(safe_divide_layer, "safe divide");
+DEFINE_ENTRYWISE_BINARY_LAYER(add_layer,                "add");
+DEFINE_ENTRYWISE_BINARY_LAYER(subtract_layer,           "subtract");
+DEFINE_ENTRYWISE_BINARY_LAYER(multiply_layer,           "multiply");
+DEFINE_ENTRYWISE_BINARY_LAYER(divide_layer,             "divide");
+DEFINE_ENTRYWISE_BINARY_LAYER(mod_layer,                "modulo");
+DEFINE_ENTRYWISE_BINARY_LAYER(pow_layer,                "power");
+DEFINE_ENTRYWISE_BINARY_LAYER(safe_divide_layer,        "safe divide");
+DEFINE_ENTRYWISE_BINARY_LAYER(squared_difference_layer, "squared difference");
 
 // Comparison operations
 DEFINE_ENTRYWISE_BINARY_LAYER(max_layer,           "maximum");

--- a/model_zoo/tests/layer_tests/model_squared_difference.prototext
+++ b/model_zoo/tests/layer_tests/model_squared_difference.prototext
@@ -1,0 +1,110 @@
+model {
+  mini_batch_size: 11
+  block_size: 256
+  num_epochs: 0
+
+  ###################################################
+  # Objective function and metrics
+  ###################################################
+
+  objective_function {
+    layer_term { layer: "l2" }
+  }
+  metric {
+    layer_metric {
+      layer: "l2"
+      name: "L2 norm"
+    }
+  }
+
+  ###################################################
+  # Callbacks
+  ###################################################
+
+  callback { print {} }
+  callback { timer {} }
+  callback {
+    check_metric {
+      metric: "L2 norm" # Expected value: 10.28
+      lower_bound: 10.27
+      upper_bound: 10.29
+      error_on_failure: true
+      execution_modes: "test"
+    }
+  }
+  callback {
+    check_gradients {
+      verbose: false
+      error_on_failure: true
+    }
+  }
+
+  ###################################################
+  # Layers
+  ###################################################
+
+  layer {
+    name: "data"
+    data_layout: "data_parallel"
+    input {
+      io_buffer: "partitioned"
+    }
+  }
+
+  # Input data
+  layer {
+    name: "x0"
+    weights_layer {
+      dims: "5"
+    }
+    data_layout: "model_parallel"
+    weights: "x0_vals"
+  }
+  weights {
+    name: "x0_vals"
+    value_initializer {
+      values: "1 -0.5 0.25 -0.125 0.125"
+    }
+  }
+  layer {
+    name: "x1"
+    weights_layer {
+      dims: "5"
+    }
+    data_layout: "model_parallel"
+    weights: "x1_vals"
+  }
+  weights {
+    name: "x1_vals"
+    value_initializer {
+      values: "1.5 0 -1 -0.125 -0.125"
+    }
+  }
+
+  # Variations of mean absolute error layer
+  layer {
+    parents: "x0 x1"
+    name: "squared_difference_model_parallel"
+    squared_difference {}
+    data_layout: "model_parallel"
+  }
+  layer {
+    parents: "x0 x1"
+    name: "squared_difference_data_parallel"
+    squared_difference {}
+    data_layout: "data_parallel"
+  }
+
+  # Combine into objective function
+  layer {
+    parents: "squared_difference_model_parallel squared_difference_data_parallel"
+    name: "sum"
+    sum {}
+  }
+  layer {
+    parents: "sum"
+    name: "l2"
+    l2_norm2 {}
+  }
+
+}

--- a/src/layers/math/binary.cpp
+++ b/src/layers/math/binary.cpp
@@ -210,6 +210,23 @@ struct safe_divide_op {
   }
 };
 
+/** Squared difference operator. */
+struct squared_difference_op {
+  inline DataType operator()(const DataType& x1,
+                             const DataType& x2) const {
+    const auto& diff = x1 - x2;
+    return diff * diff;
+  }
+  inline void operator()(const DataType& x1,
+                         const DataType& x2,
+                         const DataType& dy,
+                         DataType& dx1,
+                         DataType& dx2) const {
+    dx1 = dy * 2*(x1-x2);
+    dx2 = dy * 2*(x2-x1);
+  }
+};
+
 /** Maximum operator. */
 struct max_op {
   inline DataType operator()(const DataType& x1,
@@ -451,6 +468,7 @@ struct logical_xor_op {
   INSTANTIATE(mod_layer, mod_op)
   INSTANTIATE(pow_layer, pow_op)
   INSTANTIATE(safe_divide_layer, safe_divide_op)
+  INSTANTIATE(squared_difference_layer, squared_difference_op)
   INSTANTIATE(max_layer, max_op)
   INSTANTIATE(min_layer, min_op)
   INSTANTIATE(equal_layer, equal_op)

--- a/src/layers/math/binary.cu
+++ b/src/layers/math/binary.cu
@@ -234,6 +234,23 @@ struct safe_divide_op {
   }
 };
 
+/** Squared difference operator. */
+struct squared_difference_op {
+  inline __device__ DataType operator()(const DataType& x1,
+                                        const DataType& x2) const {
+    const auto& diff = x1 - x2;
+    return diff * diff;
+  }
+  inline __device__ void operator()(const DataType& x1,
+                                    const DataType& x2,
+                                    const DataType& dy,
+                                    DataType& dx1,
+                                    DataType& dx2) const {
+    dx1 = dy * 2*(x1-x2);
+    dx2 = dy * 2*(x2-x1);
+  }
+};
+
 /** Maximum operator. */
 struct max_op {
   inline __device__ DataType operator()(const DataType& x1,
@@ -475,6 +492,7 @@ struct logical_xor_op {
   INSTANTIATE(mod_layer, mod_op)
   INSTANTIATE(pow_layer, pow_op)
   INSTANTIATE(safe_divide_layer, safe_divide_op)
+  INSTANTIATE(squared_difference_layer, squared_difference_op)
   INSTANTIATE(max_layer, max_op)
   INSTANTIATE(min_layer, min_op)
   INSTANTIATE(equal_layer, equal_op)

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -527,6 +527,7 @@ Layer* construct_layer(lbann_comm* comm,
   CONSTRUCT_LAYER(mod);
   CONSTRUCT_LAYER(pow);
   CONSTRUCT_LAYER(safe_divide);
+  CONSTRUCT_LAYER(squared_difference);
   CONSTRUCT_LAYER(max);
   CONSTRUCT_LAYER(min);
   CONSTRUCT_LAYER(equal);

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -858,17 +858,18 @@ message Layer {
    Mod mod = 454;
    Pow pow = 455;
    SafeDivide safe_divide = 456;
-   Max max = 457;
-   Min min = 458;
-   Equal equal = 459;
-   NotEqual not_equal = 460;
-   Less less = 461;
-   LessEqual less_equal = 462;
-   Greater greater = 463;
-   GreaterEqual greater_equal = 464;
-   LogicalAnd logical_and = 465;
-   LogicalOr logical_or = 466;
-   LogicalXor logical_xor = 467;
+   SquaredDifference squared_difference = 457;
+   Max max = 458;
+   Min min = 459;
+   Equal equal = 460;
+   NotEqual not_equal = 461;
+   Less less = 462;
+   LessEqual less_equal = 463;
+   Greater greater = 464;
+   GreaterEqual greater_equal = 465;
+   LogicalAnd logical_and = 466;
+   LogicalOr logical_or = 467;
+   LogicalXor logical_xor = 468;
 
    // Target layers
    Target target = 18;
@@ -948,6 +949,7 @@ message Divide {}
 message Mod {}
 message Pow {}
 message SafeDivide {}
+message SquaredDifference {}
 message Max {}
 message Min {}
 message Equal {}


### PR DESCRIPTION
Computes the entry-wise squared difference between two tensors, in a similar manner as https://www.tensorflow.org/api_docs/python/tf/math/squared_difference. The Bamboo unit test passes.