### PR TITLE
update find_package for conduit to reflect latest changes on their end.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,15 +338,15 @@ if (LBANN_WITH_CONDUIT)
     message(STATUS "Found HDF5: ${HDF5_DIR}")
   endif ()
 
-  find_package(CONDUIT CONFIG QUIET
-    HINTS ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
+  find_package(Conduit CONFIG QUIET
+    HINTS ${Conduit_DIR} $ENV{Conduit_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
     PATH_SUFFIXES lib64/cmake lib/cmake
     NO_DEFAULT_PATH)
-  if (NOT CONDUIT_FOUND)
-    find_package(CONDUIT CONFIG QUIET REQUIRED
+  if (NOT Conduit_FOUND)
+    find_package(Conduit CONFIG QUIET REQUIRED
       PATH_SUFFIXES lib64/cmake lib/cmake)
   endif ()
-  message(STATUS "Found CONDUIT: ${CONDUIT_DIR}")
+  message(STATUS "Found CONDUIT: ${Conduit_DIR}")
 
   # Ugh. I don't like that this requires intimate knowledge of
   # specific targets that CONDUIT exports. It should support


### PR DESCRIPTION
In [this commit](https://github.com/LLNL/conduit/commit/b30a8e2b216d0039020a5645fe708e721fc47f19) the conduit package changed the name of the exported CMake config file. This addresses that change.