### PR TITLE
Power9 optimizations on Sierra/Lassen

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -15,6 +15,8 @@ if [ "${CLUSTER}" == "surface" -o "${CLUSTER}" == "pascal" ]; then
     # NVCC in CUDA 9.1 does not support GCC versions later than 6
     COMPILER=gnu
     module load gcc/4.9.3
+elif [ "${CLUSTER}" == "sierra" -o "${CLUSTER}" == "lassen" ]; then
+    module load gcc/7.3.1
 fi
 if [ "${ARCH}" == "x86_64" ]; then
     MPI=mvapich2
@@ -441,9 +443,9 @@ if [ "${BUILD_TYPE}" == "Release" ]; then
             Fortran_FLAGS="${Fortran_FLAGS} -mcpu=power8 -mtune=power8"
         elif [ "${CLUSTER}" == "sierra" -o "${CLUSTER}" == "lassen" ]; then
 			# no power9 option shown in the manual
-            C_FLAGS="${C_FLAGS} -mcpu=power8 -mtune=power8"
-            CXX_FLAGS="${CXX_FLAGS} -mcpu=power8 -mtune=power8"
-            Fortran_FLAGS="${Fortran_FLAGS} -mcpu=power8 -mtune=power8"
+            C_FLAGS="${C_FLAGS} -mcpu=power9 -mtune=power9"
+            CXX_FLAGS="${CXX_FLAGS} -mcpu=power9 -mtune=power9"
+            Fortran_FLAGS="${Fortran_FLAGS} -mcpu=power9 -mtune=power9"
         fi
     fi
 else


### PR DESCRIPTION
This sets the `-mcpu=power9 -mtune=power9` when building on Sierra/Lassen. The `power9` arch requires recent versions of GCC (4.9.3 doesn't cut it), so this has the build script force gcc/7.3.1 (since 4.9.3 is the default GCC on Sierra).

I noticed small but consistent performance improvements with this (probably mostly due to OpenCV being faster).