### PR TITLE
Add a driver that just prints help and exits

### DIFF
--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -41,6 +41,9 @@ void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p);
 /// prints usage information
 void print_help(const lbann_comm& comm);
 
+/// prints usage information
+void print_help(std::ostream& os);
+
 /// prints prototext file, cmd line, etc to file
 void save_session(const lbann_comm& comm, const int argc, char * const* argv, lbann_data::LbannPB& p);
 

--- a/model_zoo/CMakeLists.txt
+++ b/model_zoo/CMakeLists.txt
@@ -3,6 +3,8 @@ add_executable( lbann-bin lbann.cpp )
 target_link_libraries(lbann-bin lbann )
 set_target_properties(lbann-bin PROPERTIES OUTPUT_NAME lbann)
 
+add_executable( lbann-help lbann_help.cpp )
+target_link_libraries(lbann-help lbann )
 
 #this can be done simler - quick copy/paste hack //d hysom
 add_executable( lbann-bin2 lbann2.cpp )
@@ -28,6 +30,7 @@ set_target_properties(lbann-inf-bin PROPERTIES OUTPUT_NAME lbann_inf)
 # Install the binaries
 install(
   TARGETS lbann-bin lbann-bin2 lbann-gan-bin lbann-cycgan-bin lbann-aecycgan-bin
+  lbann-help
   EXPORT LBANNTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/model_zoo/lbann_help.cpp
+++ b/model_zoo/lbann_help.cpp
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// lbann_proto.cpp - prototext application
+////////////////////////////////////////////////////////////////////////////////
+
+#include <lbann/proto/proto_common.hpp>
+
+#include <iostream>
+
+using namespace lbann;
+
+int main(int, char **) {
+  print_help(std::cerr);
+  return EXIT_SUCCESS;
+}

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -850,11 +850,14 @@ void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p)
 
 void print_help(const lbann_comm& comm)
 {
-  if (!comm.am_world_master()) {
-    return;
+  if (comm.am_world_master()) {
+    print_help(std::cerr);
   }
+}
 
-  std::cerr <<
+void print_help(std::ostream& os)
+{
+  os <<
        "General usage: you need to specify three prototext files, e.g:\n"
        "  srun -n# proto --model=<string> --optimizer=<string> --reader=<string> --metadata=<string>\n"
        "\n"


### PR DESCRIPTION
This patches around the fact that the help logic requires MPI and CUDA
to be initialized.

The original signature is still there because I didn't want to chase around all the tests/frontends/etc. This guarantees no breakage of existing code.

Don't call `lbann-help` with an MPI launcher. If you do, you might get multiple output. `MPI_Init` is never called; there is absolutely no logic in this driver. It stupidly prints the help to `stderr` and exits.
