### PR TITLE
Don't enable CUDA-aware MPI in experiment scripts

### DIFF
--- a/experiments/run_lbann_aecycgan_experiment.sh
+++ b/experiments/run_lbann_aecycgan_experiment.sh
@@ -373,11 +373,6 @@ echo "# ======== Useful info and initialization ========" >> ${BATCH_SCRIPT}
 echo "date"                                             >> ${BATCH_SCRIPT}
 echo "${MPIRUN} hostname > ${NODE_LIST}"                >> ${BATCH_SCRIPT}
 echo "sort --unique --output=${NODE_LIST} ${NODE_LIST}" >> ${BATCH_SCRIPT}
-case ${USE_GPU} in
-    YES|yes|TRUE|true|ON|on|1)
-        #echo "export MV2_USE_CUDA=0"                    >> ${BATCH_SCRIPT}
-        ;;
-esac
 case ${CLUSTER} in
     pascal)
         echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}

--- a/experiments/run_lbann_cycgan_experiment.sh
+++ b/experiments/run_lbann_cycgan_experiment.sh
@@ -372,11 +372,6 @@ echo "# ======== Useful info and initialization ========" >> ${BATCH_SCRIPT}
 echo "date"                                             >> ${BATCH_SCRIPT}
 echo "${MPIRUN} hostname > ${NODE_LIST}"                >> ${BATCH_SCRIPT}
 echo "sort --unique --output=${NODE_LIST} ${NODE_LIST}" >> ${BATCH_SCRIPT}
-case ${USE_GPU} in
-    YES|yes|TRUE|true|ON|on|1)
-        echo "export MV2_USE_CUDA=0"                    >> ${BATCH_SCRIPT}
-        ;;
-esac
 case ${CLUSTER} in
     pascal)
         echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}

--- a/experiments/run_lbann_cycgan_inference.sh
+++ b/experiments/run_lbann_cycgan_inference.sh
@@ -226,11 +226,6 @@ echo "# ======== Useful info and initialization ========" >> ${BATCH_SCRIPT}
 echo "date"                                             >> ${BATCH_SCRIPT}
 echo "${MPIRUN} hostname > ${NODE_LIST}"                >> ${BATCH_SCRIPT}
 echo "sort --unique --output=${NODE_LIST} ${NODE_LIST}" >> ${BATCH_SCRIPT}
-case ${USE_GPU} in
-    YES|yes|TRUE|true|ON|on|1)
-        echo "export MV2_USE_CUDA=0"                    >> ${BATCH_SCRIPT}
-        ;;
-esac
 case ${CLUSTER} in
     pascal)
         echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}

--- a/experiments/run_lbann_experiment.sh
+++ b/experiments/run_lbann_experiment.sh
@@ -364,12 +364,6 @@ echo "# ======== Useful info and initialization ========" >> ${BATCH_SCRIPT}
 echo "date"                                             >> ${BATCH_SCRIPT}
 echo "${MPIRUN} hostname > ${NODE_LIST}"                >> ${BATCH_SCRIPT}
 echo "sort --unique --output=${NODE_LIST} ${NODE_LIST}" >> ${BATCH_SCRIPT}
-case ${USE_GPU} in
-    YES|yes|TRUE|true|ON|on|1)
-        echo "export MV2_USE_CUDA=1"                    >> ${BATCH_SCRIPT}
-        echo "export MV2_CUDA_ALLGATHER_FGP=0"          >> ${BATCH_SCRIPT}
-        ;;
-esac
 case ${CLUSTER} in
     pascal)
         echo "export OMP_NUM_THREADS=8"                 >> ${BATCH_SCRIPT}


### PR DESCRIPTION
I did a clean build today on Pascal (`scripts/build_lbann_lc.sh --verbose --clean-build`) and got the following error when I tried to run AlexNet:
```text
GPU CUDA support is not configured. Please reconfigure MVAPICH2 library with --enable-cuda option.
```
Things run fine if I unset `MV2_USE_CUDA`.

I'm not sure what's changed, perhaps @benson31's recent reworking of the build system causes the build script to pick up a non-CUDA-aware version of MVAPICH. In any case, this is a change we've been wanting to make for a while (see the almost identical PR #692). This should close #595.