### PR TITLE
patch SB to build HDF5 with zlib

### DIFF
--- a/superbuild/conduit/CMakeLists.txt
+++ b/superbuild/conduit/CMakeLists.txt
@@ -8,7 +8,7 @@ option(CONDUIT_CLONE_VIA_SSH
 if (CONDUIT_CLONE_VIA_SSH)
   message(WARNING "Requested CONDUIT clone via SSH. This will happen.\n"
     "However, CONDUIT has a git submodule that will still clone via HTTPS.")
-  
+
   set(CONDUIT_URL git@github.com:llnl/conduit.git
     CACHE STRING "The URL from which to clone CONDUIT")
 else ()
@@ -27,7 +27,7 @@ set(CONDUIT_CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}"
 
 option(CONDUIT_BUILD_SHARED_LIBS
   "Whether CONDUIT should build dynamically linked libraries."
-  "${BUILD_SHARED_LIBS}")
+  ON)
 
 # CONDUIT-specific configuration options explicitly exposed
 option(CONDUIT_ENABLE_MPI "Enable MPI support in CONDUIT." ON)

--- a/superbuild/hdf5/CMakeLists.txt
+++ b/superbuild/hdf5/CMakeLists.txt
@@ -13,7 +13,7 @@ if (HDF5_CLONE_VIA_SSH)
   message(FATAL_ERROR
     "SSH cloning of HDF5 currently disabled. "
     "I don't know the SSH URL at this time.")
-  
+
   set(HDF5_URL I_DONT_KNOW
     CACHE STRING "The URL from which to clone HDF5")
 else ()
@@ -32,7 +32,7 @@ set(HDF5_CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}"
 
 option(HDF5_BUILD_SHARED_LIBS
   "Whether HDF5 should build dynamically linked libraries."
-  "${BUILD_SHARED_LIBS}")
+  ON)
 
 set(HDF5_CMAKE_COMMAND "${CMAKE_COMMAND}"
   CACHE FILEPATH
@@ -45,8 +45,10 @@ option(HDF5_USE_16_API_DEFAULT "Use 1.6 API by default" OFF)
 option(HDF5_USE_18_API_DEFAULT "Use 1.8 API by default" ON)
 option(HDF5_USE_110_API_DEFAULT "Use 1.10 API by default" OFF)
 option(HDF5_USE_112_API_DEFAULT "Use 1.12 API by default" OFF)
-
 option(HDF5_BUILD_FORTRAN "Build HDF5 with fortran support" OFF)
+
+# At present, this is required for LBANN/JAG use.
+option(HDF5_ENABLE_Z_LIB_SUPPORT "Build HDF5 with ZLIB support" ON)
 
 if (HDF5_BUILD_FORTRAN)
   enable_language(Fortran)


### PR DESCRIPTION
Requires HDF5 and CONDUIT to use shared libraries, see llnl/conduit#355.