### PR TITLE
Bump OpenCV version.

### DIFF
--- a/superbuild/opencv/CMakeLists.txt
+++ b/superbuild/opencv/CMakeLists.txt
@@ -41,7 +41,7 @@ else ()
     CACHE STRING "The URL from which to clone OpenCV")
 endif ()
 
-set(OPENCV_TAG "3.3.0"
+set(OPENCV_TAG "3.4.5"
   CACHE STRING "The git tag or hash to checkout for OpenCV")
 
 include(ExternalProject)


### PR DESCRIPTION
Bump OpenCV version from 3.3.0 to 3.4.5 (the most recent release on the 3.x branch). OpenCV has moved on to 4.x now, so we should look at that, but I'm not sure whether they make major API changes.

Built/seems to run fine on Sierra. You may want to test other systems.