### PR TITLE
Updating documentation with OSX build instructions and publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ the MPI launcher.
 More details about running LBANN are documented
 [here](https://lbann.readthedocs.io/en/latest/running_lbann.html).
 
+## Publications
+
+A list of publications, presentations and posters are shown
+[here](https://lbann.readthedocs.io/en/latest/publications.html).
 
 ## Reporting issues
 Issues, questions, and bugs can be raised on the [Github issue

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -23,6 +23,9 @@ if (SPHINX_FOUND)
       build_spack_extra_config.rst
       build_with_cmake.rst
       build_with_superbuild.rst
+      build_osx.rst
+      publications.rst
+      lbann.rst
       callbacks.rst
       data_readers.rst
       data_store.rst

--- a/docs/build_osx.rst
+++ b/docs/build_osx.rst
@@ -1,0 +1,101 @@
+.. role:: bash(code)
+          :language: bash
+
+====================
+Building LBANN on OS X
+====================
+
+.. warning:: This section is still under development and being
+             tested. It contains known issues. This warning will be
+             removed when it is believed to be generally usable.
+
+
+--------------------
+Getting Started
+--------------------
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setup Spack and local base tools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To get started follow the general directions on building LBANN to
+`setup spack
+<https://lbann.readthedocs.io/en/latest/building_lbann.html#setup-spack-and-local-base-tools>`_.
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setup Homebrew
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note:: Setting up Homebrew only needs to be done once per system,.
+
+1.  Download and install `Homebrew <https://brew.sh>`_.  Setup base
+    development packages.  Note that at the moment we use brew to
+    install llvm, open-mpi, scalapack, and cmake.
+
+    .. code-block:: bash
+
+       brew install llvm
+       brew install open-mpi
+       brew install scalapack
+       brew install cmake
+
+    Put the brew based clang in your path:
+
+    .. code-block:: bash
+
+       export PATH="/usr/local/opt/llvm/bin:$PATH";
+
+    Install lmmod so that we can use modules to put spack built
+    packages into your path.
+
+    .. code-block:: bash
+
+       brew install lmod
+       brew install luarocks
+
+    Update your .profile to enable use of modules via lmod
+
+    .. code-block:: bash
+
+       source $(brew --prefix lmod)/init/$(basename $SHELL)
+
+    .. code-block:: console
+
+        cd ${LBANN_BUILD_DIR}
+        cmake \
+          -G Ninja \
+          -D CMAKE_BUILD_TYPE:STRING=Release \
+          -D CMAKE_INSTALL_PREFIX:PATH=${LBANN_INSTALL_DIR} \
+          \
+          -D LBANN_SB_BUILD_ALUMINUM=ON \
+          -D ALUMINUM_ENABLE_MPI_CUDA=OFF \
+          -D ALUMINUM_ENABLE_NCCL=OFF \
+          \
+          -D LBANN_SB_BUILD_HYDROGEN=ON \
+          -D Hydrogen_ENABLE_ALUMINUM=ON \
+          -D Hydrogen_ENABLE_CUB=OFF \
+          -D Hydrogen_ENABLE_CUDA=OFF \
+          \
+          -D LBANN_SB_BUILD_LBANN=ON \
+          -D LBANN_DATATYPE:STRING=float \
+          -D LBANN_SEQUENTIAL_INITIALIZATION:BOOL=OFF \
+          -D LBANN_WITH_ALUMINUM:BOOL=ON \
+          -D LBANN_WITH_CONDUIT:BOOL=ON \
+          -D LBANN_WITH_CUDA:BOOL=OFF \
+          -D LBANN_WITH_CUDNN:BOOL=OFF \
+          -D LBANN_WITH_NCCL:BOOL=OFF \
+          -D LBANN_WITH_NVPROF:BOOL=OFF \
+          -D LBANN_WITH_SOFTMAX_CUDA:BOOL=OFF \
+          -D LBANN_WITH_TOPO_AWARE:BOOL=ON \
+          -D LBANN_WITH_TBINF=OFF \
+          -D LBANN_WITH_VTUNE:BOOL=OFF \
+          \
+          -D CMAKE_CXX_COMPILER=$(which clang) \
+          -D CMAKE_C_COMPILER=$(which clang) \
+          -D LBANN_SB_FWD_ALUMINUM_OpenMP_CXX_LIB_NAMES=omp \
+          -D LBANN_SB_FWD_ALUMINUM_OpenMP_CXX_FLAGS=-fopenmp \
+          -D LBANN_SB_FWD_ALUMINUM_OpenMP_omp_LIBRARY=/usr/local/opt/llvm/lib/libomp.dylib \
+          ${LBANN_HOME}/superbuild
+
+        ninja

--- a/docs/build_osx.rst
+++ b/docs/build_osx.rst
@@ -60,6 +60,35 @@ Setup Homebrew
 
        source $(brew --prefix lmod)/init/$(basename $SHELL)
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Building & Installing LBANN as a developer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+1.  Establish a Spack environment and install software dependencies.
+
+    .. note:: This spack environment has to be setup once each time
+              you create a new build directory.
+
+    .. code-block:: bash
+
+        export LBANN_HOME=/path/to/lbann/git/repo
+        export LBANN_BUILD_DIR=/path/to/a/build/directory
+        export LBANN_INSTALL_DIR=/path/to/an/install/directory
+        cd ${LBANN_BUILD_DIR}
+        spack env create -d . ${LBANN_HOME}/spack_environments/developer_release_osx_spack.yaml
+        spack install
+        spack env loads # Spack creates a file named loads that has all of the correct modules
+        source loads
+        unset LIBRARY_PATH
+
+
+2.  Build LBANN locally from source and build Hydrogen and Aluminum
+    using the superbuild. See :ref:`here <building-with-the-superbuild>`
+    for a list and descriptions of all CMake flags known to LBANN's
+    "Superbuild" build system. A representative CMake command line
+    that expects :bash:`LBANN_HOME`, :bash:`LBANN_BUILD_DIR`,
+    :bash:`LBANN_INSTALL_DIR` environment variables might be:
+
     .. code-block:: console
 
         cd ${LBANN_BUILD_DIR}

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -129,7 +129,7 @@ Setup Spack and local base tools
 Building & Installing LBANN as a user
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning:: This section is still underdevelopment and being
+.. warning:: This section is still under development and being
              tested. It contains known issues. This warning will be
              removed when it is believed to be generally usable.
 
@@ -287,6 +287,7 @@ Advanced build methods
 .. toctree::
    :maxdepth: 1
 
+   build_osx
    build_with_cmake
    build_with_superbuild
    build_containers

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ html_theme_options = {
 }
 
 breathe_projects_source = {
+  "lbann"           : ( "../include/lbann/", [""]),
   "callback"        : ( "../include/lbann/callbacks/", [""]),
   "data_readers"    : ( "../include/lbann/data_readers/", [""]),
   "data_store"      : ( "../include/lbann/data_store/", [""]),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,11 +33,17 @@ methods.
    building_lbann
    running_lbann
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Publications
+
+   publications
 
 .. toctree::
    :maxdepth: 2
    :caption: Developer Documentation
 
+   lbann
    callbacks
    data_readers
    data_store
@@ -56,7 +62,3 @@ methods.
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-
-
-CMakeLists.txt
-Elemental_extensions.cpp      comm.cpp   base.cpp   data_distributions       io    models    proto    weights

--- a/docs/lbann.rst
+++ b/docs/lbann.rst
@@ -1,0 +1,7 @@
+LBANN
+=================================
+
+Top of the LBANN developers documentation.
+
+.. autodoxygenindex::
+  :project: lbann

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -1,4 +1,4 @@
-LBANN Publications
+Papers and Presentations
 =================================
 
 Publications about or related to using LBANN
@@ -36,7 +36,10 @@ Publications about or related to using LBANN
 + Brian Van Essen, Hyojin Kim, Roger Pearce, Kofi Boakye, Barry
   Chen. ```LBANN: Livermore Big Artificial Neural Network HPC
   Toolkit'' <https://dl.acm.org/citation.cfm?id=2834897>`_, in
-  Proceedings of the Workshop on Machine Learning in High-Performance
-  Computing Environments (MLHPC '15), pages 5:1-6, Nov. 2015. DOI:
+  *Proceedings of the Workshop on Machine Learning in High-Performance
+  Computing Environments (MLHPC '15)*, pages 5:1-6, Nov. 2015. DOI:
   `10.1145/2834892.2834897 <https://doi.org/10.1145/2834892.2834897>`_
 
+Presentations highlighting LBANN and its impact on science applications
+
+.. note:: Presentations and links to be added

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -1,45 +1,68 @@
-Papers and Presentations
+Papers, Presentations, and Posters
 =================================
 
-Publications about or related to using LBANN
+Publications about or related to using LBANN:
 
 + Nikoli Dryden, Naoya Maruyama, Tom Benson, Tim Moon, Marc Snir,
-  Brian Van Essen. ```Improving Strong-Scaling of CNN Training by
-  Exploiting Finer-Grained Parallelism''
+  Brian Van Essen. `"Improving Strong-Scaling of CNN Training by
+  Exploiting Finer-Grained Parallelism"
   <https://arxiv.org/abs/1903.06681>`_, to appear in *IEEE
   International Parallel & Distributed Processing Symposium*, 2019.
 
+  + `IPDPS'19 <http://www.ipdps.org/ipdps2019/2019-advance-program.html>`
+
 + Nikoli Dryden, Naoya Maruyama, Tim Moon, Tom Benson, Andy Yoo, Marc
-  Snir, Brian Van Essen. ```Aluminum: An Asynchronous, GPU-Aware
+  Snir, Brian Van Essen. `"Aluminum: An Asynchronous, GPU-Aware
   Communication Library Optimized for Large-Scale Training of Deep
-  Neural Networks on HPC Systems''
+  Neural Networks on HPC Systems"
   <https://ieeexplore.ieee.org/document/8638639>`_, in *Proceedings of
   the Workshop on Machine Learning in High-Performance Computing
   Environments (MLHPC '18)*, Nov. 2018. DOI:
   `10.1109/MLHPC.2018.8638639
   <https://doi.org/10.1109/MLHPC.2018.8638639>`_
 
+  + `MLHPC'18  <https://ornlcda.github.io/MLHPC2018/>`_
+
 + Sam Ade Jacobs, Nikoli Dryden, Roger Pearce, and Brian Van
-  Essen. ```Towards Scalable Parallel Training of Deep Neural
-  Networks'' <https://dl.acm.org/citation.cfm?id=3146353>`_, in *Proceedings of the Workshop on Machine Learning in
+  Essen. `"Towards Scalable Parallel Training of Deep Neural
+  Networks" <https://dl.acm.org/citation.cfm?id=3146353>`_, in *Proceedings of the Workshop on Machine Learning in
   High-Performance Computing Environments (MLHPC '17)*, pages 1-8,
   Nov. 2017.  DOI: `10.1145/3146347.3146353 <https://doi.org/10.1145/3146347.3146353>`_
 
+  + `MLHPC'17  <https://ornlcda.github.io/MLHPC2017/>`_
+
 + Nikoli Dryden, Sam Ade Jacobs, Tim Moon, Brian Van
-  Essen. ```Communication quantization for data-parallel training of
-  deep neural networks''
+  Essen. `"Communication quantization for data-parallel training of
+  deep neural networks"
   <https://ieeexplore.ieee.org/document/7835789>`_, in *Proceedings of
   the Workshop on Machine Learning in High-Performance Computing
   Environments (MLHPC '16)*, pages 1-8, Nov. 2016. DOI:
   `10.1109/MLHPC.2016.004 <https://doi.org/10.1109/MLHPC.2016.004>`_
 
+  + `MLHPC'16  <https://ornlcda.github.io/MLHPC2016/>`_
+
 + Brian Van Essen, Hyojin Kim, Roger Pearce, Kofi Boakye, Barry
-  Chen. ```LBANN: Livermore Big Artificial Neural Network HPC
-  Toolkit'' <https://dl.acm.org/citation.cfm?id=2834897>`_, in
+  Chen. `"LBANN: Livermore Big Artificial Neural Network HPC
+  Toolkit" <https://dl.acm.org/citation.cfm?id=2834897>`_, in
   *Proceedings of the Workshop on Machine Learning in High-Performance
   Computing Environments (MLHPC '15)*, pages 5:1-6, Nov. 2015. DOI:
   `10.1145/2834892.2834897 <https://doi.org/10.1145/2834892.2834897>`_
 
-Presentations highlighting LBANN and its impact on science applications
+  + `MLHPC'15  <https://ornlcda.github.io/MLHPC2015/>`_
+
+Presentations highlighting LBANN and its impact on science applications:
 
 .. note:: Presentations and links to be added
+
+Posters about LBANN and its core algorthms and features:
+
+.. note:: Posters and links to be added
+
++ Nikoli Dryden, Naoya Maruyama, Tom Benson, Tim Moon, Marc Snir,
+  Brian Van Essen. **"Scalable CNN Training on Large-Scale HPC
+  Systems"** in *Proceedings of the Workshop on Systems for ML and
+  Open Source Software at NeurIPS 2018*, December 7,
+  2018. `abs
+  <http://learningsys.org/nips18/assets/papers/85CameraReadySubmissionsysforml-abs.pdf>`_
+
+  + `Systems for ML 2018 <http://learningsys.org/nips18/acceptedpapers.html>`_

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -1,0 +1,42 @@
+LBANN Publications
+=================================
+
+Publications about or related to using LBANN
+
++ Nikoli Dryden, Naoya Maruyama, Tom Benson, Tim Moon, Marc Snir,
+  Brian Van Essen. ```Improving Strong-Scaling of CNN Training by
+  Exploiting Finer-Grained Parallelism''
+  <https://arxiv.org/abs/1903.06681>`_, to appear in *IEEE
+  International Parallel & Distributed Processing Symposium*, 2019.
+
++ Nikoli Dryden, Naoya Maruyama, Tim Moon, Tom Benson, Andy Yoo, Marc
+  Snir, Brian Van Essen. ```Aluminum: An Asynchronous, GPU-Aware
+  Communication Library Optimized for Large-Scale Training of Deep
+  Neural Networks on HPC Systems''
+  <https://ieeexplore.ieee.org/document/8638639>`_, in *Proceedings of
+  the Workshop on Machine Learning in High-Performance Computing
+  Environments (MLHPC '18)*, Nov. 2018. DOI:
+  `10.1109/MLHPC.2018.8638639
+  <https://doi.org/10.1109/MLHPC.2018.8638639>`_
+
++ Sam Ade Jacobs, Nikoli Dryden, Roger Pearce, and Brian Van
+  Essen. ```Towards Scalable Parallel Training of Deep Neural
+  Networks'' <https://dl.acm.org/citation.cfm?id=3146353>`_, in *Proceedings of the Workshop on Machine Learning in
+  High-Performance Computing Environments (MLHPC '17)*, pages 1-8,
+  Nov. 2017.  DOI: `10.1145/3146347.3146353 <https://doi.org/10.1145/3146347.3146353>`_
+
++ Nikoli Dryden, Sam Ade Jacobs, Tim Moon, Brian Van
+  Essen. ```Communication quantization for data-parallel training of
+  deep neural networks''
+  <https://ieeexplore.ieee.org/document/7835789>`_, in *Proceedings of
+  the Workshop on Machine Learning in High-Performance Computing
+  Environments (MLHPC '16)*, pages 1-8, Nov. 2016. DOI:
+  `10.1109/MLHPC.2016.004 <https://doi.org/10.1109/MLHPC.2016.004>`_
+
++ Brian Van Essen, Hyojin Kim, Roger Pearce, Kofi Boakye, Barry
+  Chen. ```LBANN: Livermore Big Artificial Neural Network HPC
+  Toolkit'' <https://dl.acm.org/citation.cfm?id=2834897>`_, in
+  Proceedings of the Workshop on Machine Learning in High-Performance
+  Computing Environments (MLHPC '15), pages 5:1-6, Nov. 2015. DOI:
+  `10.1145/2834892.2834897 <https://doi.org/10.1145/2834892.2834897>`_
+

--- a/spack_environments/developer_release_osx_spack.yaml
+++ b/spack_environments/developer_release_osx_spack.yaml
@@ -1,0 +1,76 @@
+# This is a Spack Environment file.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+spack:
+  # add package specs to the `specs` list
+  specs:
+  - protobuf@3.6.1 build_type=Release +shared
+  - conduit@master~doc~doxygen+hdf5+mpi+python+shared~silo
+  - cnpy@master build_type=RelWithDebInfo
+  - opencv@3.4.3 build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png+powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab+vsx~vtk+zlib
+  - cereal@1.2.2 build_type=RelWithDebInfo patches=2dfa0bff9816d0ebd8a1bcc70ced4483b3cda83a982ea5027f1aaadceaa15aac,720265382f29b744488d67e8df5000f2ca1b4dceb2018835fb5dc7a3a1c23f75,91f968e9ac3964e1a689a9ad379ab16f7803ac3d34d24f87ebcaecaa3f9a2f16
+  - ninja@1.8.2
+  - zlib@1.2.11
+  - openblas@0.3.4 cpu_target=auto ~ilp64+pic+shared threads=none ~virtual_machine
+  - hwloc@2.0.2
+  - cmake@3.12.1
+  - py-cython@0.29
+  - py-breathe
+  - py-m2r
+  - py-sphinx
+  - py-certifi
+  - py-urllib3
+  - py-idna
+  - py-chardet
+  - doxygen
+  mirrors: {}
+  modules:
+    enable: []
+  repos: []
+  config: {}
+################################################################################
+# Include paths to standard compilers and packages on LLNL LC systems
+# Remove and/or replace these with your site specific packages and paths
+################################################################################
+# include:
+#   - externals_llnl_lc_cz.yaml
+  packages:
+    all:
+      providers:
+        mpi: [openmpi@4.0 arch=darwin-highsierra-x86_64]
+      buildable: true
+      version: []
+      paths: {}
+      modules: {}
+      compiler: [clang@7.0.1 arch=darwin-highsierra-x86_64]
+
+    cmake:
+      variants: ~openssl ~ncurses
+      paths:
+        cmake@3.14.0 arch=darwin-highsierra--x86_64:  /usr/local/
+    python:
+      buildable: True
+      variants: +shared
+      version: [3.7.2]
+
+    openmpi:
+      buildable: False
+      version: [4.0]
+      paths:
+        openmpi@4.0 arch=darwin-highsierra-x86_64: /usr/local/
+
+  compilers:
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags: {}
+      modules: []
+      operating_system: highsierra
+      paths:
+        cc: /usr/local/Cellar/llvm/7.0.1/bin/clang
+        cxx: /usr/local/Cellar/llvm/7.0.1/bin/clang++
+        f77: /usr/local/bin/gfortran
+        fc: /usr/local/bin/gfortran
+      spec: clang@7.0.1
+      target: x86_64


### PR DESCRIPTION
I have added a list and set of links to our publications as well as an initial set of directions for building on OS X.