### PR TITLE
CUDA/CUBLAS error checking

### DIFF
--- a/include/lbann/utils/cublas.hpp
+++ b/include/lbann/utils/cublas.hpp
@@ -60,6 +60,18 @@
       }                                                                 \
     }                                                                   \
   } while (0)
+#define FORCE_CHECK_CUBLAS_NOSYNC(cublas_call)                          \
+  do {                                                                  \
+    {                                                                   \
+      /* Make cuBLAS call and check for errors. */                      \
+      const cublasStatus_t status_FORCE_CHECK_CUBLAS = (cublas_call);   \
+      if (status_FORCE_CHECK_CUBLAS != CUBLAS_STATUS_SUCCESS) {         \
+        cudaDeviceReset();                                              \
+        LBANN_ERROR(std::string("cuBLAS error: ")                       \
+                    + lbann::cublas::get_error_string(status_FORCE_CHECK_CUBLAS)); \
+      }                                                                 \
+    }                                                                   \
+  } while (0)
 #define FORCE_CHECK_CUBLAS_SYNC(cuda_call)                                    \
   do {                                                                        \
     const cudaError_t cuda_status = cuda_call;                                \
@@ -77,7 +89,7 @@
       FORCE_CHECK_CUBLAS_SYNC(cudaDeviceSynchronize()); \
   } while (0)
 #else
-#define CHECK_CUBLAS(cublas_call) (cublas_call)
+#define CHECK_CUBLAS(cublas_call) FORCE_CHECK_CUBLAS_NOSYNC(cublas_call)
 #endif // LBANN_DEBUG
 
 namespace lbann {

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -83,10 +83,19 @@
     }                                                           \
     LBANN_CUDA_SYNC(false);                                     \
   } while (0)
+#define FORCE_CHECK_CUDA_NOSYNC(cuda_call)                      \
+  do {                                                          \
+    cudaError_t status_CHECK_CUDA = (cuda_call);                \
+    if (status_CHECK_CUDA != cudaSuccess) {                     \
+      LBANN_ERROR(std::string("CUDA error (")                   \
+                  + cudaGetErrorString(status_CHECK_CUDA)       \
+                  + std::string(")"));                          \
+    }                                                           \
+  } while (0)
 #ifdef LBANN_DEBUG
 #define CHECK_CUDA(cuda_call) FORCE_CHECK_CUDA(cuda_call);
 #else
-#define CHECK_CUDA(cuda_call) (cuda_call)
+#define CHECK_CUDA(cuda_call) FORCE_CHECK_CUDA_NOSYNC(cuda_call)
 #endif // #ifdef LBANN_DEBUG
 
 namespace lbann {


### PR DESCRIPTION
This adds `NOSYNC` versions of the `FORCE_CHECK_CUDA`/`CUBLAS` error checking macros. This also enables error checking in release mode. (This is just a quick check of return values, and so shouldn't add much overhead.) We already do this for cuDNN.