### PR TITLE
Change a -= to an Axpy for back compatibility

### DIFF
--- a/model_zoo/tests/test_utils.hpp
+++ b/model_zoo/tests/test_utils.hpp
@@ -172,7 +172,7 @@ lbann::DataType absolute_error(lbann::CPUMat& approx_val, lbann::CPUMat& true_va
   ASSERT_EQ(approx_val.Width(), true_val.Width());
   ASSERT_EQ(approx_val.Height(), true_val.Height());
   elemerr = true_val;
-  elemerr -= approx_val;
+  El::Axpy(lbann::DataType{-1}, approx_val, elemerr);
   lbann::DataType abs_err = El::EntrywiseNorm(elemerr, 1);
   El::EntrywiseMap(elemerr, std::function<lbann::DataType(const lbann::DataType&)>(
   [](const lbann::DataType& x) {


### PR DESCRIPTION
Matrix<T,D>::operator-= just calls Axpy under the hood. I would like
to remove that operator anyway along with the other "compute"
functions built into the interface. IMO, the *Matrix* classes should
just be storage classes.

This is the only change required before merging llnl/elemental#75.