### PR TITLE
Corrected a bug in the jag conduit reader where shuffling and then

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -64,7 +64,7 @@ class generic_data_reader : public lbann_image_preprocessor {
  public:
 
  #define JAG_NOOP_VOID if (m_jag_partitioned) { return; }
- #define JAG_NOOP_INT if (m_jag_partitioned) { return 0; } 
+ #define JAG_NOOP_INT if (m_jag_partitioned) { return 0; }
 
   /**
    * ctor
@@ -782,8 +782,10 @@ class generic_data_reader : public lbann_image_preprocessor {
    */
   virtual void postprocess_data_source(int tid) {};
 
-  /// Shuffle indices
+  /// Shuffle indices (uses the data_seq_generator)
   virtual void shuffle_indices();
+  /// Shuffle indices and profide a random number generator
+  virtual void shuffle_indices(rng_gen& gen);
 
   int m_mini_batch_size;
   int m_current_pos;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -330,6 +330,9 @@ class data_reader_jag_conduit : public generic_data_reader {
 #ifndef _JAG_OFFLINE_TOOL_MODE_
   /// Shuffle sample indices
   void shuffle_indices() override;
+  /// Shuffle sammple indices using a different RNG
+  void shuffle_indices(rng_gen& gen) override;
+
   /**
    * Compute the number of parallel readers based on the type of io_buffer,
    * the mini batch size, the requested number of parallel readers.

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -38,10 +38,14 @@ namespace lbann {
 //#define DEBUG
 
 void generic_data_reader::shuffle_indices() {
+  shuffle_indices(get_data_seq_generator());
+}
+
+void generic_data_reader::shuffle_indices(rng_gen& gen) {
   // Shuffle the data
   if (m_shuffle) {
     std::shuffle(m_shuffled_indices.begin(), m_shuffled_indices.end(),
-                 get_data_seq_generator());
+                 gen);
   }
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -162,7 +162,7 @@ void data_reader_jag_conduit::shuffle_indices(rng_gen& gen) {
   // Shuffle the data
   if (m_shuffle) {
     std::shuffle(m_valid_samples.begin(), m_valid_samples.end(),
-                 get_data_seq_generator());
+                 gen);
   }
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -155,18 +155,25 @@ int data_reader_jag_conduit::get_num_data() const {
 }
 
 void data_reader_jag_conduit::shuffle_indices() {
+  shuffle_indices(get_data_seq_generator());
+}
+
+void data_reader_jag_conduit::shuffle_indices(rng_gen& gen) {
   // Shuffle the data
   if (m_shuffle) {
     std::shuffle(m_valid_samples.begin(), m_valid_samples.end(),
                  get_data_seq_generator());
   }
-  m_valid_samples.resize(m_local_num_samples_to_use);
 }
 
 void data_reader_jag_conduit::select_subset_of_data() {
 
   m_local_num_samples_to_use = get_num_valid_local_samples();
-  shuffle_indices();
+  // Use the normal (non-data sequence) generator for shuffling and
+  // finding a subset of samples.  Otherwise the different ranks will
+  // get out of step due to initial imbalance of available samples.
+  shuffle_indices(get_generator());
+  m_valid_samples.resize(m_local_num_samples_to_use);
 
   const size_t count = get_absolute_sample_count();
   const double use_percent = get_use_percent();


### PR DESCRIPTION
downselecting the number of samples that each rank has caused the
data_seq_generator random number generators to get out of step.  This
patch allows the shuffle_indices function to take an alternate data
reader.  In this scenario the jag reader can use the normal random
generator for down selecting samples and leave the normal generator in
good order.