### PR TITLE
Output dumping callback supports multiple file formats

### DIFF
--- a/include/lbann/callbacks/callback_dump_outputs.hpp
+++ b/include/lbann/callbacks/callback_dump_outputs.hpp
@@ -32,14 +32,18 @@
 namespace lbann {
 
 /** Dump layer output tensors to files.
- *  This callback generates a text file for each output tensor of each
- *  selected layer, computed at each mini-batch step. Each line
- *  contains flattened tensor data corresponding to one mini-batch
- *  sample (note that this is the transpose of the column-major matrix
- *  representation we use internally). Output files are in the form
- *  "<prefix><model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.csv". This
- *  is primarily intended as a debugging tool, although it can be used
- *  for inference when performance is not critical.
+ *  This callback saves a file for each output tensor of each selected
+ *  layer, computed at each mini-batch step. Output files have the
+ *  form
+ *  "<prefix><model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.<format>".
+ *  This is primarily intended as a debugging tool, although it can be
+ *  used for inference when performance is not critical.
+ *
+ *  For NumPy file formats (npy and npz), tensor dimensions are
+ *  recorded. For text file formats (CSV and TSV), each line contains
+ *  flattened tensor data corresponding to one mini-batch sample
+ *  (which is the transpose of the column-major matrix representation
+ *  we use internally).
  */
 class lbann_callback_dump_outputs : public lbann_callback {
 public:
@@ -52,14 +56,14 @@ public:
    *  @param batch_interval Frequency of output dumps (default: dump
    *                        outputs at each mini-batch step).
    *  @param file_prefix    Prefix for output file names.
-   *  @param file_format    Output file format, e.g. csv, tsv, bin
-   *                        (default: csv).
+   *  @param file_format    Output file format. Options are csv, tsv,
+   *                        npy, npz (default: csv).
    */
   lbann_callback_dump_outputs(std::set<std::string> layer_names = {},
                               std::set<execution_mode> modes = {},
                               El::Int batch_interval = 0,
                               std::string file_prefix = "",
-                              std::string file_Format = "");
+                              std::string file_format = "");
   lbann_callback_dump_outputs* copy() const override {
     return new lbann_callback_dump_outputs(*this);
   }
@@ -85,11 +89,6 @@ private:
 
   /** Output file format. */
   std::string m_file_format;
-
-  /** Delimiter for output files.
-   *  Only used with text file formats, e.g. csv or tsv.
-   */
-  std::string m_delimiter;
 
   /** Dump outputs to file.
    *  Returns immediately if an output dump is not needed.

--- a/include/lbann/callbacks/callback_dump_outputs.hpp
+++ b/include/lbann/callbacks/callback_dump_outputs.hpp
@@ -40,8 +40,6 @@ namespace lbann {
  *  "<prefix><model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.csv". This
  *  is primarily intended as a debugging tool, although it can be used
  *  for inference when performance is not critical.
- *
- *  Currently, only CSV output files are supported.
  */
 class lbann_callback_dump_outputs : public lbann_callback {
 public:
@@ -54,11 +52,14 @@ public:
    *  @param batch_interval Frequency of output dumps (default: dump
    *                        outputs at each mini-batch step).
    *  @param file_prefix    Prefix for output file names.
+   *  @param file_format    Output file format, e.g. csv, tsv, bin
+   *                        (default: csv).
    */
   lbann_callback_dump_outputs(std::set<std::string> layer_names = {},
                               std::set<execution_mode> modes = {},
                               El::Int batch_interval = 0,
-                              std::string file_prefix = "");
+                              std::string file_prefix = "",
+                              std::string file_Format = "");
   lbann_callback_dump_outputs* copy() const override {
     return new lbann_callback_dump_outputs(*this);
   }
@@ -82,10 +83,13 @@ private:
   /** Prefix for output files. */
   std::string m_file_prefix;
 
+  /** Output file format. */
+  std::string m_file_format;
+
   /** Delimiter for output files.
-   *  Currently hard-coded to output CSV files.
+   *  Only used with text file formats, e.g. csv or tsv.
    */
-  std::string m_delimiter = ",";
+  std::string m_delimiter;
 
   /** Dump outputs to file.
    *  Returns immediately if an output dump is not needed.

--- a/src/callbacks/callback_dump_outputs.cpp
+++ b/src/callbacks/callback_dump_outputs.cpp
@@ -31,11 +31,28 @@ namespace lbann {
 lbann_callback_dump_outputs::lbann_callback_dump_outputs(std::set<std::string> layer_names,
                                                          std::set<execution_mode> modes,
                                                          El::Int batch_interval,
-                                                         std::string file_prefix)
+                                                         std::string file_prefix,
+                                                         std::string file_format)
   : lbann_callback(std::max(batch_interval, El::Int(1))),
     m_layer_names(std::move(layer_names)),
     m_modes(std::move(modes)),
-    m_file_prefix(std::move(file_prefix)) {}
+    m_file_prefix(std::move(file_prefix)),
+    m_file_format(std::move(file_format)) {
+
+  // Initialize file format
+  if (m_file_format.empty()) { m_file_format = "csv"; }
+  if (m_file_format == "csv") {
+    m_delimiter = ",";
+  } else if (m_file_format == "txt") {
+    m_delimiter = ",";
+  } else if (m_file_format == "tsv") {
+    m_delimiter = "\t";
+  } else if (m_file_format == "bin") {
+  } else {
+    LBANN_ERROR("invalid file format (" + m_file_format + ")");
+  }
+
+}
 
 void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
 
@@ -58,13 +75,15 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
   if (!m_layer_names.empty()
       && m_layer_names.count(l.get_name()) == 0) { return; }
 
-  // Save layer outputs
+  // Save layer outputs on root process
   // Note: Each line corresponds to a mini-batch sample. This is the
   // transpose of our internal column-major matrix representation.
   for (int i = 0; i < l.get_num_children(); ++i) {
     const CircMat<El::Device::CPU> circ_data(l.get_activations(i));
     if (circ_data.CrossRank() == circ_data.Root()) {
       const auto& data = circ_data.LockedMatrix();
+
+      // Open output file
       const std::string filename = (m_file_prefix
                                     + m.get_name()
                                     + "-" + _to_string(mode)
@@ -72,14 +91,38 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
                                     + "-step" + std::to_string(step)
                                     + "-" + l.get_name()
                                     + "-output" + std::to_string(i)
-                                    + ".csv");
-      std::ofstream fs(filename.c_str());
-      for (El::Int col = 0; col < data.Width(); ++col) {
-        for (El::Int row = 0; row < data.Height(); ++row) {
-          fs << (row > 0 ? m_delimiter : "") << data(row, col);
-        }
-        fs << "\n";
+                                    + "." + m_file_format);
+      std::ios_base::openmode fs_flags = (m_file_format == "bin" ?
+                                          std::ios_base::out | std::ios_base::binary :
+                                          std::ios_base::out);
+      std::ofstream fs(filename.c_str(), fs_flags);
+      if (!fs.is_open()) {
+        std::stringstream err;
+        err << "callback \"" << name() << "\" "
+            << "failed to open output file (" << filename << ")";
+        LBANN_ERROR(err);
       }
+
+      // Write to output file
+      if (m_file_format == "bin") {
+        std::vector<float> float_data(data.Height() * data.Width());
+        LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+        for (El::Int col = 0; col < data.Width(); ++col) {
+          for (El::Int row = 0; row < data.Height(); ++row) {
+            float_data[row + col * data.Height()] = data(row, col);
+          }
+        }
+        fs.write(reinterpret_cast<const char*>(float_data.data()),
+                 float_data.size() * sizeof(float));
+      } else {
+        for (El::Int col = 0; col < data.Width(); ++col) {
+          for (El::Int row = 0; row < data.Height(); ++row) {
+            fs << (row > 0 ? m_delimiter : "") << data(row, col);
+          }
+          fs << "\n";
+        }
+      }
+
     }
   }
 

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -342,7 +342,8 @@ lbann_callback* construct_callback(lbann_comm* comm,
     return new lbann_callback_dump_outputs(layer_names,
                                            modes,
                                            params.batch_interval(),
-                                           params.prefix());
+                                           params.prefix(),
+                                           params.format());
   }
   if (proto_cb.has_dump_error_signals()) {
     const auto& params = proto_cb.dump_error_signals();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -488,7 +488,7 @@ message CallbackDumpOutputs {
   string execution_modes = 2; // Default: all modes
   int64 batch_interval = 3;   // Frequency for output dumping (default: all steps)
   string prefix = 4;          // Prefix for output files
-  string format = 5;          // Options: csv, tsv, bin (default: csv)
+  string format = 5;          // Options: csv, tsv, npy, npz (default: csv)
 }
 
 message CallbackDumpErrorSignals {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -488,6 +488,7 @@ message CallbackDumpOutputs {
   string execution_modes = 2; // Default: all modes
   int64 batch_interval = 3;   // Frequency for output dumping (default: all steps)
   string prefix = 4;          // Prefix for output files
+  string format = 5;          // Options: csv, tsv, bin (default: csv)
 }
 
 message CallbackDumpErrorSignals {


### PR DESCRIPTION
The output dumping callback can now output data in CSV, TSV, .npy, and .npz file formats. For example, suppose I add the following callbacks to the AlexNet prototext:
```
  callback {
    dump_outputs {
      layers: "prob"
      execution_modes: "test"
    }
  }
  callback {
    dump_outputs {
      layers: "prob"
      execution_modes: "test"
      format: "tsv"
    }
  }
  callback {
    dump_outputs {
      layers: "prob"
      execution_modes: "test"
      format: "npy"
    }
  }
  callback {
    dump_outputs {
      layers: "prob"
      execution_modes: "test"
      format: "npz"
    }
  }
```
After I run an experiment, my directory looks like:
```
-rw------- 1 moon13 moon13 2967490 Dec  7 19:13 Model0-testing-epoch0-step0-prob-output0.csv
-rw------- 1 moon13 moon13 1024080 Dec  7 19:13 Model0-testing-epoch0-step0-prob-output0.npy
-rw------- 1 moon13 moon13 1024210 Dec  7 19:13 Model0-testing-epoch0-step0-prob-output0.npz
-rw------- 1 moon13 moon13 2967490 Dec  7 19:13 Model0-testing-epoch0-step0-prob-output0.tsv
-rw------- 1 moon13 moon13 2828022 Dec  7 19:13 Model0-testing-epoch0-step1-prob-output0.csv
-rw------- 1 moon13 moon13  976080 Dec  7 19:13 Model0-testing-epoch0-step1-prob-output0.npy
-rw------- 1 moon13 moon13  976210 Dec  7 19:13 Model0-testing-epoch0-step1-prob-output0.npz
-rw------- 1 moon13 moon13 2828022 Dec  7 19:13 Model0-testing-epoch0-step1-prob-output0.tsv
-rw------- 1 moon13 moon13    3380 Dec  7 19:12 batch.sh
-rw------- 1 moon13 moon13    8773 Dec  7 19:13 model.prototext
-rw------- 1 moon13 moon13       9 Dec  7 19:13 nodes.txt
-rw------- 1 moon13 moon13   14317 Dec  7 19:13 output.txt
-rwx------ 1 moon13 moon13   16733 Dec  7 19:12 run_lbann_experiment.sh
```