### PR TITLE
Bugfix for data store with bad indices

### DIFF
--- a/include/lbann/data_store/data_store_jag.hpp
+++ b/include/lbann/data_store/data_store_jag.hpp
@@ -69,6 +69,12 @@ class data_store_jag : public generic_data_store {
 
 protected :
 
+  /// The size of the mini-batch that was used to calculate ownership
+  /// of samples when building the owner map.  This size has to be
+  /// used consistently when computing the indices that will be sent
+  /// and received.
+  int m_owner_map_mb_size;
+
   bool m_super_node;
 
   /// this is pure virtual in generic_data_reader, so must include it for

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -785,7 +785,7 @@ void data_reader_jag_conduit::load() {
   load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
 
   /// Check the data that each rank loaded
-  if (!m_is_data_loaded) {
+  if (!m_is_data_loaded && !m_sample_list.empty()) {
     m_is_data_loaded = true;
 
     /// Open the first sample to make sure that all of the fields are correct

--- a/src/data_store/data_store_jag.cpp
+++ b/src/data_store/data_store_jag.cpp
@@ -41,6 +41,7 @@ namespace lbann {
 data_store_jag::data_store_jag(
   generic_data_reader *reader, model *m) :
   generic_data_store(reader, m),
+  m_owner_map_mb_size(0),
   m_super_node(false),
   m_super_node_overhead(0),
   m_compacted_sample_size(0) {
@@ -237,6 +238,12 @@ void data_store_jag::set_conduit_node(int data_id, conduit::Node &node) {
 }
 
 const conduit::Node & data_store_jag::get_conduit_node(int data_id) const {
+  /**
+   * dah: commenting this out since it gives a false positive for test
+   *      case with unshuffled indices. Since we currently send samples
+   *      to ourselves, they should be in m_minibatch_data. The following
+   *      block is only useful if, at some future time, we do not send
+   *      indices to ourself
   std::unordered_map<int, conduit::Node>::const_iterator t = m_data.find(data_id);
   if (t != m_data.end()) {
     if(m_super_node) {
@@ -245,6 +252,7 @@ const conduit::Node & data_store_jag::get_conduit_node(int data_id) const {
       return t->second["data"];
     }
   }
+  */
 
   std::unordered_map<int, conduit::Node>::const_iterator t2 = m_minibatch_data.find(data_id);
   if (t2 == m_minibatch_data.end()) {
@@ -383,7 +391,7 @@ int data_store_jag::build_indices_i_will_recv(int current_pos, int mb_size) {
   int k = 0;
   for (int i=current_pos; i< current_pos + mb_size; ++i) {
     auto index = (*m_shuffled_indices)[i];
-    if ((i % mb_size) % m_np == m_rank) {
+    if ((i % m_owner_map_mb_size) % m_np == m_rank) {
       int owner = m_owner[index];
       m_indices_to_recv[owner].insert(index);
       k++;
@@ -400,7 +408,7 @@ int data_store_jag::build_indices_i_will_send(int current_pos, int mb_size) {
     auto index = (*m_shuffled_indices)[i];
     /// If this rank owns the index send it to the (i%m_np)'th rank
     if (m_data.find(index) != m_data.end()) {
-      m_indices_to_send[(i % mb_size) % m_np].insert(index);
+      m_indices_to_send[(i % m_owner_map_mb_size) % m_np].insert(index);
 
       // Sanity check
       if (m_owner[index] != m_rank) {
@@ -416,12 +424,13 @@ int data_store_jag::build_indices_i_will_send(int current_pos, int mb_size) {
 
 void data_store_jag::build_owner_map(int mini_batch_size) {
   m_owner.clear();
+  m_owner_map_mb_size = mini_batch_size;
   for (size_t i = 0; i < m_shuffled_indices->size(); i++) {
     auto index = (*m_shuffled_indices)[i];
     /// To compute the owner index first find its position inside of
     /// the mini-batch (mod mini-batch size) and then find how it is
     /// striped across the ranks in the trainer
-    m_owner[index] = (i % mini_batch_size) % m_np;
+    m_owner[index] = (i % m_owner_map_mb_size) % m_np;
   }
 }
 


### PR DESCRIPTION
Fixed a bug identified by Dave Hysom where the mini-batch size that
was used to create the owner list was not uniformly applied when
building the indices that were sent and received.  This fix captures
the original mini-batch size used and uses it consistently.
Additionally, adds a guard in the data reader for the JAG Conduit data
to only apply the data checkes on ranks that loaded samples.

Note that this supersedes PR #974.