### PR TITLE
Minor improvements to dump outputs callback

### DIFF
--- a/include/lbann/callbacks/callback_dump_outputs.hpp
+++ b/include/lbann/callbacks/callback_dump_outputs.hpp
@@ -31,10 +31,10 @@
 
 namespace lbann {
 
-/** Dump layer output tensors to files.
- *  This callback saves a file for each output tensor of each selected
- *  layer, computed at each mini-batch step. Output files have the
- *  form
+/** @brief Dump layer output tensors to files.
+ *
+ *  Saves a file for each output tensor of each selected layer,
+ *  computed at each mini-batch step. Output files have the form
  *  "<prefix><model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.<format>".
  *  This is primarily intended as a debugging tool, although it can be
  *  used for inference when performance is not critical.
@@ -44,12 +44,13 @@ namespace lbann {
  *  flattened tensor data corresponding to one mini-batch sample
  *  (which is the transpose of the column-major matrix representation
  *  we use internally).
+ *
+ *  CNPY is required to export to NumPy file formats (npy and npz).
  */
 class lbann_callback_dump_outputs : public lbann_callback {
 public:
 
-  /** Constructor.
-   *  @param layer_names    Names of layers with output dumps
+  /** @param layer_names    Names of layers with output dumps
    *                        (default: dump outputs for all layers).
    *  @param modes          Execution modes with output dumps
    *                        (default: dump outputs for all modes).
@@ -75,11 +76,13 @@ public:
 private:
 
   /** Names of layers with output dumps.
+   *
    *  If empty, outputs will be dumped for all layers.
    */
   std::set<std::string> m_layer_names;
 
   /** Execution modes with output dumps.
+   *
    *  If empty, outputs will be dumped for all execution modes.
    */
   std::set<execution_mode> m_modes;
@@ -91,12 +94,13 @@ private:
   std::string m_file_format;
 
   /** Dump outputs to file.
+   *
    *  Returns immediately if an output dump is not needed.
    */
   void dump_outputs(const model& m, const Layer& l);
 
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_CALLBACKS_CALLBACK_DUMP_OUTPUTS_HPP_INCLUDED
+#endif // LBANN_CALLBACKS_CALLBACK_DUMP_OUTPUTS_HPP_INCLUDED

--- a/include/lbann/callbacks/callback_dump_outputs.hpp
+++ b/include/lbann/callbacks/callback_dump_outputs.hpp
@@ -35,7 +35,7 @@ namespace lbann {
  *
  *  Saves a file for each output tensor of each selected layer,
  *  computed at each mini-batch step. Output files have the form
- *  "<prefix><model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.<format>".
+ *  "<model>-<mode>-epoch<#>-step<#>-<layer>-output<#>.<format>".
  *  This is primarily intended as a debugging tool, although it can be
  *  used for inference when performance is not critical.
  *
@@ -56,14 +56,15 @@ public:
    *                        (default: dump outputs for all modes).
    *  @param batch_interval Frequency of output dumps (default: dump
    *                        outputs at each mini-batch step).
-   *  @param file_prefix    Prefix for output file names.
+   *  @param directory      Directory for output files (default: current
+   *                        working directory).
    *  @param file_format    Output file format. Options are csv, tsv,
    *                        npy, npz (default: csv).
    */
   lbann_callback_dump_outputs(std::set<std::string> layer_names = {},
                               std::set<execution_mode> modes = {},
                               El::Int batch_interval = 0,
-                              std::string file_prefix = "",
+                              std::string directory = "",
                               std::string file_format = "");
   lbann_callback_dump_outputs* copy() const override {
     return new lbann_callback_dump_outputs(*this);
@@ -75,27 +76,26 @@ public:
 
 private:
 
-  /** Names of layers with output dumps.
-   *
-   *  If empty, outputs will be dumped for all layers.
+  /** @brief   Names of layers with output dumps.
+   *  @details If empty, outputs will be dumped for all layers.
    */
   std::set<std::string> m_layer_names;
 
-  /** Execution modes with output dumps.
-   *
-   *  If empty, outputs will be dumped for all execution modes.
+  /** @brief   Execution modes with output dumps.
+   *  @details If empty, outputs will be dumped for all execution modes.
    */
   std::set<execution_mode> m_modes;
 
-  /** Prefix for output files. */
-  std::string m_file_prefix;
+  /** @brief   Directory for output files.
+   *  @details Pathname has trailing '/'.
+   */
+  std::string m_directory;
 
-  /** Output file format. */
+  /** @brief Output file format. */
   std::string m_file_format;
 
-  /** Dump outputs to file.
-   *
-   *  Returns immediately if an output dump is not needed.
+  /** @brief   Dump outputs to file.
+   *  @details Returns immediately if an output dump is not needed.
    */
   void dump_outputs(const model& m, const Layer& l);
 

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m1.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m1.prototext
@@ -538,7 +538,7 @@ model {
   }
   #callback {
   #  dump_outputs {
-  #    prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m1/"
+  #    directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m1/"
   #    layers: "image_data_dummy"
   #    execution_modes: "test"
   #  }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m2.prototext
@@ -519,7 +519,7 @@ model {
   }
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m2/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m2/"
       layers: "image_data_dummy gen1fc4_1 gen1fc4_2"
       execution_modes: "test"
     }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m2_template.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m2_template.prototext
@@ -59,7 +59,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m2/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m2/"
       layers: "image_data_dummy gen1fc4_1 gen1fc4_2"
       execution_modes: "test"
     }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m3.prototext
@@ -580,7 +580,7 @@ model {
   }
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m3/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m3/"
       layers: "param_data_id gen2fc4_1 gen2fc4_2"
       execution_modes: "test"
     }

--- a/model_zoo/models/gan/jags/cycle_gan/cycgan_m3_template.prototext
+++ b/model_zoo/models/gan/jags/cycle_gan/cycgan_m3_template.prototext
@@ -59,7 +59,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m3/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jagsv2/cycgan_m3/"
       layers: "param_data_id gen2fc4_1 gen2fc4_2"
       execution_modes: "test"
     }

--- a/model_zoo/models/gan/mnist/adversarial_model.prototext
+++ b/model_zoo/models/gan/mnist/adversarial_model.prototext
@@ -43,7 +43,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dump_acts_32mb/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dump_acts_32mb/"
       layers: "fc4_tanh sum"
       #layers: "fc4_tanh data sum"
       #batch_interval: 844

--- a/model_zoo/models/gan/mnist/discriminator_model.prototext
+++ b/model_zoo/models/gan/mnist/discriminator_model.prototext
@@ -43,7 +43,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dismodel_dump_acts/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/fcgan_dismodel_dump_acts/"
       #layers: "fc4_tanh data sum sigmoid2"
       layers: "fc4_tanh"
       #batch_interval: 844

--- a/model_zoo/models/jag/ae_cycle_gan/3models/ae.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/3models/ae.prototext
@@ -354,9 +354,9 @@ model {
   }
   callback {
     dump_outputs {
-     # prefix:"/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss/"
-     # #prefix:"/p/gpfs1/jacobs32/EuroViz3/ae_loss/"
-      prefix:"ae_loss/"
+     # directory:"/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss/"
+     # #directory:"/p/gpfs1/jacobs32/EuroViz3/ae_loss/"
+      directory:"ae_loss/"
       layers: "ae_err"
       execution_modes: "test"
     }

--- a/model_zoo/models/jag/ae_cycle_gan/3models/ae_cyc.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/3models/ae_cyc.prototext
@@ -1,10 +1,10 @@
 #Combines encoder portion ae with cycgan models for inference (forward prediction) in output space.
 model {
   name: "ae_cycgan_model"
-  shareable_training_data_reader:false 
+  shareable_training_data_reader:false
   serialize_background_io: true
   data_layout: "data_parallel"
-  mini_batch_size: 256 
+  mini_batch_size: 256
   block_size: 256
   num_epochs: 1
   num_parallel_readers: 0
@@ -163,7 +163,7 @@ model {
     weights: "gen1fc4linearity"
     parents: "gen1relu3_1"
   }
-  
+
   weights {
     name: "gen1fc1linearity"
     he_normal_initializer {
@@ -437,8 +437,8 @@ model {
   }
   callback {
     dump_outputs {
-      #prefix:"/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
-      prefix:"fw_out_loss/"
+      #directory:"/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
+      directory:"fw_out_loss/"
       layers: "fw_out_loss"
       execution_modes: "test"
     }

--- a/model_zoo/models/jag/ae_cycle_gan/3models/ae_cyc2.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/3models/ae_cyc2.prototext
@@ -2,10 +2,10 @@
 #Streamlines inference to use of only 1 model checkpoint (saved by using this prototext in training). Weights are copied from autoencoder and cyclegan and saved after training.
 model {
   name: "ae_cycgan_model"
-  shareable_training_data_reader:false 
+  shareable_training_data_reader:false
   serialize_background_io: true
   data_layout: "data_parallel"
-  mini_batch_size: 256 
+  mini_batch_size: 256
   block_size: 256
   num_epochs: 1
   num_parallel_readers: 0
@@ -159,7 +159,7 @@ model {
     weights: "gen1fc4linearity gen1fc4bias"
     parents: "gen1relu3_1"
   }
-  
+
   weights {
     name: "gen1fc1linearity"
     he_normal_initializer {
@@ -304,7 +304,7 @@ model {
   #  sum {}
     identity {}
   }
-  ####output of encoder goes to decoder and cycGAN duplicates 
+  ####output of encoder goes to decoder and cycGAN duplicates
   ######################
   # Decoder for foward output loss
   ######################
@@ -674,7 +674,7 @@ model {
     weights: "gen1fc4linearity gen1fc4bias"
     parents: "latent_gen1relu3_1"
   }
-  
+
   layer {
     name: "gsample_minus_latentsample"
     data_layout: "data_parallel"
@@ -702,9 +702,9 @@ model {
   }
   callback {
     dump_outputs {
-      #prefix:"/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
-      prefix:"ae_latent_out_losses/"
-      #prefix:"save_img_acts/"
+      #directory:"/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
+      directory:"ae_latent_out_losses/"
+      #directory:"save_img_acts/"
       #ae_reconstruction === autoencoder reconstrcution
       #reconstruction ==== cycgan+autoencoder reconstruction
       #layers: "ae_reconstruction image_data_id reconstruction"

--- a/model_zoo/models/jag/ae_cycle_gan/3models/cycle_gan.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/3models/cycle_gan.prototext
@@ -889,8 +889,8 @@ model {
 
   callback {
     dump_outputs {
-      prefix:"fw_latent_loss/"
-      #prefix:"/p/gpfs1/jacobs32/EuroViz3/fw_latent_loss/"
+      directory:"fw_latent_loss/"
+      #directory:"/p/gpfs1/jacobs32/EuroViz3/fw_latent_loss/"
       #layer_names: "image_data_dummy gen1fc4 gsample_minus_y l_l2_y"
       layers: "fw_latent_loss"
       execution_modes: "test"

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m2.prototext
@@ -732,9 +732,9 @@ model {
   callback { timer {} }
   callback {
     dump_outputs {
-      #prefix: "/p/lscratchh/jacobs32/EuroViz/fw_latent_loss/"
-      #general prefix: "/p/gpfs1/jacobs32/EuroViz2/fw_latent_loss/"
-      prefix: "fw_latent_loss/"
+      #directory: "/p/lscratchh/jacobs32/EuroViz/fw_latent_loss/"
+      #general directory: "/p/gpfs1/jacobs32/EuroViz2/fw_latent_loss/"
+      directory: "fw_latent_loss/"
       layers: "fw_latent_loss"
       execution_modes: "test"
       format: "npy"
@@ -742,8 +742,8 @@ model {
   }
  #callback {
  #   dump_outputs {
- #     prefix: "/dir/to/dump_y_activations/"
-  #    prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jags10K_multi/cycgan_m2/"
+ #     directory: "/dir/to/dump_y_activations/"
+  #    directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jags10K_multi/cycgan_m2/"
   #    batch_interval: 100
   #    layers: "image_data_dummy gen1fc4_1 l_l2_y"
   #    execution_modes: "test"

--- a/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/cycgan_m3.prototext
@@ -785,7 +785,7 @@ model {
   callback { timer {} }
   #callback {
   #  dump_outputs {
-  #    prefix: "/dir/to/dump_x_activations/"
+  #    directory: "/dir/to/dump_x_activations/"
   #    layers: "param_data_id gen2fc4_1"
   #    execution_modes: "test"
   #  }

--- a/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae1.prototext
@@ -431,9 +431,9 @@ model {
   }
   callback {
     dump_outputs {
-      #prefix: "/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss"
-      #prefix: "/p/gpfs1/jacobs32/EuroViz2/ae_loss/"
-      prefix: "ae_loss/"
+      #directory: "/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss"
+      #directory: "/p/gpfs1/jacobs32/EuroViz2/ae_loss/"
+      directory: "ae_loss/"
       layers: "ae_err"
       execution_modes: "test"
       format: "npy"
@@ -449,7 +449,7 @@ model {
 
   #callback {
   #  dump_outputs {
-  #    prefix:"/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss"
+  #    directory:"/p/lscratchh/brainusr/jacobs32/EuroViz/ae_loss"
   #    layers: "squared_error"
   #    execution_modes: "test"
   #  }

--- a/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
+++ b/model_zoo/models/jag/ae_cycle_gan/vae_cyc.prototext
@@ -520,9 +520,9 @@ model {
   }
   callback {
     dump_outputs {
-      #prefix: "/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
-      #prefix: "/p/gpfs1/jacobs32/EuroViz2/fw_out_loss/"
-      prefix: "fw_out_loss/"
+      #directory: "/p/lscratchh/jacobs32/EuroViz/fw_out_loss/"
+      #directory: "/p/gpfs1/jacobs32/EuroViz2/fw_out_loss/"
+      directory: "fw_out_loss/"
       layers: "fw_out_loss"
       execution_modes: "test"
       format: "npy"
@@ -539,7 +539,7 @@ model {
 
   #callback {
   #  dump_outputs {
-  #    prefix:"/p/lscratchh/brainusr/jacobs32/EuroViz/"
+  #    directory:"/p/lscratchh/brainusr/jacobs32/EuroViz/"
   #    layers: "squared_error"
   #    execution_modes: "test"
   #  }

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2.prototext
@@ -524,7 +524,7 @@ model {
   }
   #callback {
   #  dump_outputs {
-  #    prefix: "/dir/to/dump_y_activations/"
+  #    directory: "/dir/to/dump_y_activations/"
   #    batch_interval: 100
   #    layers: "image_data_dummy gen1fc4_1 l_l2_y"
   #    execution_modes: "test"

--- a/model_zoo/models/jag/cycle_gan/cycgan_m2_template.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m2_template.prototext
@@ -51,7 +51,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/dir/to/dump_y_activations/"
+      directory: "/dir/to/dump_y_activations/"
       layers: "image_data_dummy gen1fc4_1"
       execution_modes: "test"
     }

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3.prototext
@@ -587,7 +587,7 @@ model {
   }
   #callback {
   #  dump_outputs {
-  #    prefix: "/dir/to/dump_x_activations/"
+  #    directory: "/dir/to/dump_x_activations/"
   #    layers: "param_data_id gen2fc4_1"
   #    execution_modes: "test"
   #  }

--- a/model_zoo/models/jag/cycle_gan/cycgan_m3_template.prototext
+++ b/model_zoo/models/jag/cycle_gan/cycgan_m3_template.prototext
@@ -51,7 +51,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/dir/to/dump_x_activations/"
+      directory: "/dir/to/dump_x_activations/"
       layers: "param_data_id gen2fc4_1"
       execution_modes: "test"
     }

--- a/model_zoo/models/jag/gan/cyclic/model_template.prototext
+++ b/model_zoo/models/jag/gan/cyclic/model_template.prototext
@@ -85,7 +85,7 @@ model {
   #Optional callbacks
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jag_imgs/cyclic_gan/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jag_imgs/cyclic_gan/"
       batch_interval: 100
       layers: "image_data_dummy gen1fc4 param_data_id gen2fc4"
       execution_modes: "test"

--- a/model_zoo/models/jag/gan/vanilla/gan.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan.prototext
@@ -453,7 +453,7 @@ model {
   }
   #callback {
   #  dump_outputs {
-  #    prefix: "/dir/to/save/imgs"
+  #    directory: "/dir/to/save/imgs"
   #    batch_interval: 10
   #    layers: "gen1fc4"
   #    execution_modes: "test"
@@ -470,5 +470,5 @@ model {
 
  # }
   block_size: 256
-  procs_per_model:0 
+  procs_per_model:0
 }

--- a/model_zoo/models/jag/gan/vanilla/gan_template.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan_template.prototext
@@ -61,7 +61,7 @@ model {
 
   callback {
     dump_outputs {
-      prefix: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jag_imgs/gan/"
+      directory: "/usr/workspace/wsa/jacobs32/github.saj.lbann/jag_imgs/gan/"
       #batch_interval: 100
       layers: "image_data_dummy gen1fc4"
       execution_modes: "tests"

--- a/model_zoo/models/jag/vae_fcn.prototext
+++ b/model_zoo/models/jag/vae_fcn.prototext
@@ -44,7 +44,7 @@ model {
   callback { timer {} }
   callback {
     dump_outputs {
-      prefix: "dump_acts/"
+      directory: "dump_acts/"
       layers: "data sigmoid"
       execution_modes: "test"
     }

--- a/src/callbacks/callback_dump_outputs.cpp
+++ b/src/callbacks/callback_dump_outputs.cpp
@@ -27,8 +27,6 @@
 #include "lbann/callbacks/callback_dump_outputs.hpp"
 #include "lbann/io/file_io.hpp"
 
-#include <libgen.h>
-
 #ifdef LBANN_HAS_CNPY
 #include <cnpy.h>
 #endif // LBANN_HAS_CNPY
@@ -38,6 +36,7 @@ namespace lbann {
 namespace {
 
 /** Save text file.
+ *
  *  Each line corresponds to a mini-batch sample. This is the
  *  transpose of our internal column-major matrix representation.
  */
@@ -56,12 +55,14 @@ void save_text(const std::string& file_name,
   }
 }
 
-#ifdef LBANN_HAS_CNPY
 
 /** Save NumPy binary file. */
 void save_npy(const std::string& file_name,
               const std::vector<int>& dims,
               const CPUMat& data) {
+#ifndef LBANN_HAS_CNPY
+  LBANN_ERROR("CNPY not detected");
+#else
   if (!data.Contiguous()) {
     LBANN_ERROR("expected contiguous data matrix");
   }
@@ -69,6 +70,7 @@ void save_npy(const std::string& file_name,
   shape.push_back(data.Width());
   for (const auto& d : dims) { shape.push_back(d); }
   cnpy::npy_save(file_name, data.LockedBuffer(), shape);
+#endif // LBANN_HAS_CNPY
 }
 
 /** Save NumPy zip file. */
@@ -76,6 +78,9 @@ void save_npz(const std::string& file_name,
               const std::string& tensor_name,
               const std::vector<int>& dims,
               const CPUMat& data) {
+#ifndef LBANN_HAS_CNPY
+  LBANN_ERROR("CNPY not detected");
+#else
   if (!data.Contiguous()) {
     LBANN_ERROR("expected contiguous data matrix");
   }
@@ -83,31 +88,44 @@ void save_npz(const std::string& file_name,
   shape.push_back(data.Width());
   for (const auto& d : dims) { shape.push_back(d); }
   cnpy::npz_save(file_name, tensor_name, data.LockedBuffer(), shape);
-}
-
 #endif // LBANN_HAS_CNPY
+}
 
 } // namespace
 
 lbann_callback_dump_outputs::lbann_callback_dump_outputs(std::set<std::string> layer_names,
                                                          std::set<execution_mode> modes,
                                                          El::Int batch_interval,
-                                                         std::string file_prefix,
+                                                         std::string directory,
                                                          std::string file_format)
   : lbann_callback(std::max(batch_interval, El::Int(1))),
     m_layer_names(std::move(layer_names)),
     m_modes(std::move(modes)),
-    m_file_prefix(std::move(file_prefix)),
+    m_directory(std::move(directory)),
     m_file_format(std::move(file_format)) {
+  std::stringstream err;
+
+  // Initialize directory for output files
+  // Note: Default directory is current working directory. Make sure
+  // pathname has trailing slash.
+  if (m_directory.empty()) { m_directory = "./"; }
+  if (m_directory.back() != '/') { m_directory += "/"; }
 
   // Initialize file format
   if (m_file_format.empty()) { m_file_format = "csv"; }
-  if (m_file_format != "csv" && m_file_format != "tsv"
-#ifdef LBANN_HAS_CNPY
-      && m_file_format != "npy" && m_file_format != "npz"
+#ifndef LBANN_HAS_CNPY
+  if (m_file_format == "npy" || m_file_format == "npz") {
+    err << "callback \"" << this->name() << "\" attempted "
+        << "to use NumPy file format (" << m_file_format << "), "
+        << "but CNPY was not detected";
+    LBANN_ERROR(err.str());
+  }
 #endif // LBANN_HAS_CNPY
-      ) {
-    LBANN_ERROR("invalid file format (" + m_file_format + ")");
+  if (m_file_format != "csv" && m_file_format != "tsv"
+      && m_file_format != "npy" && m_file_format != "npz") {
+    err << "callback \"" << this->name() << "\" attempted "
+        << "to use invalid file format (" << m_file_format << ")";
+    LBANN_ERROR(err.str());
   }
 
 }
@@ -133,24 +151,15 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
   if (!m_layer_names.empty()
       && m_layer_names.count(l.get_name()) == 0) { return; }
 
-  // Create directory if needed
-  // Note: dirname takes a non-const C-string as input and ignores
-  // trailing '/' characters.
-  std::vector<char> prefix_(m_file_prefix.size() + 2);
-  m_file_prefix.copy(prefix_.data(), m_file_prefix.size());
-  prefix_[prefix_.size()-2] = 'a';
-  prefix_[prefix_.size()-1] = '\0';
-  const std::string dir = dirname(prefix_.data());
-  if (dir != ".") {
-    lbann::makedir(dir.c_str());
-  }
+  // Create directory
+  lbann::makedir(m_directory.c_str());
 
   // Save layer outputs on root process
   for (int i = 0; i < l.get_num_children(); ++i) {
     const CircMat<El::Device::CPU> circ_data(l.get_activations(i));
     if (circ_data.CrossRank() == circ_data.Root()) {
       const auto& data = static_cast<const CPUMat&>(circ_data.LockedMatrix());
-      const std::string file_name = (m_file_prefix
+      const std::string file_name = (m_directory
                                      + m.get_name()
                                      + "-" + _to_string(mode)
                                      + "-epoch" + std::to_string(epoch)
@@ -162,9 +171,7 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
         save_text(file_name, ",", data);
       } else if (m_file_format == "tsv") {
         save_text(file_name, "\t", data);
-      }
-#ifdef LBANN_HAS_CNPY
-      else if (m_file_format == "npy") {
+      } else if (m_file_format == "npy") {
         save_npy(file_name, l.get_output_dims(i), data);
       } else if (m_file_format == "npz") {
         save_npz(file_name,
@@ -172,7 +179,6 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
                  l.get_output_dims(i),
                  data);
       }
-#endif // LBANN_HAS_CNPY
     }
   }
 

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -346,7 +346,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
     return new lbann_callback_dump_outputs(layer_names,
                                            modes,
                                            params.batch_interval(),
-                                           params.prefix(),
+                                           params.directory(),
                                            params.format());
   }
   if (proto_cb.has_dump_error_signals()) {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -494,7 +494,7 @@ message CallbackDumpOutputs {
   string layers = 1;          // Default: all layers
   string execution_modes = 2; // Default: all modes
   int64 batch_interval = 3;   // Frequency for output dumping (default: all steps)
-  string prefix = 4;          // Prefix for output files
+  string directory = 4;       // Directory for output files
   string format = 5;          // Options: csv, tsv, npy, npz (default: csv)
 }
 


### PR DESCRIPTION
Changes:
- Check the `prefix` parameter to see if a directory needs to be created. I previously got a bunch of errors when I left `prefix` as an empty string.
- The `prefix` parameter is now a file prefix. For instance, setting the prefix to "something" will create files that look like "somethingmodel0-training-epoch0-step0-conv1-output0.csv". Setting the prefix to "something/" will create a directory called "something" and put the files inside, e.g. "something/model0-training-epoch0-step0-conv1-output0.csv". If we prefer the old behavior, we should change the parameter name from `prefix` to `dir`.
- Hide CNPY functionality inside `LBANN_HAS_CNPY` macros. I haven't checked yet if we can compile LBANN without CNPY. See Issue #787.