### PR TITLE
remove obsolete layer references in the siamese prototext files

### DIFF
--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
@@ -966,7 +966,6 @@ model {
   layer {
     parents: "fc8_new"
     name: "prob_new"
-    children: "target_new"
     data_layout: "data_parallel"
     softmax {}
   }

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -1552,7 +1552,6 @@ model {
   layer {
     parents: "fc9"
     name: "prob"
-    children: "target"
     data_layout: "data_parallel"
     softmax {}
   }


### PR DESCRIPTION
remove obsolete layer references (target layer) in the prototext files that cause parsing errors.