### PR TITLE
Bugfix for thread safe random number generators

### DIFF
--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -59,6 +59,21 @@ fast_rng_gen& get_fast_generator();
  * @note If compiling with OpenMP, this is stored in a threadprivate variable.
  */
 rng_gen& get_data_seq_generator();
+
+/**
+ * Return a reference to the global LBANN random number generator used
+ * for shuffling the data samples within each mini-batch
+ * @note This is stored in a threadprivate variable.
+ */
+rng_gen& get_io_generator();
+
+/**
+ * Return a reference to the fast global LBANN random number generator used
+ * for the I/O threads
+ * @note This is stored in a threadprivate variable.
+ */
+fast_rng_gen& get_fast_io_generator();
+
 /**
  * Return random integers uniformly distributed in [0, max).
  * @param g C++ uniform random bit generator.
@@ -98,9 +113,6 @@ inline T fast_rand_int_pow2(Generator& g, T max) {
  *  @param comm If present, mixes the process's rank within the model
  *              into the seed; if not, uses the MPI world rank.
  *
- *  @todo Support saving/restoring the generator's state. This is directly
- *  supported via the >> and << operators on the generator (reading/writing
- *  from/to a stream).
  */
 void init_random(int seed = -1, lbann_comm *comm = nullptr);
 
@@ -110,11 +122,17 @@ void init_random(int seed = -1, lbann_comm *comm = nullptr);
  * samples.  Using a separate RNG for the data sequences helps provide
  * a stable training result that does not vary with how much I/O
  * parallelism is applied.
- * @todo Support saving/restoring the generator's state. This is directly
- * supported via the >> and << operators on the generator (reading/writing
- * from/to a stream).
  */
 void init_data_seq_random(int seed = -1);
+
+/**
+ * Initialize a random number generator (with optional seed) that is
+ * specifically used by the I/O threads for tasks such as data
+ * preprocessing, etc.
+ *
+ * Called from init_random
+ */
+void init_io_random(int seed = -1);
 
 /**
  * Make mat into an m x n matrix where each entry is independently drawn from

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -55,22 +55,22 @@ fast_rng_gen& get_fast_generator();
 
 /**
  * Return a reference to the global LBANN random number generator used
- * for shuffling the data samples within each mini-bathc
- * @note If compiling with OpenMP, this is stored in a threadprivate variable.
+ * for shuffling the data samples within each mini-batch
+ * @note RThis is stored in a thread_local variable.
  */
 rng_gen& get_data_seq_generator();
 
 /**
  * Return a reference to the global LBANN random number generator used
  * for shuffling the data samples within each mini-batch
- * @note This is stored in a threadprivate variable.
+ * @note This is stored in a thread_local variable.
  */
 rng_gen& get_io_generator();
 
 /**
  * Return a reference to the fast global LBANN random number generator used
  * for the I/O threads
- * @note This is stored in a threadprivate variable.
+ * @note This is stored in a thread_local variable.
  */
 fast_rng_gen& get_fast_io_generator();
 

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -56,7 +56,7 @@ fast_rng_gen& get_fast_generator();
 /**
  * Return a reference to the global LBANN random number generator used
  * for shuffling the data samples within each mini-batch
- * @note RThis is stored in a thread_local variable.
+ * @note This is stored in a thread_local variable.
  */
 rng_gen& get_data_seq_generator();
 

--- a/src/data_readers/cv_augmenter.cpp
+++ b/src/data_readers/cv_augmenter.cpp
@@ -120,7 +120,7 @@ bool cv_augmenter::determine_transform(const cv::Mat& image) {
     return false;
   }
 
-  rng_gen& gen = get_generator();
+  rng_gen& gen = get_io_generator();
 
   std::uniform_int_distribution<int> bool_dist(0, 1);
 
@@ -251,4 +251,3 @@ std::ostream& cv_augmenter::print(std::ostream& os) const {
 
 } // end of namespace lbann
 #endif // LBANN_HAS_OPENCV
-

--- a/src/data_readers/cv_cropper.cpp
+++ b/src/data_readers/cv_cropper.cpp
@@ -85,7 +85,7 @@ void cv_cropper::set(const unsigned int width, const unsigned int height,
 }
 
 void cv_cropper::reset() {
-  m_enabled = false; 
+  m_enabled = false;
   m_zoom = 1.0;
   m_interpolation = m_interpolation_choices[0];
 }
@@ -152,8 +152,8 @@ bool cv_cropper::apply(cv::Mat& image) {
 
   // Get random crop of image
   if(m_rand_crop) {
-    const int rnd_dw = fast_rand_int(get_fast_generator(), static_cast<int>(2*(zoomed_roi_width - zoomed_width)) + 1);
-    const int rnd_dh = fast_rand_int(get_fast_generator(), static_cast<int>(2*(zoomed_roi_height - zoomed_height)) + 1);
+    const int rnd_dw = fast_rand_int(get_fast_io_generator(), static_cast<int>(2*(zoomed_roi_width - zoomed_width)) + 1);
+    const int rnd_dh = fast_rand_int(get_fast_io_generator(), static_cast<int>(2*(zoomed_roi_height - zoomed_height)) + 1);
     crop_x_start = static_cast<int>(image.cols - zoomed_roi_width + rnd_dw + 1) / 2;
     crop_y_start = static_cast<int>(image.rows - zoomed_roi_height + rnd_dh + 1) / 2;
   } else {
@@ -194,4 +194,3 @@ std::ostream& cv_cropper::print(std::ostream& os) const {
 
 } // end of namespace lbann
 #endif // LBANN_HAS_OPENCV
-

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -68,7 +68,7 @@ void mesh_reader::load() {
 
 bool mesh_reader::fetch_datum(CPUMat& X, int data_id, int mb_idx) {
   if (m_random_flips) {
-    fast_rng_gen& gen = get_fast_generator();
+    fast_rng_gen& gen = get_fast_io_generator();
     std::uniform_int_distribution<int> dist(0, 1);
     m_flip_choices[data_id].first = dist(gen);
     m_flip_choices[data_id].second = dist(gen);

--- a/src/data_readers/data_reader_moving_mnist.cpp
+++ b/src/data_readers/data_reader_moving_mnist.cpp
@@ -130,10 +130,10 @@ bool moving_mnist_reader::fetch_datum(CPUMat& X, int data_id, int col) {
     const auto& object_width = bounds[obj][1] - bounds[obj][0];
     const auto& object_height = bounds[obj][3] - bounds[obj][2];
     pos[obj].resize(m_num_frames);
-    pos[obj][0][0] = (m_image_width - object_width + 1) * dist(get_generator());
-    pos[obj][0][1] = (m_image_height - object_height + 1) * dist(get_generator());
-    const DataType vnorm = vmax * dist(get_generator());
-    const DataType theta = 2 * M_PI * dist(get_generator());
+    pos[obj][0][0] = (m_image_width - object_width + 1) * dist(get_io_generator());
+    pos[obj][0][1] = (m_image_height - object_height + 1) * dist(get_io_generator());
+    const DataType vnorm = vmax * dist(get_io_generator());
+    const DataType theta = 2 * M_PI * dist(get_io_generator());
     v[obj][0] = vnorm * std::sin(theta);
     v[obj][1] = vnorm * std::cos(theta);
   }

--- a/src/data_readers/data_reader_synthetic.cpp
+++ b/src/data_readers/data_reader_synthetic.cpp
@@ -37,7 +37,7 @@ namespace {
 
 void fill_matrix(CPUMat& mat) {
   std::normal_distribution<DataType> dist(DataType(0), DataType(1));
-  auto& gen = get_fast_generator();
+  auto& gen = get_fast_io_generator();
   const El::Int height = mat.Height();  // Width is 1.
   DataType * __restrict__ buf = mat.Buffer();
   for (El::Int i = 0; i < height; ++i) {
@@ -74,7 +74,7 @@ bool data_reader_synthetic::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
   if (m_num_labels == 0) {
     LBANN_ERROR("Synthetic data reader does not have labels");
   }
-  Y.Set(fast_rand_int(get_fast_generator(), m_num_labels), mb_idx, 1);
+  Y.Set(fast_rand_int(get_fast_io_generator(), m_num_labels), mb_idx, 1);
   return true;
 }
 

--- a/src/data_readers/image_preprocessor.cpp
+++ b/src/data_readers/image_preprocessor.cpp
@@ -60,7 +60,7 @@ void lbann_image_preprocessor::augment(Mat& pixels, unsigned imheight,
                       m_shear_range;
   if (do_transform) {
     cv::Mat sqpixels = cv_pixels(pixels, imheight, imwidth, num_channels);
-    rng_gen& gen = get_generator();
+    rng_gen& gen = get_io_generator();
     std::uniform_int_distribution<int> bool_dist(0, 1);
     // Flips.
     bool horiz_flip = bool_dist(gen) && m_horizontal_flip;

--- a/src/data_readers/patchworks/patchworks.cpp
+++ b/src/data_readers/patchworks/patchworks.cpp
@@ -129,7 +129,7 @@ cv::Mat drop_2channels(const cv::Mat& _img) {
   // compute channel to remain
   pw_fp_t m[3] = {0.0 _f, 0.0 _f, 0.0 _f};
 
-  ::lbann::rng_gen& gen = ::lbann::get_generator();
+  ::lbann::rng_gen& gen = ::lbann::get_io_generator();
 
   std::uniform_int_distribution<int> rg_ch(0, 2);
   const int chosenCh = rg_ch(gen);

--- a/src/data_readers/patchworks/patchworks_patch_descriptor.cpp
+++ b/src/data_readers/patchworks/patchworks_patch_descriptor.cpp
@@ -110,7 +110,7 @@ bool patch_descriptor::get_first_patch(ROI& patch) {
     y_margin = m_height + (m_height+1)/2 + 2*m_jitter + m_gap;
   }
 
-  ::lbann::rng_gen& gen = ::lbann::get_generator();
+  ::lbann::rng_gen& gen = ::lbann::get_io_generator();
 
   if ((m_mode_center == 0u || m_mode_center == 1u)) {
     // area where the center of a center patch can be in
@@ -160,7 +160,7 @@ bool patch_descriptor::get_first_patch(ROI& patch) {
 bool patch_descriptor::get_next_patch(ROI& patch) {
   bool got_one = false;
 
-  ::lbann::rng_gen& gen = ::lbann::get_generator();
+  ::lbann::rng_gen& gen = ::lbann::get_io_generator();
 
   do {
     ROI p = m_patch_center;
@@ -218,7 +218,7 @@ bool patch_descriptor::extract_patches(const cv::Mat& img, std::vector<cv::Mat>&
   }
 
   std::uniform_int_distribution<int> rg_patch_idx(0, m_displacements.size()-1);
-  ::lbann::rng_gen& gen = ::lbann::get_generator();
+  ::lbann::rng_gen& gen = ::lbann::get_io_generator();
   m_cur_patch_idx = rg_patch_idx(gen);
 
   if (!get_next_patch(roi)) {

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -104,6 +104,7 @@ bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
   makedir(dirname.c_str());
   std::string rng_name;
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_seq_generator";
   std::ofstream rng_seq(rng_name);
   rng_seq << ::data_seq_generator;
@@ -121,10 +122,12 @@ bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
     rank_in_world = std::to_string(comm->get_rank_in_world());
   }
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_io_generator_" + rank_in_world;
   std::ofstream rng_io(rng_name);
   rng_io << ::io_generator;
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_fast_io_generator_" + rank_in_world;
   std::ofstream rng_fast_io(rng_name);
   rng_fast_io << ::fast_io_generator;
@@ -158,6 +161,7 @@ bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm) {
   std::string dirname = std::string(p.m_checkpoint_dir) + "/rng_state";
   std::string rng_name;
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_seq_generator";
   std::ifstream rng_seq(rng_name);
   rng_seq >> ::data_seq_generator;
@@ -175,10 +179,12 @@ bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm) {
     rank_in_world = std::to_string(comm->get_rank_in_world());
   }
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_io_generator_" + rank_in_world;
   std::ifstream rng_io(rng_name);
   rng_io >> ::io_generator;
 
+  /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_fast_io_generator_" + rank_in_world;
   std::ifstream rng_fast_io(rng_name);
   rng_fast_io >> ::fast_io_generator;

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -35,9 +35,6 @@ lbann::rng_gen generator;
 
 lbann::fast_rng_gen fast_generator;
 #pragma omp threadprivate(fast_generator)
-
-lbann::rng_gen data_seq_generator;
-#pragma omp threadprivate(data_seq_generator)
 #else
 // Random number generator, file-visible only.
 // Defined like this to work around a GCC problem with threadprivate objects:
@@ -49,11 +46,19 @@ lbann::rng_gen generator;
 extern lbann::fast_rng_gen fast_generator;
 #pragma omp threadprivate(fast_generator)
 lbann::fast_rng_gen fast_generator;
-
-extern lbann::rng_gen data_seq_generator;
-#pragma omp threadprivate(data_seq_generator)
-lbann::rng_gen data_seq_generator;
 #endif
+
+thread_local lbann::rng_gen data_seq_generator;
+thread_local bool data_seq_generator_inited = false;
+int data_seq_generator_seed_base = 0;
+
+thread_local lbann::rng_gen io_generator;
+thread_local bool io_generator_inited = false;
+int io_generator_seed_base = 0;
+
+thread_local lbann::fast_rng_gen fast_io_generator;
+thread_local bool fast_io_generator_inited = false;
+int fast_io_generator_seed_base = 0;
 }
 
 namespace lbann {
@@ -67,7 +72,31 @@ fast_rng_gen& get_fast_generator() {
 }
 
 rng_gen& get_data_seq_generator() {
+  if (!::data_seq_generator_inited) {
+    ::data_seq_generator.seed(::data_seq_generator_seed_base);
+    ::data_seq_generator_inited = true;
+  }
   return ::data_seq_generator;
+}
+
+rng_gen& get_io_generator() {
+  if (!::io_generator_inited) {
+    std::hash<std::thread::id> h;
+    ::io_generator.seed((::io_generator_seed_base << 8) |
+                        h(std::this_thread::get_id()));
+    ::io_generator_inited = true;
+  }
+  return ::io_generator;
+}
+
+fast_rng_gen& get_fast_io_generator() {
+  if (!::fast_io_generator_inited) {
+    std::hash<std::thread::id> h;
+    ::fast_io_generator.seed((::fast_io_generator_seed_base << 8) |
+                             h(std::this_thread::get_id()));
+    ::fast_io_generator_inited = true;
+  }
+  return ::fast_io_generator;
 }
 
 bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
@@ -78,6 +107,7 @@ bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
   rng_name = dirname + "/rng_seq_generator";
   std::ofstream rng_seq(rng_name);
   rng_seq << ::data_seq_generator;
+
 #ifdef LBANN_SET_EL_RNG
   rng_name = dirname + "/EL_generator";
   std::ofstream rng_EL(rng_name);
@@ -89,8 +119,16 @@ bool save_rng_to_checkpoint_shared(persist& p, const lbann_comm* comm) {
     rank_in_world = std::to_string(El::mpi::Rank(El::mpi::COMM_WORLD));
   } else {
     rank_in_world = std::to_string(comm->get_rank_in_world());
-
   }
+
+  rng_name = dirname + "/rng_io_generator_" + rank_in_world;
+  std::ofstream rng_io(rng_name);
+  rng_io << ::io_generator;
+
+  rng_name = dirname + "/rng_fast_io_generator_" + rank_in_world;
+  std::ofstream rng_fast_io(rng_name);
+  rng_fast_io << ::fast_io_generator;
+
 #ifdef _OPENMP
   #pragma omp parallel private(rng_name)
   {
@@ -123,6 +161,7 @@ bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm) {
   rng_name = dirname + "/rng_seq_generator";
   std::ifstream rng_seq(rng_name);
   rng_seq >> ::data_seq_generator;
+
 #ifdef LBANN_SET_EL_RNG
   rng_name = dirname + "/EL_generator";
   std::ifstream rng_EL(rng_name);
@@ -135,6 +174,14 @@ bool load_rng_from_checkpoint_shared(persist& p, const lbann_comm* comm) {
   } else {
     rank_in_world = std::to_string(comm->get_rank_in_world());
   }
+
+  rng_name = dirname + "/rng_io_generator_" + rank_in_world;
+  std::ifstream rng_io(rng_name);
+  rng_io >> ::io_generator;
+
+  rng_name = dirname + "/rng_fast_io_generator_" + rank_in_world;
+  std::ifstream rng_fast_io(rng_name);
+  rng_fast_io >> ::fast_io_generator;
 
 #ifdef _OPENMP
   #pragma omp parallel private(rng_name)
@@ -199,6 +246,8 @@ void init_random(int seed, lbann_comm *comm) {
     El::Generator().seed(rand_val);
 #endif
   }
+
+  init_io_random(seed);
 }
 
 void init_data_seq_random(int seed) {
@@ -208,16 +257,25 @@ void init_data_seq_random(int seed) {
     seed = rd();
   }
 
-  // Seed every OpenMP thread, if present.
-  // Note: Threadprivate OMP variables don't work with dynamic threads.
-#ifdef _OPENMP
-  #pragma omp parallel
-  {
-    get_data_seq_generator().seed(seed);
+  ::data_seq_generator_seed_base = seed;
+  /// Reset the init flag so that generator will reinitialize
+  ::data_seq_generator_inited = false;
+}
+
+void init_io_random(int seed) {
+  if (seed == -1) {
+    // Seed with a random value.
+    std::random_device rd;
+    seed = rd();
   }
-#else
-  get_data_seq_generator().seed(seed);
-#endif
+
+  ::io_generator_seed_base = seed;
+  /// Reset the init flag so that generator will reinitialize
+  ::io_generator_inited = false;
+
+  ::fast_io_generator_seed_base = seed;
+  /// Reset the init flag so that generator will reinitialize
+  ::fast_io_generator_inited = false;
 }
 
 void gaussian_fill(AbsDistMat& mat, El::Int m, El::Int n, DataType mean,


### PR DESCRIPTION
Updated the data sequence random number generator to use std thread 
local storage.  Added random number generators for the I/O threads
that are thread safe for std threads.  Closes #900.
