### PR TITLE
numpy_conduit_cache class

### DIFF
--- a/include/lbann/data_readers/numpy_conduit_cache.hpp
+++ b/include/lbann/data_readers/numpy_conduit_cache.hpp
@@ -41,7 +41,57 @@ namespace lbann {
 /**
  * A numpy_conduit_cache has functionality to read numpy files,
  * convert them to conduit, and return the conduit::Node
- * upon request.
+ * upon request. This is a genaral class that can handle all numpy_npz
+ * data. In general the schema is:
+ *
+ * {
+ *   data_id (int) :
+ *   // one or more of the following sections
+ *   {
+ *     section_name :
+ *     {
+ *       "word_size": <int>,
+ *       "fortran_order: <0|1>,
+ *       "num_vals": <int>,
+ *       "shape": <[ vector ]>,
+ *       "data": <char*>
+ *     }  
+ *   }  
+ * }  
+ *
+ * The following is the schema for cosmoflow data, where the data_id 
+ * (which is assigned by the data_reader) is 42:
+ *
+ * {
+ *  "42": 
+ *  {
+ *    "data": 
+ *    {
+ *      "word_size": 2,
+ *      "fortran_order": 0,
+ *      "num_vals": 8388608,
+ *      "shape": [1, 4, 128, 128, 128]
+ *      "data": //char*
+ *    },
+ *    "frm": 
+ *    {
+ *      "word_size": 4,
+ *      "fortran_order": 0,
+ *      "num_vals": 1,
+ *      "shape": [1, 1]
+ *      "data": //char*
+ *    },
+ *    "responses": 
+ *    {
+ *      "word_size": 4,
+ *      "fortran_order": 0,
+ *      "num_vals": 4,
+ *      "shape": [1, 4]
+ *      "data": //char*
+ *    }
+ *  }
+ *}
+ *
  */
 
 class numpy_conduit_cache {
@@ -61,7 +111,7 @@ class numpy_conduit_cache {
   //! a single ndarray per file; this may change in the future
   void load(const std::string filename, int data_id);
 
-  const conduit::Node & get_data(int data_id) const;
+  const conduit::Node & get_conduit_node(int data_id) const;
 
 protected :
 

--- a/include/lbann/data_readers/numpy_conduit_cache.hpp
+++ b/include/lbann/data_readers/numpy_conduit_cache.hpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef NUMPY_CONDUIT_CACHE_HPP
+#define NUMPY_CONDUIT_CACHE_HPP
+
+#include "lbann/base.hpp"
+#include <cnpy.h>
+
+
+
+namespace lbann {
+
+
+/**
+ * A numpy_conduit_cache has functionality to read numpy files,
+ * convert them to conduit, and return the conduit::Node
+ * upon request.
+ */
+class numpy_conduit_cache {
+ public:
+
+  numpy_conduit_cache(lbann_comm *comm) : m_comm(comm)
+  {}
+
+  numpy_conduit_cache(const numpy_conduit_cache&);
+
+  numpy_conduit_cache& operator=(const numpy_conduit_cache&);
+
+  ~numpy_conduit_cache() {}
+
+  //! Load a numpy array from file; assign it the given data_id;
+  //! and cache it internally. For now we assume there is 
+  //! a single ndarray per file; this may change in the future
+  void load(const std::string filename, int data_id);
+
+  const conduit::Node get_data(int data_id);
+
+protected :
+
+  void copy_members(const numpy_conduit_cache &rhs);
+
+  lbann_comm *m_comm;
+
+  std::unordered_map<int, conduit::Node> m_data;
+
+  // we keep the numpy data to avoid copying it in m_data;
+  std::unordered_map<int, const npz_t> m_numpy;
+
+};
+
+}  // namespace lbann
+
+#endif  // NUMPY_CONDUIT_CACHE_HPP

--- a/include/lbann/data_readers/numpy_conduit_cache.hpp
+++ b/include/lbann/data_readers/numpy_conduit_cache.hpp
@@ -1,4 +1,3 @@
-////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
@@ -28,19 +27,23 @@
 #ifndef NUMPY_CONDUIT_CACHE_HPP
 #define NUMPY_CONDUIT_CACHE_HPP
 
-#include "lbann/base.hpp"
+#include "lbann_config.hpp"
+
+#ifdef LBANN_HAS_CONDUIT
+
 #include <cnpy.h>
-
-
+#include "lbann/comm.hpp"
+#include <unordered_map>
+#include "conduit/conduit.hpp"
 
 namespace lbann {
-
 
 /**
  * A numpy_conduit_cache has functionality to read numpy files,
  * convert them to conduit, and return the conduit::Node
  * upon request.
  */
+
 class numpy_conduit_cache {
  public:
 
@@ -58,7 +61,7 @@ class numpy_conduit_cache {
   //! a single ndarray per file; this may change in the future
   void load(const std::string filename, int data_id);
 
-  const conduit::Node get_data(int data_id);
+  const conduit::Node & get_data(int data_id) const;
 
 protected :
 
@@ -68,11 +71,13 @@ protected :
 
   std::unordered_map<int, conduit::Node> m_data;
 
-  // we keep the numpy data to avoid copying it in m_data;
-  std::unordered_map<int, const npz_t> m_numpy;
+  // we keep the numpy data to avoid a deep copy in m_data;
+  std::unordered_map<int, std::map<std::string, cnpy::NpyArray> > m_numpy;
 
 };
 
 }  // namespace lbann
+
+#endif  // #ifdef LBANN_HAS_CONDUIT
 
 #endif  // NUMPY_CONDUIT_CACHE_HPP

--- a/include/lbann/data_readers/numpy_conduit_cache.hpp
+++ b/include/lbann/data_readers/numpy_conduit_cache.hpp
@@ -100,22 +100,20 @@ class numpy_conduit_cache {
   numpy_conduit_cache(lbann_comm *comm) : m_comm(comm)
   {}
 
-  numpy_conduit_cache(const numpy_conduit_cache&);
+  numpy_conduit_cache(const numpy_conduit_cache&) = default;
 
-  numpy_conduit_cache& operator=(const numpy_conduit_cache&);
+  numpy_conduit_cache& operator=(const numpy_conduit_cache&) = default;
 
   ~numpy_conduit_cache() {}
 
-  //! Load a numpy array from file; assign it the given data_id;
-  //! and cache it internally. For now we assume there is 
-  //! a single ndarray per file; this may change in the future
+  //! Load a zipped numpy array from file; assign it the given data_id
   void load(const std::string filename, int data_id);
 
   const conduit::Node & get_conduit_node(int data_id) const;
 
 protected :
 
-  void copy_members(const numpy_conduit_cache &rhs);
+  void load(const std::string filename, int data_id, bool is_npz);
 
   lbann_comm *m_comm;
 

--- a/model_zoo/jag_utils/CMakeLists.txt
+++ b/model_zoo/jag_utils/CMakeLists.txt
@@ -55,4 +55,9 @@ if (LBANN_HAS_CONDUIT)
   add_executable( generate_corrupt_samples-bin generate_corrupt_samples.cpp )
   target_link_libraries(generate_corrupt_samples-bin lbann )
   set_target_properties(generate_corrupt_samples-bin PROPERTIES OUTPUT_NAME generate_corrupt_samples)
+
+  add_executable( test_numpy_conduit_cache-bin test_numpy_conduit_cache.cpp )
+  target_link_libraries(test_numpy_conduit_cache-bin lbann )
+  set_target_properties(test_numpy_conduit_cache-bin PROPERTIES OUTPUT_NAME test_numpy_conduit_cache)
+
 endif ()

--- a/model_zoo/jag_utils/test_numpy_conduit_cache.cpp
+++ b/model_zoo/jag_utils/test_numpy_conduit_cache.cpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann_config.hpp"
+
+#ifdef LBANN_HAS_CONDUIT
+
+#include "conduit/conduit.hpp"
+#include "conduit/conduit_relay.hpp"
+#include "conduit/conduit_relay_io_hdf5.hpp"
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include "lbann/lbann.hpp"
+#include "lbann/utils/jag_utils.hpp"
+#include "lbann/data_readers/numpy_conduit_cache.hpp"
+
+using namespace lbann;
+
+int main(int argc, char *argv[]) {
+  int random_seed = lbann_default_random_seed;
+  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  bool master = comm->am_world_master();
+
+  try {
+
+  numpy_conduit_cache n(comm.get());
+  n.load("/g/g10/hysom/test.npz", 42);
+
+  } catch (std::exception const &e) {
+    if (master) std::cerr << "caught exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "unknown exception in main\n";
+    return EXIT_FAILURE;
+  }
+
+  // Clean up
+  return EXIT_SUCCESS;
+}
+
+#endif //#ifdef LBANN_HAS_CONDUIT

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -38,6 +38,7 @@ set_full_path(THIS_DIR_SOURCES
   offline_patches_npz.cpp
   image_preprocessor.cpp
   image_utils.cpp
+  numpy_conduit_cache.cpp 
   )
 
 # Add the subdirectories

--- a/src/data_readers/numpy_conduit_cache.cpp
+++ b/src/data_readers/numpy_conduit_cache.cpp
@@ -33,25 +33,8 @@
 namespace lbann {
 
 
-numpy_conduit_cache::numpy_conduit_cache(const numpy_conduit_cache& rhs) {
-  copy_members(rhs);
-}
-
-numpy_conduit_cache& numpy_conduit_cache::operator=(const numpy_conduit_cache& rhs) {
-  // check for self-assignment
-  if (this == &rhs) {
-    return (*this);
-  }
-  copy_members(rhs);
-  return (*this);
-}
-
-void numpy_conduit_cache::copy_members(const numpy_conduit_cache& rhs) {
-  //TODO
-  LBANN_ERROR("needs to be impelemented");
-}
-
 void numpy_conduit_cache::load(const std::string filename, int data_id) {
+
   try {
     m_numpy[data_id] = cnpy::npz_load(filename);
     conduit::Node &n = m_data[data_id];

--- a/src/data_readers/numpy_conduit_cache.cpp
+++ b/src/data_readers/numpy_conduit_cache.cpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/data_readers/numpy_conduit_cache.hpp"
+#include "lbann/utils/exception.hpp"
+
+#ifdef LBANN_HAS_CONDUIT
+
+namespace lbann {
+
+
+numpy_conduit_cache::numpy_conduit_cache(const numpy_conduit_cache& rhs) {
+  copy_members(rhs);
+}
+
+numpy_conduit_cache& numpy_conduit_cache::operator=(const numpy_conduit_cache& rhs) {
+  // check for self-assignment
+  if (this == &rhs) {
+    return (*this);
+  }
+  copy_members(rhs);
+  return (*this);
+}
+
+void numpy_conduit_cache::copy_members(const numpy_conduit_cache& rhs) {
+  //TODO
+  LBANN_ERROR("needs to be impelemented");
+}
+
+void numpy_conduit_cache::load(const std::string filename, int data_id) {
+  try {
+    m_numpy[data_id] = cnpy::npz_load(filename);
+
+    std::map<std::string, cnpy::NpyArray> &a = m_numpy[data_id];
+    for (auto &&t : a) {
+      std::cout << t.first << "\n";
+      cnpy::NpyArray &b = t.second;
+      std::cout << "word size: " << b.word_size << "\n";
+      std::cout << "fortran order: " << b.fortran_order << "\n";
+      std::cout << "num_vals: " << b.num_vals << "\n";
+      std::cout << "\n";
+    }
+  } catch (...) {
+    //note: npz_load throws std::runtime_error, but I don't want to assume
+    //      that won't change in the future
+    LBANN_ERROR("failed to open " + filename + " during cnpy::npz_load");
+  }
+}
+
+const conduit::Node & numpy_conduit_cache::get_data(int data_id) const {
+  std::unordered_map<int, conduit::Node>::const_iterator it = m_data.find(data_id);
+  if (it == m_data.end()) {
+    LBANN_ERROR("failed to find data_id: " + std::to_string(data_id) + " in m_data");
+  }
+  return it->second;
+}
+
+
+
+} // end of namespace lbann
+
+#endif // LBANN_HAS_CONDUIT

--- a/test_numpy_conduit_cache.cpp
+++ b/test_numpy_conduit_cache.cpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann_config.hpp"
+
+#ifdef LBANN_HAS_CONDUIT
+
+#include "conduit/conduit.hpp"
+#include "conduit/conduit_relay.hpp"
+#include "conduit/conduit_relay_io_hdf5.hpp"
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <string>
+#include <sstream>
+#include "lbann/lbann.hpp"
+#include "lbann/utils/jag_utils.hpp"
+#include "lbann/data_readers/numpy_conduit_cache.hpp"
+
+using namespace lbann;
+
+int main(int argc, char *argv[]) {
+  int random_seed = lbann_default_random_seed;
+  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  bool master = comm->am_world_master();
+
+  try {
+
+  numpy_conduit_cache n(comm.get());
+  n.load("/g/g10/hysom/test.npz", 42);
+
+  } catch (std::exception const &e) {
+    if (master) std::cerr << "caught exception: " << e.what() << "\n";
+    return EXIT_FAILURE;
+  } catch (...) {
+    std::cerr << "unknown exception in main\n";
+    return EXIT_FAILURE;
+  }
+
+  // Clean up
+  return EXIT_SUCCESS;
+}
+
+#endif //#ifdef LBANN_HAS_CONDUIT


### PR DESCRIPTION
Class for uncapsulating zipped numpy arrays inside a conduit::Node.