### PR TITLE
Refactoring convolution layer

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -999,13 +999,14 @@ private:
       cudnnDataType_t data_type;
       cudnnTensorFormat_t format;
       int num_dims;
+      std::vector<int> dims(1);
       CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
-                                             0,
+                                             dims.size(),
                                              &data_type,
                                              &format,
                                              &num_dims,
-                                             nullptr));
-      std::vector<int> dims(num_dims);
+                                             dims.data()));
+      dims.resize(num_dims);
       CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
                                              num_dims,
                                              &data_type,

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -24,12 +24,11 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_BASE_CONVOLUTION_HPP_INCLUDED
-#define LBANN_LAYER_BASE_CONVOLUTION_HPP_INCLUDED
+#ifndef LBANN_LAYERS_LEARNING_BASE_CONVOLUTION_HPP_INCLUDED
+#define LBANN_LAYERS_LEARNING_BASE_CONVOLUTION_HPP_INCLUDED
 
 #include <vector>
 #include <omp.h>
-#include "lbann/layers/learning/learning.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/weights/initializer.hpp"
 #include "lbann/weights/variance_scaling_initializers.hpp"
@@ -43,15 +42,16 @@ namespace lbann {
 
 /** @brief Computation kernels for convolution and deconvolution layers.
  */
-template <El::Device Dev>
-class base_convolution_layer : public learning_layer {
+template <El::Device Device>
+class base_convolution_layer : public Layer {
 
 protected:
 
-  /** Convolution kernel dimensions. */
-  std::vector<int> m_kernel_dims;
-  /** Size of convolutional kernel. */
-  int m_kernel_size;
+  int m_output_channels;
+  /** @brief Spatial dimensions for convolution kernel.
+   *  @detailed Excludes number of input and output channels.
+   */
+  std::vector<int> m_conv_dims;
   /** Convolution padding. */
   std::vector<int> m_pads;
   /** Convolution strides. */
@@ -74,21 +74,21 @@ protected:
    *  This is this layer's contribution to the objective function
    *  gradient w.r.t. the convolutional kernel weights.
    */
-  StarMat<Dev> m_kernel_gradient;
+  StarMat<Device> m_kernel_gradient;
   /** Bias gradient.
    *  This is this layer's contribution to the objective function
    *  gradient w.r.t. the bias weights.
    */
-  StarMat<Dev> m_bias_gradient;
+  StarMat<Device> m_bias_gradient;
 
 #ifdef LBANN_HAS_CUDNN
 
   /** Convolution kernel cuDNN descriptor. */
-  cudnnFilterDescriptor_t m_kernel_cudnn_desc;
+  cudnnFilterDescriptor_t m_kernel_cudnn_desc = nullptr;
   /** Convolution cuDNN descriptor. */
-  cudnnConvolutionDescriptor_t m_convolution_cudnn_desc;
+  cudnnConvolutionDescriptor_t m_convolution_cudnn_desc = nullptr;
   /** Bias tensor cuDNN descriptor. */
-  cudnnTensorDescriptor_t m_bias_cudnn_desc;
+  cudnnTensorDescriptor_t m_bias_cudnn_desc = nullptr;
   /** Tensor cuDNN descriptors. */
   cudnn::data_parallel_layer_tensor_manager m_tensors_cudnn_desc;
 
@@ -96,79 +96,65 @@ protected:
 
 public:
 
-  base_convolution_layer(lbann_comm *comm,
-                         int num_data_dims,
-                         int num_output_channels,
-                         const std::vector<int> conv_dims,
-                         const std::vector<int> pads,
-                         const std::vector<int> strides,
-                         const std::vector<int> dilations,
+  base_convolution_layer(lbann_comm* comm,
+                         int num_data_dims, /// @todo Remove
+                         int output_channels,
+                         std::vector<int> conv_dims,
+                         std::vector<int> pads,
+                         std::vector<int> strides,
+                         std::vector<int> dilations,
                          int groups,
                          bool has_bias)
-    : learning_layer(comm),
-      m_kernel_dims(conv_dims),
-      m_kernel_size(0),
-      m_pads(pads),
-      m_strides(strides),
-      m_dilations(dilations),
-      m_num_groups(groups),
-      m_bias_scaling_factor(has_bias ? DataType(1) : DataType(0)),
-      m_kernel_gradient(this->m_comm->get_trainer_grid()),
-      m_bias_gradient(this->m_comm->get_trainer_grid())
+    : Layer(comm),
+      m_output_channels(std::max(output_channels, 1)),
+      m_conv_dims(std::move(conv_dims)),
+      m_pads(std::move(pads)),
+      m_strides(std::move(strides)),
+      m_dilations(std::move(dilations)),
+      m_num_groups(std::max(groups, 1)),
+      m_bias_scaling_factor(has_bias ? 1 : 0),
+      m_kernel_gradient(this->get_comm()->get_trainer_grid()),
+      m_bias_gradient(this->get_comm()->get_trainer_grid())
 #ifdef LBANN_HAS_CUDNN
-    , m_kernel_cudnn_desc(nullptr),
-      m_convolution_cudnn_desc(nullptr),
-      m_bias_cudnn_desc(nullptr),
-      m_tensors_cudnn_desc(this)
+    , m_tensors_cudnn_desc(this)
 #endif // LBANN_HAS_CUDNN
   {
+    std::ostringstream err;
 
-    bool nonunit_dilation = false;
-    for (const auto& d : m_dilations) {
-      if (d != 1) {
-        nonunit_dilation = true;
-        break;
-      }
-    }
-    if (Dev == El::Device::CPU && nonunit_dilation) {
-      std::stringstream err;
-      err << "layer \"" << get_name() << "\" "
-          << "has nonunit dilation which is only supported on GPUs";
+    // Make sure that configuration is supported
+    if (Device == El::Device::CPU
+        && std::any_of(m_dilations.begin(), m_dilations.end(),
+                       [](El::Int d) { return d != 1; })) {
+      err << "layer \"" << this->get_name() << "\" "
+          << "has non-unit dilation, which is not yet supported on CPU";
       LBANN_ERROR(err.str());
     }
-    if (Dev == El::Device::CPU && m_num_groups > 1) {
-      std::stringstream err;
-      err << "layer \"" << get_name() << "\" "
-          << "has nonunit groups " << m_num_groups
-          << " which is only supported on GPUs";
+    if (Device == El::Device::CPU && m_num_groups != 1) {
+      err << "layer \"" << this->get_name() << "\" "
+          << "has " << m_num_groups << ", "
+          << "but only unit groups are currently supported on CPU";
       LBANN_ERROR(err.str());
     }
 
     // Check dimensions of convolution parameters
-    if ((int) m_kernel_dims.size() != num_data_dims
-        || (int) m_pads.size() != num_data_dims
-        || (int) m_strides.size() != num_data_dims
-        || (int) m_dilations.size() != num_data_dims) {
-      std::stringstream err;
-      err << "layer \"" << get_name() << "\" "
+    if (m_pads.size() != m_conv_dims.size()
+        || m_strides.size() != m_conv_dims.size()
+        || m_dilations.size() != m_conv_dims.size()) {
+      err << " layer \"" << this->get_name() << "\" "
           << "has an invalid number of convolution parameters "
-          << "(expected " << num_data_dims << " parameters, "
-          << "conv_dims has " << m_kernel_dims.size() << ", "
+          << "(conv_dims has " << m_conv_dims.size() << " entries, "
           << "pads has " << m_pads.size() << ", "
           << "strides has " << m_strides.size() << ", "
           << "dilations has " << m_dilations.size() << ")";
       LBANN_ERROR(err.str());
     }
 
-    // Record number of output channels
-    m_kernel_dims.insert(m_kernel_dims.begin(), num_output_channels);
-
   }
 
   base_convolution_layer(const base_convolution_layer& other)
-    : learning_layer(other),
-      m_kernel_dims(other.m_kernel_dims),
-      m_kernel_size(other.m_kernel_size),
+    : Layer(other),
+      m_output_channels(other.m_output_channels),
+      m_conv_dims(other.m_conv_dims),
       m_pads(other.m_pads),
       m_strides(other.m_strides),
       m_dilations(other.m_dilations),
@@ -177,10 +163,7 @@ public:
       m_kernel_gradient(other.m_kernel_gradient),
       m_bias_gradient(other.m_bias_gradient)
 #ifdef LBANN_HAS_CUDNN
-    , m_kernel_cudnn_desc(nullptr),
-      m_convolution_cudnn_desc(nullptr),
-      m_bias_cudnn_desc(nullptr),
-      m_tensors_cudnn_desc(other.m_tensors_cudnn_desc)
+    , m_tensors_cudnn_desc(other.m_tensors_cudnn_desc)
 #endif // LBANN_HAS_CUDNN
   {
 #ifdef LBANN_HAS_CUDNN
@@ -195,9 +178,9 @@ public:
   }
 
   base_convolution_layer& operator=(const base_convolution_layer& other) {
-    learning_layer::operator=(other);
-    m_kernel_dims = other.m_kernel_dims;
-    m_kernel_size = other.m_kernel_size;
+    Layer::operator=(other);
+    m_output_channels = other.m_output_channels;
+    m_conv_dims = other.m_conv_dims;
     m_pads = other.m_pads;
     m_strides = other.m_strides;
     m_dilations = other.m_dilations;
@@ -236,14 +219,14 @@ public:
   }
 
   description get_description() const override {
-    auto&& desc = learning_layer::get_description();
-    std::stringstream ss;
+    auto&& desc = Layer::get_description();
+    std::ostringstream ss;
 
     // Convolution dimensions
     ss.str(std::string{});
     ss.clear();
-    for (size_t i = 2; i < m_kernel_dims.size(); ++i) {
-      ss << (i > 2 ? ", " : "" ) << m_kernel_dims[i];
+    for (size_t i = 0; i < m_conv_dims.size(); ++i) {
+      ss << (i > 0 ? ", " : "" ) << m_conv_dims[i];
     }
     desc.add("Convolution dimensions", ss.str());
 
@@ -290,9 +273,15 @@ public:
    *  The kernel weights are setup in the convolution and
    *  deconvolution classes. */
   void setup_data() override {
-    learning_layer::setup_data();
+    Layer::setup_data();
+
+    // Tensor dimensions
     const auto& input_dims = get_input_dims();
     const auto& output_dims = get_output_dims();
+    const auto& kernel_dims = get_kernel_dims();
+    const auto& kernel_size = std::accumulate(kernel_dims.begin(),
+                                              kernel_dims.end(),
+                                              1, std::multiplies<int>());
 
     // Initialize default weights if none are provided
     if (this->m_weights.size() > 2) {
@@ -329,15 +318,15 @@ public:
     auto* cast_initializer
       = dynamic_cast<variance_scaling_initializer*>(kernel_weights.get_initializer());
     if (cast_initializer != nullptr) {
-      cast_initializer->set_fan_in(m_kernel_size / output_dims[0]);
-      cast_initializer->set_fan_out(m_kernel_size / input_dims[0]);
+      cast_initializer->set_fan_in(kernel_size / output_dims[0]);
+      cast_initializer->set_fan_out(kernel_size / input_dims[0]);
     }
 
     // Initialize weight matrices
     auto dist = get_prev_activations().DistData();
     dist.colDist = El::STAR;
     dist.rowDist = El::STAR;
-    kernel_weights.set_dims(m_kernel_dims);
+    kernel_weights.set_dims(kernel_dims);
     kernel_weights.set_matrix_distribution(dist);
     bias_weights.set_dims(output_dims[0]);
     bias_weights.set_matrix_distribution(dist);
@@ -373,20 +362,21 @@ public:
 
   /// Initialize GPU objects
   void setup_gpu() override {
-    learning_layer::setup_gpu();
+    Layer::setup_gpu();
 #ifndef LBANN_HAS_CUDNN
     LBANN_ERROR("cuDNN not detected");
 #else
 
     const auto& output_dims = get_output_dims();
+    const auto& kernel_dims = get_kernel_dims();
 
     // Set kernel descriptor
     CHECK_CUDNN(cudnnCreateFilterDescriptor(&m_kernel_cudnn_desc));
     CHECK_CUDNN(cudnnSetFilterNdDescriptor(m_kernel_cudnn_desc,
                                            cudnn::get_data_type(),
                                            CUDNN_TENSOR_NCHW,
-                                           m_kernel_dims.size(),
-                                           m_kernel_dims.data()));
+                                           kernel_dims.size(),
+                                           kernel_dims.data()));
 
     // Set convolution descriptor
     CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&m_convolution_cudnn_desc));
@@ -409,6 +399,9 @@ public:
   }
 
 protected:
+
+  /** Dimensions of convolution kernel. */
+  virtual std::vector<int> get_kernel_dims() const = 0;
 
   /** Convolution with cuDNN. */
   void apply_convolution_cudnn(bool during_forward_prop) {
@@ -752,14 +745,18 @@ protected:
       input_dims = get_output_dims();
       output_dims = get_input_dims();
     }
+    const auto& kernel_dims = get_kernel_dims();
+    const auto& kernel_size = std::accumulate(kernel_dims.begin(),
+                                              kernel_dims.end(),
+                                              1, std::multiplies<int>());
 
     // Initialize matrices
     const int m = output_size / output_dims[0];
     const int n = output_dims[0];
-    const int k = m_kernel_size / output_dims[0];
-    DMat<Dev> input_col, output_col;
-    DMat<Dev> im2col_matrix(k, m);
-    const DMat<Dev> kernel_matrix(k, n, local_kernel.LockedBuffer(), k);
+    const int k = kernel_size / output_dims[0];
+    DMat<Device> input_col, output_col;
+    DMat<Device> im2col_matrix(k, m);
+    const DMat<Device> kernel_matrix(k, n, local_kernel.LockedBuffer(), k);
 
     // Iterate through input columns
     for (El::Int col = 0; col < local_width; ++col) {
@@ -772,7 +769,7 @@ protected:
              input_dims.size() - 1,
              &input_dims[1],
              m_pads.data(),
-             &m_kernel_dims[2],
+             &kernel_dims[2],
              m_strides.data());
 
       // Apply convolution to current input column
@@ -793,9 +790,9 @@ protected:
     const auto& local_input = (during_forward_prop ?
                                get_local_prev_activations() :
                                get_local_prev_error_signals());
-    DMat<Dev>& local_output = (during_forward_prop ?
-                               get_local_activations() :
-                               get_local_error_signals());
+    DMat<Device>& local_output = (during_forward_prop ?
+                                  get_local_activations() :
+                                  get_local_error_signals());
 
     // Matrix parameters
     const int input_size = local_input.Height();
@@ -809,14 +806,18 @@ protected:
       input_dims = get_output_dims();
       output_dims = get_input_dims();
     }
+    const auto& kernel_dims = get_kernel_dims();
+    const auto& kernel_size = std::accumulate(kernel_dims.begin(),
+                                              kernel_dims.end(),
+                                              1, std::multiplies<int>());
 
     // Initialize matrices
-    const int m = m_kernel_size / input_dims[0];
+    const int m = kernel_size / input_dims[0];
     const int n = input_size / input_dims[0];
     const int k = input_dims[0];
-    DMat<Dev> input_col, output_col;
-    DMat<Dev> im2col_matrix(m, n);
-    const DMat<Dev> kernel_matrix(m, k, local_kernel.LockedBuffer(), m);
+    DMat<Device> input_col, output_col;
+    DMat<Device> im2col_matrix(m, n);
+    const DMat<Device> kernel_matrix(m, k, local_kernel.LockedBuffer(), m);
 
     // Iterate through input columns
     for (El::Int col = 0; col < local_width; ++col) {
@@ -836,7 +837,7 @@ protected:
              output_dims.size() - 1,
              &output_dims[1],
              m_pads.data(),
-             &m_kernel_dims[2],
+             &kernel_dims[2],
              m_strides.data());
 
     }
@@ -876,8 +877,8 @@ protected:
   void compute_gradients_im2col(bool using_transposed_convolution) {
 
     // Local matrices
-    const DMat<Dev>& local_input = get_local_prev_activations();
-    const DMat<Dev>& local_gradient_wrt_output = get_local_prev_error_signals();
+    const DMat<Device>& local_input = get_local_prev_activations();
+    const DMat<Device>& local_gradient_wrt_output = get_local_prev_error_signals();
     auto& local_kernel_gradient = m_kernel_gradient.Matrix();
     auto& local_bias_gradient = m_bias_gradient.Matrix();
 
@@ -889,6 +890,10 @@ protected:
     const int num_output_channels = output_dims[0];
     const int num_per_output_channel = get_output_size() / num_output_channels;
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
+    const auto& kernel_dims = get_kernel_dims();
+    const auto& kernel_size = std::accumulate(kernel_dims.begin(),
+                                              kernel_dims.end(),
+                                              1, std::multiplies<int>());
 
     // Compute bias gradient
     // Note: Sum is computed with Kahan summation
@@ -921,23 +926,23 @@ protected:
 
     // Initialize matrices
     const int m = (using_transposed_convolution ?
-                   m_kernel_size / num_input_channels :
-                   m_kernel_size / num_output_channels);
+                   kernel_size / num_input_channels :
+                   kernel_size / num_output_channels);
     const int n = (using_transposed_convolution ?
                    num_input_channels :
                    num_output_channels);
     const int k = (using_transposed_convolution ?
                    get_input_size() / num_input_channels :
                    get_output_size() / num_output_channels);
-    DMat<Dev> im2col_matrix(m, k);
-    DMat<Dev> kernel_gradient_matrix(m, n, local_kernel_gradient.Buffer(), m);
+    DMat<Device> im2col_matrix(m, k);
+    DMat<Device> kernel_gradient_matrix(m, n, local_kernel_gradient.Buffer(), m);
     El::Zero(kernel_gradient_matrix);
 
     // Compute kernel gradient contributions from each data sample
     for (El::Int col = 0; col < local_width; ++col) {
       if (using_transposed_convolution) {
-        const DMat<Dev> input_col(k, n, local_input.LockedBuffer(0,col), k);
-        const DMat<Dev> gradient_wrt_output_col =
+        const DMat<Device> input_col(k, n, local_input.LockedBuffer(0,col), k);
+        const DMat<Device> gradient_wrt_output_col =
           El::LockedView(local_gradient_wrt_output, El::ALL, El::IR(col));
         im2col(gradient_wrt_output_col,
                im2col_matrix,
@@ -945,23 +950,23 @@ protected:
                output_dims.size() - 1,
                &output_dims[1],
                m_pads.data(),
-               &m_kernel_dims[2],
+               &kernel_dims[2],
                m_strides.data());
         El::Gemm(El::NORMAL, El::NORMAL,
                  DataType(1), im2col_matrix, input_col,
                  DataType(1), kernel_gradient_matrix);
       }
       else {
-        const DMat<Dev> input_col
+        const DMat<Device> input_col
           = El::LockedView(local_input, El::ALL, El::IR(col));
-        const DMat<Dev> gradient_wrt_output_col(k, n, local_gradient_wrt_output.LockedBuffer(0,col), k);
+        const DMat<Device> gradient_wrt_output_col(k, n, local_gradient_wrt_output.LockedBuffer(0,col), k);
         im2col(input_col,
                im2col_matrix,
                num_input_channels,
                input_dims.size() - 1,
                &input_dims[1],
                m_pads.data(),
-               &m_kernel_dims[2],
+               &kernel_dims[2],
                m_strides.data());
         El::Gemm(El::NORMAL, El::NORMAL,
                  DataType(1), im2col_matrix, gradient_wrt_output_col,
@@ -1079,4 +1084,4 @@ private:
 
 } // namespace lbann
 
-#endif // LBANN_LAYER_BASE_CONVOLUTION_HPP_INCLUDED
+#endif // LBANN_LAYERS_LEARNING_BASE_CONVOLUTION_HPP_INCLUDED

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -78,10 +78,10 @@ public:
         comm,
         num_data_dims,
         num_output_channels,
-        conv_dims,
-        pads,
-        strides,
-        dilations,
+        std::move(conv_dims),
+        std::move(pads),
+        std::move(strides),
+        std::move(dilations),
         groups,
         has_bias) {
     static_assert(Layout == data_layout::DATA_PARALLEL,
@@ -97,36 +97,17 @@ public:
 
   El::Device get_device_allocation() const override { return Device; }
 
+protected:
+
   void setup_dims() override {
     base_convolution_layer<Device>::setup_dims();
-    std::stringstream err;
 
     // Get tensor dimensions
     const auto& input_dims = this->get_input_dims();
     auto output_dims = input_dims;
-    const auto input_channels = input_dims[0];
-    const auto output_channels = this->m_output_channels;
-
-    // Check that number of groups is valid
-    if (this->m_num_groups < 1) {
-      err << this->get_type() << " layer "
-          << "\"" << this->get_name() << "\" "
-          << "has " << this->m_num_groups << " groups";
-      LBANN_ERROR(err.str());
-    } else if (input_channels % this->m_num_groups != 0
-               || output_channels % this->m_num_groups != 0) {
-      err << this->get_type() << " layer "
-          << "\"" << this->get_name() << "\" has "
-          << input_channels << " input channels, "
-          << output_channels << " output channels, and "
-          << this->m_num_groups << " groups "
-          << "(groups must evenly divide "
-          << "the input channels and output channels)";
-      LBANN_ERROR(err.str());
-    }
 
     // Initialize output tensor dimensions
-    output_dims[0] = output_channels;
+    output_dims[0] = this->m_output_channels;
     for (size_t i = 0; i < output_dims.size() - 1; ++i) {
       const auto& input_dim = input_dims[i+1];
       const auto& kernel_dim = this->m_conv_dims[i];
@@ -141,8 +122,6 @@ public:
     this->set_output_dims(output_dims);
 
   }
-
-protected:
 
   std::vector<int> get_kernel_dims() const {
     std::vector<int> dims;

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -24,10 +24,9 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_CONVOLUTION_HPP_INCLUDED
-#define LBANN_LAYER_CONVOLUTION_HPP_INCLUDED
+#ifndef LBANN_LAYERS_LEARNING_CONVOLUTION_HPP_INCLUDED
+#define LBANN_LAYERS_LEARNING_CONVOLUTION_HPP_INCLUDED
 
-#include <vector>
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/utils/exception.hpp"
 
@@ -39,8 +38,8 @@ namespace lbann {
  *  tensors. This is primarily optimized for image data in NCHW
  *  format.
  */
-template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
-class convolution_layer : public base_convolution_layer<Dev> {
+template <data_layout Layout = data_layout::DATA_PARALLEL, El::Device Device = El::Device::CPU>
+class convolution_layer : public base_convolution_layer<Device> {
 private:
 
   friend class lbann_callback_imcomm;
@@ -75,17 +74,18 @@ public:
                     std::vector<int> dilations,
                     int groups,
                     bool has_bias = true)
-    : base_convolution_layer<Dev>(comm,
-                                  num_data_dims,
-                                  num_output_channels,
-                                  conv_dims,
-                                  pads,
-                                  strides,
-                                  dilations,
-                                  groups,
-                                  has_bias) {
-    static_assert(T_layout == data_layout::DATA_PARALLEL,
-                  "convolution only supports DATA_PARALLEL");
+    : base_convolution_layer<Device>(
+        comm,
+        num_data_dims,
+        num_output_channels,
+        conv_dims,
+        pads,
+        strides,
+        dilations,
+        groups,
+        has_bias) {
+    static_assert(Layout == data_layout::DATA_PARALLEL,
+                  "convolution layer only supports DATA_PARALLEL");
 
   }
 
@@ -93,19 +93,19 @@ public:
 
   std::string get_type() const override { return "convolution"; }
 
-  data_layout get_data_layout() const override { return T_layout; }
+  data_layout get_data_layout() const override { return Layout; }
 
-  El::Device get_device_allocation() const override { return Dev; }
+  El::Device get_device_allocation() const override { return Device; }
 
   void setup_dims() override {
-    base_convolution_layer<Dev>::setup_dims();
+    base_convolution_layer<Device>::setup_dims();
     std::stringstream err;
 
     // Get tensor dimensions
     const auto& input_dims = this->get_input_dims();
     auto output_dims = input_dims;
     const auto input_channels = input_dims[0];
-    const auto output_channels = this->m_kernel_dims[0];
+    const auto output_channels = this->m_output_channels;
 
     // Check that number of groups is valid
     if (this->m_num_groups < 1) {
@@ -125,32 +125,11 @@ public:
       LBANN_ERROR(err.str());
     }
 
-    // Initialize convolution kernel dimensions
-    this->m_kernel_dims.insert(this->m_kernel_dims.begin() + 1,
-                               input_channels / this->m_num_groups);
-    this->m_kernel_size = std::accumulate(this->m_kernel_dims.begin(),
-                                          this->m_kernel_dims.end(),
-                                          1, std::multiplies<int>());
-    if (this->m_kernel_dims.size() != input_dims.size() + 1) {
-      err << this->get_type() << " layer "
-          << "\"" << this->get_name() << "\" "
-          << "has a ";
-      for (size_t i = 0; i < input_dims.size(); ++i) {
-        err << (i > 0 ? " x " : "") << input_dims[i];
-      }
-      err << " input tensor and a ";
-      for (size_t i = 0; i < this->m_kernel_dims.size(); ++i) {
-        err << (i > 0 ? " x " : "") << this->m_kernel_dims[i];
-      }
-      err << " convolution kernel";
-      LBANN_ERROR(err.str());
-    }
-
     // Initialize output tensor dimensions
     output_dims[0] = output_channels;
     for (size_t i = 0; i < output_dims.size() - 1; ++i) {
       const auto& input_dim = input_dims[i+1];
-      const auto& kernel_dim = this->m_kernel_dims[i+2];
+      const auto& kernel_dim = this->m_conv_dims[i];
       const auto& stride = this->m_strides[i];
       const auto& pad = this->m_pads[i];
       const auto& dilation = this->m_dilations[i];
@@ -165,23 +144,33 @@ public:
 
 protected:
 
+  std::vector<int> get_kernel_dims() const {
+    std::vector<int> dims;
+    dims.push_back(this->m_output_channels);
+    dims.push_back(this->get_input_dims()[0]);
+    dims.insert(dims.end(),
+                this->m_conv_dims.begin(),
+                this->m_conv_dims.end());
+    return dims;
+  }
+
   void fp_compute() override {
     if(this->using_gpus()) {
-      base_convolution_layer<Dev>::apply_convolution_cudnn(true);
-      base_convolution_layer<Dev>::apply_bias_cudnn();
+      base_convolution_layer<Device>::apply_convolution_cudnn(true);
+      base_convolution_layer<Device>::apply_bias_cudnn();
     } else {
-      base_convolution_layer<Dev>::apply_convolution_im2col(true);
-      base_convolution_layer<Dev>::apply_bias_cpu();
+      base_convolution_layer<Device>::apply_convolution_im2col(true);
+      base_convolution_layer<Device>::apply_bias_cpu();
     }
   }
 
   void bp_compute() override {
     if(this->using_gpus()) {
-      base_convolution_layer<Dev>::compute_gradients_cudnn(false);
-      base_convolution_layer<Dev>::apply_transposed_convolution_cudnn(false);
+      base_convolution_layer<Device>::compute_gradients_cudnn(false);
+      base_convolution_layer<Device>::apply_transposed_convolution_cudnn(false);
     } else {
-      base_convolution_layer<Dev>::compute_gradients_im2col(false);
-      base_convolution_layer<Dev>::apply_transposed_convolution_im2col(false);
+      base_convolution_layer<Device>::compute_gradients_im2col(false);
+      base_convolution_layer<Device>::apply_transposed_convolution_im2col(false);
     }
   }
 
@@ -189,4 +178,4 @@ protected:
 
 } // namespace lbann
 
-#endif // LBANN_LAYER_CONVOLUTION_HPP_INCLUDED
+#endif // LBANN_LAYERS_LEARNING_CONVOLUTION_HPP_INCLUDED

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -24,10 +24,9 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_LAYER_DECONVOLUTION_HPP_INCLUDED
-#define LBANN_LAYER_DECONVOLUTION_HPP_INCLUDED
+#ifndef LBANN_LAYERS_LEARNING_DECONVOLUTION_HPP_INCLUDED
+#define LBANN_LAYERS_LEARNING_DECONVOLUTION_HPP_INCLUDED
 
-#include <vector>
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/utils/exception.hpp"
 
@@ -39,8 +38,8 @@ class lbann_callback_imcomm;
 /** @brief Transpose of the convolution layer.
  *  @todo Rename to "transposed_convolution_layer".
  */
-template <data_layout T_layout = data_layout::DATA_PARALLEL, El::Device Dev = El::Device::CPU>
-class deconvolution_layer : public base_convolution_layer<Dev> {
+template <data_layout Layout = data_layout::DATA_PARALLEL, El::Device Device = El::Device::CPU>
+class deconvolution_layer : public base_convolution_layer<Device> {
 private:
 
   friend class lbann_callback_imcomm;
@@ -75,17 +74,18 @@ public:
                       std::vector<int> dilations,
                       int groups,
                       bool has_bias = true)
-    : base_convolution_layer<Dev>(comm,
-                                  num_data_dims,
-                                  num_output_channels,
-                                  conv_dims,
-                                  pads,
-                                  strides,
-                                  dilations,
-                                  groups,
-                                  has_bias) {
-    static_assert(T_layout == data_layout::DATA_PARALLEL,
-                  "convolution only supports DATA_PARALLEL");
+    : base_convolution_layer<Device>(
+        comm,
+        num_data_dims,
+        num_output_channels,
+        conv_dims,
+        pads,
+        strides,
+        dilations,
+        groups,
+        has_bias) {
+    static_assert(Layout == data_layout::DATA_PARALLEL,
+                  "deconvolution layer only supports DATA_PARALLEL");
 
   }
 
@@ -93,19 +93,19 @@ public:
 
   std::string get_type() const override { return "deconvolution"; }
 
-  data_layout get_data_layout() const override { return T_layout; }
+  data_layout get_data_layout() const override { return Layout; }
 
-  El::Device get_device_allocation() const override { return Dev; }
+  El::Device get_device_allocation() const override { return Device; }
 
   void setup_dims() override {
-    base_convolution_layer<Dev>::setup_dims();
+    base_convolution_layer<Device>::setup_dims();
     std::stringstream err;
 
     // Get tensor dimensions
     const auto& input_dims = this->get_input_dims();
     auto output_dims = input_dims;
     const auto input_channels = input_dims[0];
-    const auto output_channels = this->m_kernel_dims[0];
+    const auto output_channels = this->m_output_channels;
 
     // Check for unsupported features
     /// @todo Implement dilated and grouped deconvolution
@@ -147,35 +147,12 @@ public:
       LBANN_ERROR(err.str());
     }
 
-    // Initialize convolution kernel dimensions
-    // Note: Unlike the convolutional kernel, the previous layer's
-    // number of channels is now the leading position -- keep in mind
-    // that deconvolution is the transpose of a convolution.
-    this->m_kernel_dims.insert(this->m_kernel_dims.begin(),
-                               input_channels / this->m_num_groups);
-    this->m_kernel_size = std::accumulate(this->m_kernel_dims.begin(),
-                                          this->m_kernel_dims.end(),
-                                          1, std::multiplies<int>());
-    if (this->m_kernel_dims.size() != input_dims.size() + 1) {
-      err << this->get_type() << " layer "
-          << "\"" << this->get_name() << "\" has a ";
-      for (size_t i = 0; i < input_dims.size(); ++i) {
-        err << (i > 0 ? " x " : "") << input_dims[i];
-      }
-      err << " input tensor and a ";
-      for (size_t i = 0; i < this->m_kernel_dims.size(); ++i) {
-        err << (i > 0 ? " x " : "") << this->m_kernel_dims[i];
-      }
-      err << " convolution kernel";
-      LBANN_ERROR(err.str());
-    }
-
     // Initialize output tensor dimensions
     /// @todo Dilated deconvolution
     output_dims[0] = output_channels;
     for (size_t i = 0; i < output_dims.size() - 1; ++i) {
       const auto& input_dim = input_dims[i+1];
-      const auto& kernel_dim = this->m_kernel_dims[i+2];
+      const auto& kernel_dim = this->m_conv_dims[i];
       const auto& stride = this->m_strides[i];
       const auto& pad = this->m_pads[i];
       // const auto& dilation = this->m_dilations[i];
@@ -187,23 +164,33 @@ public:
 
 protected:
 
+  std::vector<int> get_kernel_dims() const {
+    std::vector<int> dims;
+    dims.push_back(this->get_input_dims()[0]);
+    dims.push_back(this->m_output_channels);
+    dims.insert(dims.end(),
+                this->m_conv_dims.begin(),
+                this->m_conv_dims.end());
+    return dims;
+  }
+
   void fp_compute() override {
     if(this->using_gpus()) {
-      base_convolution_layer<Dev>::apply_transposed_convolution_cudnn(true);
-      base_convolution_layer<Dev>::apply_bias_cudnn();
+      base_convolution_layer<Device>::apply_transposed_convolution_cudnn(true);
+      base_convolution_layer<Device>::apply_bias_cudnn();
     } else {
-      base_convolution_layer<Dev>::apply_transposed_convolution_im2col(true);
-      base_convolution_layer<Dev>::apply_bias_cpu();
+      base_convolution_layer<Device>::apply_transposed_convolution_im2col(true);
+      base_convolution_layer<Device>::apply_bias_cpu();
     }
   }
 
   void bp_compute() override {
     if(this->using_gpus()) {
-      base_convolution_layer<Dev>::compute_gradients_cudnn(true);
-      base_convolution_layer<Dev>::apply_convolution_cudnn(false);
+      base_convolution_layer<Device>::compute_gradients_cudnn(true);
+      base_convolution_layer<Device>::apply_convolution_cudnn(false);
     } else {
-      base_convolution_layer<Dev>::compute_gradients_im2col(true);
-      base_convolution_layer<Dev>::apply_convolution_im2col(false);
+      base_convolution_layer<Device>::compute_gradients_im2col(true);
+      base_convolution_layer<Device>::apply_convolution_im2col(false);
     }
   }
 
@@ -211,4 +198,4 @@ protected:
 
 } // namespace lbann
 
-#endif // LBANN_LAYER_DECONVOLUTION_HPP_INCLUDED
+#endif // LBANN_LAYERS_LEARNING_DECONVOLUTION_HPP_INCLUDED

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -532,7 +532,7 @@ private:
                                                 nullptr));
         std::vector<int> dims(num_dims), pads(num_dims), strides(num_dims);
         CHECK_CUDNN(cudnnGetPoolingNdDescriptor(src,
-                                                0,
+                                                num_dims,
                                                 &mode,
                                                 &nan_propagation,
                                                 &num_dims,


### PR DESCRIPTION
This PR makes some bugfixes so that a model can be setup multiple times. This is helpful for MTNN, where a model might be copied, modified, and re-setup. In conjunction with #908, I can now setup AlexNet multiple times, copy it, setup the copy multiple times, and train the original model without incident (I can't yet run the copied model).

Major changes:
- Bugfixes in conv and pooling layer copy constructors (PR #907).
- Convolution kernel dimensions are now constructed with a virtual function, not stored in a variable.
- Minor stylistic changes in convolution layer.
- Check convolution parameters during setup.

Pinging @naoyam to minimize merge conflicts with his distconv work.