### PR TITLE
Correct batchnorm defaults

### DIFF
--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -503,11 +503,20 @@ Layer* construct_layer(lbann_comm* comm,
         LBANN_ERROR(err.str());
         return nullptr;
       }
+      // Set defaults if not given.
+      auto decay = params.decay();
+      if (decay == 0.0) {
+        decay = 0.9;
+      }
+      auto epsilon = params.epsilon();
+      if (epsilon == 0.0) {
+        epsilon = 1e-5;
+      }
       return new batch_normalization_layer<data_layout::DATA_PARALLEL, Dev>(
-              comm,
-              params.decay(),
-              params.epsilon(),
-              aggr);
+        comm,
+        decay,
+        epsilon,
+        aggr);
     } 
     LAYOUT_ERR(proto_layer.name(), "batch_normalization");
   }
@@ -518,7 +527,8 @@ Layer* construct_layer(lbann_comm* comm,
   if (proto_layer.has_local_response_normalization()) {
  const auto& params = proto_layer.local_response_normalization();
     if (layout == data_layout::DATA_PARALLEL) {
-      return new local_response_normalization_layer<data_layout::DATA_PARALLEL, Dev>(        comm,
+      return new local_response_normalization_layer<data_layout::DATA_PARALLEL, Dev>(
+             comm,
              params.window_width(),
              params.lrn_alpha(),
              params.lrn_beta(),


### PR DESCRIPTION
We claim that batchnorm's decay defaults to 0.9 and its epsilon to 1e-5. But we just pass the protobuf parameters directly to the layer constructor, and protobuf will default them to 0.0 if not present. This fixes that.