### PR TITLE
Replacing AbsMat::operator*= with El::Scale.

### DIFF
--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -184,7 +184,7 @@ protected:
     m_mask->Resize(height, width);
 #ifdef LBANN_DETERMINISTIC
     bernoulli_fill_procdet(*m_mask, height, width, DataType(m_keep_prob));
-    *m_mask *= scale;
+    El::Scale(scale, *m_mask);
 #else
     El::EntrywiseMap(*m_mask,
                      (std::function<DataType(const DataType&)>)

--- a/src/data_readers/image_preprocessor.cpp
+++ b/src/data_readers/image_preprocessor.cpp
@@ -192,22 +192,22 @@ void lbann_image_preprocessor::unit_scale(Mat& pixels,
     unsigned num_channels) {
   // Pixels are in range [0, 255], normalize using that.
   // Channels are not relevant here.
-  pixels *= DataType(1) / 255;
+  El::Scale(DataType(1) / 255, pixels);
 }
 
 
-void lbann_image_preprocessor::pixel_noise(Mat& pixels) 
+void lbann_image_preprocessor::pixel_noise(Mat& pixels)
 {
   if(m_noise_factor){
     Mat X_noise;
     El::Gaussian(X_noise, pixels.Height(), pixels.Width(), DataType(0), DataType(1));
     El::Axpy(m_noise_factor,X_noise,pixels);
     //@todo - clip to min and max of input entry
-    auto clip = [](const DataType& z) { 
+    auto clip = [](const DataType& z) {
          return std::max(DataType(0), std::min(z,DataType(1)));
     };
     EntrywiseMap(pixels, El::MakeFunction(clip));
-  } 
+  }
 }
 
 void lbann_image_preprocessor::z_score(Mat& pixels,

--- a/src/utils/statistics.cpp
+++ b/src/utils/statistics.cpp
@@ -412,8 +412,8 @@ void columnwise_covariance(const AbsDistMat& data1,
     }
     local_covs(0, col) = sum;
   }
-  AllReduce(covs, covs.RedundantComm(), El::mpi::SUM);
-  local_covs *= DataType(1) / height;
+  El::AllReduce(covs, covs.RedundantComm(), El::mpi::SUM);
+  El::Scale(DataType(1) / height, local_covs);
 
 }
 

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -397,7 +397,7 @@ void weights::set_value(DataType value, int row, int col) {
 void weights::reconcile_values() {
   auto& values = get_values();
   if (values.RedundantSize() > 1) {
-    values *= DataType(1) / values.RedundantSize();
+    El::Scale(DataType(1) / values.RedundantSize(), values);
     m_comm->allreduce(values, values.RedundantComm());
   }
 }
@@ -405,7 +405,7 @@ void weights::reconcile_values() {
 void weights::reconcile_values(Al::request& req) {
   auto& values = get_values();
   if (values.RedundantSize() > 1) {
-    values *= DataType(1) / values.RedundantSize();
+    El::Scale(DataType(1) / values.RedundantSize(), values);
     m_comm->nb_allreduce(values, values.RedundantComm(), req);
   }
 }


### PR DESCRIPTION
While looking into #876, I got a hang inside the data preprocessor. Under TotalView, the stack looked like:
```
3. AbstractMatrix<T> const& AbstractMatrix<T>::operator*=(T const& alpha) (lbann/src/data_readers/image_preprocessor.cpp: line 195)
2. Device AbstractMatrix<T>::GetDevice() (Hydrogen/include/El/core/AbstractMatrix.hpp: line 433)
1. Device AbstractMatrix<T>::do_get_device_() (Hydrogen/include/El/core/AbstractMatrix.hpp: line 176)
```
It's unclear why switching from `AbsMat::operator*=` to `El::Scale` fixed things. In any case, @benson31 has been making complaining noises about removing computation functionality from the matrix class so that it can be purely devoted to data storage. This helps move toward that direction.