### PR TITLE
hack to avoid triggering "duplicate ID" in data_store::set_conduit_no…

### DIFF
--- a/src/data_store/data_store_jag.cpp
+++ b/src/data_store/data_store_jag.cpp
@@ -277,6 +277,9 @@ void data_store_jag::error_check_compacted_node(const conduit::Node &nd, int dat
 
 void data_store_jag::set_conduit_node(int data_id, conduit::Node &node) {
   if (m_data.find(data_id) != m_data.end()) {
+    if (m_reader->get_role() == "validate") {
+      return;
+    }
     LBANN_ERROR("duplicate data_id: " + std::to_string(data_id) + " in data_store_jag::set_conduit_node");
   }
 


### PR DESCRIPTION
…de() when in validation mode. This is needed for LTFB when --use_data_store since validation is run multiple times in an epoch.

THIS PR SHOULD NOT BE MERGED WITH DEVELOP -- because a more comprehensive fix will be implemented in the future.