### PR TITLE
Multi-trainer model initialization and metrics

### DIFF
--- a/src/callbacks/callback_print.cpp
+++ b/src/callbacks/callback_print.cpp
@@ -212,6 +212,13 @@ void lbann_callback_print::report_results(model *m) {
                                                         num_samples_list.end(),
                                                         0));
           const EvalType max_score = *std::max_element(score_list.begin(), score_list.end());
+          EvalType scores_stdev = EvalType(0);
+          for (const auto& t : score_list) {
+            const auto& diff = t - avg_score;
+            scores_stdev += diff * diff;
+          }
+          scores_stdev /= score_list.size() - 1;
+          scores_stdev = std::sqrt(std::max(scores_stdev, EvalType(0)));
           std::cout << m->get_name() << " (global average) "  << mode_string << " "
                     << met->name() << " : "
                     << avg_score << met->get_unit()
@@ -223,6 +230,10 @@ void lbann_callback_print::report_results(model *m) {
           std::cout << m->get_name() << " (global max) "  << mode_string << " "
                     << met->name() << " : "
                     << max_score << met->get_unit()
+                    << std::endl;
+          std::cout << m->get_name() << " (global stdev) "  << mode_string << " "
+                    << met->name() << " : "
+                    << scores_stdev << met->get_unit()
                     << std::endl;
         }
       } else {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -213,21 +213,19 @@ std::unique_ptr<model> build_model_from_prototext(
     }
   }
 
-  if (first_model) {
 #ifndef LBANN_DETERMINISTIC
-    // Under normal conditions, reinitialize the random number generator so
-    // that regularization techniques (e.g. dropout) generate unique patterns
-    // on different ranks.
-    init_random(random_seed + comm->get_rank_in_world());
+  // Under normal conditions, reinitialize the random number generator so
+  // that regularization techniques (e.g. dropout) generate unique patterns
+  // on different ranks.
+  init_random(random_seed + comm->get_rank_in_world());
 #else
-    if(comm->am_world_master()) {
-      std::cout <<
-        "--------------------------------------------------------------------------------\n"
-        "ALERT: executing in sequentially consistent mode -- performance will suffer\n"
-        "--------------------------------------------------------------------------------\n";
-    }
-#endif
+  if(comm->am_world_master()) {
+    std::cout <<
+      "--------------------------------------------------------------------------------\n"
+      "ALERT: executing in sequentially consistent mode -- performance will suffer\n"
+      "--------------------------------------------------------------------------------\n";
   }
+#endif
   return ret_model;
 }
 


### PR DESCRIPTION
1. Fix a bug where models are not initialize differently as expected in multi-trainer scenario. In particular, we comm->split_trainer() needs to be called first to get appropriate trainer_rank to be mixed with random seed
2. Add stdev to metric scores 