### PR TITLE
Refactoring model class

### DIFF
--- a/include/lbann/callbacks/callback_save_images.hpp
+++ b/include/lbann/callbacks/callback_save_images.hpp
@@ -55,7 +55,6 @@ public:
     return new lbann_callback_save_images(*this);
   }
   void on_epoch_end(model *m) override;
-  void on_phase_end(model *m) override;
   void on_test_end(model *m) override;
   std::string name() const override { return "save images"; }
 

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -53,6 +53,10 @@ class lbann_callback;
 class model {
 public:
 
+  // ===========================================
+  // Life cycle functions
+  // ===========================================
+
   model(lbann_comm *comm,
         El::Int mini_batch_size,
         objective_function *obj_fn,
@@ -62,50 +66,29 @@ public:
   virtual ~model();
   virtual model* copy() const = 0;
 
-  /** Return model type's name.
-   *
-   *  The model type name should be a brief, human-readable
-   *  description.
+  // ===========================================
+  // Access functions
+  // ===========================================
+
+  /** @brief Model type's name.
+   *  @detailed Should be a brief, human-readable description of the
+   *  model's architecture.
    */
   virtual std::string get_type() const = 0;
 
-  /** Set model instance's name.
-   *
-   *  Each model should have a unique, preferably human-readable,
-   *  name.
+  /** @brief Model instance name.
+   *  @detailed Each model in a trainer should have a unique, and
+   *  preferably human-readable, name.
+   */
+  std::string get_name() const noexcept { return m_name; }
+  /** @brief Model instance name.
+   *  @detailed Each model in a trainer should have a unique, and
+   *  preferably human-readable, name.
    */
   void set_name(std::string name);
 
-  /** Return model instance's name. */
-  std::string get_name() const { return m_name; }
-
   /** Human-readable description. */
   virtual description get_description() const;
-
-  /** Set up the model. */
-  virtual void setup(std::shared_ptr<thread_pool> io_thread_pool);
-
-  /** Add layer to model. */
-  virtual void add_layer(std::unique_ptr<Layer> l);
-
-  /** Add weights to model. */
-  void add_weights(weights *w);
-
-  /** Register a new callback for the model. */
-  void add_callback(lbann_callback *cb);
-
-  /** Get the list of callbacks for the model. */
-  virtual std::vector<lbann_callback*>& get_callbacks() {
-    return m_callbacks;
-  }
-
-  /** Register a new metric for the model. */
-  void add_metric(metric *m);
-
-  /** Construct an instance of the default optimizer.
-   *  If there is no default optimizer, a null pointer is returned.
-   */
-  optimizer* create_optimizer() const;
 
   /** Return the model's objective function. */
   objective_function* get_objective_function() const {
@@ -113,7 +96,7 @@ public:
   }
 
   /** Return the model's metrics. */
-  virtual const std::vector<metric *>& get_metrics() const {
+  virtual const std::vector<metric*>& get_metrics() const {
     return m_metrics;
   }
 
@@ -136,13 +119,10 @@ public:
 
   std::vector<weights*> get_weights();
 
-  /** Replace the model's weights. */
-  void replace_weights(std::vector<weights *>& w);
-
-  /** Copy trained weights from input parameter w.
- *  Only weight values are placed, pointers and layer structure are in place.
- *  Weights to be copied are of the same name */
-  void copy_trained_weights_from(std::vector<weights *>& w);
+  /** Get the list of callbacks for the model. */
+  virtual std::vector<lbann_callback*>& get_callbacks() {
+    return m_callbacks;
+  }
 
   /** Return the I/O thread pool */
   std::shared_ptr<thread_pool> get_io_thread_pool() { return m_io_thread_pool; }
@@ -152,31 +132,22 @@ public:
     return m_comm;
   }
 
-  /** Get the current epoch for the model. */
-  inline int get_cur_epoch() const {
-    return m_current_epoch;
-  }
-  /** Get the current step for the model. */
-  inline int get_cur_step() const {
-    return m_current_step;  /// @todo This should be renamed to get_cur_training step and replaced with one that returns the current based on execution mode
-  }
+  void set_execution_mode(execution_mode mode);
+  execution_mode get_execution_mode() const noexcept;
 
-  /** Get the current validation step for the model. */
-  inline int get_cur_validation_step() const {
-    return m_current_validation_step;
-  }
-  /** Get the current testing step for the model. */
-  inline int get_cur_testing_step() const {
-    return m_current_testing_step;
-  }
-  /** Set the model (and all layers') execution mode. */
-  inline void set_execution_mode(execution_mode mode) {
-    m_execution_mode = mode;
-  }
-  /** Get the model's execution mode. */
-  inline execution_mode get_execution_mode() const {
-    return m_execution_mode;
-  }
+  /** Number of times the training set has been traversed. */
+  inline El::Int get_epoch() const noexcept { return m_epoch; }
+
+  /** @brief Current mini-batch step for current execution mode.
+   *  @detailed Step counts are not reset after each epoch.
+   */
+  El::Int get_step() const noexcept;
+
+  /** @brief Current mini-batch step for given execution mode.
+   *  @detailed Step counts are not reset after each epoch.
+   */
+  El::Int get_step(execution_mode mode) const noexcept;
+
   /** Set the model's current mini-batch size. */
   inline void set_current_mini_batch_size(int mini_batch_size) {
     m_current_mini_batch_size = mini_batch_size;
@@ -204,6 +175,81 @@ public:
     return m_current_phase;
   }
 
+  /** Return true if the flag to stop training is set. */
+  bool get_terminate_training() const {
+    return m_terminate_training;
+  }
+  /** Set the terminate training flag (on or off). */
+  void set_terminate_training(bool f) {
+    m_terminate_training = f;
+  }
+
+  // ===========================================
+  // Model specification
+  // ===========================================
+
+  /** Add layer to model. */
+  virtual void add_layer(std::unique_ptr<Layer> l);
+
+  /** Add weights to model. */
+  void add_weights(weights *w);
+
+  /** Register a new callback for the model. */
+  void add_callback(lbann_callback *cb);
+
+  /** Register a new metric for the model. */
+  void add_metric(metric *m);
+
+  /** Replace the model's weights. */
+  void replace_weights(std::vector<weights *>& w);
+
+  /** Copy trained weights from input parameter w.
+ *  Only weight values are placed, pointers and layer structure are in place.
+ *  Weights to be copied are of the same name */
+  void copy_trained_weights_from(std::vector<weights *>& w);
+
+  /** Construct an instance of the default optimizer.
+   *  If there is no default optimizer, a null pointer is returned.
+   */
+  optimizer* create_optimizer() const;
+
+  /** Set a flag that can be used to enable / disable the background I/O activities */
+  void allow_background_io_activity(bool enable) { m_background_io_allowed = enable; }
+
+  /** Are background I/O activities enabled by the input layers */
+  bool background_io_activity_allowed() { return m_background_io_allowed; }
+
+  // ===========================================
+  // Setup
+  // ===========================================
+
+  /** @detailed Must be called after model specification and before
+   *  execution. */
+  virtual void setup(std::shared_ptr<thread_pool> io_thread_pool);
+
+  // ===========================================
+  // Execution
+  // ===========================================
+
+  /** Evaluate model. */
+  virtual void evaluate(execution_mode mode, int num_batches=0);
+
+  /** Train model. */
+  virtual void train(int num_epochs, int num_batches=0);
+
+  /** Run one epoch using only the input layer; this supports
+   *  data_store functionality
+   */
+  void collect_indices(execution_mode mode);
+
+  /** Complete any background I/O data fetch for the execution
+      mode requested */
+  virtual void collect_background_data_fetch(execution_mode mode);
+
+  // ===========================================
+  // Summarizer
+  // ===========================================
+
   /**
    * Summarize statistics (e.g. timers, counters); these should be computable
    * quickly.
@@ -215,34 +261,9 @@ public:
    */
   virtual void summarize_matrices(lbann_summary& summarizer);
 
-  /** Return true if the flag to stop training is set. */
-  bool get_terminate_training() const {
-    return m_terminate_training;
-  }
-  /** Set the terminate training flag (on or off). */
-  void set_terminate_training(bool f) {
-    m_terminate_training = f;
-  }
-
-  /** Train model. */
-  virtual void train(int num_epochs, int num_batches=0);
-  /** Evaluate model. */
-  virtual void evaluate(execution_mode mode, int num_batches=0);
-
-  /** Run one epoch using only the input layer; this supports
-   *  data_store functionality
-   */
-  void collect_indices(execution_mode mode);
-
-  /** Complete any background I/O data fetch for the execution
-      mode requested */
-  virtual void collect_background_data_fetch(execution_mode mode);
-
-  /** Set a flag that can be used to enable / disable the background I/O activities */
-  void allow_background_io_activity(bool enable) { m_background_io_allowed = enable; }
-
-  /** Are background I/O activities enabled by the input layers */
-  bool background_io_activity_allowed() { return m_background_io_allowed; }
+  // ===========================================
+  // Checkpointing
+  // ===========================================
 
   /** Checkpoint model to given file descriptor, return number of bytes written */
   virtual bool save_to_checkpoint_shared(persist& p);
@@ -266,63 +287,6 @@ public:
   virtual void write_proto(lbann_data::Model* proto);
 
 protected:
-
-  /** The objective function used to train the model. */
-  objective_function *m_objective_function;
-  /** Give model a name. */
-  std::string m_name;
-  /** The model's current execution mode. */
-  execution_mode m_execution_mode;
-  /** Flag telling the model to terminate training. */
-  bool m_terminate_training;
-  /** Most recent/current epoch for the model. */
-  int m_current_epoch;
-  /** Most recent/current training step for the model. */
-  int m_current_step;
-  int m_current_validation_step;
-  int m_current_testing_step;
-  /** @details Maximum possible minibatch size supported by layers in
-   *  this model.  Note that this is local to the particular model,
-   *  not across multiple models.
-   */
-  int m_max_mini_batch_size;
-  /** Size of the current mini-batch in the model. */
-  int m_current_mini_batch_size;
-  /** The "effective" size of a minibatch.
-   *
-   *  This is the size of the minibatch across all models and used for
-   *  e.g.  correctly averaging gradients from multiple models.
-   */
-  int m_effective_mini_batch_size;
-  /** current phase (multiple of epoch counts) in training a model */
-  int m_current_phase;
-  /** Communicator for the model. */
-  lbann_comm *m_comm;
-  /** Current callbacks to process. */
-  std::vector<lbann_callback *> m_callbacks;
-
-  /** Default optimizer.
-   *
-   *  If a layer needs to construct an optimizer during setup, it will
-   *  make a copy of the default optimizer.
-   */
-  optimizer *m_default_optimizer;
-
-  /** List of model metrics.
-   *
-   *  A metric can be used to evaluate the performance of the model
-   *  without affecting the training process.
-   */
-  std::vector<metric *> m_metrics;
-
-  /** List of weights in model. */
-  std::vector<weights *> m_weights;
-
-  /** Threads available for I/O */
-  std::shared_ptr<thread_pool> m_io_thread_pool;
-
-  /** Flag that allows input layers to fetch data in the background */
-  bool m_background_io_allowed;
 
   /** Check if the model execution mode is valid. */
   virtual bool is_execution_mode_valid(execution_mode mode) const;
@@ -461,6 +425,78 @@ protected:
   virtual void do_weight_optimize_end_cbs(weights *w);
 
 private:
+
+  /** Mathematical function to be minimized during training. */
+  objective_function* m_objective_function;
+
+  /** @brief Model instance's name.
+   *  @detailed Each model in a trainer should have a unique,
+   *  preferably human-readable, name.
+   */
+  std::string m_name;
+
+  /** Current execution mode. */
+  execution_mode m_execution_mode = execution_mode::training;
+
+  /** @brief Whether to terminate training.
+   *  @detailed If set to true, training will terminate immediately
+   *  before the next epoch.
+   */
+  bool m_terminate_training = false;
+
+  /** Current epoch. */
+  El::Int m_epoch = 0;
+  /** @brief Current mini-batch step for each execution mode.
+   *  @detailed Step counts are not reset after each epoch.
+   */
+  std::map<execution_mode, El::Int> m_step;
+
+  /** Most recent/current training step for the model. */
+  int m_current_step;
+  int m_current_validation_step;
+  int m_current_testing_step;
+  /** @details Maximum possible minibatch size supported by layers in
+   *  this model.  Note that this is local to the particular model,
+   *  not across multiple models.
+   */
+  int m_max_mini_batch_size;
+  /** Size of the current mini-batch in the model. */
+  int m_current_mini_batch_size;
+  /** The "effective" size of a minibatch.
+   *
+   *  This is the size of the minibatch across all models and used for
+   *  e.g.  correctly averaging gradients from multiple models.
+   */
+  int m_effective_mini_batch_size;
+  /** current phase (multiple of epoch counts) in training a model */
+  int m_current_phase;
+  /** Communicator for the model. */
+  lbann_comm *m_comm;
+  /** Current callbacks to process. */
+  std::vector<lbann_callback *> m_callbacks;
+
+  /** Default optimizer.
+   *
+   *  If a layer needs to construct an optimizer during setup, it will
+   *  make a copy of the default optimizer.
+   */
+  optimizer *m_default_optimizer;
+
+  /** List of model metrics.
+   *
+   *  A metric can be used to evaluate the performance of the model
+   *  without affecting the training process.
+   */
+  std::vector<metric *> m_metrics;
+
+  /** List of weights in model. */
+  std::vector<weights *> m_weights;
+
+  /** Threads available for I/O */
+  std::shared_ptr<thread_pool> m_io_thread_pool;
+
+  /** Flag that allows input layers to fetch data in the background */
+  bool m_background_io_allowed;
 
   /** @brief List of layers in model.
    *  @details The list is in execution order for forward propagation.

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -90,7 +90,7 @@ public:
   /** Human-readable description. */
   virtual description get_description() const;
 
-  /** Return the model's objective function. */
+  /** Mathematical function to be minimized during training. */
   objective_function* get_objective_function() const {
     return m_objective_function;
   }
@@ -169,11 +169,6 @@ public:
     m_effective_mini_batch_size = mini_batch_size;
   }
   int get_num_iterations_per_epoch(execution_mode mode) const;
-
-  /** Get the current phase (multiple epochs) in layer-wise model training. */
-  inline int get_current_phase() const {
-    return m_current_phase;
-  }
 
   /** Return true if the flag to stop training is set. */
   bool get_terminate_training() const {
@@ -451,10 +446,6 @@ private:
    */
   std::map<execution_mode, El::Int> m_step;
 
-  /** Most recent/current training step for the model. */
-  int m_current_step;
-  int m_current_validation_step;
-  int m_current_testing_step;
   /** @details Maximum possible minibatch size supported by layers in
    *  this model.  Note that this is local to the particular model,
    *  not across multiple models.
@@ -468,8 +459,6 @@ private:
    *  e.g.  correctly averaging gradients from multiple models.
    */
   int m_effective_mini_batch_size;
-  /** current phase (multiple of epoch counts) in training a model */
-  int m_current_phase;
   /** Communicator for the model. */
   lbann_comm *m_comm;
   /** Current callbacks to process. */

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -85,10 +85,6 @@ int main(int argc, char *argv[]) {
     model *model = build_model_from_prototext(argc, argv, pb,
                                               comm, io_thread_pool, true);
 
-    /// @todo Remove
-    auto* model_copy = model->copy();
-    delete model_copy;
-
     if (! (opts->has_bool("exit_after_setup") && opts->get_bool("exit_after_setup"))) {
 
       // Train model

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -85,6 +85,10 @@ int main(int argc, char *argv[]) {
     model *model = build_model_from_prototext(argc, argv, pb,
                                               comm, io_thread_pool, true);
 
+    /// @todo Remove
+    auto* model_copy = model->copy();
+    delete model_copy;
+
     if (! (opts->has_bool("exit_after_setup") && opts->get_bool("exit_after_setup"))) {
 
       // Train model

--- a/src/callbacks/callback_check_dataset.cpp
+++ b/src/callbacks/callback_check_dataset.cpp
@@ -58,16 +58,16 @@ void lbann_callback_check_dataset::add_to_set(model *m, Layer *l, int64_t step, 
 }
 
 void lbann_callback_check_dataset::on_forward_prop_end(model *m, Layer *l) {
-  add_to_set(m, l, m->get_cur_step(), training_set);
+  add_to_set(m, l, m->get_step(), training_set);
 }
 
 void lbann_callback_check_dataset::on_evaluate_forward_prop_end(model *m, Layer *l) {
   switch(m->get_execution_mode()) {
   case execution_mode::validation:
-    add_to_set(m, l, m->get_cur_validation_step(), validation_set);
+    add_to_set(m, l, m->get_step(), validation_set);
     break;
   case execution_mode::testing:
-    add_to_set(m, l, m->get_cur_testing_step(), testing_set);
+    add_to_set(m, l, m->get_step(), testing_set);
     break;
   default:
     throw lbann_exception("lbann_callback_check_dataset: invalid execution phase");

--- a/src/callbacks/callback_check_init.cpp
+++ b/src/callbacks/callback_check_init.cpp
@@ -33,7 +33,7 @@ namespace lbann {
 
 void lbann_callback_check_init::on_train_begin(model *m) {
   // Skip after the first epoch.
-  if (m->get_cur_epoch() != 0) {
+  if (m->get_epoch() != 0) {
     return;
   }
   lbann_comm *comm = m->get_comm();

--- a/src/callbacks/callback_checknan.cpp
+++ b/src/callbacks/callback_checknan.cpp
@@ -80,8 +80,8 @@ void dump_network(model *m) {
     std::stringstream ss;
     ss << "model" << m->get_comm()->get_trainer_rank()
        << "-rank" << m->get_comm()->get_rank_in_trainer()
-       << "-epoch" << m->get_cur_epoch()
-       << "-step" << m->get_cur_step()
+       << "-epoch" << m->get_epoch()
+       << "-step" << m->get_step(execution_mode::training)
        << "-" << l->get_name() << "-";
     const std::string prefix = ss.str();
     for (int i = 0; i < l->get_num_children(); ++i) {
@@ -99,8 +99,8 @@ void dump_network(model *m) {
     std::stringstream ss;
     ss << "model" << m->get_comm()->get_trainer_rank()
        << "-rank" << m->get_comm()->get_rank_in_trainer()
-       << "-epoch" << m->get_cur_epoch()
-       << "-step" << m->get_cur_step()
+       << "-epoch" << m->get_epoch()
+       << "-step" << m->get_step(execution_mode::training)
        << "-" << w->get_name() << "-";
     const std::string prefix = ss.str();
     El::Write(w->get_values().LockedMatrix(),

--- a/src/callbacks/callback_checkpoint.cpp
+++ b/src/callbacks/callback_checkpoint.cpp
@@ -76,7 +76,7 @@ bool lbann_callback_checkpoint::need_checkpoint(model *m) {
   m_checkpoint_shared = false;
   m_checkpoint_dist = false;
   lbann_comm *comm = m->get_comm();
-  int cur_epoch = m->get_cur_epoch();
+  int cur_epoch = m->get_epoch();
   // If we are at the end of a training epoch and the training epoch lands on defined interval, ckpt
   if (!m_checkpoint_shared && m_checkpoint_epochs > 0 && (p.get_cb_type() == callback_type::epoch || p.get_cb_type() == callback_type::validation)){
       m_checkpoint_shared = (cur_epoch > 0) && (cur_epoch % m_checkpoint_epochs == 0);
@@ -88,11 +88,11 @@ bool lbann_callback_checkpoint::need_checkpoint(model *m) {
 
   // If we are at the end of a training mb step and the training mb step lands on defined interval, trigger checkpoint
   if (!m_checkpoint_shared && m_checkpoint_steps > 0) {
-    m_checkpoint_shared = (m->get_cur_step() > 0) && (m->get_cur_step() % m_checkpoint_steps == 0);
+    m_checkpoint_shared = (m->get_step(execution_mode::training) > 0) && (m->get_step(execution_mode::training) % m_checkpoint_steps == 0);
   }
 
   if(!m_checkpoint_dist && m_ckpt_dist_steps > 0){
-      m_checkpoint_dist = (m->get_cur_step() > 0) && (m->get_cur_step() % m_ckpt_dist_steps == 0);
+      m_checkpoint_dist = (m->get_step(execution_mode::training) > 0) && (m->get_step(execution_mode::training) % m_ckpt_dist_steps == 0);
   }
 
   // check the clock if time-based checkpoint is enabled
@@ -135,8 +135,8 @@ bool lbann_callback_checkpoint::checkpoint(model *m) {
   comm->trainer_barrier();
   // let user know we're saving a checkpoint
   if (comm->am_trainer_master()) {
-    epoch = m->get_cur_epoch();
-    step = m->get_cur_step();
+    epoch = m->get_epoch();
+    step = m->get_step(execution_mode::training);
     timer.Start();
     printf("Checkpoint: epoch %d step %d ...\n", epoch, step);
     fflush(stdout);

--- a/src/callbacks/callback_checksmall.cpp
+++ b/src/callbacks/callback_checksmall.cpp
@@ -36,7 +36,7 @@ void lbann_callback_checksmall::on_forward_prop_end(model *m, Layer *l) {
     ss << name() << ": "
        << "[" << std::to_string(m->get_comm()->get_rank_in_world()) << "]: "
        << "error in activations of " << l->get_name() << " "
-       << "(step=" << std::to_string(m->get_cur_step()) << ")";
+       << "(step=" << std::to_string(m->get_step(execution_mode::training)) << ")";
     throw lbann_exception(ss.str());
   }
 }
@@ -49,7 +49,7 @@ void lbann_callback_checksmall::on_backward_prop_end(model *m) {
       ss << name() << ": "
          << "[" << std::to_string(m->get_comm()->get_rank_in_world()) << "]: "
          << "error in weights gradient of " << w->get_name() << " "
-         << "(step=" << std::to_string(m->get_cur_step()) << ")";
+         << "(step=" << std::to_string(m->get_step(execution_mode::training)) << ")";
       throw lbann_exception(ss.str());
     }
   }
@@ -62,7 +62,7 @@ void lbann_callback_checksmall::on_batch_end(model *m) {
       ss << name() << ": "
          << "[" << std::to_string(m->get_comm()->get_rank_in_world()) << "]: "
          << "error in weights of " << w->get_name() << " "
-         << "(step=" << std::to_string(m->get_cur_step()-1) << ")";
+         << "(step=" << std::to_string(m->get_step(execution_mode::training)-1) << ")";
       throw lbann_exception(ss.str());
     }
   }

--- a/src/callbacks/callback_confusion_matrix.cpp
+++ b/src/callbacks/callback_confusion_matrix.cpp
@@ -207,10 +207,10 @@ void lbann_callback_confusion_matrix::save_confusion_matrix(const model& m) {
     std::string mode_string;
     switch (mode) {
     case execution_mode::training:
-      mode_string = "train-epoch" + std::to_string(m.get_cur_epoch());
+      mode_string = "train-epoch" + std::to_string(m.get_epoch());
       break;
     case execution_mode::validation:
-      mode_string = "validation-epoch" + std::to_string(m.get_cur_epoch());
+      mode_string = "validation-epoch" + std::to_string(m.get_epoch());
       break;
     case execution_mode::testing:
       mode_string = "test";

--- a/src/callbacks/callback_debug.cpp
+++ b/src/callbacks/callback_debug.cpp
@@ -62,17 +62,8 @@ std::string weights_string(const weights& w) {
 std::string batch_step_string(const model& m) {
   std::stringstream msg;
   const auto& mode = m.get_execution_mode();
-  msg << _to_string(mode) << " batch";
-  switch (mode) {
-  case execution_mode::training:
-    msg << " " << m.get_cur_step(); break;
-  case execution_mode::validation:
-    msg << " " << m.get_cur_validation_step(); break;
-  case execution_mode::testing:
-    msg << " " << m.get_cur_testing_step(); break;
-  default: break;
-  }
-  msg << " (epoch " << m.get_cur_epoch() << ")";
+  msg << _to_string(mode) << " batch " << m.get_step();
+  msg << " (epoch " << m.get_epoch() << ")";
   return msg.str();
 }
 

--- a/src/callbacks/callback_debug_io.cpp
+++ b/src/callbacks/callback_debug_io.cpp
@@ -52,23 +52,10 @@ void lbann::lbann_callback_debug_io::on_forward_prop_begin(model *m, Layer *l) {
 }
 
 void lbann::lbann_callback_debug_io::print_fp_start(model *m, generic_input_layer *input) {
-  int64_t step;
-  switch(m->get_execution_mode()) {
-  case execution_mode::training:
-    step = m->get_cur_step();
-    break;
-  case execution_mode::validation:
-    step = m->get_cur_validation_step();
-    break;
-  case execution_mode::testing:
-    step = m->get_cur_testing_step();
-    break;
-  default:
-    throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-  }
+  const auto& step = m->get_step();
   std::cout << "[" << m->get_comm()->get_trainer_rank()
             << "." << m->get_comm()->get_rank_in_trainer()
-            << "] @" << m->get_cur_epoch() << "." << step
+            << "] @" << m->get_epoch() << "." << step
             << " Phase: " << _to_string(m->get_execution_mode())
             << " starting forward propagation for layer " << input->get_name()
             << " type: " << input->get_type()
@@ -97,17 +84,7 @@ void lbann::lbann_callback_debug_io::print_phase_start(model *m, execution_mode 
   }
   if (data_reader == nullptr) { return; }
 
-  int64_t step;
-  switch(mode) {
-  case execution_mode::training:
-    step = m->get_cur_step(); break;
-  case execution_mode::validation:
-    step = m->get_cur_validation_step(); break;
-  case execution_mode::testing:
-    step = m->get_cur_testing_step(); break;
-  default:
-    throw lbann_exception("Illegal execution mode in evaluate forward prop function");
-  }
+  const auto& step = m->get_step();
 
   if(data_reader->get_rank() < data_reader->get_num_parallel_readers()) {
     std::cout << "[" << m->get_comm()->get_trainer_rank()

--- a/src/callbacks/callback_dump_error_signals.cpp
+++ b/src/callbacks/callback_dump_error_signals.cpp
@@ -37,8 +37,8 @@ void lbann_callback_dump_error_signals::on_backward_prop_end(model *m, Layer *l)
     std::stringstream file;
     file << m_basename
          << "model" << m->get_comm()->get_trainer_rank() << "-"
-         << "epoch" << m->get_cur_epoch() << "-"
-         << "step" << m->get_cur_step() << "-"
+         << "epoch" << m->get_epoch() << "-"
+         << "step" << m->get_step() << "-"
          << l->get_name() << "-"
          << "ErrorSignals";
     if (l->get_num_parents() > 1) { file << i; }

--- a/src/callbacks/callback_dump_gradients.cpp
+++ b/src/callbacks/callback_dump_gradients.cpp
@@ -38,8 +38,8 @@ void lbann_callback_dump_gradients::on_backward_prop_end(model *m) {
       const std::string file
         = (m_basename
            + "model" + std::to_string(m->get_comm()->get_trainer_rank())
-           + "-epoch" + std::to_string(m->get_cur_epoch())
-           + "-step" + std::to_string(m->get_cur_step())
+           + "-epoch" + std::to_string(m->get_epoch())
+           + "-step" + std::to_string(m->get_step())
            + "-" + w->get_name()
            + "-Gradient");
       El::Write(opt->get_gradient(), file, El::ASCII);

--- a/src/callbacks/callback_dump_minibatch_sample_indices.cpp
+++ b/src/callbacks/callback_dump_minibatch_sample_indices.cpp
@@ -58,8 +58,8 @@ void lbann_callback_dump_minibatch_sample_indices::dump_to_file(model *m, Layer 
          + _to_string(m->get_execution_mode())
          + "-model" + std::to_string(m->get_comm()->get_trainer_rank())
          + "-rank" + std::to_string(m->get_comm()->get_rank_in_trainer())
-         + "-epoch" + std::to_string(m->get_cur_epoch())
-         + "-step" + std::to_string(m->get_cur_step())
+         + "-epoch" + std::to_string(m->get_epoch())
+         + "-step" + std::to_string(m->get_step(execution_mode::training))
          + "-" + l->get_name()
          + "-MB_Sample_Indices");
     El::Write(*indices, file, El::ASCII);
@@ -67,20 +67,11 @@ void lbann_callback_dump_minibatch_sample_indices::dump_to_file(model *m, Layer 
 }
 
 void lbann_callback_dump_minibatch_sample_indices::on_forward_prop_end(model *m, Layer *l) {
-  dump_to_file(m, l, m->get_cur_step());
+  dump_to_file(m, l, m->get_step());
 }
 
 void lbann_callback_dump_minibatch_sample_indices::on_evaluate_forward_prop_end(model *m, Layer *l) {
-  switch(m->get_execution_mode()) {
-  case execution_mode::validation:
-    dump_to_file(m, l, m->get_cur_validation_step());
-    break;
-  case execution_mode::testing:
-    dump_to_file(m, l, m->get_cur_testing_step());
-    break;
-  default:
-    throw lbann_exception("lbann_callback_dump_minibatch_sample_indices: invalid execution phase");
-  }
+  dump_to_file(m, l, m->get_step());
 }
 
 }  // namespace lbann

--- a/src/callbacks/callback_dump_outputs.cpp
+++ b/src/callbacks/callback_dump_outputs.cpp
@@ -134,17 +134,8 @@ void lbann_callback_dump_outputs::dump_outputs(const model& m, const Layer& l) {
 
   // Get mini-batch step information
   const auto& mode = m.get_execution_mode();
-  const auto& epoch = m.get_cur_epoch();
-  El::Int step = 0;
-  switch (mode) {
-  case execution_mode::training:
-    step = m.get_cur_step();            break;
-  case execution_mode::validation:
-    step = m.get_cur_validation_step(); break;
-  case execution_mode::testing:
-    step = m.get_cur_testing_step();    break;
-  default: LBANN_ERROR("invalid execution mode");
-  }
+  const auto& epoch = m.get_epoch();
+  const auto& step = m.get_step();
 
   // Quit if output dump isn't needed
   if (!m_modes.empty() && m_modes.count(mode) == 0) { return; }

--- a/src/callbacks/callback_dump_weights.cpp
+++ b/src/callbacks/callback_dump_weights.cpp
@@ -41,7 +41,7 @@ void lbann_callback_dump_weights::on_epoch_end(model *m) {
 
 void lbann_callback_dump_weights::dump_weights(model *m, std::string s) {
   for (weights *w : m->get_weights()) {
-    std::string epoch = "-epoch" + std::to_string(m->get_cur_epoch()-1);
+    std::string epoch = "-epoch" + std::to_string(m->get_epoch()-1);
     if(s != "") {
       epoch = "-" + s;
     }

--- a/src/callbacks/callback_imcomm.cpp
+++ b/src/callbacks/callback_imcomm.cpp
@@ -132,7 +132,7 @@ void lbann_callback_imcomm::do_summary(model *m, weights *w,
   }
   std::string prefix = w->get_name() + "/imcomm_";
   m_summarizer->reduce_scalar(prefix + "time",
-                              im_time, m->get_cur_step());
+                              im_time, m->get_step(execution_mode::training));
   // Use the same approximation the comm layer does.
   const CPUMat& local_gradients =
     static_cast<const CPUMat&>(w->get_optimizer()->get_gradient().LockedMatrix());
@@ -141,9 +141,9 @@ void lbann_callback_imcomm::do_summary(model *m, weights *w,
   size_t bytes_received =
     sizeof(DataType) * local_gradients.Height() * local_gradients.Width();
   m_summarizer->reduce_scalar(prefix + "bytes_sent",
-                              bytes_sent, m->get_cur_step());
+                              bytes_sent, m->get_step(execution_mode::training));
   m_summarizer->reduce_scalar(prefix + "bytes_received",
-                              bytes_received, m->get_cur_step());
+                              bytes_received, m->get_step(execution_mode::training));
 }
 
 static std::vector<std::string> comm_type_names  =

--- a/src/callbacks/callback_io.cpp
+++ b/src/callbacks/callback_io.cpp
@@ -48,7 +48,7 @@ void lbann_callback_io::on_epoch_end(model *m) {
         std::cout << "Rank " << comm->get_trainer_rank() << "." << comm->get_rank_in_trainer() << " processed "
                   << input->get_num_samples_trained() << " training samples of "
                   << input->get_total_num_training_samples() << " ("
-                  << input->get_num_samples_trained() / m->get_cur_epoch() << " per epoch)" << std::endl;
+                  << input->get_num_samples_trained() / m->get_epoch() << " per epoch)" << std::endl;
       }
     }
   }
@@ -64,7 +64,7 @@ void lbann_callback_io::on_test_end(model *m) {
         std::cout << "Rank " << comm->get_trainer_rank() << "." << comm->get_rank_in_trainer() << " processed "
                   << input->get_num_samples_tested() << " test samples of "
                   << input->get_total_num_testing_samples() << " ("
-                  << input->get_num_samples_tested() / m->get_cur_epoch() << " per epoch)" << std::endl;
+                  << input->get_num_samples_tested() / m->get_epoch() << " per epoch)" << std::endl;
       }
     }
   }

--- a/src/callbacks/callback_learning_rate.cpp
+++ b/src/callbacks/callback_learning_rate.cpp
@@ -71,7 +71,7 @@ void lbann_callback_learning_rate::on_epoch_end(model *m) {
   if (comm->am_trainer_master() && new_lr != old_global_lr) {
     std::cout << "Model " << comm->get_trainer_rank() << ": "
               << "changing global learning rate to " << new_lr
-              << " at epoch " << m->get_cur_epoch() << std::endl;
+              << " at epoch " << m->get_epoch() << std::endl;
   }
   for (weights *w : m_weights) {
     optimizer *opt = w->get_optimizer();
@@ -102,7 +102,7 @@ lbann_callback_step_learning_rate::lbann_callback_step_learning_rate(
   lbann_callback_learning_rate(weights_list), m_step(step), m_amt(amt) {}
 
 float lbann_callback_step_learning_rate::global_schedule(model *m) {
-  if (m->get_cur_epoch() % m_step == 0) {
+  if (m->get_epoch() % m_step == 0) {
     return m_cur_global_lr * m_amt;
   } else {
     return m_cur_global_lr;
@@ -120,8 +120,8 @@ lbann_callback_adaptive_learning_rate::lbann_callback_adaptive_learning_rate(
 
 float lbann_callback_adaptive_learning_rate::global_schedule(model *m) {
   // Determine behavior the first time this is called in an epoch
-  if (m_cur_epoch != m->get_cur_epoch()) {
-    m_cur_epoch = m->get_cur_epoch();
+  if (m_cur_epoch != m->get_epoch()) {
+    m_cur_epoch = m->get_epoch();
     const execution_mode mode = m->get_execution_mode();
     const EvalType score = m->get_objective_function()->get_mean_value(mode);
     if (score < m_last_score) {
@@ -164,12 +164,12 @@ lbann_callback_drop_fixed_learning_rate::lbann_callback_drop_fixed_learning_rate
 float lbann_callback_drop_fixed_learning_rate::global_schedule(model* m) {
   // Delete last drop epoch if we have already passed it
   while (!m_drop_epochs.empty()
-         && m->get_cur_epoch() > m_drop_epochs.back()) {
+         && m->get_epoch() > m_drop_epochs.back()) {
     m_drop_epochs.pop_back();
   }
 
   // Adjust learning rate if at a drop epoch
-  if (!m_drop_epochs.empty() && m->get_cur_epoch() == m_drop_epochs.back()) {
+  if (!m_drop_epochs.empty() && m->get_epoch() == m_drop_epochs.back()) {
     return m_cur_global_lr * m_amt;
   } else {
     return m_cur_global_lr;
@@ -203,10 +203,10 @@ void lbann_callback_linear_growth_learning_rate::setup(model *m) {
 }
 
 float lbann_callback_linear_growth_learning_rate::global_schedule(model *m) {
-  if (m->get_cur_epoch() < m_delay) {
+  if (m->get_epoch() < m_delay) {
     return m_cur_global_lr;
-  } else if (m->get_cur_epoch() <= m_num_epochs + m_delay) {
-    int num_left = m_num_epochs + m_delay - m->get_cur_epoch();
+  } else if (m->get_epoch() <= m_num_epochs + m_delay) {
+    int num_left = m_num_epochs + m_delay - m->get_epoch();
     return m_base_lr + m_inc*(m_num_epochs - num_left);
   } else {
     return m_cur_global_lr;
@@ -255,7 +255,7 @@ float lbann_callback_poly_learning_rate::global_schedule(model *m) {
  * Compute the learning rate for the next iteration.
  */
 float lbann_callback_poly_learning_rate::optimizer_schedule(model *m, optimizer &opt) {
-  const uint64_t cur_iter = static_cast<uint64_t>(m->get_cur_step());
+  const uint64_t cur_iter = static_cast<uint64_t>(m->get_step(execution_mode::training));
   if (m_max_iter > cur_iter) {
     m_lr = static_cast<float>(std::pow(static_cast<double>(m_max_iter - cur_iter)/m_max_iter, m_p));
   }

--- a/src/callbacks/callback_ltfb.cpp
+++ b/src/callbacks/callback_ltfb.cpp
@@ -160,7 +160,7 @@ void exchange_models__checkpoint_file(lbann_comm& comm,
 
   // Checkpoint directories
   const auto local_trainer = comm.get_trainer_rank();
-  const auto step = m.get_cur_step();
+  const auto step = m.get_step();
   const std::string send_dir = (m.get_name()
                                 + "_trainer" + std::to_string(local_trainer)
                                 + "_step" + std::to_string(step));
@@ -219,7 +219,7 @@ void restore_local_model__checkpoint_file(lbann_comm& comm, model& m) {
 
   // Checkpoint directories
   const auto local_trainer = comm.get_trainer_rank();
-  const auto step = m.get_cur_step();
+  const auto step = m.get_step();
   const std::string checkpoint_dir = (m.get_name()
                                       + "_trainer" + std::to_string(local_trainer)
                                       + "_step" + std::to_string(step));
@@ -345,7 +345,7 @@ void lbann_callback_ltfb::on_batch_begin(model *m) {
 
   // Check whether to start LTFB round
   const auto mode = m->get_execution_mode();
-  const auto step = m->get_cur_step();
+  const auto step = m->get_step();
   if (mode != execution_mode::training || step == 0) { return; }
 
   // Print message

--- a/src/callbacks/callback_perturb_adam.cpp
+++ b/src/callbacks/callback_perturb_adam.cpp
@@ -49,7 +49,7 @@ void lbann_callback_perturb_adam::setup(model* m) {
 }
 
 void lbann_callback_perturb_adam::on_batch_begin(model* m) {
-  if (m_perturb_during_training && m->get_cur_step() > 0) {
+  if (m_perturb_during_training && m->get_step() > 0) {
     perturb(*m);
   }
 }

--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -58,7 +58,7 @@ void lbann_callback_print::on_epoch_begin(model *m) {
     // Print message
     std::cout << "--------------------------------------------------------------------------------"
               << std::endl;
-    std::cout << "[" << m->get_cur_epoch() << "] Epoch : stats formated [tr/v/te]"
+    std::cout << "[" << m->get_epoch() << "] Epoch : stats formated [tr/v/te]"
               << " iter/epoch ="
               << " ["
               << input->get_num_iterations_per_epoch(execution_mode::training)
@@ -135,7 +135,7 @@ void lbann_callback_print::report_results(model *m) {
   std::string mode_string;
   switch (mode) {
   case execution_mode::training:
-    mode_string = "training epoch " + std::to_string(m->get_cur_epoch()-1);
+    mode_string = "training epoch " + std::to_string(m->get_epoch()-1);
     break;
   case execution_mode::validation:
     mode_string = "validation";

--- a/src/callbacks/callback_replace_weights.cpp
+++ b/src/callbacks/callback_replace_weights.cpp
@@ -29,11 +29,11 @@
 namespace lbann {
 
 void lbann_callback_replace_weights::on_batch_end(model *m) {
-  const auto& step = m->get_cur_step();
+  const auto& step = m->get_step(execution_mode::training);
   if(step % m_batch_interval == 0) {
     for(size_t i = 0; i < m_src_layers.size(); i++) {
       m_dst_layers[i]->replace_weights(m_src_layers[i]);
-    } 
+    }
   }
 }
 

--- a/src/callbacks/callback_save_images.cpp
+++ b/src/callbacks/callback_save_images.cpp
@@ -117,13 +117,13 @@ void save_image(std::string prefix,
 
       // Write image to file
       cv::imwrite(prefix + "-" + name + "." + format, img);
-        
+
     }
-      
+
   }
 #endif // LBANN_HAS_OPENCV
 }
-  
+
 } // namespace
 
 lbann_callback_save_images::lbann_callback_save_images(std::vector<std::string> layer_names,
@@ -139,7 +139,7 @@ lbann_callback_save_images::lbann_callback_save_images(std::vector<std::string> 
 }
 
 void lbann_callback_save_images::on_epoch_end(model *m) {
-  save_image(m_image_prefix + "epoch" + std::to_string(m->get_cur_epoch()),
+  save_image(m_image_prefix + "epoch" + std::to_string(m->get_epoch()),
              m_image_format,
              m->get_layers(),
              m_layer_names);

--- a/src/callbacks/callback_save_images.cpp
+++ b/src/callbacks/callback_save_images.cpp
@@ -145,13 +145,6 @@ void lbann_callback_save_images::on_epoch_end(model *m) {
              m_layer_names);
 }
 
-void lbann_callback_save_images::on_phase_end(model *m) {
-  save_image(m_image_prefix + "phase" + std::to_string(m->get_current_phase()),
-             m_image_format,
-             m->get_layers(),
-             m_layer_names);
-}
-
 void lbann_callback_save_images::on_test_end(model *m) {
   save_image(m_image_prefix + "test",
              m_image_format,

--- a/src/callbacks/callback_save_model.cpp
+++ b/src/callbacks/callback_save_model.cpp
@@ -93,8 +93,8 @@ bool lbann_callback_save_model::save_model_weights(model *m) {
   lbann_comm *comm = m->get_comm();
   comm->trainer_barrier();
   // let user know we're saving the weights
-  int epoch = m->get_cur_epoch();
-  int step = m->get_cur_step();
+  int epoch = m->get_epoch();
+  int step = m->get_step(execution_mode::training);
   if (comm->am_trainer_master()) {
     timer.Start();
     printf("[%s.%d] Saving model weights: epoch %d step %d ...\n", m->get_name().c_str(), comm->get_trainer_rank(), epoch, step);

--- a/src/callbacks/callback_timer.cpp
+++ b/src/callbacks/callback_timer.cpp
@@ -40,8 +40,8 @@ void lbann_callback_timer::batch_timing_end(const model& m) {
   const auto& batch_time = get_time() - m_batch_start_times[mode];
   m_batch_times[mode].push_back(batch_time);
   if (m_summarizer != nullptr) {
-    m_summarizer->reduce_scalar("minibatch_time", batch_time, m.get_cur_step()-1);
-    m_summarizer->reduce_scalar_all("minibatch_time", batch_time, m.get_cur_step()-1);
+    m_summarizer->reduce_scalar("minibatch_time", batch_time, m.get_step(execution_mode::training)-1);
+    m_summarizer->reduce_scalar_all("minibatch_time", batch_time, m.get_step(execution_mode::training)-1);
   }
 }
 
@@ -88,7 +88,7 @@ void lbann_callback_timer::timing_end(model& m) {
   std::string mode_string;
   switch(mode) {
   case execution_mode::training:
-    mode_string = "training epoch " + std::to_string(m.get_cur_epoch()-1);
+    mode_string = "training epoch " + std::to_string(m.get_epoch()-1);
     break;
   case execution_mode::validation:
     mode_string = "validation";

--- a/src/callbacks/callback_variable_minibatch.cpp
+++ b/src/callbacks/callback_variable_minibatch.cpp
@@ -39,7 +39,7 @@ lbann_callback_variable_minibatch::lbann_callback_variable_minibatch(
 
 void lbann_callback_variable_minibatch::on_train_begin(model *m) {
   // Avoid issues with the train method being called multiple times.
-  if (m->get_cur_epoch() != 0) { return; }
+  if (m->get_epoch() != 0) { return; }
 
   // Get first input layer in model
   generic_input_layer* input = nullptr;
@@ -103,12 +103,12 @@ void lbann_callback_variable_minibatch::on_epoch_end(model *m) {
         std::cout << "Model " << comm->get_trainer_rank() <<
           ": Changing mini-batch size to " << new_mbsize <<
           " and learning rate to " << new_lr << " at epoch " <<
-          m->get_cur_epoch() << std::endl;
+          m->get_epoch() << std::endl;
       }
     } else if (comm->am_trainer_master()) {
       std::cout << "Model " << comm->get_trainer_rank() <<
         ": Changing mini-batch size to " << new_mbsize <<
-        " at epoch " << m->get_cur_epoch() << std::endl;
+        " at epoch " << m->get_epoch() << std::endl;
     }
   }
   // Ramp the learning rate, if needed.
@@ -152,7 +152,7 @@ lbann_callback_step_minibatch::lbann_callback_step_minibatch(
 
 bool lbann_callback_step_minibatch::schedule(
   model *m, int& new_mbsize, float& new_lr, int& ramp_time) {
-  if (m->get_cur_epoch() % m_step == 0) {
+  if (m->get_epoch() % m_step == 0) {
     new_mbsize = m_current_mini_batch_size * 2;
     new_lr = get_current_learning_rate(m) * 2;
     ramp_time = m_ramp_time;
@@ -173,7 +173,7 @@ lbann_callback_minibatch_schedule::lbann_callback_minibatch_schedule(
 
 bool lbann_callback_minibatch_schedule::schedule(
   model *m, int& new_mbsize, float& new_lr, int& ramp_time) {
-  if (!m_steps.empty() && m->get_cur_epoch() == m_steps.back().epoch) {
+  if (!m_steps.empty() && m->get_epoch() == m_steps.back().epoch) {
     new_mbsize = m_steps.back().mbsize;
     new_lr = m_steps.back().lr;
     ramp_time = m_steps.back().ramp_time;

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -50,55 +50,55 @@ lbann_callback_profiler::lbann_callback_profiler(bool sync, bool skip_init) :
 
 void lbann_callback_profiler::on_epoch_begin(model *m) {
   // Skip the first epoch
-  if (m_skip_init && m->get_cur_epoch() == 1) {
+  if (m_skip_init && m->get_epoch() == 1) {
     prof_start();
   }
-  prof_region_begin(("epoch " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_begin(("epoch " + std::to_string(m->get_epoch())).c_str(),
                     prof_colors[0], m_sync);
 }
 
 void lbann_callback_profiler::on_epoch_end(model *m) {
-  prof_region_end(("epoch " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_end(("epoch " + std::to_string(m->get_epoch())).c_str(),
                   m_sync);
 }
 
 void lbann_callback_profiler::on_validation_begin(model *m) {
-  prof_region_begin(("val " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_begin(("val " + std::to_string(m->get_epoch())).c_str(),
                     prof_colors[0], m_sync);
 }
 
 void lbann_callback_profiler::on_validation_end(model *m) {
-  prof_region_end(("val " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_end(("val " + std::to_string(m->get_epoch())).c_str(),
                   m_sync);
 }
 
 void lbann_callback_profiler::on_test_begin(model *m) {
-  prof_region_begin(("test " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_begin(("test " + std::to_string(m->get_epoch())).c_str(),
                     prof_colors[0], m_sync);
 }
 
 void lbann_callback_profiler::on_test_end(model *m) {
-  prof_region_end(("test " + std::to_string(m->get_cur_epoch())).c_str(),
+  prof_region_end(("test " + std::to_string(m->get_epoch())).c_str(),
                   m_sync);
 }
 
 void lbann_callback_profiler::on_batch_begin(model *m) {
-  prof_region_begin(("batch " + std::to_string(m->get_cur_step())).c_str(),
+  prof_region_begin(("batch " + std::to_string(m->get_step(execution_mode::training))).c_str(),
                     prof_colors[1], m_sync);
 }
 
 void lbann_callback_profiler::on_batch_end(model *m) {
-  prof_region_end(("batch " + std::to_string(m->get_cur_step())).c_str(),
+  prof_region_end(("batch " + std::to_string(m->get_step(execution_mode::training))).c_str(),
                   m_sync);
 }
 
 void lbann_callback_profiler::on_batch_evaluate_begin(model *m) {
-  prof_region_begin(("batch eval " + std::to_string(m->get_cur_step())).c_str(),
+  prof_region_begin(("batch eval " + std::to_string(m->get_step(execution_mode::training))).c_str(),
                     prof_colors[1], m_sync);
 }
 
 void lbann_callback_profiler::on_batch_evaluate_end(model *m) {
-  prof_region_end(("batch eval " + std::to_string(m->get_cur_step())).c_str(),
+  prof_region_end(("batch eval " + std::to_string(m->get_step(execution_mode::training))).c_str(),
                   m_sync);
 }
 

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -711,13 +711,13 @@ void generic_data_reader::setup_data_store(model *m, int mini_batch_size) {
 bool generic_data_reader::data_store_active() const {
   return (m_data_store != nullptr
           && (m_model->get_execution_mode() == execution_mode::training)
-          && m_model->get_cur_epoch() > 0);
+          && m_model->get_epoch() > 0);
 }
 
 bool generic_data_reader::priming_data_store() const {
   return (m_data_store != nullptr
           && (m_model->get_execution_mode() == execution_mode::training)
-          && m_model->get_cur_epoch() == 0);
+          && m_model->get_epoch() == 0);
 }
 
 void generic_data_reader::set_data_store(generic_data_store *g) {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -1401,14 +1401,14 @@ bool data_reader_jag_conduit::fetch_response(CPUMat& X, int data_id, int mb_idx)
   bool ok = true;
   // Create a node to hold all of the data
   conduit::Node node;
-  if (m_jag_store != nullptr && m_model->get_cur_epoch() > 0) {
+  if (m_jag_store != nullptr && m_model->get_epoch() > 0) {
     const conduit::Node& ds_node = m_jag_store->get_conduit_node(data_id);
     node.set_external(ds_node);
   }
   for(size_t i = 0u; ok && (i < X_v.size()); ++i) {
     ok = fetch(X_v[i], data_id, node, 0, tid, m_dependent[i], "response");
   }
-  if (m_jag_store != nullptr && m_model->get_cur_epoch() == 0) {
+  if (m_jag_store != nullptr && m_model->get_epoch() == 0) {
     // Once the node has been populated save it in the data store
     if (m_jag_store != nullptr) {
       m_jag_store->set_conduit_node(data_id, node);

--- a/src/data_readers/data_reader_moving_mnist.cpp
+++ b/src/data_readers/data_reader_moving_mnist.cpp
@@ -90,7 +90,7 @@ bool moving_mnist_reader::fetch_datum(CPUMat& X, int data_id, int col) {
   for (El::Int obj = 0; obj < m_num_objects; ++obj) {
     size_t hash = 1234;
     hash_combine(hash, data_id);
-    hash_combine(hash, m_model->get_cur_epoch());
+    hash_combine(hash, m_model->get_epoch());
     hash_combine(hash, obj);
     raw_image_indices[obj] = hash % m_num_raw_images;
   }
@@ -225,7 +225,7 @@ bool moving_mnist_reader::fetch_label(CPUMat& Y, int data_id, int col) {
   for (El::Int obj = 0; obj < m_num_objects; ++obj) {
     size_t hash = 1234;
     hash_combine(hash, data_id);
-    hash_combine(hash, m_model->get_cur_epoch());
+    hash_combine(hash, m_model->get_epoch());
     hash_combine(hash, obj);
     raw_image_indices[obj] = hash % m_num_raw_images;
   }

--- a/src/data_store/data_store_jag.cpp
+++ b/src/data_store/data_store_jag.cpp
@@ -245,7 +245,7 @@ const conduit::Node & data_store_jag::get_conduit_node(int data_id) const {
 
   std::unordered_map<int, conduit::Node>::const_iterator t2 = m_minibatch_data.find(data_id);
   if (t2 == m_minibatch_data.end()) {
-    LBANN_ERROR("failed to find data_id: " + std::to_string(data_id) + " in m_minibatch_data; m_minibatch_data.size: " + std::to_string(m_minibatch_data.size()) + "; epoch:"  + std::to_string(m_model->get_cur_epoch()));
+    LBANN_ERROR("failed to find data_id: " + std::to_string(data_id) + " in m_minibatch_data; m_minibatch_data.size: " + std::to_string(m_minibatch_data.size()) + "; epoch:"  + std::to_string(m_model->get_epoch()));
   }
 
   return t2->second;

--- a/src/data_store/generic_data_store.cpp
+++ b/src/data_store/generic_data_store.cpp
@@ -211,7 +211,7 @@ size_t generic_data_store::get_file_size(std::string dir, std::string fn) {
 }
 
 void generic_data_store::set_shuffled_indices(const std::vector<int> *indices, bool exchange_indices) {
-if (m_master)std::cerr<<"starting set_shuffled_indices; epoch: "<<m_model->get_cur_epoch()<<" role: " << m_reader->get_role()<<";  n: " << m_n << "\n";
+if (m_master)std::cerr<<"starting set_shuffled_indices; epoch: "<<m_model->get_epoch()<<" role: " << m_reader->get_role()<<";  n: " << m_n << "\n";
   m_shuffled_indices = indices;
 }
 


### PR DESCRIPTION
### Summary
This fixes some bugs in the constructor and destructor of the model class, so I can now copy AlexNet and immediately delete the copy. This expands on and supersedes #907.

In the process, I've done some major cleaning up in the model class. There's more to be done, but it seems like a reasonable point to consolidate.

### Major changes
- Bugfixes in copy constructors in conv and pooling layers (see PR #907).
- Better handling of optimizer in model copy constructor.
- Make all member variables in model class private.
- Consolidate multiple access functions for mini-batch step into `El::Int get_step(execution_mode)`.
- Remove redundant "current" from variable and function names.
- Remove "phase" logic from model class (this was used for greedy layer-wise autoencoders in ancient times).
- Expanded documentation.

### Warning
This will break backward compatibility with old checkpointed models.