### PR TITLE
removed 'FATAL ERROR' warning about unsuitable for multi-model use.

### DIFF
--- a/src/data_store/generic_data_store.cpp
+++ b/src/data_store/generic_data_store.cpp
@@ -90,6 +90,7 @@ m_n(0),
     m_dir = m_reader->get_local_file_dir();
   }
 
+/*
   if (m_comm->get_num_trainers() != 1) {
     if (m_master) {
       std::cerr << "\nFATAL ERROR: data store classes currently assume there is\n"
@@ -97,6 +98,7 @@ m_n(0),
     }
     exit(9);
   }
+*/
 }
 
 void generic_data_store::get_minibatch_index_vector() {
@@ -222,6 +224,7 @@ void generic_data_store::exchange_mb_counts() {
 }
 
 void generic_data_store::exchange_mb_indices() {
+  LBANN_ERROR("comm calls are incorrect. I didn't think this method was used any longer");
   exchange_mb_counts();
   //setup data structures to exchange minibatch indices with all processors
   //displacement vector
@@ -334,6 +337,7 @@ std::pair<std::string, std::string> generic_data_store::get_pathname_and_prefix(
 }
 
 void generic_data_store::create_dirs(std::string s) {
+  LBANN_ERROR("broken; obsolete");
   if (m_comm->get_rank_in_node() == 0) {
     if (s.back() != '/') {
       s += '/';
@@ -391,6 +395,7 @@ int generic_data_store::get_index_owner(int idx) {
 }
 
 void generic_data_store::build_index_owner() {
+  LBANN_ERROR("broken; obsolete");
   m_owner.clear();
   int num_indices = m_my_datastore_indices.size();
   if (num_indices == 0) {


### PR DESCRIPTION
At the time I wrote that I didn't know if it worked in that scenario or not; turns out it does. Aldo added some exceptions to deprecated methods.