### PR TITLE
Changed the save_model callback so that there is an explicit flag to

### DIFF
--- a/include/lbann/callbacks/callback_save_model.hpp
+++ b/include/lbann/callbacks/callback_save_model.hpp
@@ -47,9 +47,9 @@ class lbann_callback_save_model : public lbann_callback {
    * @param file extension e.g., model, state ......
    */
   lbann_callback_save_model(std::string dir,
-                            El::Int steps,
+                            bool disable_save_after_training,
                             std::string extension="prototext") :
-    lbann_callback(), m_dir(std::move(dir)), m_save_interval_steps(steps), m_extension(std::move(extension))
+    lbann_callback(), m_dir(std::move(dir)), m_disable_save_after_training(disable_save_after_training), m_extension(std::move(extension))
     {}
   lbann_callback_save_model(const lbann_callback_save_model&) = default;
   lbann_callback_save_model& operator=(
@@ -65,12 +65,11 @@ class lbann_callback_save_model : public lbann_callback {
   std::string name() const override { return "save model"; }
  private:
   std::string m_dir; //directory to save file
-  El::Int m_save_interval_steps;
+  bool m_disable_save_after_training; /// Disables the normal behavior of saving when training is complete
   std::string m_extension; //file extension
   persist p;
   void write_proto_binary(const lbann_data::Model& proto, const std::string filename);
   void write_proto_text(const lbann_data::Model& proto, const std::string filename);
-  bool need_save(model *m);
 };
 
 }  // namespace lbann

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -165,6 +165,9 @@ int main(int argc, char *argv[]) {
       super_step++;
     }
 
+    model_1->save_model();
+    model_2->save_model();
+    model_3->save_model();
     ae_cycgan_model->save_model();
 
     //has no affect unless option: --st_on was given

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m1.prototext
@@ -757,7 +757,7 @@ model {
   callback {
     save_model {
       dir: "model"
-      steps: 10000
+      disable_save_after_training: true
     }
   }
   block_size: 256

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
@@ -750,7 +750,7 @@ model {
   callback {
     save_model {
       dir: "model"
-      steps: 10000
+      disable_save_after_training: true
     }
   }
   block_size: 256

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
@@ -792,7 +792,7 @@ model {
   callback {
     save_model {
       dir: "model"
-      steps: 10000
+      disable_save_after_training: true
     }
   }
   block_size: 256

--- a/model_zoo/models/jag/ae_cycle_gan/data_reader_jag_conduit_lustre.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/data_reader_jag_conduit_lustre.prototext
@@ -15,7 +15,7 @@ data_reader {
     data_filename: "*.bundle"
 
     validation_percent: 0
-    absolute_sample_count: 0 
+    absolute_sample_count: 0
     percent_of_data_to_use: 0.5
     disable_responses: true
     disable_labels: true

--- a/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
@@ -542,7 +542,12 @@ model {
   #    execution_modes: "test"
   #  }
   #}
-  callback { save_model { dir: "model" } }
+  callback {
+    save_model {
+      dir: "model"
+      disable_save_after_training: true
+    }
+  }
   ###################################################
   # end of layers
   ###################################################

--- a/src/callbacks/callback_save_model.cpp
+++ b/src/callbacks/callback_save_model.cpp
@@ -42,28 +42,9 @@ namespace lbann {
 
 /// Save the model's prototext and weights
 void lbann_callback_save_model::on_train_end(model *m) {
-  if(need_save(m)){
+  if(!m_disable_save_after_training){
     save_model(m);
   }
-}
-
-// Decide if we need to trigger a checkpoint for either mode, based on prototext defined intervals
-bool lbann_callback_save_model::need_save(model *m) {
-  // If a save interval was not set, then we save at the end of training
-  if (m_save_interval_steps == 0) {
-    return true;
-  }
-
-  /// The following code is to allow complex models like the CycleGAN that don't use epochs normally to control
-  /// how often they are checkpointed
-  bool save_model_now = false;
-
-  // If we are at the end of a training and the training mb step lands on defined interval, trigger save
-  if (m_save_interval_steps > 0) {
-    save_model_now = (m->get_cur_step() > 0) && (m->get_cur_step() % m_save_interval_steps == 0);
-  }
-
-  return save_model_now;
 }
 
 void lbann_callback_save_model::write_proto_binary(const lbann_data::Model& proto,

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1567,6 +1567,7 @@ bool model::save_model() {
       return cb->save_model(this);
     }
   }
+  LBANN_WARNING("save_model was called, but the callback_save_model was not loaded");
   return false;
 }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1567,7 +1567,9 @@ bool model::save_model() {
       return cb->save_model(this);
     }
   }
-  LBANN_WARNING("save_model was called, but the callback_save_model was not loaded");
+  if(m_comm->am_model_master()) {
+    LBANN_WARNING("save_model was called, but the callback_save_model was not loaded");
+  }
   return false;
 }
 

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -236,11 +236,11 @@ lbann_callback* construct_callback(lbann_comm* comm,
     const auto& params = proto_cb.save_model();
     if(params.extension().size() != 0) {
       return new lbann_callback_save_model(params.dir(),
-                                           params.steps(),
+                                           params.disable_save_after_training(),
                                            params.extension());
     }else {
       return new lbann_callback_save_model(params.dir(),
-                                           params.steps());
+                                           params.disable_save_after_training());
     }
   }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -610,7 +610,7 @@ message CallbackCheckpoint {
 message CallbackSaveModel {
   string dir = 1;
   string extension = 2;
-  int64 steps = 3;
+  bool disable_save_after_training = 3;
 }
 
 message CallbackReplaceWeights {


### PR DESCRIPTION
disable the save at the end of training.  This deprecates the need for
an explicit steps parameter to the callback.  When saving at the end
of training is disabled, the callback can still be used to explicitly
save the model via the model->save_model() function.  This feature is
used in training complex models like the CycleGAN.