### PR TITLE
Bugfixes in layer copy constructors

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -999,13 +999,14 @@ private:
       cudnnDataType_t data_type;
       cudnnTensorFormat_t format;
       int num_dims;
+      std::vector<int> dims(1);
       CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
-                                             0,
+                                             dims.size(),
                                              &data_type,
                                              &format,
                                              &num_dims,
-                                             nullptr));
-      std::vector<int> dims(num_dims);
+                                             dims.data()));
+      dims.resize(num_dims);
       CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
                                              num_dims,
                                              &data_type,

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -532,7 +532,7 @@ private:
                                                 nullptr));
         std::vector<int> dims(num_dims), pads(num_dims), strides(num_dims);
         CHECK_CUDNN(cudnnGetPoolingNdDescriptor(src,
-                                                0,
+                                                num_dims,
                                                 &mode,
                                                 &nan_propagation,
                                                 &num_dims,


### PR DESCRIPTION
I can now call the copy constructor on AlexNet without running into issues.