### PR TITLE
bug fix: only master was throwing exception if "unknown name for data…

### DIFF
--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -337,11 +337,9 @@ void init_data_readers(
                   "but LBANN is not built with Python/C API");
 #endif // LBANN_HAS_PYTHON
     } else {
-      if (master) {
         err << __FILE__ << " " << __LINE__ << " :: unknown name for data reader: "
             << name;
         throw lbann_exception(err.str());
-      }
     }
     reader->set_comm(comm);
 


### PR DESCRIPTION
… reader: triplet;" this caused all other procs to continue execution, resulting in seg faults.