### PR TITLE
Option to choose weights with L2 regularization.

### DIFF
--- a/include/lbann/objective_functions/weight_regularization/l2.hpp
+++ b/include/lbann/objective_functions/weight_regularization/l2.hpp
@@ -24,25 +24,26 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_OBJECTIVE_FUNCTION_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED
-#define LBANN_OBJECTIVE_FUNCTION_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED
+#ifndef LBANN_OBJECTIVE_FUNCTIONS_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED
+#define LBANN_OBJECTIVE_FUNCTIONS_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED
 
 #include "lbann/objective_functions/objective_function_term.hpp"
 
 namespace lbann {
 
-/** Objective function term for L2 weight regularization.
- *  Given weights \f$w_1,\cdots,w_n\f$, the L2 weight regularization
- *  term is
- *    \f[
- *    L2(w) = \frac{1}{2} \sum\limits_{i} w_i^2
- *    \f]
- *  Note the \f$1/2\f$ scaling factor.
+/** @brief Apply L2 regularization to a set of weights.
+ *
+ *  Given a weights tensor @f$ w @f$,
+ *  @f[ L2(w) = \frac{1}{2} \sum\limits_{i} w(i)^2 @f]
+ *  Note the @f$ 1/2 @f$ scaling factor.
  */
 class l2_weight_regularization : public objective_function_term {
- public:
+public:
 
-  l2_weight_regularization(EvalType scale_factor = EvalType(1));
+  /** @param scale_factor   The objective function term is
+   *                        @f$ \text{scale\_factor} \times \sum L2(w_i) @f$
+   */
+  l2_weight_regularization(EvalType scale_factor = 1);
   l2_weight_regularization* copy() const override { return new l2_weight_regularization(*this); }
   std::string name() const override { return "L2 weight regularization"; }
   void setup(model& m) override;
@@ -50,39 +51,43 @@ class l2_weight_regularization : public objective_function_term {
   EvalType finish_evaluation() override;
 
   /** Compute the gradient w.r.t. the activations.
-   *  L2 weight regularization is independent of the activations.
+   *
+   *  L2 regularization is independent of forward prop output, so
+   *  nothing needs to be done here.
+   *
+   *  @todo Come up with a better function name in the base class.
    */
   void differentiate() override {};
 
   /** Compute the gradient w.r.t. the weights.
-   *  The gradient w.r.t. the weights is
-   *    \f[
-   *    \nabla_w L2(w) = w
-   *    \f]
+   *
+   *  @f[ \nabla_w L2(w) = w @f]
    */
   void compute_weight_regularization() override;
 
- private:
+private:
 
   /** Contributions to evaluated value. */
   std::map<El::Device, CPUMat> m_contributions;
-  /** Non-blocking allreduce request. */
+
+  /** For non-blocking allreduces. */
   Al::request m_allreduce_req;
 #ifdef LBANN_HAS_GPU
-  /** CUDA event after a non-blocking GPU-CPU memory copy. */
+  /** For non-blocking GPU-CPU memory copies. */
   cuda::event_wrapper m_copy_event;
 #endif // LBANN_HAS_GPU
 
-  /** Accumulate contribution to L2 regularization term.
-   *  The sum of squares of 'vals' is added to the value in
-   *  'contribution'.
+  /** Add the sum of squares of @c vals to @c contribution.
+   *
+   *  @param contribution   @f$ 1 \times 1 @f$ matrix. Used as an
+   *                        accumulation variable.
    */
   template <El::Device Device>
   static void accumulate_contribution(const DMat<Device>& vals,
                                       DMat<Device>& contribution);
-  
+
 };
 
 } // namespace lbann
 
-#endif // LBANN_OBJECTIVE_FUNCTION_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED
+#endif // LBANN_OBJECTIVE_FUNCTIONS_WEIGHT_REGULARIZATION_L2_WEIGHT_REGULARIZATION_HPP_INCLUDED

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -71,11 +71,7 @@ void l2_weight_regularization::setup(model& m) {
 
   // Add all weights in model if no weights pointers are provided
   if (m_weights.empty()) {
-    for (auto* w : m.get_weights()) {
-      if (w->get_optimizer() != nullptr) {
-        m_weights.push_back(w);
-      }
-    }
+    m_weights = m.get_weights();
   }
 
   // Construct accumulation variables for each device
@@ -164,12 +160,12 @@ EvalType l2_weight_regularization::finish_evaluation() {
 
 void l2_weight_regularization::compute_weight_regularization() {
   if (m_scale_factor == EvalType(0)) { return; }
-
-  // Compute gradient of L2 regularization term for weights
   for (auto&& w : m_weights) {
-    w->get_optimizer()->add_to_gradient(w->get_values(), m_scale_factor);
+    auto&& opt = w->get_optimizer();
+    if (opt != nullptr) {
+      opt->add_to_gradient(w->get_values(), m_scale_factor);
+    }
   }
-
 }
 
 } // namespace lbann

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -56,8 +56,12 @@ model* instantiate_model(lbann_comm* comm,
 
 }
 
+/** Setup pointers from objective function to layers.
+ *
+ *  Layer terms require pointers to layers.
+ */
 void assign_layers_to_objective_function(std::vector<Layer*>& layer_list,
-                                         objective_function* obj,
+                                         objective_function& obj,
                                          const lbann_data::ObjectiveFunction& proto_obj) {
   std::stringstream err;
 
@@ -73,13 +77,12 @@ void assign_layers_to_objective_function(std::vector<Layer*>& layer_list,
   }
 
   // Assign layers to layer terms in objective function
-  auto&& obj_terms = obj->get_terms();
-  int num_layer_terms = 0;
+  auto&& obj_terms = obj.get_terms();
+  El::Int num_layer_terms = 0;
   for (size_t i = 0; i < obj_terms.size(); ++i) {
     auto&& term = dynamic_cast<layer_term*>(obj_terms[i]);
     if (term != nullptr) {
       ++num_layer_terms;
-      if (num_layer_terms > proto_obj.layer_term_size()) { continue; }
       const auto& params = proto_obj.layer_term(num_layer_terms-1);
       auto* l = names_to_layers[params.layer()];
       if (l == nullptr) {
@@ -178,6 +181,51 @@ void assign_weights_to_layers(std::vector<Layer*>& layer_list,
 
 }
 
+/** Setup pointers from objective function to weights.
+ *
+ *  L2 weight regularization requires pointers to weights.
+ */
+void assign_weights_to_objective_function(std::vector<weights*>& weights_list,
+                                          objective_function& obj,
+                                          const lbann_data::ObjectiveFunction& proto_obj) {
+  std::stringstream err;
+
+  // Construct map from weights names to weights
+  std::unordered_map<std::string, weights*> names_to_weights;
+  for (auto&& w : weights_list) {
+    const auto& name = w->get_name();
+    if (names_to_weights.count(name) > 0) {
+      err << "weights name \"" << name << "\" is not unique";
+      LBANN_ERROR(err.str());
+    }
+    names_to_weights[name] = w;
+  }
+
+  // Setup weights with L2 regularization
+  auto&& obj_terms = obj.get_terms();
+  El::Int num_l2_weight_regularization_terms = 0;
+  for (size_t i = 0; i < obj_terms.size(); ++i) {
+    auto&& term = dynamic_cast<l2_weight_regularization*>(obj_terms[i]);
+    if (term != nullptr) {
+      ++num_l2_weight_regularization_terms;
+      const auto& params = proto_obj.l2_weight_regularization(num_l2_weight_regularization_terms-1);
+      std::vector<weights*> term_weights;
+      for (auto&& weights_name : parse_list<std::string>(params.weights())) {
+        auto&& w = names_to_weights[weights_name];
+        if (w == nullptr) {
+          err << "attempted to apply L2 weight regularization to "
+              << "weights \"" << weights_name << "\", "
+              << "but no such weights exists";
+          LBANN_ERROR(err.str());
+        }
+        term_weights.push_back(w);
+      }
+      term->set_weights_pointers(term_weights);
+    }
+  }
+
+}
+
 } // namespace
 
 model* construct_model(lbann_comm* comm,
@@ -193,7 +241,7 @@ model* construct_model(lbann_comm* comm,
   // Construct objective function
   const auto& proto_obj = proto_model.objective_function();
   auto&& obj = construct_objective_function(proto_obj);
-  assign_layers_to_objective_function(layer_list, obj, proto_obj);
+  assign_layers_to_objective_function(layer_list, *obj, proto_obj);
 
   // Construct weights
   std::vector<weights*> weights_list;
@@ -203,6 +251,7 @@ model* construct_model(lbann_comm* comm,
                                              proto_model.weights(i)));
   }
   assign_weights_to_layers(layer_list, weights_list, proto_model);
+  assign_weights_to_objective_function(weights_list, *obj, proto_obj);
 
   // Construct metrics
   std::vector<metric*> metric_list;

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -321,6 +321,7 @@ message L1WeightRegularization {
 
 message L2WeightRegularization {
   double scale_factor = 1;
+  string weights = 2;   // If empty, L2 regularization is applied to all weights
 }
 
 message GroupLassoWeightRegularization {


### PR DESCRIPTION
If no weights are provided, L2 regularization is applied to all weights. Example usage:
```text
objective_function {
  l2_weight_regularization {
    scale_factor: 0.01
    weights: "conv1_kernel conv1_bias fc_matrix fc_bias"
  }
}
```
Each of the weights specified for L2 regularization must be defined in the prototext. This closes #810.