### PR TITLE
Refactoring some file IO utility functions.

### DIFF
--- a/include/lbann/io/file_io.hpp
+++ b/include/lbann/io/file_io.hpp
@@ -26,6 +26,8 @@
 // lbann_file_io .hpp .cpp - Input / output utilities
 ////////////////////////////////////////////////////////////////////////////////
 
+/// @todo Remove this file.
+
 #ifndef LBANN_IO_H
 #define LBANN_IO_H
 
@@ -34,15 +36,17 @@
 #include <fcntl.h>
 
 namespace lbann {
-
+/// @todo Deprecated.
 int makedir(const char *dirname);
-
+/// @todo Deprecated.
 int exists(const char *filename);
-
+/// @todo Deprecated.
 int openread(const char *filename);
+/// @todo Deprecated.
 int closeread(int fd, const char *filename);
-
+/// @todo Deprecated.
 int openwrite(const char *filename);
+/// @todo Deprecated.
 int closewrite(int fd, const char *filename);
 }
 

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -8,6 +8,7 @@ set_full_path(THIS_DIR_HEADERS
   description.hpp
   entrywise_operator.hpp
   exception.hpp
+  file_utils.hpp
   glob.hpp
   im2col.hpp
   mild_exception.hpp

--- a/include/lbann/utils/file_utils.hpp
+++ b/include/lbann/utils/file_utils.hpp
@@ -22,11 +22,13 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef _LBANN_FILE_UTILS_HPP_
-#define _LBANN_FILE_UTILS_HPP_
+/// @todo Rename this file to file.hpp
+
+#ifndef LBANN_UTILS_FILE_HPP_INCLUDED
+#define LBANN_UTILS_FILE_HPP_INCLUDED
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -53,14 +55,19 @@ std::vector<int> get_tokens(std::string str, const std::vector<char> delims);
 /// Tokenize a string into substrings by set of delimiter characters.
 std::vector<std::string> get_tokens(const std::string str, const std::string delims = " :;\t\r\n");
 
+/** @todo Deprecated. Use @c lbann::file::extract_parent_directory and
+ *  @c lbann::file::extract_base_name instead. */
 bool parse_path(const std::string& path, std::string& dir, std::string& basename);
 std::string get_ext_name(const std::string file_name);
 std::string get_basename_without_ext(const std::string file_name);
 std::string add_delimiter(const std::string dir);
 std::string modify_file_name(const std::string file_name, const std::string tag, const std::string new_ext="");
 
+/** @todo Deprecated. Use @c lbann::file::file_exists instead. */
 bool check_if_file_exists(const std::string& filename);
+/** @todo Deprecated. Use @c lbann::file::directory_exists instead. */
 bool check_if_dir_exists(const std::string& dirname);
+/** @todo Deprecated. Use @c lbann::file::make_directory instead. */
 bool create_dir(const std::string output_dir);
 
 bool load_file(const std::string filename, std::vector<char>& buf);
@@ -69,5 +76,37 @@ inline void __swapEndianInt(unsigned int& ui) {
   ui = ((ui >> 24) | ((ui<<8) & 0x00FF0000) | ((ui>>8) & 0x0000FF00) | (ui << 24));
 }
 
-} // end of namespace lbann
-#endif // _LBANN_FILE_UTILS_HPP_
+namespace file {
+
+/** @brief Wrapper around @c dirname.
+ *
+ *  Deletes any suffix beginning with the last '/' (ignoring trailing
+ *  slashes).
+ */
+std::string extract_parent_directory(const std::string& path);
+
+/** @brief Wrapper around @c basename.
+ *
+ *  Deletes any prefix up to the last '/' (ignoring trailing slashes).
+ */
+std::string extract_base_name(const std::string& path);
+
+/** @brief Check if file exists. */
+bool file_exists(const std::string& path);
+
+/** @brief Check if directory exists. */
+bool directory_exists(const std::string& path);
+
+/** @brief Create directory if needed.
+ *
+ *  Does nothing if directory already exists. Parent directories are
+ *  created recursively if needed. This is thread-safe (provided @c
+ *  mkdir is thread-safe).
+ */
+void make_directory(const std::string& path);
+
+} // namespace file
+
+} // namespace lbann
+
+#endif // LBANN_UTILS_FILE_HPP_INCLUDED

--- a/src/callbacks/callback_dump_outputs.cpp
+++ b/src/callbacks/callback_dump_outputs.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/callback_dump_outputs.hpp"
-#include "lbann/io/file_io.hpp"
+#include "lbann/utils/file_utils.hpp"
 
 #ifdef LBANN_HAS_CNPY
 #include <cnpy.h>
@@ -152,7 +152,7 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
       && m_layer_names.count(l.get_name()) == 0) { return; }
 
   // Create directory
-  lbann::makedir(m_directory.c_str());
+  file::make_directory(m_directory);
 
   // Save layer outputs on root process
   for (int i = 0; i < l.get_num_children(); ++i) {

--- a/src/io/file_io.cpp
+++ b/src/io/file_io.cpp
@@ -24,8 +24,11 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+/// @todo Remove this file.
+
 #include "lbann/io/file_io.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/file_utils.hpp"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -39,30 +42,24 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <string>
 #include <sstream>
 
-#include "mpi.h"
 
-/* creates directory given in dir (absolute path),
- * returns 1 if dir was created, 0 otherwise */
+/// @todo Deprecated.
 int lbann::makedir(const char *dir) {
-  int mkdir_rc = mkdir(dir, S_IRWXU | S_IRWXG);
-  if (mkdir_rc == 0 || errno == EEXIST) {
-    return 1;
-  } else {
-    std::stringstream err;
-    err << "failed to create directory (" << dir << ") "
-        << "with error " << errno << " (" << strerror(errno) << ")";
-    LBANN_ERROR(err.str());
-    return 0;
-  }
+  std::string dir_(dir);
+  file::make_directory(dir_);
+  return 1;
 }
 
+/// @todo Deprecated.
 int lbann::exists(const char *file) {
-  struct stat buffer;
-  return (stat(file, &buffer) == 0) ? 1 : 0;
+  std::string file_(file);
+  return (file::file_exists(file_) ? 1 : 0);
 }
 
+/// @todo Deprecated.
 int lbann::openread(const char *file) {
   // open the file for writing
   int fd = open(file, O_RDONLY);
@@ -71,6 +68,7 @@ int lbann::openread(const char *file) {
   return fd;
 }
 
+/// @todo Deprecated.
 int lbann::closeread(int fd, const char *file) {
   // close file
   int close_rc = close(fd);
@@ -84,6 +82,7 @@ int lbann::closeread(int fd, const char *file) {
   return close_rc;
 }
 
+/// @todo Deprecated.
 int lbann::openwrite(const char *file) {
   // define mode (permissions) for new file
   mode_t mode_file = S_IWUSR | S_IRUSR | S_IWGRP | S_IRGRP;
@@ -98,6 +97,7 @@ int lbann::openwrite(const char *file) {
   return fd;
 }
 
+/// @todo Deprecated.
 int lbann::closewrite(int fd, const char *file) {
   // fsync file
   int fsync_rc = fsync(fd);

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -22,18 +22,24 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
-//
 ////////////////////////////////////////////////////////////////////////////////
 
+/// @todo Rename this file to file.cpp.
+
 #include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/exception.hpp"
+
 #include <algorithm>
 #include <fstream>
-//#include <iostream> // std::cerr
+#include <sstream>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <errno.h>
+#include <libgen.h>
 
 namespace lbann {
 
 const std::string path_delimiter::characters = "/";
-
 
 std::vector<int> get_tokens(std::string str, const std::vector<char> delims) {
   std::vector<int> tokens;
@@ -67,19 +73,12 @@ std::vector<std::string> get_tokens(const std::string str, const std::string del
   return parsed;
 }
 
-/// Divide a given path into dir and basename.
+/// @todo Deprecated.
 bool parse_path(const std::string& path, std::string& dir, std::string& basename) {
-  std::string::const_iterator nb =
-    std::find_if(path.rbegin(), path.rend(), path_delimiter()).base();
-  dir =  std::string(path.begin(), nb);
-  basename = std::string(nb, path.end());
-  if (basename.empty()) {
-    return false;
-  }
-
-  return true;
+  dir = file::extract_parent_directory(path);
+  basename = file::extract_parent_directory(path);
+  return !basename.empty();
 }
-
 
 /// Return file extention name.
 std::string get_ext_name(const std::string file_name) {
@@ -150,70 +149,19 @@ std::string modify_file_name(const std::string file_name, const std::string tag,
   return (dir + name + '.' + ext);
 }
 
-
-/// Return true if a file with the given name exists.
+/// @todo Deprecated.
 bool check_if_file_exists(const std::string& filename) {
-  std::ifstream ifile(filename);
-  return static_cast<bool>(ifile);
+  return file::file_exists(filename);
 }
 
-
-#ifdef _POSIX_SOURCE
-#include <sys/stat.h>
-#include <errno.h>
-/// Return true if a directory with the given name exists.
+/// @todo Deprecated.
 bool check_if_dir_exists(const std::string& dirname) {
-  struct stat sb;
-
-  return (stat(dirname.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode));
+  return file::directory_exists(dirname);
 }
-#else
-bool check_if_dir_exists(const std::string& dirname) {
-  return check_if_file_exists(dirname);
-}
-#endif
 
-
-#include <cstdlib>
-/**
- * Create a directory, and return true if successful.
- * If a directory with the same name already exists, simply return true.
- */
+/// @todo Deprecated.
 bool create_dir(const std::string dirname) {
-  std::string dir = dirname;
-  if (!dir.empty() && path_delimiter::check(dir.back())) {
-    dir.pop_back();
-  }
-
-  if (dir.empty()) {
-    return true;
-  }
-
-  const bool file_exists = check_if_file_exists(dir);
-
-  if (file_exists) {
-    if (!check_if_dir_exists(dir)) {
-      return false;
-    } else {
-      return true;
-    }
-  }
-
-  std::string cmd = std::string("mkdir -p ") + dir;
-#if 1 // for ray
-  char cmdstr[cmd.size()+1];
-  std::copy(cmd.begin(), cmd.end(), &cmdstr[0]);
-  cmdstr[cmd.size()] = '\0';
-  const int r = ::system(&cmdstr[0]);
-#else
-  const int r = ::system(cmd.c_str());
-#endif
-
-  if (WEXITSTATUS(r) == 0x10) {
-    return true;
-  } else if (!check_if_dir_exists(dir)) {
-    return false;
-  }
+  file::make_directory(dirname);
   return true;
 }
 
@@ -238,4 +186,59 @@ bool load_file(const std::string filename, std::vector<char>& buf) {
   return true;
 }
 
-} // end of namespace lbann
+namespace file {
+
+std::string extract_parent_directory(const std::string& path) {
+  std::vector<char> buffer(path.size()+1);
+  path.copy(buffer.data(), path.size());
+  buffer.back() = '\0';
+  return ::dirname(buffer.data());
+}
+
+std::string extract_base_name(const std::string& path) {
+  std::vector<char> buffer(path.size()+1);
+  path.copy(buffer.data(), path.size());
+  buffer.back() = '\0';
+  return ::basename(buffer.data());
+}
+
+bool file_exists(const std::string& path) {
+  if (path.empty() || path == "." || path == "/") {
+    return true;
+  }
+  struct ::stat buffer;
+  return (::stat(path.c_str(), &buffer) == 0);
+}
+
+bool directory_exists(const std::string& path) {
+  if (path.empty() || path == "." || path == "/") {
+    return true;
+  }
+  struct ::stat buffer;
+  return (::stat(path.c_str(), &buffer) == 0
+          && S_ISDIR(buffer.st_mode));
+}
+
+void make_directory(const std::string& path) {
+  if (directory_exists(path)) { return; }
+
+  // Create parent directory if needed
+  const auto& parent = extract_parent_directory(path);
+  make_directory(parent);
+
+  // Create directory
+  // Note: Don't complain if the directory already exists.
+  auto status = ::mkdir(path.c_str(), S_IRWXU | S_IRWXG); // chmod 770
+  if (status != 0 && errno != EEXIST) {
+    std::stringstream err;
+    err << "failed to create directory (" << path << ") "
+        << "with error " << errno << " "
+        << "(" << strerror(errno) << ")";
+    LBANN_ERROR(err.str());
+  }
+
+}
+
+} // namespace file
+
+} // namespace lbann


### PR DESCRIPTION
This PR was motivated by a race condition I got when checkpointing VRAM (a process tried to create a subdirectory for RNG state before the checkpoint directory was created). As I was working on a fix, I found that we have duplicated file IO utility functions in two header files: include/lbann/io/file_io.hpp (mostly used by checkpointing code) and include/lbann/utils/file_utils.hpp (mostly used by data pipeline code). I think the latter is nicer than the former because it has a more natural location and uses C++ functionality. The former is basically written in C and should be deprecated.

Changes:
- Consolidated file IO functionality in utils/file_utils.hpp. I haven't removed any functions (the functions in io/file_io.hpp just call into their analogues in utils/file_utils.hpp), but they've been marked as deprecated. We can remove them Later™.
- The file IO utility functions have been moved to the `file` namespace. This change is not important and can be undone if desired. I think this will make it more obvious where these utility functions are coming from.
- Added documentation.
- The `make_directory` function will create parent directories recursively if needed, in a similar manner as `mkdir -p`.