### PR TITLE
Strict dimension checks for layer input tensors

### DIFF
--- a/include/lbann/layers/loss/categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/categorical_accuracy.hpp
@@ -55,25 +55,25 @@ public:
   void setup_dims() override {
     Layer::setup_dims();
     set_output_dims({1});
+
+    // Check that input dimensions match
     if (get_input_size(0) != get_input_size(1)) {
       const auto& parents = get_parent_layers();
-      const auto& dims0 = get_input_dims(0);
-      const auto& dims1 = get_input_dims(1);
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects inputs with identical dimensions, but "
-          << "layer \"" << parents[0]->get_name() << "\" outputs a ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? "x" : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " tensor and "
-          << "layer \"" << parents[1]->get_name() << "\" outputs a ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? "x" : "") << dims1[i];
-      }
-      err << " tensor";
+      err << ")";
       LBANN_ERROR(err.str());
     }
+
   }
 
   void fp_compute() override;

--- a/include/lbann/layers/loss/categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/categorical_accuracy.hpp
@@ -57,11 +57,11 @@ public:
     set_output_dims({1});
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/loss/cross_entropy.hpp
+++ b/include/lbann/layers/loss/cross_entropy.hpp
@@ -70,24 +70,21 @@ public:
     Layer::setup_dims();
     set_output_dims({1});
 
-    // Check that input dimensions are valid
-    std::stringstream err;
-    const auto& parents = get_parent_layers();
-    const auto& dims0 = get_input_dims(0);
-    const auto& dims1 = get_input_dims(1);
-    if (dims0 != dims1) {
+    // Check that input dimensions match
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with identical dimensions, "
-          << "but parent layer \"" << parents[0]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " and parent layer \"" << parents[1]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims1[i];
-      }
+      err << ")";
       LBANN_ERROR(err.str());
     }
 

--- a/include/lbann/layers/loss/cross_entropy.hpp
+++ b/include/lbann/layers/loss/cross_entropy.hpp
@@ -71,11 +71,11 @@ public:
     set_output_dims({1});
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/loss/mean_absolute_error.hpp
+++ b/include/lbann/layers/loss/mean_absolute_error.hpp
@@ -70,24 +70,21 @@ public:
     Layer::setup_dims();
     set_output_dims({1});
 
-    // Check that input dimensions are valid
-    std::stringstream err;
-    const auto& parents = get_parent_layers();
-    const auto& dims0 = get_input_dims(0);
-    const auto& dims1 = get_input_dims(1);
-    if (dims0 != dims1) {
+    // Check that input dimensions match
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with identical dimensions, "
-          << "but parent layer \"" << parents[0]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " and parent layer \"" << parents[1]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims1[i];
-      }
+      err << ")";
       LBANN_ERROR(err.str());
     }
 

--- a/include/lbann/layers/loss/mean_absolute_error.hpp
+++ b/include/lbann/layers/loss/mean_absolute_error.hpp
@@ -71,11 +71,11 @@ public:
     set_output_dims({1});
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -70,24 +70,21 @@ public:
     Layer::setup_dims();
     set_output_dims({1});
 
-    // Check that input dimensions are valid
-    std::stringstream err;
-    const auto& parents = get_parent_layers();
-    const auto& dims0 = get_input_dims(0);
-    const auto& dims1 = get_input_dims(1);
-    if (dims0 != dims1) {
+    // Check that input dimensions match
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with identical dimensions, "
-          << "but parent layer \"" << parents[0]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " and parent layer \"" << parents[1]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims1[i];
-      }
+      err << ")";
       LBANN_ERROR(err.str());
     }
 

--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -71,11 +71,11 @@ public:
     set_output_dims({1});
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -62,24 +62,21 @@ protected:
     Layer::setup_dims();
     set_output_dims({1});
 
-    // Check that input dimensions are valid
-    std::stringstream err;
-    const auto& parents = get_parent_layers();
-    const auto& dims0 = get_input_dims(0);
-    const auto& dims1 = get_input_dims(1);
-    if (dims0 != dims1) {
+    // Check that input dimensions match
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with identical dimensions, "
-          << "but parent layer \"" << parents[0]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " and parent layer \"" << parents[1]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims1[i];
-      }
+      err << ")";
       LBANN_ERROR(err.str());
     }
 

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -63,11 +63,11 @@ protected:
     set_output_dims({1});
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -57,15 +57,15 @@ protected:
     set_output_dims(get_input_dims());
 
     // Check that input dimensions match
-    if (get_input_dims(0) != get_input_dims(1)) {
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with different dimensions (";
+          << "has input tensors with incompatible dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
-        err << (i > 0 ? ", " : "")
-            << "layer \"" << m_parent_layers[i]->get_name() << "\" "
-            << "outputs ";
         const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
         for (size_t j = 0; j < dims.size(); ++j) {
           err << (j > 0 ? " x " : "") << dims[j];
         }

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -57,11 +57,11 @@ protected:
     set_output_dims(get_input_dims());
 
     // Check that input dimensions match
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/misc/covariance.hpp
+++ b/include/lbann/layers/misc/covariance.hpp
@@ -73,36 +73,20 @@ protected:
   void setup_dims() override {
     Layer::setup_dims();
     set_output_dims({1});
-
-    // Check that input dimensions are valid
-    std::stringstream err;
-    const auto& parents = get_parent_layers();
-    const auto& dims0 = get_input_dims(0);
-    const auto& dims1 = get_input_dims(1);
-    if (dims0 != dims1) {
+    if (get_input_size(0) != get_input_size(1)) {
+      const auto& parents = get_parent_layers();
+      std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with identical dimensions, "
-          << "but parent layer \"" << parents[0]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
+          << "has input tensors with incompatible dimensions (";
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& dims = get_input_dims(i);
+        err << (i > 0 ? ", " : "")
+            << "layer \"" << parents[i]->get_name() << "\" outputs ";
+        for (size_t j = 0; j < dims.size(); ++j) {
+          err << (j > 0 ? " x " : "") << dims[j];
+        }
       }
-      err << " and parent layer \"" << parents[1]->get_name() << "\" "
-          << "outputs a tensor with dimensions ";
-      for (size_t i = 0; i < dims1.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims1[i];
-      }
-      LBANN_ERROR(err.str());
-    }
-    if (get_input_size() <= 1) {
-      err << get_type() << " layer \"" << get_name() << "\" "
-          << "expects input tensors with at least two entries, "
-          << "but parent layers \"" << parents[0]->get_name() << "\" "
-          << "and \"" << parents[1]->get_name() << "\" "
-          << "output tensors with dimensions ";
-      for (size_t i = 0; i < dims0.size(); ++i) {
-        err << (i > 0 ? " x " : "") << dims0[i];
-      }
+      err << ")";
       LBANN_ERROR(err.str());
     }
   }

--- a/include/lbann/layers/misc/covariance.hpp
+++ b/include/lbann/layers/misc/covariance.hpp
@@ -73,11 +73,11 @@ protected:
   void setup_dims() override {
     Layer::setup_dims();
     set_output_dims({1});
-    if (get_input_size(0) != get_input_size(1)) {
+    if (get_input_dims(0) != get_input_dims(1)) {
       const auto& parents = get_parent_layers();
       std::stringstream err;
       err << get_type() << " layer \"" << get_name() << "\" "
-          << "has input tensors with incompatible dimensions (";
+          << "has input tensors with different dimensions (";
       for (int i = 0; i < get_num_parents(); ++i) {
         const auto& dims = get_input_dims(i);
         err << (i > 0 ? ", " : "")

--- a/include/lbann/layers/transform/hadamard.hpp
+++ b/include/lbann/layers/transform/hadamard.hpp
@@ -51,27 +51,41 @@ public:
 
 protected:
 
+  void setup_pointers() override {
+    transform_layer::setup_pointers();
+    if (get_num_parents() < 1) {
+      std::stringstream err;
+      err << get_type() << " layer \"" << get_name() << "\" "
+          << "has no parent layers";
+      LBANN_ERROR(err.str());
+    }
+  }
+
   void setup_dims() override {
     transform_layer::setup_dims();
-    const auto& output_dims = get_output_dims();
+    set_output_dims(get_input_dims());
+
+    // Check that input dimensions match
+    const auto& output_size = get_output_size();
     for (int i = 0; i < get_num_parents(); ++i) {
-      const auto& input_dims = get_input_dims(i);
-      if (input_dims != output_dims) {
+      if (get_input_size(i) != output_size) {
+        const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "
-            << "expects input tensors with dimensions ";
-        for (size_t j = 0; j < output_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << output_dims[j];
+            << "has input tensors with incompatible dimensions (";
+        for (int j = 0; j < get_num_parents(); ++j) {
+          const auto& dims = get_input_dims(j);
+          err << (j > 0 ? ", " : "")
+              << "layer \"" << parents[j]->get_name() << "\" outputs ";
+          for (size_t k = 0; k < dims.size(); ++k) {
+            err << (k > 0 ? " x " : "") << dims[k];
+          }
         }
-        err << ", but parent layer "
-            << "\"" << m_parent_layers[i]->get_name() << "\" "
-            << "outputs with dimensions ";
-        for (size_t j = 0; j < input_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << input_dims[j];
-        }
+        err << ")";
         LBANN_ERROR(err.str());
       }
     }
+
   }
 
   void fp_compute() override {

--- a/include/lbann/layers/transform/hadamard.hpp
+++ b/include/lbann/layers/transform/hadamard.hpp
@@ -66,9 +66,9 @@ protected:
     set_output_dims(get_input_dims());
 
     // Check that input dimensions match
-    const auto& output_size = get_output_size();
+    const auto& output_dims = get_output_dims();
     for (int i = 0; i < get_num_parents(); ++i) {
-      if (get_input_size(i) != output_size) {
+      if (get_input_dims(i) != output_dims) {
         const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -62,25 +62,28 @@ protected:
   void setup_dims() override {
     transform_layer::setup_dims();
     set_output_dims(get_input_dims());
-    const auto& output_dims = get_output_dims();
+
+    // Check that input dimensions match
+    const auto& output_size = get_output_size();
     for (int i = 0; i < get_num_parents(); ++i) {
-      const auto& input_dims = get_input_dims(i);
-      if (input_dims != output_dims) {
+      if (get_input_size(i) != output_size) {
+        const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "
-            << "expects input tensors with dimensions ";
-        for (size_t j = 0; j < output_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << output_dims[j];
+            << "has input tensors with incompatible dimensions (";
+        for (int j = 0; j < get_num_parents(); ++j) {
+          const auto& dims = get_input_dims(j);
+          err << (j > 0 ? ", " : "")
+              << "layer \"" << parents[j]->get_name() << "\" outputs ";
+          for (size_t k = 0; k < dims.size(); ++k) {
+            err << (k > 0 ? " x " : "") << dims[k];
+          }
         }
-        err << ", but parent layer "
-            << "\"" << m_parent_layers[i]->get_name() << "\" "
-            << "outputs with dimensions ";
-        for (size_t j = 0; j < input_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << input_dims[j];
-        }
+        err << ")";
         LBANN_ERROR(err.str());
       }
     }
+
   }
 
   void fp_compute() override {

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -64,9 +64,9 @@ protected:
     set_output_dims(get_input_dims());
 
     // Check that input dimensions match
-    const auto& output_size = get_output_size();
+    const auto& output_dims = get_output_dims();
     for (int i = 0; i < get_num_parents(); ++i) {
-      if (get_input_size(i) != output_size) {
+      if (get_input_dims(i) != output_dims) {
         const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -87,25 +87,28 @@ protected:
   void setup_dims() override {
     transform_layer::setup_dims();
     set_output_dims(get_input_dims());
-    const auto& output_dims = get_output_dims();
+
+    // Check that input dimensions match
+    const auto& output_size = get_output_size();
     for (int i = 0; i < get_num_parents(); ++i) {
-      const auto& input_dims = get_input_dims(i);
-      if (input_dims != output_dims) {
+      if (get_input_size(i) != output_size) {
+        const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "
-            << "expects input tensors with dimensions ";
-        for (size_t j = 0; j < output_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << output_dims[j];
+            << "has input tensors with incompatible dimensions (";
+        for (int j = 0; j < get_num_parents(); ++j) {
+          const auto& dims = get_input_dims(j);
+          err << (j > 0 ? ", " : "")
+              << "layer \"" << parents[j]->get_name() << "\" outputs ";
+          for (size_t k = 0; k < dims.size(); ++k) {
+            err << (k > 0 ? " x " : "") << dims[k];
+          }
         }
-        err << ", but parent layer "
-            << "\"" << m_parent_layers[i]->get_name() << "\" "
-            << "outputs with dimensions ";
-        for (size_t j = 0; j < input_dims.size(); ++j) {
-          err << (j > 0 ? " x " : "") << input_dims[j];
-        }
+        err << ")";
         LBANN_ERROR(err.str());
       }
     }
+
   }
 
   void fp_compute() override {

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -89,9 +89,9 @@ protected:
     set_output_dims(get_input_dims());
 
     // Check that input dimensions match
-    const auto& output_size = get_output_size();
+    const auto& output_dims = get_output_dims();
     for (int i = 0; i < get_num_parents(); ++i) {
-      if (get_input_size(i) != output_size) {
+      if (get_input_dims(i) != output_dims) {
         const auto& parents = get_parent_layers();
         std::stringstream err;
         err << get_type() << " layer \"" << get_name() << "\" "


### PR DESCRIPTION
Currently, many of our layers require input tensors to have identical dimensions, e.g. binary math layers or some loss layers. This can get annoying since, for example, you can't directly compute the cross entropy between a 1000x1x1-tensor and a 1000-tensor. This PR relaxes the requirement to only require that input tensors have the same number of entries. I'm personally ambivalent about this change since you can now add a 2x3x4-tensor and a 6x2x2-tensor without any warning.

For reviewing, it will be helpful to know that the dimension checks for the categorical accuracy, cross entropy, mean absolute error, mean squared error, top-k categorical accuracy, binary math, and covariance layers are identical. The dimension checks for the Hadamard, sum, and weighted sum layers are also identical.