### PR TITLE
Correcting modulo arithmetic to correct for mini-batch size

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -691,7 +691,7 @@ class generic_data_reader : public lbann_image_preprocessor {
   }
 
   /// sets up a data_store.
-  virtual void setup_data_store(model *m);
+  virtual void setup_data_store(model *m, int mini_batch_size);
 
   void set_gan_labelling(bool has_gan_labelling) {
      m_gan_labelling = has_gan_labelling;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -237,7 +237,7 @@ class data_reader_jag_conduit : public generic_data_reader {
 
 #ifndef _JAG_OFFLINE_TOOL_MODE_
   /// sets up a data_store.
-  void setup_data_store(model *m) override;
+  void setup_data_store(model *m, int mini_batch_size) override;
 #endif // _JAG_OFFLINE_TOOL_MODE_
 
   /// A untiliy function to convert the pointer to image data into an opencv image

--- a/include/lbann/data_store/data_store_jag.hpp
+++ b/include/lbann/data_store/data_store_jag.hpp
@@ -57,7 +57,7 @@ class data_store_jag : public generic_data_store {
   //! dtor
   ~data_store_jag() override;
 
-  void setup() override;
+  void setup(int mini_batch_size) override;
 
   /// returns the conduit node
   const conduit::Node & get_conduit_node(int data_id) const;
@@ -125,7 +125,7 @@ protected :
   void build_node_for_sending(const conduit::Node &node_in, conduit::Node &node_out);
 
   /// fills in m_owner, which maps index -> owning processor
-  void build_owner_map();
+  void build_owner_map(int mini_batch_size);
 
   /// maps processor id -> set of indices (whose associated samples)
   /// this proc needs to send. (formerly called "proc_to_indices)

--- a/include/lbann/data_store/generic_data_store.hpp
+++ b/include/lbann/data_store/generic_data_store.hpp
@@ -63,7 +63,7 @@ class generic_data_store {
   virtual generic_data_store * copy() const = 0;
 
   /// called by generic_data_reader::setup_data_store
-  virtual void setup();
+  virtual void setup(int mini_batch_size);
 
   /// called by generic_data_reader::update;
   /// this method calls exchange_data if m_epoch > 1

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -704,7 +704,7 @@ double generic_data_reader::get_use_percent() const {
   return m_use_percent;
 }
 
-void generic_data_reader::setup_data_store(model *m) {
+void generic_data_reader::setup_data_store(model *m, int mini_batch_size) {
   m_data_store = nullptr;
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -1427,13 +1427,13 @@ bool data_reader_jag_conduit::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
   return true;
 }
 
-void data_reader_jag_conduit::setup_data_store(model *m) {
+void data_reader_jag_conduit::setup_data_store(model *m, int mini_batch_size) {
   if (m_data_store != nullptr) {
     delete m_data_store;
   }
   m_jag_store = new data_store_jag(this, m);  // *data_store_jag
   m_data_store = m_jag_store;                 // *generic_data_store
-  m_data_store->setup();
+  m_data_store->setup(mini_batch_size);
 }
 
 void data_reader_jag_conduit::save_image(Mat& pixels, const std::string filename, bool do_scale) {

--- a/src/data_store/generic_data_store.cpp
+++ b/src/data_store/generic_data_store.cpp
@@ -130,7 +130,7 @@ void generic_data_store::get_my_datastore_indices() {
   }
 }
 
-void generic_data_store::setup() {
+void generic_data_store::setup(int mini_batch_size) {
   set_shuffled_indices( &(m_reader->get_shuffled_indices()) );
   set_num_global_indices();
   m_num_readers = m_reader->get_num_parallel_readers();

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -192,7 +192,7 @@ model *build_model_from_prototext(int argc, char **argv,
       }
       for (auto r : data_readers) {
         if (!r.second) continue;
-        r.second->setup_data_store(model);
+        r.second->setup_data_store(model, pb_model->mini_batch_size());
       }
     }
 


### PR DESCRIPTION
Fixed a bug where the mapping of samples to ranks in the data store
did not properly take into account the bracketing by the mini-batch
size.  When computing the original owners it is necessary to have the
original mini-batch size.  To compute the owner index first find its
position inside of the mini-batch (mod mini-batch size) and then find
how it is striped across the ranks in the trainer.  For the exchange
data routines, the sample target or owner is calculated modulo the
active mini-batch size.