### PR TITLE
Bug fix for invalid data reader position

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -346,6 +346,12 @@ class generic_data_reader : public lbann_image_preprocessor {
   virtual bool position_valid() const {
     return (m_current_pos < (int)m_shuffled_indices.size());
   }
+  /// True if the data reader's current position is not valid but within # ranks per model
+  /// of the end of the data set (e.g. it is a rank with no valid data on the last iteration)
+  virtual bool position_is_overrun() const {
+    int end_pos = (int)m_shuffled_indices.size();
+    return (m_current_pos >= end_pos && (m_current_pos - end_pos) < m_comm->get_procs_per_model());
+  }
   /// True if the data reader is at the start of an epoch.
   bool at_new_epoch() const {
     /// Note that data readers can start at a non-zero index if there

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -277,11 +277,11 @@ class generic_input_layer : public io_layer {
     if(io_buffer->num_samples_ready(mode) > 0) {
       num_samples_in_batch = io_buffer->num_samples_ready(mode);
     }else {
-        std::stringstream err;
-        err << __FILE__ << " " << __LINE__ << " :: "
-            << "I/O buffer does not contain valid samples ("<< num_samples_in_batch
-            << ")";
-        throw lbann_exception(err.str());
+        if(!get_data_reader()->position_is_overrun()) {
+          std::stringstream err;
+          err << "I/O buffer does not contain valid samples ("<< num_samples_in_batch << ")";
+          LBANN_ERROR(err.str());
+        }
     }
 
     if(dynamic_cast<partitioned_io_buffer*>(io_buffer) != nullptr) {


### PR DESCRIPTION
Fixed a bug where the data reader's current position is not valid but within # ranks per model of the end of the data set (e.g. it is a rank with no valid data on the last iteration).