### PR TITLE
Callback to perturb Adam hyperparameters

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -21,6 +21,7 @@ set_full_path(THIS_DIR_HEADERS
   callback_io.hpp
   callback_learning_rate.hpp
   callback_ltfb.hpp
+  callback_perturb_adam.hpp
   callback_print.hpp
   callback_save_images.hpp
   callback_save_model.hpp

--- a/include/lbann/callbacks/callback_perturb_adam.hpp
+++ b/include/lbann/callbacks/callback_perturb_adam.hpp
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_PERTURB_ADAM_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_PERTURB_ADAM_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+#include "lbann/optimizers/adam.hpp"
+#include <set>
+
+namespace lbann {
+
+/** @brief Hyperparameter exploration with Adam optimizers.
+ *
+ *  Goes through the Adam optimizers in a model and perturbs four
+ *  hyperparameters: the learning rate, @f$\beta_1@f$, @f$\beta_2@f$,
+ *  and @f$\epsilon@f$. Since these hyperparameters can range over
+ *  orders of magnitude, the perturbations are performed in log space.
+ *  More precisely, random values are drawn from normal distributions
+ *  (with user-provided standard deviations) and added to
+ *  @f$\log(\text{learning rate})@f$, @f$\log(1-\beta_1)@f$,
+ *  @f$\log(1-\beta_2)@f$, and @f$\log\epsilon@f$.
+ */
+class lbann_callback_perturb_adam : public lbann_callback {
+public:
+
+  /** @param learning_rate_factor   Standard deviation of learning rate
+   *                                perturbation (in log space).
+   *  @param beta1_factor           Standard deviation of @f$\beta_1@f$
+   *                                perturbation (in log space).
+   *  @param beta2_factor           Standard deviation of @f$\beta_2@f$
+   *                                perturbation (in log space).
+   *  @param eps_factor             Standard deviation of @f$\epsilon@f$
+   *                                perturbation (in log space).
+   *  @param perturb_during_training    Whether to periodically perturb
+   *                                    hyperparameters during training
+   *                                    or to only perturb once during
+   *                                    setup.
+   *  @param batch_interval Number of training mini-batch steps between
+   *                        perturbations. Only used if
+   *                        @c perturb_during_training is @c true.
+   *  @param weights_name   Names of weights with Adam optimizers. If
+   *                        empty, all Adam optimizers in the model are
+   *                        perturbed.
+   */
+  lbann_callback_perturb_adam(DataType learning_rate_factor,
+                              DataType beta1_factor,
+                              DataType beta2_factor,
+                              DataType eps_factor = 0,
+                              bool perturb_during_training = false,
+                              El::Int batch_interval = 1,
+                              std::set<std::string> weights_names = {});
+  lbann_callback_perturb_adam* copy() const override { return new lbann_callback_perturb_adam(*this); }
+  std::string name() const override { return "perturb Adam"; }
+
+  void setup(model* m);
+  void on_batch_begin(model* m);
+
+private:
+
+  /** Standard deviation of learning rate perturbation.
+   *
+   *  In log space.
+   */
+  DataType m_learning_rate_factor;
+  /** Standard deviation of @f$\beta_1@f$ perturbation.
+   *
+   *  In log space.
+   */
+  DataType m_beta1_factor;
+  /** Standard deviation of @f$\beta_2@f$ perturbation.
+   *
+   *  In log space.
+   */
+  DataType m_beta2_factor;
+  /** Standard deviation of @f$\epsilon@f$ perturbation.
+   *
+   *  In log space.
+   */
+  DataType m_eps_factor;
+
+  /** Whether to periodically perturb during training.
+   *
+   *  If false, only perturb once during setup.
+   */
+  bool m_perturb_during_training;
+
+  /** Optimizers for these weights will be perturbed.
+   *
+   *  If empty, all Adam optimizers in the model will be perturbed.
+   */
+  std::set<std::string> m_weights_names;
+
+  /** Perturb Adam optimizers in model. */
+  void perturb(model& m) const;
+  /** Perturb Adam optimizer hyperparameters. */
+  void perturb(lbann_comm& comm, adam& m) const;
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_CALLBACKS_CALLBACK_PERTURB_ADAM_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -172,6 +172,7 @@
 #include "lbann/callbacks/callback_confusion_matrix.hpp"
 #include "lbann/callbacks/callback_check_gradients.hpp"
 #include "lbann/callbacks/callback_check_metric.hpp"
+#include "lbann/callbacks/callback_perturb_adam.hpp"
 
 /// Weights and weight initializers
 #include "lbann/weights/weights.hpp"

--- a/include/lbann/optimizers/adam.hpp
+++ b/include/lbann/optimizers/adam.hpp
@@ -36,7 +36,7 @@ namespace lbann {
  *  Kingma, D. and Ba, J. 2014. Adam: A Method for Stochastic Optimization.
  */
 class adam : public optimizer {
- public:
+public:
 
   /** Constructor. */
   adam(lbann_comm *comm,
@@ -70,7 +70,7 @@ class adam : public optimizer {
   void step_compute_gpu(AbsDistMat& values, const AbsDistMat& gradient) override;
 #endif // LBANN_HAS_CUDNN
 
- private:
+private:
 
   /** Update factor for first moment estimate. */
   DataType m_beta1;
@@ -87,10 +87,13 @@ class adam : public optimizer {
   /** Second moment estimates. */
   AbsDistMat *m_moment2;
 
-//************************************************************************
-// Checkpointing
-//************************************************************************
- private:
+  /** Hyperparameter exploration. */
+  friend class lbann_callback_perturb_adam;
+
+  // ===========================================
+  // Checkpointing
+  // ===========================================
+
   /* struct used to serialize mode fields in file and MPI transfer */
   struct packing_header {
     DataType beta1;
@@ -138,6 +141,7 @@ class adam : public optimizer {
   bool load_from_checkpoint_shared(persist& p, std::string m_name) override;
   bool save_to_checkpoint_distributed(persist& p, std::string m_name) override;
   bool load_from_checkpoint_distributed(persist& p, std::string m_name) override;
+
 };
 
 } // namespace lbann

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -20,6 +20,7 @@ set_full_path(THIS_DIR_SOURCES
   callback_io.cpp
   callback_learning_rate.cpp
   callback_ltfb.cpp
+  callback_perturb_adam.cpp
   callback_print.cpp
   callback_save_images.cpp
   callback_save_model.cpp

--- a/src/callbacks/callback_perturb_adam.cpp
+++ b/src/callbacks/callback_perturb_adam.cpp
@@ -1,0 +1,163 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_perturb_adam.hpp"
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+
+lbann_callback_perturb_adam::lbann_callback_perturb_adam(DataType learning_rate_factor,
+                                                         DataType beta1_factor,
+                                                         DataType beta2_factor,
+                                                         DataType eps_factor,
+                                                         bool perturb_during_training,
+                                                         El::Int batch_interval,
+                                                         std::set<std::string> weights_names)
+  : lbann_callback(batch_interval),
+    m_learning_rate_factor(learning_rate_factor),
+    m_beta1_factor(beta1_factor),
+    m_beta2_factor(beta2_factor),
+    m_eps_factor(eps_factor),
+    m_perturb_during_training(perturb_during_training),
+    m_weights_names(std::move(weights_names)) {}
+
+void lbann_callback_perturb_adam::setup(model* m) {
+  perturb(*m);
+}
+
+void lbann_callback_perturb_adam::on_batch_begin(model* m) {
+  if (m_perturb_during_training && m->get_cur_step() > 0) {
+    perturb(*m);
+  }
+}
+
+void lbann_callback_perturb_adam::perturb(model& m) const {
+  auto* comm = m.get_comm();
+  for (auto* w : m.get_weights()) {
+    if (w == nullptr) {
+      std::stringstream err;
+      err << "callback \"" << name() << "\" "
+          << "got a weights pointer that is a null pointer";
+      LBANN_ERROR(err.str());
+    }
+    if (m_weights_names.empty()
+        || m_weights_names.count(w->get_name()) > 0) {
+
+      // Check if weights has Adam optimizer
+      auto* opt = dynamic_cast<adam*>(w->get_optimizer());
+      if (!m_weights_names.empty() && opt == nullptr) {
+        auto* opt_ = w->get_optimizer();
+        std::stringstream err;
+        err << "callback \"" << name() << "\" "
+            << "expected weights \"" << w->get_name() << "\" "
+            << "to have an Adam optimizer, but found ";
+        if (opt_ == nullptr) {
+          err << "no optimizer";
+        } else {
+          err << opt_->get_type();
+        }
+        LBANN_ERROR(err.str());
+      }
+
+      // Perturb Adam optimizer
+      if (opt != nullptr) {
+        perturb(*comm, *opt);
+      }
+
+    }
+  }
+}
+
+void lbann_callback_perturb_adam::perturb(lbann_comm& comm, adam& opt) const {
+
+  // Perturb hyperparameters on master process
+  std::vector<DataType> hyperparameters(4);
+  if (comm.am_model_master()) {
+
+    // Useful constants
+    // Note: half_epsilon is the difference between 1.0 and the next
+    // smallest representable value.
+    constexpr DataType zero = 0;
+    constexpr DataType one = 1;
+    constexpr DataType min_val = std::numeric_limits<DataType>::min();
+    constexpr DataType half_epsilon = std::numeric_limits<DataType>::epsilon() / 2;
+
+    // RNG
+    auto& gen = get_generator();
+    std::normal_distribution<DataType> dist(zero, one);
+
+    // Perturb log(learning_rate)
+    auto learning_rate = opt.get_learning_rate();
+    if (m_learning_rate_factor != zero && learning_rate >= zero) {
+      auto log_val = std::log(std::max(learning_rate, min_val));
+      log_val += m_learning_rate_factor * dist(gen);
+      learning_rate = std::exp(log_val);
+    }
+    hyperparameters[0] = learning_rate;
+
+    // Perturb log(1 - beta1)
+    auto beta1 = opt.m_beta1;
+    if (m_beta1_factor != zero && zero <= beta1 && beta1 <= one) {
+      auto log_val = std::log(std::max(one - beta1, half_epsilon));
+      log_val += m_beta1_factor * dist(gen);
+      beta1 = std::max(one - std::exp(log_val), zero);
+    }
+    hyperparameters[1] = beta1;
+
+    // Perturb log(1 - beta2)
+    auto beta2 = opt.m_beta2;
+    if (m_beta2_factor != zero && zero <= beta2 && beta2 <= one) {
+      auto log_val = std::log(std::max(one - beta2, half_epsilon));
+      log_val += m_beta2_factor * dist(gen);
+      beta2 = std::max(one - std::exp(log_val), zero);
+    }
+    hyperparameters[2] = beta2;
+
+    // Perturb log(eps)
+    auto eps = opt.m_eps;
+    if (m_eps_factor != zero && eps >= zero) {
+      auto log_val = std::log(std::max(eps, min_val));
+      log_val += m_eps_factor * dist(gen);
+      eps = std::exp(log_val);
+    }
+    hyperparameters[3] = eps;
+
+  }
+
+  // Communicate hyperparameters from master processes
+  comm.model_broadcast(comm.get_model_master(),
+                       hyperparameters.data(),
+                       hyperparameters.size());
+
+  // Update hyperparameters
+  opt.set_learning_rate(hyperparameters[0]);
+  opt.m_beta1 = hyperparameters[1];
+  opt.m_beta2 = hyperparameters[2];
+  opt.m_eps = hyperparameters[3];
+
+}
+
+} // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -410,6 +410,21 @@ lbann_callback* construct_callback(lbann_comm* comm,
     return new lbann_callback_gpu_memory_usage();
   }
 
+  //////////////////////////////////////////////////////////////
+  // Hyperparameter exploration
+  //////////////////////////////////////////////////////////////
+  if (proto_cb.has_perturb_adam()) {
+    const auto& params = proto_cb.perturb_adam();
+    return new lbann_callback_perturb_adam(
+                 params.learning_rate_factor(),
+                 params.beta1_factor(),
+                 params.beta2_factor(),
+                 params.eps_factor(),
+                 params.perturb_during_training(),
+                 params.batch_interval(),
+                 parse_set<std::string>(params.weights()));
+  }
+
   return nullptr;
 }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -435,6 +435,7 @@ message Callback {
    CallbackSyncSelected sync_selected = 34;
    CallbackConfusionMatrix confusion_matrix = 36;
    CallbackCheckMetric check_metric = 37;
+   CallbackPerturbAdam perturb_adam = 38;
 }
 
 message CallbackLTFB {
@@ -660,6 +661,16 @@ message CallbackConfusionMatrix {
   string prediction = 1; // Prediction layer
   string label = 2;      // Label layer
   string prefix = 3;     // Prefix for output files
+}
+
+message CallbackPerturbAdam {
+  float learning_rate_factor = 1;   // Learning rate perturbation (in log space)
+  float beta1_factor = 2;           // beta1 perturbation (in log space)
+  float beta2_factor = 3;           // beta2 perturbation (in log space)
+  float eps_factor = 4;             // eps perturbation (in log space)
+  bool perturb_during_training = 5; // Whether to periodically perturb during training
+  int64 batch_interval = 6;         // Frequency of perturbation if perturb_during_training is true
+  string weights = 7;               // Weights with Adam optimizer
 }
 
 //========================================================================


### PR DESCRIPTION
This reproduces the Adam hyperparameter exploration functionality in #615, but in a much less hacky way. I think a good approach for hyperparameter exploration is to create a bunch of callbacks that each handle an individual set of hyperparameters, e.g. one for dropout, another for SGD, and so on.

I'm under the impression that Adam hyperparameters can range over orders of magnitude, so the perturbations take place in log space. I am more precise in the documentation and I would appreciate comments if it's at all unclear. The user has the option to perturb Adam just during setup or periodically during training. For instance, doing it after each LTFB round is similar the exploration stage in population-based training.