### PR TITLE
layer_factory: improved error messages

### DIFF
--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -30,6 +30,28 @@
 namespace lbann {
 namespace proto {
 
+#define LAYOUT_ERR(layer_name, layer_type) \
+  { \
+    std::stringstream s;  \
+    s << "\nlayer type: " << layer_type << " layer name: " << layer_name << " -- is only supported for data_layout::DATA_PARALLEL";                  \
+    LBANN_ERROR(s.str()); \
+  }
+
+#define DEVICE_ERR(layer_name, layer_type, layout, Dev) \
+  { \
+    if (layout != data_layout::DATA_PARALLEL) { \
+      LAYOUT_ERR(layer_name, layer_type)  \
+    } else if (Dev != El::Device::CPU) { \
+      std::stringstream s;  \
+      s << "\nlayer type: " << layer_type " layer name: " << layer_name << " -- is only supported for El::Device::CPU; it looks like you're attempting to run with a cuda build. You should be able to run by adding --disable_cuda to your command line (in which case you won't be using GPUs, which may not be what you want)";\
+      LBANN_ERROR(s.str()); \
+    } else {     \
+      std::stringstream s;  \
+      s << "\nsomething is weird with data_layout and/or El::Device but we can't determine what."; \
+      LBANN_ERROR(s.str()); \
+    } \
+  }
+
 std::vector<El::Int> get_slice_points_from_reader(const generic_data_reader* dr,
                                                   const std::string& var_category,
                                                   bool& is_supported);
@@ -171,6 +193,7 @@ Layer* construct_layer(lbann_comm* comm,
                      dims, pads, strides, dilations, num_groups, bias
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "convolution");
     } else {
       const auto& num_dims = params.num_dims();
       const auto& dim = params.conv_dims_i();
@@ -186,6 +209,7 @@ Layer* construct_layer(lbann_comm* comm,
                      dim, pad, stride, dilation, num_groups, bias
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "convolution");
     }
   }
   if (proto_layer.has_deconvolution()) {
@@ -217,6 +241,7 @@ Layer* construct_layer(lbann_comm* comm,
                      dims, pads, strides, dilations, num_groups, bias
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "deconvolution");
     } else {
       const auto& num_dims = params.num_dims();
       const auto& dim = params.conv_dims_i();
@@ -232,6 +257,7 @@ Layer* construct_layer(lbann_comm* comm,
                      dim, pad, stride, dilation, num_groups, bias
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "deconvolution");
     }
   }
 
@@ -371,6 +397,7 @@ Layer* construct_layer(lbann_comm* comm,
                      comm, dims.size(), dims, pads, strides, mode
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "pooling");
     } else {
       const auto& num_dims = params.num_dims();
       const auto& dim = params.pool_dims_i();
@@ -381,12 +408,14 @@ Layer* construct_layer(lbann_comm* comm,
                      comm, num_dims, dim, pad, stride, mode
                    );
       }
+      LAYOUT_ERR(proto_layer.name(), "pooling");
     }
   }
   if (proto_layer.has_unpooling()) {
     if (layout == data_layout::DATA_PARALLEL && Dev == El::Device::CPU) {
       return new unpooling_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(comm);
     }
+    DEVICE_ERR(proto_layer.name(), "unpooling", layout, Dev);
   }
   if (proto_layer.has_reduction()) {
     const auto& params = proto_layer.reduction();
@@ -397,6 +426,7 @@ Layer* construct_layer(lbann_comm* comm,
     if (layout == data_layout::DATA_PARALLEL) {
       return new reduction_layer<data_layout::DATA_PARALLEL, Dev>(comm, mode);
     }
+    LAYOUT_ERR(proto_layer.name(), "reduction");
   }
   if (proto_layer.has_evaluation()) {
     return new evaluation_layer<layout, Dev>(comm);
@@ -407,12 +437,14 @@ Layer* construct_layer(lbann_comm* comm,
     if (layout == data_layout::DATA_PARALLEL) {
       return new crop_layer<data_layout::DATA_PARALLEL, Dev>(comm, dims);
     }
+    LAYOUT_ERR(proto_layer.name(), "crop");
   }
   if (proto_layer.has_categorical_random()) {
     if (layout == data_layout::DATA_PARALLEL
         && Dev == El::Device::CPU) {
       return new categorical_random_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(comm);
     }
+    DEVICE_ERR(proto_layer.name(), "categorical_random", layout, Dev);
   }
   if (proto_layer.has_discrete_random()) {
     const auto& params = proto_layer.discrete_random();
@@ -423,6 +455,7 @@ Layer* construct_layer(lbann_comm* comm,
       return new discrete_random_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(
                    comm, values, dims);
     }
+    DEVICE_ERR(proto_layer.name(), "discrete_random", layout, Dev);
   }
   if (proto_layer.has_dummy()) {
     return new dummy_layer<layout, Dev>(comm);
@@ -439,6 +472,7 @@ Layer* construct_layer(lbann_comm* comm,
     if (layout == data_layout::DATA_PARALLEL) {
       return new sort_layer<data_layout::DATA_PARALLEL, Dev>(comm, params.descending());
     }
+    LAYOUT_ERR(proto_layer.name(), "sort");
   }
   if (proto_layer.has_weights_layer()) {
     const auto& params = proto_layer.weights_layer();
@@ -455,13 +489,13 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_batch_normalization()) {
     const auto& params = proto_layer.batch_normalization();
     if (layout == data_layout::DATA_PARALLEL) {
-      return new batch_normalization_layer<data_layout::DATA_PARALLEL, Dev>(comm,
-                                                                            params.decay(),
-                                                                            params.epsilon(),
-                                                                            params.global_stats());
-    } else {
-      LBANN_ERROR("batch normalization is only supported in a data-parallel layout");
-    }
+      return new batch_normalization_layer<data_layout::DATA_PARALLEL, Dev>(
+              comm,
+              params.decay(),
+              params.epsilon(),
+              params.global_stats());
+    } 
+    LAYOUT_ERR(proto_layer.name(), "batch_normalization");
   }
   if (proto_layer.has_dropout()) {
     const auto& params = proto_layer.dropout();
@@ -470,12 +504,13 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_local_response_normalization()) {
  const auto& params = proto_layer.local_response_normalization();
     if (layout == data_layout::DATA_PARALLEL) {
-      return new local_response_normalization_layer<data_layout::DATA_PARALLEL, Dev>(comm,
-                                                                                     params.window_width(),
-                                                                                     params.lrn_alpha(),
-                                                                                     params.lrn_beta(),
-                                                                                     params.lrn_k());
+      return new local_response_normalization_layer<data_layout::DATA_PARALLEL, Dev>(        comm,
+             params.window_width(),
+             params.lrn_alpha(),
+             params.lrn_beta(),
+             params.lrn_k());
     }
+    LAYOUT_ERR(proto_layer.name(), "local_response_normalization");
   }
   if (proto_layer.has_selu_dropout()) {
     const auto& params = proto_layer.selu_dropout();
@@ -592,10 +627,12 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_bilinear_resize()) {
     const auto& params = proto_layer.bilinear_resize();
     if (layout == data_layout::DATA_PARALLEL) {
-      return new bilinear_resize_layer<data_layout::DATA_PARALLEL, Dev>(comm,
-                                                                        params.height(),
-                                                                        params.width());
+      return new bilinear_resize_layer<data_layout::DATA_PARALLEL, Dev>(
+                         comm,
+                         params.height(),
+                         params.width());
     }
+    LAYOUT_ERR(proto_layer.name(), "bilinear_resize");
   }
 
   // Miscellaneous layers
@@ -611,6 +648,7 @@ Layer* construct_layer(lbann_comm* comm,
     if (layout == data_layout::DATA_PARALLEL) {
       return new channelwise_mean_layer<data_layout::DATA_PARALLEL, Dev>(comm);
     }
+    LAYOUT_ERR(proto_layer.name(), "channelwise_mean");
   }
 
   // Throw exception if layer has not been constructed


### PR DESCRIPTION
This PR improves exception messages in layer_factory.cpp. It was prompted by an exception that a new user encountered: "could not construct layer unpool1". Nikoli's 1st thoughts were: "Is it saying later that it ran out of memory?" "That's not an out-of-memory error, but I have no idea why that's occurring." Mine was, "there's an error in the prototext file."
Nikoli then pointed out, "The unpooling layer doesn't currently support GPUs"
So ... that information should have been included in the exception message. This PR makes it so.
