### PR TITLE
LTFB communication with checkpoint files

### DIFF
--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -69,7 +69,7 @@ public:
   enum class communication_algorithm {
     /** Directly exchange weights values with sendrecv.
      *
-     *  Corresponding ranks in partner models will iterate through
+     *  Corresponding ranks in partner trainers will iterate through
      *  their weights and exchange values with sendrecvs.
      *
      *  Notes:
@@ -77,10 +77,11 @@ public:
      *      weights values, so this is not suitable for hyperparameter
      *      or model architecture exploration.
      *    - Optimal if communication performance between ranks is
-     *      uniform and independent. If intra-model communication is
-     *      fast, it may be advantageous to gather model data on the
-     *      model master ranks and only perform inter-model
-     *      communication between the model master ranks.
+     *      uniform and independent. If intra-trainer communication is
+     *      fast or if communication performance is sensitive to
+     *      network traffic, it may be advantageous to gather model
+     *      data on the trainer master ranks and only perform
+     *      inter-trainer communication between them.
      */
     sendrecv_weights,
 

--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -55,13 +55,12 @@ namespace lbann {
  *    - Can this be used to explore model architectures?
  *
  *  @todo Exchange optimizer state.
- *  @todo Exchange using checkpointing.
  *  @todo Support heterogeneous models.
  */
 class lbann_callback_ltfb : public lbann_callback {
 public:
 
-  /** LTFB communication scheme.
+  /** Inter-trainer communication scheme for LTFB.
    *
    *  The specifics of these algorithms are experimental and will be
    *  in flux.
@@ -76,6 +75,8 @@ public:
      *    - Requires all models to be identical aside from their
      *      weights values, so this is not suitable for hyperparameter
      *      or model architecture exploration.
+     *    - Optimizer state is not exchanged, so there may be wonky
+     *      learning behavior immediately after a tournament.
      *    - Optimal if communication performance between ranks is
      *      uniform and independent. If intra-trainer communication is
      *      fast or if communication performance is sensitive to
@@ -110,6 +111,7 @@ public:
    *                        If empty, then all weights are exchanged.
    *  @param low_score_wins Whether low-scoring or high-scoring models
    *                        survive a tournament.
+   *  @param comm_algo      Inter-trainer communication scheme.
    */
   lbann_callback_ltfb(El::Int batch_interval,
                       std::string metric_name,
@@ -147,7 +149,7 @@ private:
    *  tournament. */
   bool m_low_score_wins;
 
-  /** Communication scheme. */
+  /** Inter-trainer communication scheme. */
   communication_algorithm m_comm_algo;
 
   /** Workspace weights.

--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -125,6 +125,13 @@ public:
   void setup(model *m) override;
   void on_batch_begin(model *m) override;
 
+  /** Convert string to LTFB communication algorithm.
+   *
+   *  If an empty string is provided, returns @c
+   *  communication_algorithm::sendrecv_weights.
+   */
+  static communication_algorithm string_to_comm_algo(const std::string& str);
+
 private:
 
   /** Metric for tournament evaluation. */
@@ -140,6 +147,7 @@ private:
    *  tournament. */
   bool m_low_score_wins;
 
+  /** Communication scheme. */
   communication_algorithm m_comm_algo;
 
   /** Workspace weights.

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1500,6 +1500,9 @@ bool model::save_to_checkpoint_shared(persist& p) {
       p.write_uint64(persist_type::validate, "current_validataion_step",       (uint64_t) m_current_validation_step);
     }
     save_rng_to_checkpoint_shared(p, m_comm);
+    for (weights *w : m_weights) {
+      w->save_to_checkpoint_shared(p);
+    }
     for (size_t l = 0; l < m_layers.size(); l++) {
       if (! m_layers[l]->save_to_checkpoint_shared(p)) {
         return false;
@@ -1518,35 +1521,43 @@ bool model::load_from_checkpoint_shared(persist& p) {
   struct lbann_model_header header;
   // Assume checkpoint reload from epoch end not step end
   if (m_comm->am_model_master()) {
-    p.read_uint32(persist_type::train, "execution_mode",     &header.execution_mode);
-    p.read_uint32(persist_type::train, "terminate_training", &header.terminate_training);
-    p.read_uint64(persist_type::train, "current_epoch",      &header.current_epoch);
-    p.read_uint64(persist_type::train, "current_step",       &header.current_step);
-    if(get_num_iterations_per_epoch(execution_mode::validation) != 0)
+    if (p.get_cb_type() != callback_type::validation) {
+      p.read_uint32(persist_type::train, "execution_mode",     &header.execution_mode);
+      p.read_uint32(persist_type::train, "terminate_training", &header.terminate_training);
+      p.read_uint64(persist_type::train, "current_epoch",      &header.current_epoch);
+      p.read_uint64(persist_type::train, "current_step",       &header.current_step);
+      if(get_num_iterations_per_epoch(execution_mode::validation) != 0)
+        p.read_uint64(persist_type::validate, "current_validation_step",       &header.current_validation_step);
+      p.read_uint64(persist_type::train, "current_testing_step",       &header.current_testing_step);
+      p.read_uint32(persist_type::train, "max_mini_batch_size",      &header.max_mini_batch_size);
+      p.read_uint32(persist_type::train, "current_mini_batch_size",      &header.current_mini_batch_size);
+      p.read_uint32(persist_type::train, "current_phase",      &header.current_phase);
+      p.read_uint32(persist_type::train, "persist_callback_type",     &header.callback_type);
+    } else {
       p.read_uint64(persist_type::validate, "current_validation_step",       &header.current_validation_step);
-    p.read_uint64(persist_type::train, "current_testing_step",       &header.current_testing_step);
-    p.read_uint32(persist_type::train, "max_mini_batch_size",      &header.max_mini_batch_size);
-    p.read_uint32(persist_type::train, "current_mini_batch_size",      &header.current_mini_batch_size);
-    p.read_uint32(persist_type::train, "current_phase",      &header.current_phase);
-    p.read_uint32(persist_type::train, "persist_callback_type",     &header.callback_type);
+    }
   }
   load_rng_from_checkpoint_shared(p, m_comm);
   // TODO: this assumes homogeneous processors
   // broadcast state from rank 0
   m_comm->model_broadcast(0, header);
   // set our member params from values read from disk
-  m_execution_mode     = (execution_mode) header.execution_mode;
-  m_terminate_training = (bool)           header.terminate_training;
-  m_current_epoch      = (int)            header.current_epoch;
-  m_current_step       = (int)            header.current_step;
-  if(get_num_iterations_per_epoch(execution_mode::validation) != 0)
+  if (p.get_cb_type() != callback_type::validation) {
+    m_execution_mode     = (execution_mode) header.execution_mode;
+    m_terminate_training = (bool)           header.terminate_training;
+    m_current_epoch      = (int)            header.current_epoch;
+    m_current_step       = (int)            header.current_step;
+    if(get_num_iterations_per_epoch(execution_mode::validation) != 0)
+      m_current_validation_step = (int)       header.current_validation_step;
+    m_current_testing_step = (int)          header.current_testing_step;
+    m_max_mini_batch_size = (int)           header.max_mini_batch_size;
+    m_current_mini_batch_size = (int)       header.current_mini_batch_size;
+    m_current_phase      =                  header.current_phase;
+    // set state of persist object to know which type of ckpt we are returning from.
+    p.set_cb_type((callback_type) header.callback_type);
+  } else {
     m_current_validation_step = (int)       header.current_validation_step;
-  m_current_testing_step = (int)          header.current_testing_step;
-  m_max_mini_batch_size = (int)           header.max_mini_batch_size;
-  m_current_mini_batch_size = (int)       header.current_mini_batch_size;
-  m_current_phase      =                  header.current_phase;
-  // set state of persist object to know which type of ckpt we are returning from.
-  p.set_cb_type((callback_type) header.callback_type);
+  }
 
   for (weights *w : m_weights) {
     w->load_from_checkpoint_shared(p);

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -102,7 +102,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                    params.metric(),
                                    parse_set<std::string>(params.weights()),
                                    params.low_score_wins(),
-                                   lbann_callback_ltfb::communication_algorithm::sendrecv_weights,
+                                   lbann_callback_ltfb::string_to_comm_algo(params.communication_algorithm()),
                                    summarizer);
   }
   /// @todo

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -102,6 +102,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                    params.metric(),
                                    parse_set<std::string>(params.weights()),
                                    params.low_score_wins(),
+                                   lbann_callback_ltfb::communication_algorithm::sendrecv_weights,
                                    summarizer);
   }
   /// @todo

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -443,6 +443,7 @@ message CallbackLTFB {
   string metric = 2;
   string weights = 3;       // default: all weights
   bool low_score_wins = 4;
+  string communication_algorithm = 5;   // default: "sendrecv_weights"
 }
 
 message CallbackStepLearningRate {


### PR DESCRIPTION
### The status quo
During an LTFB tournament, every trainer goes through its weights and calls sendrecv on the values. The data is exchanged directly between corresponding ranks in partner trainers.

Pros:
- Fast and compatible with GPU data.

Cons:
- Currently only exchanges weight values. Things get cumbersome if we also want to exchange optimizer state or hyperparameters.
- It doesn't work for heterogeneous model architectures.

### The new approach
During an LTFB tournament, every trainer saves a checkpoint for its model and loads a model from another trainer. We currently use "shared" checkpoints, although "distributed" checkpoints are a next step.

Pros:
- Exchanges optimizer state and hyperparameters, so we can now use LTFB for hyperparameter exploration, e.g. with PR #784.
- Reuses code for checkpointing.

Cons:
- This PR doesn't work by itself since loading checkpoint data for data readers causes weird behavior. You must disable checkpoint functionality in the input layer, or else the program will hang (see PR #808 for this hack).
- Communication goes through the file system, which is slow and swells up our disk space usage. If LTFB tournaments are infrequent and make up a small portion of runtime, this is not _that_ bad. If we can develop a wire format for model checkpoints, we should use it in conjunction with MPI.
- Our checkpoints do not store model architecture information, so we don't support LTFB with heterogeneous models. If our checkpoints were self-sufficient and could instantiate models from scratch, it would be easy to add support for heterogeneous LTFB.
- Our checkpoint functionality is old and badly in need of refactoring.

### Usage
I've been able to get LTFB working on AlexNet with 5 trainers (5 Pascal nodes, 2 procs/node, 2 procs/trainer) with something like the following:
```
# Make sure to remove the imcomm callback
callback {
  ltfb {
    batch_interval: 40
    metric: "categorical accuracy"
    weights: "conv1_kernel conv1_bias" # Leave black to exchange all weights
    low_score_wins: false
    communication_algorithm: "checkpoint_file" # Use "sendrecv_weights" for old algorithm
  }
}
```