### PR TITLE
update the LbannProto cmake to update the library target appropriately

### DIFF
--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -1,7 +1,25 @@
 # Create the LbannProto library
 if (LBANN_HAS_PROTOBUF)
-    protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS lbann.proto)
-    #protobuf_generate(LANG cpp OUT_VAR PROTO_SRCS PROTOS lbann.proto)
+
+  # In its current state, LBANN does not make complicated use of
+  # protobuf -- it's really just one file. This is the meat of the
+  # implementation of "protobuf_generate_cpp" but it gives us a custom
+  # command on which we can depend. Using this, when lbann.proto is
+  # touched, CMake will rebuild the LbannProto library.
+  set(PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/lbann.pb.cc")
+  set(PROTO_HDRS "${CMAKE_CURRENT_BINARY_DIR}/lbann.pb.h")
+  add_custom_command(
+    COMMAND protobuf::protoc
+    "--cpp_out=${DLL_EXPORT_DECL}${CMAKE_CURRENT_BINARY_DIR}"
+    "-I" "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lbann.proto"
+    OUTPUT ${PROTO_SRCS} ${PROTO_HDRS}
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/lbann.proto" protobuf::protoc
+    COMMENT "Running protoc on lbann.proto"
+    VERBATIM)
+
+  add_custom_target(LbannProto_genSrc
+    DEPENDS ${PROTO_SRCS} ${PROTO_HDRS})
 
   add_library(LbannProto ${PROTO_SRCS} ${PROTO_HDRS})
   target_link_libraries(LbannProto PUBLIC protobuf::libprotobuf)
@@ -9,6 +27,8 @@ if (LBANN_HAS_PROTOBUF)
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
   target_include_directories(LbannProto PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+  add_dependencies(LbannProto LbannProto_genSrc)
 
   # Install the library
   install(TARGETS LbannProto

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -10,7 +10,7 @@ if (LBANN_HAS_PROTOBUF)
   set(PROTO_HDRS "${CMAKE_CURRENT_BINARY_DIR}/lbann.pb.h")
   add_custom_command(
     COMMAND protobuf::protoc
-    "--cpp_out=${DLL_EXPORT_DECL}${CMAKE_CURRENT_BINARY_DIR}"
+    "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
     "-I" "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/lbann.proto"
     OUTPUT ${PROTO_SRCS} ${PROTO_HDRS}


### PR DESCRIPTION
For CMake-specific reasons, the LbannProto library target does not get marked as dirty when lbann.proto is touched. The basic conclusion that I reached was we rip out the meat of `protobuf_generate_cpp` or we jump through a bunch of different hoops to get CMake to acknowledge the custom commands generated by protobuf's CMake. It quickly became clear that LBANN's use of `protoc` is not complicated enough to justify the mess that the latter option implies. So I ripped out the 3 salient lines from `protobuf_generate_cpp` and added a few more to make everything work. Should the dark day come that LBANN has a more complicated proto situation, we can re-evaluate this.