### PR TITLE
Sample list bug for too many open files

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -59,7 +59,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   using sample_locator_t = std::pair<std::string, hid_t>;
   using sample_map_t = std::vector<sample_locator_t>; ///< valid sample map type
   using sample_t = sample_list_jag::sample_t;
-  using sample_id_t = sample_list_jag::sample_id_t;
+  using sample_file_id_t = sample_list_jag::sample_file_id_t;
   /// linear transform on X defined as: first * X + second => X'
   using linear_transform_t = std::pair<double, double>;
 

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -356,7 +356,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node) const;
   /// Check if a key exist for sample i
   bool has_conduit_path(const size_t i, const std::string& key) const;
-  void close_conduit_node(const size_t i);
+  //  void close_conduit_node(const size_t i);
 
   /// Obtain image data
   std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample) const;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -216,19 +216,19 @@ class data_reader_jag_conduit : public generic_data_reader {
   std::string get_description() const;
 
   /// Return the image simulation output of the i-th sample
-  std::vector<cv::Mat> get_cv_images(const size_t i, conduit::Node& sample);
+  std::vector<cv::Mat> get_cv_images(const size_t i, conduit::Node& sample) const;
 
   /**
    * Return the images of the i-th sample as an 1-D vector of lbann::DataType
    * There is one image per view, each of which is taken at closest to the bang time.
    */
-  std::vector<ch_t> get_images(const size_t i, conduit::Node& sample);
+  std::vector<ch_t> get_images(const size_t i, conduit::Node& sample) const;
 
   /// Return the scalar simulation output data of the i-th sample
-  std::vector<scalar_t> get_scalars(const size_t i, conduit::Node& sample);
+  std::vector<scalar_t> get_scalars(const size_t i, conduit::Node& sample) const;
 
   /// Return the simulation input parameters of the i-th sample
-  std::vector<input_t> get_inputs(const size_t i, conduit::Node& sample);
+  std::vector<input_t> get_inputs(const size_t i, conduit::Node& sample) const;
 
   template<typename S>
   static size_t add_val(const std::string key, const conduit::Node& n, std::vector<S>& vals);
@@ -247,7 +247,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   static std::string to_string(const variable_t t);
 
   /// print the schema of the specific sample identified by a given id
-  void print_schema(const size_t i);
+  void print_schema(const size_t i) const;
 
   void clear_image_normalization_params();
   void clear_scalar_normalization_params();
@@ -353,13 +353,13 @@ class data_reader_jag_conduit : public generic_data_reader {
   /** Load the conduit node with the data of the sample i identified by key
    *  from the file that contains the sample.
    */
-  bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node);
+  bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node) const;
   /// Check if a key exist for sample i
   bool has_conduit_path(const size_t i, const std::string& key) const;
   void close_conduit_node(const size_t i);
 
   /// Obtain image data
-  std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample);
+  std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample) const;
 
   bool data_store_active() const {
     bool flag = generic_data_reader::data_store_active();

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -216,19 +216,19 @@ class data_reader_jag_conduit : public generic_data_reader {
   std::string get_description() const;
 
   /// Return the image simulation output of the i-th sample
-  std::vector<cv::Mat> get_cv_images(const size_t i, conduit::Node& sample) const;
+  std::vector<cv::Mat> get_cv_images(const size_t i, conduit::Node& sample);
 
   /**
    * Return the images of the i-th sample as an 1-D vector of lbann::DataType
    * There is one image per view, each of which is taken at closest to the bang time.
    */
-  std::vector<ch_t> get_images(const size_t i, conduit::Node& sample) const;
+  std::vector<ch_t> get_images(const size_t i, conduit::Node& sample);
 
   /// Return the scalar simulation output data of the i-th sample
-  std::vector<scalar_t> get_scalars(const size_t i, conduit::Node& sample) const;
+  std::vector<scalar_t> get_scalars(const size_t i, conduit::Node& sample);
 
   /// Return the simulation input parameters of the i-th sample
-  std::vector<input_t> get_inputs(const size_t i, conduit::Node& sample) const;
+  std::vector<input_t> get_inputs(const size_t i, conduit::Node& sample);
 
   template<typename S>
   static size_t add_val(const std::string key, const conduit::Node& n, std::vector<S>& vals);
@@ -247,7 +247,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   static std::string to_string(const variable_t t);
 
   /// print the schema of the specific sample identified by a given id
-  void print_schema(const size_t i) const;
+  void print_schema(const size_t i);
 
   void clear_image_normalization_params();
   void clear_scalar_normalization_params();
@@ -353,12 +353,13 @@ class data_reader_jag_conduit : public generic_data_reader {
   /** Load the conduit node with the data of the sample i identified by key
    *  from the file that contains the sample.
    */
-  bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node) const;
+  bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node);
   /// Check if a key exist for sample i
   bool has_conduit_path(const size_t i, const std::string& key) const;
+  void close_conduit_node(const size_t i);
 
   /// Obtain image data
-  std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample) const;
+  std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample);
 
   bool data_store_active() const {
     bool flag = generic_data_reader::data_store_active();

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -356,7 +356,6 @@ class data_reader_jag_conduit : public generic_data_reader {
   bool load_conduit_node(const size_t i, const std::string& key, conduit::Node& node) const;
   /// Check if a key exist for sample i
   bool has_conduit_path(const size_t i, const std::string& key) const;
-  //  void close_conduit_node(const size_t i);
 
   /// Obtain image data
   std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample) const;

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -47,26 +47,6 @@ struct sample_list_header {
   }
 };
 
-/**
- * Maps a global index of a sample list to a local index.
- * When managing the sample list in a distributed fashion, with which every
- * one has the same copy (the whole global list), m_partition_offset must be
- * zero. In this case, the local index is the same as the global index.
- * When managing the sample list in a centralized fashion, with which each
- * has a portion of the list that corresponds to the only samples it needs,
- * a global index is subtracted by m_partition_offset for local indexing.
- */
-struct sample_list_indexer {
-  sample_list_indexer();
-  size_t operator()(size_t idx) const;
-
-  void set_partition_offset(size_t o);
-  size_t get_partition_offset() const;
-  bool check_index(size_t i) const;
-
-  size_t m_partition_offset;
-};
-
 static const std::string conduit_hdf5_exclusion_list = "CONDUIT_HDF5_EXCLUSION";
 static const std::string conduit_hdf5_inclusion_list = "CONDUIT_HDF5_INCLUSION";
 
@@ -95,12 +75,6 @@ class sample_list_jag {
 
   /// Set the number of partitions and clear internal states
   void set_num_partitions(size_t n);
-
-  /// Set the index mapping function
-  void set_indexer(const sample_list_indexer& indexer);
-
-  /// Get the index mapping function
-  const sample_list_indexer& get_indexer() const;
 
   /// Load a sample list file
   void load(const std::string& samplelist_file, size_t stride=1, size_t offset=0);
@@ -409,9 +383,6 @@ class sample_list_jag {
 
   /// Maps sample's file id to file names, file descriptors, and use counts
   file_id_stats_v_t m_file_id_stats_map;
-
-  /// Maps a global index to a local index
-  sample_list_indexer m_indexer;
 
   /// Track the number of samples per file
   std::unordered_map<std::string, size_t> m_file_map;

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -146,66 +146,27 @@ class sample_list_jag {
     /// When we enter this function the priority queue is either empty or a heap
     if(!m_open_fd_pq.empty()) {
       if(m_open_fd_pq.size() > m_max_open_files) {
-        // std::cout << "PQ is too big the queue looks like ";
-        // for(auto&& p: m_open_fd_pq) {
-        //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-        // }
-        // std::cout << std::endl;
-        // std::cout << "The file descriptors are over the limit, lets close " << m_open_fd_pq.front().first << std::endl;
-        // {
         auto& f = m_open_fd_pq.front();
         auto& victim = m_file_id_stats_map[f.first];
         hid_t victim_fd = std::get<1>(victim);
-        // std::cout << "Removing [" << f.first << ", {" << f.second.first << ", " << f.second.second << "}]" << std::endl;
         std::pop_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
         m_open_fd_pq.pop_back();
         if(victim_fd > 0) {
           conduit::relay::io::hdf5_close_file(victim_fd);
           std::get<1>(victim) = 0;
-        // }else {
-        //   std::cout << "Closing id " << id << " {" << f.second.first << ", " << f.second.second << "}" << " but the hid = " << victim_fd << std::endl;
         }
-        // std::cout << '\n';
-        // std::cout << "Now the queue looks like ";
-        // for(auto&& p: m_open_fd_pq) {
-        //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-        // }
-        // std::cout << std::endl;
       }
-
-      //      std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
     }
 
     /// Before we can enqueue the any new access times for this descriptor, remove any
     /// earlier descriptor
     std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
     if(m_open_fd_pq.front().first == id) {
-      //          LBANN_ERROR("We have weirdness here, the head of the queue is not " + std::to_string(id));
       m_open_fd_pq.pop_front();
     }
     std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
 
-    // std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-    // if(!m_open_fd_pq.empty() && m_open_fd_pq.front().first != id) {
-    //   LBANN_WARNING("We have weirdness here, the head of the queue is not " + std::to_string(id));
-    // }
-
     auto& e = m_file_id_stats_map[id];
-
-    // std::cout << "manage_open_files_hdf5_handle updated list {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
-    // for (auto&& v : std::get<2>(e)) {
-    //   std::cout << "{" << v.first << "," << v.second << "}, ";
-    // }
-    // std::cout << std::endl;
-
-    //        std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-    // if(!m_open_fd_pq.empty()) {
-      // std::cout << "manage_open_files_hdf5_handle priority queue :";
-      // auto& p = m_open_fd_pq.front();
-      // std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-      // std::cout << std::endl;
-    // }
-
     auto& file_access_queue = std::get<2>(e);
     if(!file_access_queue.empty()) {
       if(!pre_open_fd) {
@@ -220,14 +181,6 @@ class sample_list_jag {
       m_open_fd_pq.emplace_back(std::make_pair(id,std::make_pair(INT_MAX,id)));
     }
     std::push_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-    // if(!m_open_fd_pq.empty()) {
-      // std::cout << "manage_open_files_hdf5_handle new priority queue after inserting eleement :";
-      // //            auto& p = m_open_fd_pq.front();
-      // for(auto&& p: m_open_fd_pq) {
-      //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-      // }
-      // std::cout << std::endl;
-    // }
     return;
   }
 
@@ -324,13 +277,7 @@ class sample_list_jag {
   /// Track the number of samples per file
   std::unordered_map<std::string, size_t> m_file_map;
 
-  /// Track the number of open file descriptors and how many times
-  /// each file descriptor will be used
-  //  std::unordered_map<std::string, hid_t> m_open_fd_map;
-  //  std::set<fd_use_map, std::function<bool(fd_use_map_t, fd_use_map_t)>> m_open_fd_map;
-   // Using lambda to compare elements.
-  //  auto cmp = [](std::pair<string, int> left,std::pair<string, int> right) { return (left.second) > (right.second);};
-  //  std::priority_queue<fd_use_map_t, std::vector<fd_use_map_t>, std::function<bool(fd_use_map_t, fd_use_map_t)>> m_open_fd_pq;
+  /// Track the number of open file descriptors and when they will be used next
   std::deque<fd_use_map_t> m_open_fd_pq;
 
   size_t m_max_open_files;

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -21,7 +21,7 @@
 #include <cereal/types/utility.hpp>
 #include "conduit/conduit_relay_io_hdf5.hpp"
 
-#define LBANN_MAX_OPEN_DATA_FILES 16
+#define LBANN_MAX_OPEN_DATA_FILES 768
 
 namespace lbann {
 
@@ -169,55 +169,6 @@ class sample_list_jag {
   }
 
   void set_samples_hdf5_handle(sample_id_t id, hid_t h) {
-#if 0
-    int bucket_count = m_open_fd_map.bucket_count();
-    int bucket = m_open_fd_map.bucket(filename);
-    if(!allow_collisions && m_open_fd_map.bucket_size(bucket) > 0) {
-      if(m_open_fd_map.bucket_size(bucket) != 1) {
-        LBANN_ERROR(std::string{} + " :: unexpected number of open file descriptors for bucket "
-                    + std::to_string(bucket));
-      }
-      auto local_it = m_open_fd_map.begin(bucket);
-      if(local_it == m_open_fd_map.end(bucket)) {
-        LBANN_ERROR(std::string{} + " :: bucket '" + std::to_string(bucket)
-                    + "' has an empty iterator");
-      }
-      const std::string& old_filename = local_it->first;
-      hid_t old_h = local_it->second;
-      if (old_h <= static_cast<hid_t>(0)) {
-        LBANN_ERROR(std::string{} + " :: data file '" + old_filename
-                    + "' has a corrupt file descriptor = " + std::to_string(old_h));
-      }
-
-      conduit::relay::io::hdf5_close_file(old_h);
-      int num_erased = m_open_fd_map.erase(old_filename);
-      if(num_erased != 1) {
-        LBANN_ERROR(std::string{} + " :: erasing file descriptor for '" + old_filename
-                    + "' that had a file descriptor = " + std::to_string(old_h));
-      }
-    }
-
-
-    auto result = m_open_fd_map.emplace(filename, h);
-    m_open_fd_pq.emplace(std::make_pair(filename,access_count));
-
-    int bucket2 = m_open_fd_map.bucket(filename);
-    int bucket_count2 = m_open_fd_map.bucket_count();
-    if(!result.second) {
-      LBANN_WARNING(std::string{} + " :: The key for " + filename + " already existed");
-    }
-    if(bucket2 != bucket) {
-        LBANN_ERROR(std::string{} + " :: the buckets don't match original bucket "
-                    + std::to_string(bucket) + " with a count of " + std::to_string(bucket_count) + " and new bucket " + std::to_string(bucket2) + " and a new count of " + std::to_string(bucket_count2));
-    }
-    if(m_open_fd_map.bucket_size(bucket) != 1) {
-        LBANN_WARNING(std::string{} + " :: there should be one entry with an open file descriptors for bucket "
-                      + std::to_string(bucket) + " not "
-                      + std::to_string(m_open_fd_map.bucket_size(bucket)) + " entries");
-    }
-#endif
-
-    //    for (auto&& e : m_sample_id_map) {
     auto&& e = m_sample_id_map[id];
     std::get<1>(e) = h;
     // std::cout << "Attempt to set the hdf5 handle " << h << " for filename " << std::get<0>(e) << std::endl;

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -21,7 +21,9 @@
 #include <cereal/types/utility.hpp>
 #include "conduit/conduit_relay_io_hdf5.hpp"
 
-#define LBANN_MAX_OPEN_DATA_FILES 768
+/// Number of system and other files that may be open during execution
+#define LBANN_MAX_OPEN_FILE_MARGIN 128
+#define LBANN_MAX_OPEN_FILE_RETRY 3
 
 namespace lbann {
 
@@ -128,35 +130,22 @@ class sample_list_jag {
     std::get<0>(m_file_id_stats_map[id]) = filename;
   }
 
-  void set_samples_hdf5_handle(sample_file_id_t id, hid_t h) {
-    auto&& e = m_file_id_stats_map[id];
-    std::get<1>(e) = h;
-    // std::cout << "Attempt to set the hdf5 handle " << h << " for filename " << std::get<0>(e) << std::endl;
-
-    // std::cout << "set_files_hdf5_handle existing list for " << id << " {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
-    // for (auto&& v : std::get<2>(e)) {
-    //   std::cout << "{" << v.first << "," << v.second << "}, ";
-    // }
-    // std::cout << std::endl;
-
-    // if(!m_open_fd_pq.empty()) {
-    //   // std::cout << "set_files_hdf5_handle Priotirty QUeue ";
-    //   std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-    //   // auto& q = m_open_fd_pq.front();
-    //   // std::cout << q.first << " {" << q.second.first << "," << q.second.second << "}, ";
-    //   // std::cout << std::endl;
-    // }
-
-    if(!m_open_fd_pq.empty()) {
-      /// Before we can enqueue the any new access times for this descriptor, remove any
-      /// earlier descriptor
-      std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-      if(m_open_fd_pq.front().first == id) {
-        //LBANN_ERROR("We have weirdness here, the head of the queue is not " + std::to_string(id));
-        m_open_fd_pq.pop_front();
+  void set_files_hdf5_handle(const std::string& filename, hid_t h) {
+    sample_file_id_t id = 0;
+    for (auto&& e : m_file_id_stats_map) {
+      if(std::get<0>(e) == filename) {
+        std::get<1>(e) = h;
+        break;
       }
+      id++;
+    }
+    manage_open_hdf5_handles(id, true);
+  }
 
-      if(m_open_fd_pq.size() > LBANN_MAX_OPEN_DATA_FILES) {
+  void manage_open_hdf5_handles(sample_file_id_t id, bool pre_open_fd = false) {
+    /// When we enter this function the priority queue is either empty or a heap
+    if(!m_open_fd_pq.empty()) {
+      if(m_open_fd_pq.size() > m_max_open_files) {
         // std::cout << "PQ is too big the queue looks like ";
         // for(auto&& p: m_open_fd_pq) {
         //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
@@ -166,12 +155,16 @@ class sample_list_jag {
         // {
         auto& f = m_open_fd_pq.front();
         auto& victim = m_file_id_stats_map[f.first];
-        // std::cout << "{" << f.second.first << ", " << f.second.second << "}" << std::endl;
-        //   //        std::cout << q.top() << " ";
-        // }
-        m_open_fd_pq.pop_front();
-        conduit::relay::io::hdf5_close_file(std::get<1>(victim));
-        std::get<1>(victim) = 0;
+        hid_t victim_fd = std::get<1>(victim);
+        // std::cout << "Removing [" << f.first << ", {" << f.second.first << ", " << f.second.second << "}]" << std::endl;
+        std::pop_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+        m_open_fd_pq.pop_back();
+        if(victim_fd > 0) {
+          conduit::relay::io::hdf5_close_file(victim_fd);
+          std::get<1>(victim) = 0;
+        // }else {
+        //   std::cout << "Closing id " << id << " {" << f.second.first << ", " << f.second.second << "}" << " but the hid = " << victim_fd << std::endl;
+        }
         // std::cout << '\n';
         // std::cout << "Now the queue looks like ";
         // for(auto&& p: m_open_fd_pq) {
@@ -180,61 +173,65 @@ class sample_list_jag {
         // std::cout << std::endl;
       }
 
-      std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+      //      std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
     }
+
+    /// Before we can enqueue the any new access times for this descriptor, remove any
+    /// earlier descriptor
+    std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+    if(m_open_fd_pq.front().first == id) {
+      //          LBANN_ERROR("We have weirdness here, the head of the queue is not " + std::to_string(id));
+      m_open_fd_pq.pop_front();
+    }
+    std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+
+    // std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+    // if(!m_open_fd_pq.empty() && m_open_fd_pq.front().first != id) {
+    //   LBANN_WARNING("We have weirdness here, the head of the queue is not " + std::to_string(id));
+    // }
+
+    auto& e = m_file_id_stats_map[id];
+
+    // std::cout << "manage_open_files_hdf5_handle updated list {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
+    // for (auto&& v : std::get<2>(e)) {
+    //   std::cout << "{" << v.first << "," << v.second << "}, ";
+    // }
+    // std::cout << std::endl;
+
+    //        std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+    // if(!m_open_fd_pq.empty()) {
+      // std::cout << "manage_open_files_hdf5_handle priority queue :";
+      // auto& p = m_open_fd_pq.front();
+      // std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
+      // std::cout << std::endl;
+    // }
 
     auto& file_access_queue = std::get<2>(e);
     if(!file_access_queue.empty()) {
-      file_access_queue.pop_front();
-      if(!file_access_queue.empty()) {
-        m_open_fd_pq.emplace_back(std::make_pair(id,file_access_queue.front()));
-        std::push_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-        // std::cout << "set_files_hdf5_handle New priotirty queue top ";
-        //        auto& q = m_open_fd_pq.front();
-        // for(auto&& q: m_open_fd_pq) {
-        //   std::cout << q.first << " {" << q.second.first << "," << q.second.second << "}, ";
-        // }
-        // std::cout << std::endl;
+      if(!pre_open_fd) {
+        file_access_queue.pop_front();
       }
-      // std::cout << "set_files_hdf5_handle updated list for " << id << " {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
-      // for (auto&& v : std::get<2>(e)) {
-      //   std::cout << "{" << v.first << "," << v.second << "}, ";
+    }
+    if(!file_access_queue.empty()) {
+      m_open_fd_pq.emplace_back(std::make_pair(id,file_access_queue.front()));
+    }else {
+      /// If there are no future access of the file place a terminator entry to track
+      /// the open file, but is always sorted to the top of the heap
+      m_open_fd_pq.emplace_back(std::make_pair(id,std::make_pair(INT_MAX,id)));
+    }
+    std::push_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
+    // if(!m_open_fd_pq.empty()) {
+      // std::cout << "manage_open_files_hdf5_handle new priority queue after inserting eleement :";
+      // //            auto& p = m_open_fd_pq.front();
+      // for(auto&& p: m_open_fd_pq) {
+      //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
       // }
       // std::cout << std::endl;
-    }
-
-    //        std::get<1>(m_file_id_stats_map[id]) = h;
-    //        std::cout << "I am setting the hdf5 handle " << h << " for filename " << filename << std::endl;
-
-    //    m_open_fd_map.emplace(std::make_tuple(filename, h, access_count));
-    // for (auto&& e : m_file_id_stats_map) {
-    //   std::cout << "set_files_hdf5_handle {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
-    //   if(std::get<2>(e).empty()) {
-    //     std::cout << "empty" << std::endl;
-    //   }else {
-    //     for (auto&& v : std::get<2>(e)) {
-    //       std::cout << "{" << v.first << "," << v.second << "}, ";
-    //     }
-    //     std::cout << std::endl;
-    //   }
     // }
-    // for (auto&& e : m_file_id_stats_map)
-    //   std::cout << "{" << std::get<0)>(e) << ", " << std::get<1>(e) << ", " << std::get<2>(e) << "}" << std::endl;
-
+    return;
   }
 
-  void set_files_hdf5_handle(const std::string& filename, hid_t h) {
-    sample_file_id_t id = 0;
-    for (auto&& e : m_file_id_stats_map) {
-      if(std::get<0>(e) == filename) {
-        break;
-      }
-      id++;
-    }
-    set_samples_hdf5_handle(id, h);
-  }
-
-  hid_t open_samples_hdf5_handle(const size_t i) {
+  hid_t open_samples_hdf5_handle(const size_t i, bool pre_open_fd = false) {
     const sample_t& s = m_sample_list[i];
     sample_file_id_t id = s.first;
     hid_t h = get_samples_hdf5_handle(id);
@@ -244,63 +241,25 @@ class sample_list_jag {
       if (file_name.empty() || !check_if_file_exists(conduit_file_path)) {
         LBANN_ERROR(std::string{} + " :: data file '" + conduit_file_path + "' does not exist.");
       }
-      h = conduit::relay::io::hdf5_open_file_for_read( conduit_file_path );
+      bool retry = false;
+      int retry_cnt = 0;
+      do {
+        try {
+          h = conduit::relay::io::hdf5_open_file_for_read( conduit_file_path );
+        }catch (conduit::Error const& e) {
+          LBANN_WARNING(" :: trying to open the file " + conduit_file_path + " and got " + e.what());
+          retry = true;
+          retry_cnt++;
+        }
+      }while(retry && retry_cnt < 3);
+
       if (h <= static_cast<hid_t>(0)) {
         LBANN_ERROR(std::string{} + " :: data file '" + conduit_file_path + "' could not be opened.");
       }
-      set_samples_hdf5_handle(id, h);
-    }else {
-
-      if(!m_open_fd_pq.empty()) {
-        /// Before we can enqueue the any new access times for this descriptor, remove any
-        /// earlier descriptor
-        std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-        if(m_open_fd_pq.front().first == id) {
-          //          LBANN_ERROR("We have weirdness here, the head of the queue is not " + std::to_string(id));
-          m_open_fd_pq.pop_front();
-        }
-        std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-      }
-
-      // std::sort_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-      // if(!m_open_fd_pq.empty() && m_open_fd_pq.front().first != id) {
-      //   LBANN_WARNING("We have weirdness here, the head of the queue is not " + std::to_string(id));
-      // }
-
       auto& e = m_file_id_stats_map[id];
-
-      // std::cout << "open_files_hdf5_handle updated list {" << std::get<0>(e) << ", " << std::get<1>(e) << ": ";
-      // for (auto&& v : std::get<2>(e)) {
-      //   std::cout << "{" << v.first << "," << v.second << "}, ";
-      // }
-      // std::cout << std::endl;
-
-      //        std::make_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-      // if(!m_open_fd_pq.empty()) {
-      //   // std::cout << "open_files_hdf5_handle priority queue :";
-      //   auto& p = m_open_fd_pq.front();
-      //   std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-      //   std::cout << std::endl;
-      // }
-
-      auto& file_access_queue = std::get<2>(e);
-      if(!file_access_queue.empty()) {
-        file_access_queue.pop_front();
-        if(!file_access_queue.empty()) {
-          m_open_fd_pq.emplace_back(std::make_pair(id,file_access_queue.front()));
-          std::push_heap(m_open_fd_pq.begin(), m_open_fd_pq.end(), pq_cmp);
-          // if(!m_open_fd_pq.empty()) {
-          //   std::cout << "open_files_hdf5_handle new priority queue :";
-          //   //            auto& p = m_open_fd_pq.front();
-          //   for(auto&& p: m_open_fd_pq) {
-          //     std::cout << "[" << p.first << ", " << "{" << p.second.first << "," << p.second.second << "}], ";
-          //   }
-          //   std::cout << std::endl;
-          // }
-        }
-      }
+      std::get<1>(e) = h;
     }
-
+    manage_open_hdf5_handles(id, pre_open_fd);
     return h;
   }
 
@@ -312,8 +271,8 @@ class sample_list_jag {
       auto& e = m_file_id_stats_map[id];
       auto& file_access_queue = std::get<2>(e);
       if(file_access_queue.empty()) {
-      conduit::relay::io::hdf5_close_file(std::get<1>(e));
-      std::get<1>(e) = 0;
+        conduit::relay::io::hdf5_close_file(std::get<1>(e));
+        std::get<1>(e) = 0;
       }
     }
   }
@@ -374,6 +333,7 @@ class sample_list_jag {
   //  std::priority_queue<fd_use_map_t, std::vector<fd_use_map_t>, std::function<bool(fd_use_map_t, fd_use_map_t)>> m_open_fd_pq;
   std::deque<fd_use_map_t> m_open_fd_pq;
 
+  size_t m_max_open_files;
 };
 
 void handle_mpi_error(int ierr);

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -73,9 +73,6 @@ class sample_list_jag {
   sample_list_jag();
   ~sample_list_jag();
 
-  /// Set the number of partitions and clear internal states
-  void set_num_partitions(size_t n);
-
   /// Load a sample list file
   void load(const std::string& samplelist_file, size_t stride=1, size_t offset=0);
 
@@ -99,26 +96,14 @@ class sample_list_jag {
   /// Check if a sample index is in the valid range
   bool check_index(size_t idx) const;
 
-  /// Serialize sample list for a partition
-  bool to_string(size_t p, std::string& sstr) const;
-
-  /// Serialize sample list for all partitions
+  /// Serialize sample list
   bool to_string(std::string& sstr) const;
 
-  /// Write the sample list of partition p
-  void write(size_t p, const std::string filename) const;
-
-  /// Write the sample list of each partitions
+  /// Write the sample list
   void write(const std::string filename) const;
 
   /// Allow read-only access to the internal list data
   const samples_t& get_list() const;
-
-  /// Copy the internal list data for partition p
-  bool get_list(size_t p, samples_t& l_p) const;
-
-  /// Allow read-only access to the internal list data for partition p via iterators
-  std::pair<samples_t::const_iterator, samples_t::const_iterator> get_list(size_t p) const;
 
   /// Allow the read-only access to the list header
   const sample_list_header& get_header() const;
@@ -359,9 +344,6 @@ class sample_list_jag {
   /// Reads a sample list and populates the internal list
   size_t get_samples_per_file(std::istream& istrm, const std::string& filename, size_t stride=1, size_t offset=0);
 
-  /// Compute the sample index range that partition p covers
-  void get_sample_range_per_part(const size_t p, size_t& sid_start, size_t& sid_end) const;
-
   /// Add the header info to the given string
   void write_header(std::string& sstr, size_t num_files) const;
 
@@ -371,10 +353,6 @@ class sample_list_jag {
             ((left.second).second < (right.second).second)); }
 
  private:
-
-  /// The number of partitions to divide samples into
-  size_t m_num_partitions;
-
   /// header info of sample list
   sample_list_header m_header;
 

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -19,6 +19,7 @@
 
 #include <cereal/archives/binary.hpp>
 #include <sstream>
+#include <unistd.h>
 
 namespace lbann {
 
@@ -46,7 +47,9 @@ inline const std::string& sample_list_header::get_file_dir() const {
   return m_file_dir;
 }
 
-inline sample_list_jag::sample_list_jag() {}
+inline sample_list_jag::sample_list_jag() {
+  m_max_open_files = getdtablesize() - LBANN_MAX_OPEN_FILE_MARGIN;
+}
 
 inline sample_list_jag::~sample_list_jag() {
   // Close the existing open files
@@ -146,7 +149,18 @@ inline sample_list_header sample_list_jag::read_header(std::istream& istrm, cons
 }
 
 inline hid_t sample_list_jag::get_conduit_bundle_samples(std::string conduit_file_path, std::vector<std::string>& sample_names, size_t included_samples, size_t excluded_samples) {
-  hid_t hdf5_file_hnd = conduit::relay::io::hdf5_open_file_for_read( conduit_file_path );
+  hid_t hdf5_file_hnd = 0;
+  bool retry = false;
+  int retry_cnt = 0;
+  do {
+    try {
+      hdf5_file_hnd = conduit::relay::io::hdf5_open_file_for_read( conduit_file_path );
+    }catch (conduit::Error const& e) {
+      LBANN_WARNING(" :: trying to open the file " + conduit_file_path + " and got " + e.what());
+      retry = true;
+      retry_cnt++;
+    }
+  }while(retry && retry_cnt < LBANN_MAX_OPEN_FILE_RETRY);
 
   if (hdf5_file_hnd <= static_cast<hid_t>(0)) {
     std::cout << "Opening the file didn't work" << std::endl;
@@ -451,8 +465,10 @@ inline void sample_list_jag::all_gather_packed_lists(lbann_comm& comm) {
 
   // Close the existing open files
   for(auto&& e : m_file_id_stats_map) {
-    conduit::relay::io::hdf5_close_file(std::get<1>(e));
-    std::get<1>(e) = 0;
+    if(std::get<1>(e) > 0) {
+      conduit::relay::io::hdf5_close_file(std::get<1>(e));
+      std::get<1>(e) = 0;
+    }
     std::get<2>(e).clear();
   }
   m_open_fd_pq.clear();
@@ -500,7 +516,10 @@ inline void sample_list_jag::all_gather_packed_lists(lbann_comm& comm) {
 
 inline void sample_list_jag::compute_epochs_file_usage(const std::vector<int>& shuffled_indices, int mini_batch_size, const lbann_comm& comm) {
   for (auto&& e : m_file_id_stats_map) {
-    std::get<1>(e) = 0;
+    if(std::get<1>(e) > 0) {
+      conduit::relay::io::hdf5_close_file(std::get<1>(e));
+      std::get<1>(e) = 0;
+    }
     std::get<2>(e).clear();
   }
 
@@ -515,6 +534,10 @@ inline void sample_list_jag::compute_epochs_file_usage(const std::vector<int>& s
       int substep = (i % mini_batch_size) / comm.get_procs_per_trainer();
       std::get<2>(m_file_id_stats_map[index]).emplace_back(std::make_pair(step, substep));
     }
+    // hid_t hdf5_file_hnd = get_samples_hdf5_handle(index);
+    // if(hdf5_file_hnd <= static_cast<hid_t>(0)) {
+    //   open_samples_hdf5_handle(idx, true);
+    // }
   }
 }
 

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -46,34 +46,6 @@ inline const std::string& sample_list_header::get_file_dir() const {
   return m_file_dir;
 }
 
-
-inline sample_list_indexer::sample_list_indexer()
-: m_partition_offset(0u) {
-}
-
-inline bool sample_list_indexer::check_index(size_t i) const {
-  return (i >= m_partition_offset);
-}
-
-inline size_t sample_list_indexer::operator()(size_t i) const {
-  if (!check_index(i)) {
-    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
-                          + " :: index (" + std::to_string(i)
-                          + ") is less than the partition offset ("
-                          + std::to_string(m_partition_offset) + ")");
-  }
-  return i - m_partition_offset;
-}
-
-inline void sample_list_indexer::set_partition_offset(size_t o) {
-  m_partition_offset = o;
-}
-
-inline size_t sample_list_indexer::get_partition_offset() const {
-  return m_partition_offset;
-}
-
-
 inline sample_list_jag::sample_list_jag()
   : m_num_partitions(1u) {}
 
@@ -99,49 +71,29 @@ inline void sample_list_jag::set_num_partitions(size_t n) {
   m_num_partitions = n;
 }
 
-inline void sample_list_jag::set_indexer(const sample_list_indexer& indexer) {
-  m_indexer = indexer;
-}
-
-inline const sample_list_indexer& sample_list_jag::get_indexer() const {
-  return m_indexer;
-}
-
-
 inline void sample_list_jag::load(const std::string& samplelist_file, size_t stride, size_t offset) {
   std::ifstream istr(samplelist_file);
   get_samples_per_file(istr, samplelist_file, stride, offset);
   istr.close();
 }
 
-
 inline sample_list_header sample_list_jag::load_header(const std::string& samplelist_file) const {
   std::ifstream istr(samplelist_file);
   return read_header(istr, samplelist_file);
 }
-
 
 inline void sample_list_jag::load_from_string(const std::string& samplelist) {
   std::istringstream istr(samplelist);
   get_samples_per_file(istr, "<LOAD_FROM_STRING>", 1, 0);
 }
 
-
 inline size_t sample_list_jag::size() const {
   return m_sample_list.size();
 }
 
-
 inline bool sample_list_jag::empty() const {
   return m_sample_list.empty();
 }
-
-
-inline bool sample_list_jag::check_index(size_t idx) const {
-  return m_indexer.check_index(idx) &&
-         (m_indexer(idx) < m_sample_list.size());
-}
-
 
 inline std::string sample_list_jag::read_header_line(std::istream& istrm, const std::string& filename, const std::string& info) const {
   if (!istrm.good()) {
@@ -773,13 +725,7 @@ inline const sample_list_header& sample_list_jag::get_header() const {
 }
 
 inline const sample_list_jag::sample_t& sample_list_jag::operator[](size_t idx) const {
-  size_t i = m_indexer(idx);
-  if (i >= m_sample_list.size()) {
-    throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
-          + " :: index (" + std::to_string(i) + ") out of range [0 "
-          + std::to_string(m_sample_list.size()) + ")");
-  }
-  return m_sample_list[i];
+  return m_sample_list[idx];
 }
 
 } // end of namespace lbann

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -79,10 +79,14 @@ inline sample_list_jag::sample_list_jag()
 
 inline sample_list_jag::~sample_list_jag() {
   // Close the existing open files
-  // for(auto f : m_open_fd_map) {
-  //   conduit::relay::io::hdf5_close_file(f.second);
-  // }
-  // m_open_fd_map.clear();
+  for(auto f : m_sample_id_map) {
+    if(std::get<1>(f) > 0) {
+      conduit::relay::io::hdf5_close_file(std::get<1>(f));
+    }
+    std::get<1>(f) = 0;
+  }
+  m_sample_id_map.clear();
+  m_open_fd_pq.clear();
 }
 
 inline void sample_list_jag::set_num_partitions(size_t n) {

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -127,10 +127,8 @@ inline sample_list_header sample_list_jag::read_header(std::istream& istrm, cons
   size_t found = sample_list_type.find(type_exclusive);
 
   if (found != std::string::npos) {
-    std::cout << "Exclusive (" + sample_list_type + ") sample list" << std::endl;
     hdr.m_is_exclusive = true;
   } else {
-    std::cout << "Inclusive (" + sample_list_type + ") sample list" << std::endl;
     hdr.m_is_exclusive = false;
   }
 
@@ -534,10 +532,6 @@ inline void sample_list_jag::compute_epochs_file_usage(const std::vector<int>& s
       int substep = (i % mini_batch_size) / comm.get_procs_per_trainer();
       std::get<2>(m_file_id_stats_map[index]).emplace_back(std::make_pair(step, substep));
     }
-    // hid_t hdf5_file_hnd = get_samples_hdf5_handle(index);
-    // if(hdf5_file_hnd <= static_cast<hid_t>(0)) {
-    //   open_samples_hdf5_handle(idx, true);
-    // }
   }
 }
 

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -276,6 +276,8 @@ inline void sample_list_jag::read_exclusive_list(std::istream& istrm, size_t str
       continue; // skipping the file
     }
 
+    set_files_hdf5_handle(filename, hdf5_file_hnd);
+
     if(m_file_map.count(filename) > 0) {
       if(sample_names.size() != m_file_map[filename]) {
         LBANN_ERROR(std::string("The same file ")
@@ -308,8 +310,6 @@ inline void sample_list_jag::read_exclusive_list(std::istream& istrm, size_t str
                   + std::string(" samples, but found ")
                   + std::to_string(valid_sample_count));
     }
-
-    conduit::relay::io::hdf5_close_file(hdf5_file_hnd);
   }
 
   if (m_header.get_num_files() != cnt_files) {
@@ -363,6 +363,8 @@ inline void sample_list_jag::read_exclusive_list(std::istream& istrm, size_t str
       continue; // skipping the file
     }
 
+    set_files_hdf5_handle(filename, hdf5_file_hnd);
+
     if(m_file_map.count(filename) > 0) {
       if(sample_names.size() != m_file_map[filename]) {
         LBANN_ERROR(std::string("The same file ")
@@ -398,8 +400,6 @@ inline void sample_list_jag::read_exclusive_list(std::istream& istrm, size_t str
                   + std::string(" samples, but found ")
                   + std::to_string(valid_sample_count));
     }
-
-    conduit::relay::io::hdf5_close_file(hdf5_file_hnd);
   }
 
   if (m_header.get_num_files() != cnt_files) {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -758,8 +758,11 @@ void data_reader_jag_conduit::load() {
 
   /// Check the data that each rank loaded
   if (!m_is_data_loaded) {
-    std::cout << "Checking local data" << std::endl;
     m_is_data_loaded = true;
+
+    /// Open the first sample to make sure that all of the fields are correct
+    size_t data_id = (m_sample_list[0]).first;
+    m_sample_list.open_samples_hdf5_handle(data_id, true);
 
     if (m_scalar_keys.size() == 0u) {
       set_all_scalar_choices(); // use all by default if none is specified
@@ -772,6 +775,8 @@ void data_reader_jag_conduit::load() {
     check_input_keys();
 
     check_image_data();
+
+    m_sample_list.close_if_done_samples_hdf5_handle(data_id);
   }
 
   /// Merge all of the sample lists

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -126,6 +126,7 @@ void data_reader_jag_conduit::shuffle_indices(rng_gen& gen) {
     return;
   }
   generic_data_reader::shuffle_indices(gen);
+  m_sample_list.compute_epochs_file_usage(get_shuffled_indices(), get_mini_batch_size(), *m_comm);
 }
 
 int data_reader_jag_conduit::compute_max_num_parallel_readers() {
@@ -327,16 +328,16 @@ bool data_reader_jag_conduit::load_conduit_node(const size_t i, const std::strin
   return true;
 }
 
-void data_reader_jag_conduit::close_conduit_node(const size_t i) {
-  const sample_t& s = m_sample_list[i];
+// void data_reader_jag_conduit::close_conduit_node(const size_t i) {
+//   const sample_t& s = m_sample_list[i];
 
-  sample_id_t id = s.first;
-  hid_t h = m_sample_list.get_samples_hdf5_handle(id);
-  if (h > static_cast<hid_t>(0)) {
-    conduit::relay::io::hdf5_close_file(h);
-    m_sample_list.set_samples_hdf5_handle(id, 0);
-  }
-}
+//   sample_id_t id = s.first;
+//   hid_t h = m_sample_list.get_samples_hdf5_handle(id);
+//   if (h > static_cast<hid_t>(0)) {
+//     conduit::relay::io::hdf5_close_file(h);
+//     m_sample_list.set_samples_hdf5_handle(id, 0);
+//   }
+// }
 
 bool data_reader_jag_conduit::has_conduit_path(const size_t i, const std::string& key) const {
   const sample_t& s = m_sample_list[i];

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -328,17 +328,6 @@ bool data_reader_jag_conduit::load_conduit_node(const size_t i, const std::strin
   return true;
 }
 
-// void data_reader_jag_conduit::close_conduit_node(const size_t i) {
-//   const sample_t& s = m_sample_list[i];
-
-//   sample_id_t id = s.first;
-//   hid_t h = m_sample_list.get_samples_hdf5_handle(id);
-//   if (h > static_cast<hid_t>(0)) {
-//     conduit::relay::io::hdf5_close_file(h);
-//     m_sample_list.set_samples_hdf5_handle(id, 0);
-//   }
-// }
-
 bool data_reader_jag_conduit::has_conduit_path(const size_t i, const std::string& key) const {
   const sample_t& s = m_sample_list[i];
   sample_id_t id = s.first;
@@ -1411,7 +1400,6 @@ bool data_reader_jag_conduit::fetch_datum(CPUMat& X, int data_id, int mb_idx) {
   }
 
   m_sample_list.close_if_done_samples_hdf5_handle(data_id);
-  //  close_conduit_node(data_id);
   return ok;
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -314,7 +314,7 @@ bool data_reader_jag_conduit::load_conduit_node(const size_t i, const std::strin
   const std::string& sample_name = s.second;
   const std::string path = sample_name + key;
 
-  sample_id_t id = s.first;
+  sample_file_id_t id = s.first;
   hid_t h = m_sample_list.get_samples_hdf5_handle(id);
   if (h <= static_cast<hid_t>(0) || !conduit::relay::io::hdf5_has_path(h, path)) {
     const std::string& file_name = m_sample_list.get_samples_filename(id);
@@ -330,7 +330,7 @@ bool data_reader_jag_conduit::load_conduit_node(const size_t i, const std::strin
 
 bool data_reader_jag_conduit::has_conduit_path(const size_t i, const std::string& key) const {
   const sample_t& s = m_sample_list[i];
-  sample_id_t id = s.first;
+  sample_file_id_t id = s.first;
   const std::string& file_name = m_sample_list.get_samples_filename(id);
   const std::string& sample_name = s.second;
   const hid_t h = m_sample_list.get_samples_hdf5_handle(id);

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -1410,6 +1410,7 @@ bool data_reader_jag_conduit::fetch_datum(CPUMat& X, int data_id, int mb_idx) {
     m_jag_store->set_conduit_node(data_id, node);
   }
 
+  m_sample_list.close_if_done_samples_hdf5_handle(data_id);
   //  close_conduit_node(data_id);
   return ok;
 }

--- a/src/utils/file_utils.cpp
+++ b/src/utils/file_utils.cpp
@@ -147,6 +147,7 @@ std::string modify_file_name(const std::string file_name, const std::string tag,
     name = name + '_' + tag;
   }
 
+  dir = add_delimiter(dir);
   if(!ext.empty()) {
     return (dir + name + '.' + ext);
   }else {


### PR DESCRIPTION
Fixed a bug in in the sample list and JAG Conduit data reader so that
all files do not have to be opened at load time.  Instead, sample
files are dynamically opened and the file descriptors are cached.
Using a fixed sized unordered map to provide constant access time to
the file descriptor cache and random selection criteria for FD closure
on hash collision.