### PR TITLE
removing options::has_bool

### DIFF
--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -31,7 +31,6 @@ public :
   //@{
   /** Returns true if the database contains the option */
   bool has_int(std::string option);
-  bool has_bool(std::string option);
   bool has_string(std::string option);
   bool has_float(std::string option) { return has_double(option); }
   bool has_double(std::string option);

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -59,8 +59,8 @@ int main(int argc, char *argv[]) {
     }
 
     //this must be called after call to opts->init();
-    if (!opts->has_bool("disable_signal_handler")) {
-      std::string file_base = (opts->has_bool("stack_trace_to_file") ?
+    if (!opts->get_bool("disable_signal_handler")) {
+      std::string file_base = (opts->get_bool("stack_trace_to_file") ?
                                "stack_trace" : "");
       stack_trace::register_signal_handler(file_base);
     }
@@ -83,7 +83,7 @@ int main(int argc, char *argv[]) {
       return EXIT_SUCCESS;
     }
 
-    if (! (opts->has_bool("exit_after_setup") && opts->get_bool("exit_after_setup"))) {
+    if (! opts->get_bool("exit_after_setup")) {
 
       // Train model
       model->train(pb_model->num_epochs());
@@ -108,7 +108,7 @@ int main(int argc, char *argv[]) {
     }
 
   } catch (exception& e) {
-    if (options::get()->has_bool("stack_trace_to_file")) {
+    if (options::get()->get_bool("stack_trace_to_file")) {
       std::ostringstream ss("stack_trace");
       const auto& rank = get_rank_in_world();
       if (rank >= 0) {

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -57,8 +57,8 @@ int main(int argc, char *argv[]) {
     }
 
     //this must be called after call to opts->init();
-    if (!opts->has_bool("disable_signal_handler")) {
-      std::string file_base = (opts->has_bool("stack_trace_to_file") ?
+    if (!opts->get_bool("disable_signal_handler")) {
+      std::string file_base = (opts->get_bool("stack_trace_to_file") ?
                                "stack_trace" : "");
       stack_trace::register_signal_handler(file_base);
     }

--- a/src/data_store/generic_data_store.cpp
+++ b/src/data_store/generic_data_store.cpp
@@ -73,16 +73,16 @@ m_n(0),
 
   if (m_master) std::cerr << "generic_data_store::generic_data_store; np: " << m_np << "\n";
   options *opts = options::get();
-  if (opts->has_bool("extended_testing") && opts->get_bool("extended_testing")) {
+  if (opts->get_bool("extended_testing")) {
     m_extended_testing = true;
   }
 
-  if (opts->has_bool("local_disk") && opts->get_bool("local_disk")) {
+  if (opts->get_bool("local_disk")) {
     if (m_master) std::cerr << "running in out-of-memory mode\n";
     m_in_memory = false;
   }
 
-  if (opts->has_bool("verbose") && opts->get_bool("verbose")) {
+  if (opts->get_bool("verbose")) {
     m_verbose = true;
   }
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -761,7 +761,7 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
   if (opts->has_string("data_reader_percent")) {
     set_data_readers_percent(p);
   }
-  if (opts->has_bool("no_im_comm") and opts->get_bool("no_im_comm")) {
+  if (opts->get_bool("no_im_comm")) {
     int sz = model->callback_size();
     for (int j=0; j<sz; j++) {
       lbann_data::Callback *c = model->mutable_callback(j);
@@ -785,13 +785,13 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
   if (opts->has_int("num_parallel_readers")) {
     model->set_num_parallel_readers(opts->get_int("num_parallel_readers"));
   }
-  if (opts->has_bool("disable_cuda")) {
+  if (opts->get_bool("disable_cuda")) {
     model->set_disable_cuda(opts->get_bool("disable_cuda"));
   }
   if (opts->has_int("random_seed")) {
     model->set_random_seed(opts->get_int("random_seed"));
   }
-  if(opts->has_bool("serialize_io")) {
+  if(opts->get_bool("serialize_io")) {
     model->set_serialize_io(opts->get_bool("serialize_io"));
   }
 

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -191,7 +191,7 @@ std::unique_ptr<model> build_model_from_prototext(
   }
 
   //under development; experimental
-  if (opts->has_bool("use_data_store") && opts->get_bool("use_data_store")) {
+  if (opts->get_bool("use_data_store")) {
     if (master) {
       std::cout << "\nUSING DATA STORE!\n\n";
     }

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <stdexcept>
+#include <algorithm>
 
 namespace lbann {
 
@@ -106,16 +107,15 @@ bool options::get_bool(std::string option, bool the_default)
 
 bool options::get_bool(std::string option)
 {
+  if (m_opts.find(option) != m_opts.end()) {
+    std::string s1 = m_opts[option];
+    std::transform(s1.begin(), s1.end(), s1.begin(), ::tolower);
+    if (s1 == "true") return true;
+    if (s1 == "false") return false;
+  }
   int result;
   if (!m_test_int(option, result)) {
     return false;
-    /*
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__
-        << " ::options::get_int() - failed to find option: " << option
-        << ", or to convert to int";
-    throw std::runtime_error(err.str());
-    */
   }
   if (result == 0) return false;
   return true;

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -245,13 +245,6 @@ bool options::has_int(std::string option)
   return false;
 }
 
-bool options::has_bool(std::string option)
-{
-  int test;
-  if (m_test_int(option, test)) return true;
-  return false;
-}
-
 bool options::has_string(std::string option) {
   std::string test;
   if (m_test_string(option, test)) return true;

--- a/src/utils/stack_profiler.cpp
+++ b/src/utils/stack_profiler.cpp
@@ -84,11 +84,11 @@ void stack_profiler::activate(int thread) {
   c_hash_thread_id = thread;
   options *opts = options::get();
 
-  if (opts->has_bool("st_on") and opts->get_bool("st_on")) {
+  if (opts->get_bool("st_on")) {
     std::cerr << "creating hash table!\n";
     c_hash_create(10000);
     c_hash_profiling_is_turned_on = 1;
-    if (opts->has_bool("st_full_trace") and opts->get_bool("st_full_trace")) {
+    if (opts->get_bool("st_full_trace")) {
       m_full_stack_trace = true;
       if (m_thread_id == 0) {
         c_hash_fp_full_stack_trace = fopen("full_stack_trace.bin", "wb");


### PR DESCRIPTION
If a requested key does not appear in the options database, options::get_bool() returns false by default. Therefore there's no need to code: if ( opts->has_bool(key) && opts->get_bool(key)). Additionally, there were places where has_bool() was used as a conditional. No it's not! A bool can be either true or false; the existence of a boolean key does not imply "true."

Additionally, boolean options can now be specified with "true" and "false" (case independent) in addition to 0, 1.