### PR TITLE
Add `end_lr` field for polynomial weight decay

### DIFF
--- a/include/lbann/callbacks/callback_learning_rate.hpp
+++ b/include/lbann/callbacks/callback_learning_rate.hpp
@@ -238,7 +238,7 @@ class lbann_callback_linear_growth_learning_rate :
 class lbann_callback_poly_learning_rate : public lbann_callback_learning_rate {
  public:
   lbann_callback_poly_learning_rate(double p, uint64_t n_epochs, uint64_t max_iter);
-  lbann_callback_poly_learning_rate(double p, uint64_t n_epochs, uint64_t max_iter,
+  lbann_callback_poly_learning_rate(double p, uint64_t n_epochs, uint64_t max_iter, double endl_r,
     std::unordered_set<weights *> weights_list);
   lbann_callback_poly_learning_rate(
     const lbann_callback_poly_learning_rate&) = default;
@@ -259,6 +259,8 @@ class lbann_callback_poly_learning_rate : public lbann_callback_learning_rate {
   uint64_t m_num_epochs;
   /// The maximum number of iterations until which the learning rate changes
   uint64_t m_max_iter;
+  /// The minimum learning rate
+  float m_end_lr;
   /// The current rate to scale the base learning rate
   float m_lr;
   /// The learning rate scale used at the end of the last epoch

--- a/src/callbacks/callback_learning_rate.cpp
+++ b/src/callbacks/callback_learning_rate.cpp
@@ -223,12 +223,14 @@ lbann_callback_poly_learning_rate::lbann_callback_poly_learning_rate(
   double p, uint64_t n_epochs, uint64_t max_iter)
   : lbann_callback_learning_rate(std::unordered_set<weights *>()),
     m_p(p), m_num_epochs(n_epochs), m_max_iter(max_iter),
+    m_end_lr(0.0f),
     m_lr(1.0f), m_last_epoch_lr(1.0f) {}
 
 lbann_callback_poly_learning_rate::lbann_callback_poly_learning_rate(
-  double p, uint64_t n_epochs, uint64_t max_iter, std::unordered_set<weights *> weights_list)
+  double p, uint64_t n_epochs, uint64_t max_iter, double end_lr,  std::unordered_set<weights *> weights_list)
   : lbann_callback_learning_rate(weights_list),
     m_p(p), m_num_epochs(n_epochs), m_max_iter(max_iter),
+    m_end_lr(end_lr),
     m_lr(1.0f), m_last_epoch_lr(1.0f) {}
 
 /**
@@ -248,7 +250,7 @@ void lbann_callback_poly_learning_rate::setup(model *m) {
 float lbann_callback_poly_learning_rate::global_schedule(model *m) {
   const float scale = m_lr / m_last_epoch_lr;
   m_last_epoch_lr = m_lr;
-  return m_cur_global_lr * scale;
+  return (m_cur_global_lr - m_end_lr) * scale + m_end_lr;
 }
 
 /**
@@ -260,7 +262,7 @@ float lbann_callback_poly_learning_rate::optimizer_schedule(model *m, optimizer 
     m_lr = static_cast<float>(std::pow(static_cast<double>(m_max_iter - cur_iter)/m_max_iter, m_p));
   }
   const float scale = m_lr / m_last_epoch_lr;
-  return m_cur_global_lr * scale;
+  return (m_cur_global_lr - m_end_lr) * scale + m_end_lr;
 }
 
 lbann_callback_optimizerwise_adaptive_learning_rate::lbann_callback_optimizerwise_adaptive_learning_rate(

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -183,6 +183,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
     return new lbann_callback_poly_learning_rate(params.power(),
                                                  params.num_epochs(),
                                                  params.max_iter(),
+                                                 params.end_lr(),
                                                  selected_weights);
   }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -526,6 +526,7 @@ message CallbackPolyLearningRate {
   double power = 2;
   uint64 num_epochs = 3;
   uint64 max_iter = 4;
+  double end_lr = 5;
 }
 
 message CallbackStepMinibatch {


### PR DESCRIPTION
This PR adds a new attribute `end_lr` to the `CallbackPolyLearningRate` callback which determines the final learning-rate at the end of training.
This is the equivalent feature to TensorFlow's [`end_learning_rate`](https://www.tensorflow.org/api_docs/python/tf/train/polynomial_decay) argument.
It's default value is zero, with which the scheduler behaves like that without this feature.