### PR TITLE
Make Cub always log certain performance-critical events.

### DIFF
--- a/external/cub/cub_enable_alloc_free_logging.patch
+++ b/external/cub/cub_enable_alloc_free_logging.patch
@@ -1,0 +1,22 @@
+diff --git a/cub/util_allocator.cuh b/cub/util_allocator.cuh
+index 0e6dd048..f41f2e64 100644
+--- a/cub/util_allocator.cuh
++++ b/cub/util_allocator.cuh
+@@ -446,7 +446,7 @@ struct CachingDeviceAllocator
+             if (CubDebug(error = cudaMalloc(&search_key.d_ptr, search_key.bytes)) == cudaErrorMemoryAllocation)
+             {
+                 // The allocation attempt failed: free all cached blocks on device and retry
+-                if (debug) _CubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
++                _CubLog("\tDevice %d failed to allocate %lld bytes for stream %lld, retrying after freeing cached allocations",
+                       device, (long long) search_key.bytes, (long long) search_key.associated_stream);
+ 
+                 error = cudaSuccess;    // Reset the error we will return
+@@ -606,7 +606,7 @@ struct CachingDeviceAllocator
+             if (CubDebug(error = cudaFree(d_ptr))) return error;
+             if (CubDebug(error = cudaEventDestroy(search_key.ready_event))) return error;
+ 
+-            if (debug) _CubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
++            _CubLog("\tDevice %d freed %lld bytes from associated stream %lld.\n\t\t  %lld available blocks cached (%lld bytes), %lld live blocks (%lld bytes) outstanding.\n",
+                 device, (long long) search_key.bytes, (long long) search_key.associated_stream, (long long) cached_blocks.size(), (long long) cached_bytes[device].free, (long long) live_blocks.size(), (long long) cached_bytes[device].live);
+         }
+ 

--- a/superbuild/cub/CMakeLists.txt
+++ b/superbuild/cub/CMakeLists.txt
@@ -29,7 +29,8 @@ ExternalProject_Add(CUB
   PATCH_COMMAND
   ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_CURRENT_SOURCE_DIR}/CUBCMakeLists.txt
-  ${CMAKE_CURRENT_BINARY_DIR}/src/CMakeLists.txt
+  ${CMAKE_CURRENT_BINARY_DIR}/src/CMakeLists.txt &&
+  patch -p1 < ${LBANN_SRC_DIR}/external/cub/cub_enable_alloc_free_logging.patch
   INSTALL_DIR ${CUB_CMAKE_INSTALL_PREFIX}
   USES_TERMINAL_BUILD 1
   LOG_DOWNLOAD 1


### PR DESCRIPTION
Once stabilized, it is generally expected that:
- Memory request does not actually acquire a new memory chunk.
- Memory release just returns the pointer to the memory pool and never
calls cudaFree.

These events can be a significant performance penalty. Cub will log
messages when they happen only if its debug option is enabled, but the
options also enables other logging, yielding extremely verbose output.
This patch only enables logging at the above events no matter the debug
option is enabled.