### PR TITLE
Added a command line flag that can disable the background I/O fetch.

### DIFF
--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -131,6 +131,7 @@ class generic_input_layer : public io_layer {
   std::vector<std::string> get_description() const override {
     auto&& desc = io_layer::get_description();
     desc.push_back("Buffer: " + m_io_buffers[0]->get_type());
+    desc.push_back("Background I/O: " + (this->m_model->background_io_activity_allowed() ? std::string("Enabled") : std::string("Disabled")));
     return desc;
   }
 
@@ -303,7 +304,7 @@ class generic_input_layer : public io_layer {
 
     m_data_set_processed = io_buffer->update_data_set(get_data_reader(mode), mode);
 
-    if(!m_data_set_processed) {
+    if(!m_data_set_processed && this->m_model->background_io_activity_allowed()) {
       int next_active_buffer = get_active_buffer_idx(mode) + 1;
       std::future<void> background_fetch_done = this->m_model->get_io_thread_pool()->submit_job(
         std::bind(&generic_input_layer::fetch_data_in_background, this, next_active_buffer, mode));

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -239,6 +239,12 @@ public:
       mode requested */
   virtual void collect_background_data_fetch(execution_mode mode);
 
+  /** Set a flag that can be used to enable / disable the background I/O activities */
+  void allow_background_io_activity(bool enable) { m_background_io_allowed = enable; }
+
+  /** Are background I/O activities enabled by the input layers */
+  bool background_io_activity_allowed() { return m_background_io_allowed; }
+
   /** Checkpoint model to given file descriptor, return number of bytes written */
   virtual bool save_to_checkpoint_shared(persist& p);
   /** Restore model by reading checkpoint from given file descriptor, return number of bytes read */
@@ -318,6 +324,9 @@ protected:
 
   /** Threads available for I/O */
   std::shared_ptr<thread_pool> m_io_thread_pool;
+
+  /** Flag that allows input layers to fetch data in the background */
+  bool m_background_io_allowed;
 
   /** Check if the model execution mode is valid. */
   virtual bool is_execution_mode_valid(execution_mode mode) const;

--- a/include/lbann/utils/threads/thread_pool.hpp
+++ b/include/lbann/utils/threads/thread_pool.hpp
@@ -105,7 +105,7 @@ public:
   /** Convert the C++ thread id into a local thread pool id */
   int get_local_thread_id();
 
-    /** Convert the C++ thread id into a local thread pool id */
+  /** Convert the C++ thread id into a local thread pool id */
   int get_threads_offset() { return m_threads_offset; }
 
 private:

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -81,7 +81,8 @@ model::model(lbann_comm *comm,
     m_current_phase(0),
     m_comm(comm),
     m_default_optimizer(default_optimizer),
-    m_io_thread_pool() {
+    m_io_thread_pool(),
+    m_background_io_allowed(true) {
 
   // Default model name
   static El::Int num_models = 0;
@@ -101,7 +102,8 @@ model::model(const model& other) :
   m_current_mini_batch_size(other.m_current_mini_batch_size),
   m_effective_mini_batch_size(other.m_effective_mini_batch_size),
   m_current_phase(other.m_current_phase),
-  m_comm(other.m_comm) {
+  m_comm(other.m_comm),
+  m_background_io_allowed(other.m_background_io_allowed) {
 
   // Deep copies
   m_objective_function = other.m_objective_function;
@@ -156,6 +158,7 @@ model& model::operator=(const model& other) {
   m_effective_mini_batch_size = other.m_effective_mini_batch_size;
   m_current_phase = other.m_current_phase;
   m_comm = other.m_comm;
+  m_background_io_allowed = other.m_background_io_allowed;
 
   // Deep copies
   m_objective_function = other.m_objective_function;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -855,6 +855,7 @@ void print_help(lbann::lbann_comm *comm)
        "  --num_gpus=<int>\n"
        "  --num_parallel_readers=<int>\n"
        "  --num_io_threads=<int>\n"
+       "  --disable_background_io_activity=<bool>\n"
        "  --disable_cuda=<bool>\n"
        "     has no effect unless lbann was compiled with: LBANN_HAS_CUDNN\n"
        "  --random_seed=<int>\n"

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -179,7 +179,7 @@ model *build_model_from_prototext(int argc, char **argv,
                                    pb.model());
     model->setup(io_thread_pool);
 
-    if(opts->has_bool("disable_background_io_activity") && opts->get_bool("disable_background_io_activity")) {
+    if(opts->get_bool("disable_background_io_activity")) {
       model->allow_background_io_activity(false);
     }
 

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -179,6 +179,10 @@ model *build_model_from_prototext(int argc, char **argv,
                                    pb.model());
     model->setup(io_thread_pool);
 
+    if(opts->has_bool("disable_background_io_activity") && opts->get_bool("disable_background_io_activity")) {
+      model->allow_background_io_activity(false);
+    }
+
     //under development; experimental
     if (opts->has_bool("use_data_store") && opts->get_bool("use_data_store")) {
       if (master) {


### PR DESCRIPTION
This option will set a flag in each model that will then disable the
input layers from asynchronously fetching data.  When disabled, all
data will be fetched (using the thread pool) at the start of the
fp_compute call.