### PR TITLE
Node-local batch normalization

### DIFF
--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -58,6 +58,11 @@ private:
   bool m_use_global_stats;
   /** Whether to aggregate statistics within a node when training. */
   bool m_use_nodelocal_stats;
+  /**
+   * Cache of node-local num_per_sum results for node-local stats.
+   * Indexed by effective mini-batch size.
+   */
+  std::unordered_map<El::Int, El::Int> m_num_per_sum_cache;
 
   /** Current minibatch means. */
   std::unique_ptr<AbsDistMat> m_mean;
@@ -105,6 +110,7 @@ public:
       m_epsilon(other.m_epsilon),
       m_use_global_stats(other.m_use_global_stats),
       m_use_nodelocal_stats(other.m_use_nodelocal_stats),
+      m_num_per_sum_cache(other.m_num_per_sum_cache),
       m_mean(other.m_mean ? other.m_mean->Copy() : nullptr),
       m_var(other.m_var ? other.m_var->Copy() : nullptr),
       m_mean_gradient(other.m_mean_gradient ?
@@ -122,6 +128,7 @@ public:
     m_epsilon = other.m_epsilon;
     m_use_global_stats = other.m_use_global_stats;
     m_use_nodelocal_stats = other.m_use_nodelocal_stats;
+    m_num_per_sum_cache = other.m_num_per_sum_cache;
 
     // Deep copy matrices
     m_mean.reset(other.m_mean ? other.m_mean->Copy() : nullptr);

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -56,6 +56,8 @@ private:
   DataType m_epsilon;
   /** Whether to use global statistics when training. */
   bool m_use_global_stats;
+  /** Whether to aggregate statistics within a node when training. */
+  bool m_use_nodelocal_stats;
 
   /** Current minibatch means. */
   std::unique_ptr<AbsDistMat> m_mean;
@@ -82,11 +84,13 @@ public:
   batch_normalization_layer(lbann_comm *comm,
                             DataType decay=0.9,
                             DataType epsilon=1e-5,
-                            bool use_global_stats = false)
+                            bool use_global_stats = false,
+                            bool use_nodelocal_stats = false)
     : regularizer_layer(comm),
       m_decay(decay),
       m_epsilon(epsilon),
-      m_use_global_stats(use_global_stats) {
+      m_use_global_stats(use_global_stats),
+      m_use_nodelocal_stats(use_nodelocal_stats) {
     static_assert(T_layout == data_layout::DATA_PARALLEL,
                   "batch normalization only supports DATA_PARALLEL");
 #ifdef LBANN_DETERMINISTIC
@@ -100,6 +104,7 @@ public:
       m_decay(other.m_decay),
       m_epsilon(other.m_epsilon),
       m_use_global_stats(other.m_use_global_stats),
+      m_use_nodelocal_stats(other.m_use_nodelocal_stats),
       m_mean(other.m_mean ? other.m_mean->Copy() : nullptr),
       m_var(other.m_var ? other.m_var->Copy() : nullptr),
       m_mean_gradient(other.m_mean_gradient ?
@@ -116,6 +121,7 @@ public:
     m_decay = other.m_decay;
     m_epsilon = other.m_epsilon;
     m_use_global_stats = other.m_use_global_stats;
+    m_use_nodelocal_stats = other.m_use_nodelocal_stats;
 
     // Deep copy matrices
     m_mean.reset(other.m_mean ? other.m_mean->Copy() : nullptr);
@@ -142,6 +148,7 @@ public:
     desc.add("Decay", m_decay);
     desc.add("Epsilon", m_epsilon);
     desc.add("Global statistics", m_use_global_stats);
+    desc.add("Node-local statistics", m_use_nodelocal_stats);
     return desc;
   }
 

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -36,7 +36,7 @@ enum class batch_normalization_stats_aggregation {
   /** Statistics are aggregated only within a single rank. */
   local,
   /** Statistics are aggregated among every rank in a single node. */
-  nodelocal,
+  node_local,
   /** Statistics are aggregated among every rank in the model. */
   global
 };
@@ -162,7 +162,7 @@ public:
     case batch_normalization_stats_aggregation::local:
       desc.add("Statistics aggregation", "local");
       break;
-    case batch_normalization_stats_aggregation::nodelocal:
+    case batch_normalization_stats_aggregation::node_local:
       desc.add("Statistics aggregation", "node-local");
       break;
     case batch_normalization_stats_aggregation::global:
@@ -209,7 +209,7 @@ protected:
       if (output.DistRank() == 0) {
         std::cerr << err.str() << std::endl;
       }
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local
                && local_mini_batch_size*m_comm->get_procs_per_node() <= 4) {
       std::stringstream err;
       err << "LBANN warning: "

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
@@ -391,7 +391,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -441,7 +441,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -491,7 +491,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -527,7 +527,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -568,7 +568,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -625,7 +625,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -661,7 +661,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -710,7 +710,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
@@ -578,7 +578,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv1_scale bn_conv1_bias bn_conv1_running_mean bn_conv1_running_variance"
   }
@@ -634,7 +634,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv2_scale bn_conv2_bias bn_conv2_running_mean bn_conv2_running_variance"
   }
@@ -690,7 +690,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv3_scale bn_conv3_bias bn_conv3_running_mean bn_conv3_running_variance"
   }
@@ -731,7 +731,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv4_scale bn_conv4_bias bn_conv4_running_mean bn_conv4_running_variance"
   }
@@ -772,7 +772,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv5_scale bn_conv5_bias bn_conv5_running_mean bn_conv5_running_variance"
   }
@@ -835,7 +835,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -875,7 +875,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -929,7 +929,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -623,7 +623,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv1_scale bn_conv1_bias bn_conv1_running_mean bn_conv1_running_variance"
   }
@@ -679,7 +679,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv2_scale bn_conv2_bias bn_conv2_running_mean bn_conv2_running_variance"
   }
@@ -735,7 +735,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv3_scale bn_conv3_bias bn_conv3_running_mean bn_conv3_running_variance"
   }
@@ -776,7 +776,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv4_scale bn_conv4_bias bn_conv4_running_mean bn_conv4_running_variance"
   }
@@ -817,7 +817,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv5_scale bn_conv5_bias bn_conv5_running_mean bn_conv5_running_variance"
   }
@@ -868,7 +868,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_fc6_scale bn_fc6_bias bn_fc6_running_mean bn_fc6_running_variance"
   }
@@ -913,7 +913,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv1_scale bn_conv1_bias bn_conv1_running_mean bn_conv1_running_variance"
   }
@@ -969,7 +969,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv2_scale bn_conv2_bias bn_conv2_running_mean bn_conv2_running_variance"
   }
@@ -1025,7 +1025,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv3_scale bn_conv3_bias bn_conv3_running_mean bn_conv3_running_variance"
   }
@@ -1066,7 +1066,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv4_scale bn_conv4_bias bn_conv4_running_mean bn_conv4_running_variance"
   }
@@ -1107,7 +1107,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv5_scale bn_conv5_bias bn_conv5_running_mean bn_conv5_running_variance"
   }
@@ -1158,7 +1158,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_fc6_scale bn_fc6_bias bn_fc6_running_mean bn_fc6_running_variance"
   }
@@ -1203,7 +1203,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv1_scale bn_conv1_bias bn_conv1_running_mean bn_conv1_running_variance"
   }
@@ -1259,7 +1259,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv2_scale bn_conv2_bias bn_conv2_running_mean bn_conv2_running_variance"
   }
@@ -1315,7 +1315,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv3_scale bn_conv3_bias bn_conv3_running_mean bn_conv3_running_variance"
   }
@@ -1356,7 +1356,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv4_scale bn_conv4_bias bn_conv4_running_mean bn_conv4_running_variance"
   }
@@ -1397,7 +1397,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_conv5_scale bn_conv5_bias bn_conv5_running_mean bn_conv5_running_variance"
   }
@@ -1448,7 +1448,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
     weights: "bn_fc6_scale bn_fc6_bias bn_fc6_running_mean bn_fc6_running_variance"
   }
@@ -1493,7 +1493,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 
@@ -1527,7 +1527,7 @@ model {
       scale_init: 1.0
       bias_init: 0.0
       epsilon: 1e-5
-      global_stats: true
+      stats_aggregation: "global"
     }
   }
 

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -80,7 +80,13 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
     } else if (m_use_nodelocal_stats) {
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
-      num_per_sum = channel_size * local_width * m_comm->get_procs_per_node();
+      if (m_num_per_sum_cache.count(width) == 0) {
+        num_per_sum = channel_size * local_width;
+        num_per_sum = m_comm->allreduce(num_per_sum, m_comm->get_node_comm());
+        m_num_per_sum_cache[width] = num_per_sum;
+      } else {
+        num_per_sum = m_num_per_sum_cache[width];
+      }
     } else {
       num_per_sum = channel_size * local_width;
     }
@@ -247,7 +253,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
   if (m_use_global_stats) {
     num_per_sum = channel_size * width;
   } else if (m_use_nodelocal_stats) {
-    num_per_sum = channel_size * local_width * m_comm->get_procs_per_node();
+    num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   } else {
     num_per_sum = channel_size * local_width;
   }

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -77,6 +77,10 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
+    } else if (m_use_nodelocal_stats) {
+      m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
+      m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
+      num_per_sum = channel_size * local_width * m_comm->get_procs_per_node();
     } else {
       num_per_sum = channel_size * local_width;
     }
@@ -215,6 +219,13 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
       m_comm->allreduce(*m_var_gradient,
                         m_var_gradient->RedundantComm(),
                         El::mpi::SUM);
+    } else if (m_use_nodelocal_stats) {
+      m_comm->allreduce(*m_mean_gradient,
+                        m_comm->get_node_comm(),
+                        El::mpi::SUM);
+      m_comm->allreduce(*m_var_gradient,
+                        m_comm->get_node_comm(),
+                        El::mpi::SUM);
     }
   } else {
     El::Zero(*m_mean_gradient);
@@ -232,9 +243,14 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
   }
 
   // Compute error signal
-  const auto& num_per_sum = (m_use_global_stats ?
-                             width * channel_size :
-                             local_width * channel_size);
+  El::Int num_per_sum;
+  if (m_use_global_stats) {
+    num_per_sum = channel_size * width;
+  } else if (m_use_nodelocal_stats) {
+    num_per_sum = channel_size * local_width * m_comm->get_procs_per_node();
+  } else {
+    num_per_sum = channel_size * local_width;
+  }
   if (num_per_sum <= 1) {
     El::Zero(local_gradient_wrt_input);
   } else {

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -73,11 +73,11 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
       local_var(channel, 0) = sqsum;
     }
     El::Int num_per_sum;
-    if (m_use_global_stats) {
+    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
-    } else if (m_use_nodelocal_stats) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
@@ -218,14 +218,14 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
 
   // Accumulate gradients
   if (is_training) {
-    if (m_use_global_stats) {
+    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
       m_comm->allreduce(*m_mean_gradient,
                         m_mean_gradient->RedundantComm(),
                         El::mpi::SUM);
       m_comm->allreduce(*m_var_gradient,
                         m_var_gradient->RedundantComm(),
                         El::mpi::SUM);
-    } else if (m_use_nodelocal_stats) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
       m_comm->allreduce(*m_mean_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
@@ -250,9 +250,9 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
 
   // Compute error signal
   El::Int num_per_sum;
-  if (m_use_global_stats) {
+  if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
     num_per_sum = channel_size * width;
-  } else if (m_use_nodelocal_stats) {
+  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
     num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   } else {
     num_per_sum = channel_size * local_width;

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -77,7 +77,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
@@ -225,7 +225,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
       m_comm->allreduce(*m_var_gradient,
                         m_var_gradient->RedundantComm(),
                         El::mpi::SUM);
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
       m_comm->allreduce(*m_mean_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
@@ -252,7 +252,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
   El::Int num_per_sum;
   if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
     num_per_sum = channel_size * width;
-  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
     num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   } else {
     num_per_sum = channel_size * local_width;

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -339,11 +339,11 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
           local_mean.Buffer(), local_var.Buffer());
     }
     El::Int num_per_sum;
-    if (m_use_global_stats) {
+    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
-    } else if (m_use_nodelocal_stats) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
@@ -457,14 +457,14 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
 
   // Accumulate gradients
   if (is_training) {
-    if (m_use_global_stats) {
+    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
       m_comm->allreduce(*m_mean_gradient,
                         m_mean_gradient->RedundantComm(),
                         El::mpi::SUM);
       m_comm->allreduce(*m_var_gradient,
                         m_var_gradient->RedundantComm(),
                         El::mpi::SUM);
-    } else if (m_use_nodelocal_stats) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
       m_comm->allreduce(*m_mean_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
@@ -489,9 +489,9 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
 
   // Compute error signal
   El::Int num_per_sum;
-  if (m_use_global_stats) {
+  if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
     num_per_sum = channel_size * width;
-  } else if (m_use_nodelocal_stats) {
+  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
     num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   } else {
     num_per_sum = channel_size * local_width;

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -343,7 +343,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
@@ -464,7 +464,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
       m_comm->allreduce(*m_var_gradient,
                         m_var_gradient->RedundantComm(),
                         El::mpi::SUM);
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
       m_comm->allreduce(*m_mean_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
@@ -491,7 +491,7 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
   El::Int num_per_sum;
   if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
     num_per_sum = channel_size * width;
-  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::nodelocal) {
+  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
     num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   } else {
     num_per_sum = channel_size * local_width;

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -339,11 +339,13 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
           local_mean.Buffer(), local_var.Buffer());
     }
     El::Int num_per_sum;
-    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
+    switch (m_stats_aggregation) {
+    case batch_normalization_stats_aggregation::global:
       m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
       num_per_sum = channel_size * width;
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
+      break;
+    case batch_normalization_stats_aggregation::node_local:
       m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
       m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
@@ -353,8 +355,12 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
       } else {
         num_per_sum = m_num_per_sum_cache[width];
       }
-    } else {
+      break;
+    case batch_normalization_stats_aggregation::local:
       num_per_sum = channel_size * local_width;
+      break;
+    default:
+      LBANN_ERROR("Unknown batch normalization stats aggregation");
     }
 
     // Compute minibatch statistics
@@ -489,12 +495,18 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
 
   // Compute error signal
   El::Int num_per_sum;
-  if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
+  switch (m_stats_aggregation) {
+  case batch_normalization_stats_aggregation::global:
     num_per_sum = channel_size * width;
-  } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
+    break;
+  case batch_normalization_stats_aggregation::node_local:
     num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
-  } else {
+    break;
+  case batch_normalization_stats_aggregation::local:
     num_per_sum = channel_size * local_width;
+    break;
+  default:
+    LBANN_ERROR("Unknown batch normalization stats aggregation");
   }
   if (num_per_sum <= 1) {
     El::Zero(local_gradient_wrt_input);

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -493,7 +493,8 @@ Layer* construct_layer(lbann_comm* comm,
               comm,
               params.decay(),
               params.epsilon(),
-              params.global_stats());
+              params.global_stats(),
+              params.nodelocal_stats());
     } 
     LAYOUT_ERR(proto_layer.name(), "batch_normalization");
   }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -494,8 +494,8 @@ Layer* construct_layer(lbann_comm* comm,
         batch_normalization_stats_aggregation::local;
       if (aggr_str == "local" || aggr_str.empty()) {
         aggr = batch_normalization_stats_aggregation::local;
-      } else if (aggr_str == "nodelocal") {
-        aggr = batch_normalization_stats_aggregation::nodelocal;
+      } else if (aggr_str == "node_local") {
+        aggr = batch_normalization_stats_aggregation::node_local;
       } else if (aggr_str == "global") {
         aggr = batch_normalization_stats_aggregation::global;
       } else {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1028,8 +1028,7 @@ message BatchNormalization {
   double scale_init = 2;     //default: 1.0
   double bias_init = 3;      //default: 0.0
   double epsilon = 4;        //default: 1e-5
-  bool global_stats = 5;     //default: false
-  bool nodelocal_stats = 6;  //default: false
+  string stats_aggregation = 5; // default: local
 }
 
 message SeluDropout {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1029,6 +1029,7 @@ message BatchNormalization {
   double bias_init = 3;      //default: 0.0
   double epsilon = 4;        //default: 1e-5
   bool global_stats = 5;     //default: false
+  bool nodelocal_stats = 6;  //default: false
 }
 
 message SeluDropout {


### PR DESCRIPTION
Adds support for node-local batch normalization. Instead of `global_stats`, batchnorm now has a suite of aggregation options: `local` (the default, as before), `nodelocal`, and `global`.