### PR TITLE
Python data reader bugfixes

### DIFF
--- a/include/lbann/data_readers/data_reader_python.hpp
+++ b/include/lbann/data_readers/data_reader_python.hpp
@@ -123,7 +123,8 @@ private:
 
 class python_reader : public generic_data_reader {
 public:
-  python_reader(std::string script,
+  python_reader(std::string module,
+                std::string module_dir,
                 std::string sample_function,
                 std::string num_samples_function,
                 std::string sample_dims_function);

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -77,10 +77,11 @@ message Reader {
 }
 
 message PythonDataReader {
-  string script = 1;                // Python script
-  string sample_function = 2;       // Name of function that gets data sample
-  string num_samples_function = 3;  // Name of function that gets number of data samples
-  string sample_dims_function = 4;  // Name of function that gets dimensions of data sample
+  string module = 1;                // Python module
+  string module_dir = 2;            // Directory containing Python module
+  string sample_function = 3;       // Function that gets data sample
+  string num_samples_function = 4;  // Function that gets number of data samples
+  string sample_dims_function = 5;  // Function that gets dimensions of data sample
 }
 
 message ImagePreprocessor {

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -328,7 +328,8 @@ void init_data_readers(
     } else if (name == "python") {
 #ifdef LBANN_HAS_PYTHON
       const auto& params = readme.python();
-      reader = new python_reader(params.script(),
+      reader = new python_reader(params.module(),
+                                 params.module_dir(),
                                  params.sample_function(),
                                  params.num_samples_function(),
                                  params.sample_dims_function());
@@ -490,7 +491,8 @@ void init_data_readers(
       } else if (name == "python") {
 #ifdef LBANN_HAS_PYTHON
         const auto& params = readme.python();
-        reader_validation = new python_reader(params.script(),
+        reader_validation = new python_reader(params.module(),
+                                              params.module_dir(),
                                               params.sample_function(),
                                               params.num_samples_function(),
                                               params.sample_dims_function());


### PR DESCRIPTION
Changes:
- Errors from the Python data reader include the Python traceback in the error message.
- The Python data reader uses Python's module import functionality. Previously, we ran Python scripts in the global namespace, which caused namespace collisions when importing multiple scripts.