### PR TITLE
Removing a deprecated SGD field

### DIFF
--- a/bamboo/unit_tests/prototext/opt_sgd.prototext
+++ b/bamboo/unit_tests/prototext/opt_sgd.prototext
@@ -1,8 +1,7 @@
 optimizer {
   sgd {
     learn_rate: 0.01
-    momentum: 0.9 
-    decay_rate: 0
+    momentum: 0.9
     nesterov: false
-  }  
+  }
 }

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -76,7 +76,6 @@ model {
       sgd {
         learn_rate: 0.007
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -91,7 +90,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -107,7 +105,6 @@ model {
       sgd {
         learn_rate: 0.008
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -122,7 +119,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -138,7 +134,6 @@ model {
       sgd {
         learn_rate: 0.009
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -153,7 +148,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -169,7 +163,6 @@ model {
       sgd {
         learn_rate: 0.01
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -184,7 +177,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -200,7 +192,6 @@ model {
       sgd {
         learn_rate: 0.009
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -215,7 +206,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -231,7 +221,6 @@ model {
       sgd {
         learn_rate: 0.008
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -246,7 +235,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -262,7 +250,6 @@ model {
       sgd {
         learn_rate: 0.007
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -277,7 +264,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -293,7 +279,6 @@ model {
       sgd {
         learn_rate: 0.006
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -308,7 +293,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }
@@ -324,7 +308,6 @@ model {
       sgd {
         learn_rate: 0.005
         momentum: 0.9
-        decay_rate: 0.0002
         nesterov: false
       }
     }
@@ -339,7 +322,6 @@ model {
       sgd {
         learn_rate: 0.02
         momentum: 0.9
-        decay_rate: 0
         nesterov: false
       }
     }


### PR DESCRIPTION
Looks like I missed a few prototext files when I removed the `decay_rate` field in PR #931.