### PR TITLE
fix issue where comms are moved erroneously

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -217,7 +217,7 @@ void lbann_comm::allreduce(AbsMat& m,
 void lbann_comm::allreduce(AbsDistMat& m,
                            const El::mpi::Comm& c,
                            El::mpi::Op op) {
-  allreduce(m.Matrix(), std::move(c), op);
+  allreduce(m.Matrix(), c, op);
 }
 
 void lbann_comm::nb_allreduce(AbsMat& m,
@@ -301,7 +301,7 @@ void lbann_comm::nb_allreduce(AbsMat& m,
 #endif  // AL_HAS_MPI_CUDA
   bytes_received += sizeof(DataType) * local_size * (El::mpi::Size(c) - 1);
 #else
-  allreduce(m, std::move(c), op);
+  allreduce(m, c, op);
 #endif // LBANN_HAS_ALUMINUM
 }
 
@@ -309,7 +309,7 @@ void lbann_comm::nb_allreduce(AbsDistMat& m,
                               const El::mpi::Comm& c,
                               Al::request& req,
                               El::mpi::Op op) {
-  nb_allreduce(m.Matrix(), std::move(c), req, op);
+  nb_allreduce(m.Matrix(), c, req, op);
 }
 
 void lbann_comm::wait(Al::request& req) {
@@ -363,7 +363,7 @@ void lbann_comm::intertrainer_broadcast_matrix(AbsDistMat& mat, int root) {
 template<>
 void lbann_comm::broadcast<std::string>(const int root, std::string& str, const El::mpi::Comm& c) {
   std::vector<char> data(str.begin(), str.end());
-  broadcast(root, data, std::move(c));
+  broadcast(root, data, c);
   str.assign(data.begin(), data.end());
 }
 


### PR DESCRIPTION
Missed this when I made the changes for the lazy init stuff (then again, so did all the reviewers...)