### PR TITLE
Optionally start profiling after one epoch.

### DIFF
--- a/include/lbann/callbacks/profiler.hpp
+++ b/include/lbann/callbacks/profiler.hpp
@@ -37,7 +37,7 @@ namespace lbann {
  */
 class lbann_callback_profiler : public lbann_callback {
  public:
-  lbann_callback_profiler(bool sync = false);
+  lbann_callback_profiler(bool sync = false, bool skip_init = false);
   lbann_callback_profiler(const lbann_callback_profiler&) = default;
   lbann_callback_profiler& operator=(const lbann_callback_profiler&) = default;
   lbann_callback_profiler* copy() const override {
@@ -75,6 +75,8 @@ class lbann_callback_profiler : public lbann_callback {
   int get_color(Layer *l);
   /** Whether to synchronize the when setting up profile regions. */
   bool m_sync;
+  /** Whether to skip initial iterations. */
+  bool m_skip_init;
 };
 
 }  // namespace lbann

--- a/include/lbann/utils/profiling.hpp
+++ b/include/lbann/utils/profiling.hpp
@@ -37,6 +37,8 @@ constexpr int prof_colors[num_prof_colors] = {
   0x22AA99, 0xAAAA11, 0x6633CC, 0xE67300, 0x8B0707, 0x329262,
   0x5574A6, 0x3B3EAC};
 
+void prof_start();
+void prof_stop();
 void prof_region_begin(const char *s, int c, bool sync);
 void prof_region_end(const char *s, bool sync);
 

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -38,14 +38,21 @@
 
 namespace lbann {
 
-lbann_callback_profiler::lbann_callback_profiler(bool sync) :
-  lbann_callback(), m_sync(sync) {
+lbann_callback_profiler::lbann_callback_profiler(bool sync, bool skip_init) :
+    lbann_callback(), m_sync(sync), m_skip_init(skip_init) {
 #ifdef LBANN_NVPROF
   nvtxNameCudaStreamA(El::GPUManager::Stream(), "Hydrogen");
-#endif  
+#endif
+  if (!m_skip_init) {
+    prof_start();
+  }
 }
 
 void lbann_callback_profiler::on_epoch_begin(model *m) {
+  // Skip the first epoch
+  if (m_skip_init && m->get_cur_epoch() == 1) {
+    prof_start();
+  }
   prof_region_begin(("epoch " + std::to_string(m->get_cur_epoch())).c_str(),
                     prof_colors[0], m_sync);
 }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -260,7 +260,8 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                       params.mat_interval());
   }
   if (proto_cb.has_profiler()) {
-    return new lbann_callback_profiler(proto_cb.profiler().sync());
+    return new lbann_callback_profiler(proto_cb.profiler().sync(),
+                                       proto_cb.profiler().skip_init());
   }
   if (proto_cb.has_sync_layers()) {
     const auto& params = proto_cb.sync_layers();

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -445,6 +445,7 @@ message CallbackPrint {
 
 message CallbackProfiler {
   bool sync = 1;
+  bool skip_init = 2;
 }
 
 message CallbackTimer {


### PR DESCRIPTION
Add `skip_init: true` to the profiler callback and run nvprof with
`--profile-from-start off`. This will skip profiling of the
initialization phase including the first epoch, so the resulting
profiles would be smaller and easier to visualize with nvvp.