### PR TITLE
In-place gradient buffers

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -70,17 +70,6 @@ protected:
    */
   DataType m_bias_scaling_factor;
 
-  /** Convolutional kernel gradient.
-   *  This is this layer's contribution to the objective function
-   *  gradient w.r.t. the convolutional kernel weights.
-   */
-  StarMat<Device> m_kernel_gradient;
-  /** Bias gradient.
-   *  This is this layer's contribution to the objective function
-   *  gradient w.r.t. the bias weights.
-   */
-  StarMat<Device> m_bias_gradient;
-
 #ifdef LBANN_HAS_CUDNN
 
   /** Convolution kernel cuDNN descriptor. */
@@ -112,9 +101,7 @@ public:
       m_strides(std::move(strides)),
       m_dilations(std::move(dilations)),
       m_groups(groups),
-      m_bias_scaling_factor(has_bias ? 1 : 0),
-      m_kernel_gradient(this->get_comm()->get_trainer_grid()),
-      m_bias_gradient(this->get_comm()->get_trainer_grid())
+      m_bias_scaling_factor(has_bias ? 1 : 0)
 #ifdef LBANN_HAS_CUDNN
     , m_tensors_cudnn_desc(this)
 #endif // LBANN_HAS_CUDNN
@@ -128,9 +115,7 @@ public:
       m_strides(other.m_strides),
       m_dilations(other.m_dilations),
       m_groups(other.m_groups),
-      m_bias_scaling_factor(other.m_bias_scaling_factor),
-      m_kernel_gradient(other.m_kernel_gradient),
-      m_bias_gradient(other.m_bias_gradient)
+      m_bias_scaling_factor(other.m_bias_scaling_factor)
 #ifdef LBANN_HAS_CUDNN
     , m_tensors_cudnn_desc(other.m_tensors_cudnn_desc)
 #endif // LBANN_HAS_CUDNN
@@ -155,8 +140,6 @@ public:
     m_dilations = other.m_dilations;
     m_groups = other.m_groups;
     m_bias_scaling_factor = other.m_bias_scaling_factor;
-    m_kernel_gradient = other.m_kernel_gradient;
-    m_bias_gradient = other.m_bias_gradient;
 
 #ifdef LBANN_HAS_CUDNN
     // Copy cuDNN objects
@@ -383,14 +366,6 @@ public:
     kernel_weights.set_matrix_distribution(dist);
     bias_weights.set_dims(output_dims[0]);
     bias_weights.set_matrix_distribution(dist);
-
-    // Initialize gradients
-    El::Zeros(m_kernel_gradient,
-              kernel_weights.get_matrix_height(),
-              kernel_weights.get_matrix_width());
-    El::Zeros(m_bias_gradient,
-              bias_weights.get_matrix_height(),
-              bias_weights.get_matrix_width());
 
     // Initialize freeze state
     for (auto&& w : this->m_weights) {
@@ -655,9 +630,8 @@ protected:
     const auto& local_gradient_wrt_output = get_local_prev_error_signals();
 
     // Useful constants
-    const DataType zero = DataType(0);
-    const DataType one = DataType(1);
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
+    const DataType gradient_scale = DataType(1) / effective_mini_batch_size;
     const bool has_local_data = (local_input.Height() > 0
                                  && local_input.Width() > 0
                                  && local_gradient_wrt_output.Height() > 0
@@ -666,29 +640,31 @@ protected:
     // Compute bias gradient
     optimizer* bias_optimizer = m_weights[1]->get_optimizer();
     if (bias_optimizer != nullptr && m_bias_scaling_factor != DataType(0)) {
-      if (!has_local_data) {
-        El::Zero(m_bias_gradient);
+      if (has_local_data) {
+        DataType dst_scale = DataType(0);
+        auto& bias_gradient = bias_optimizer->get_gradient_buffer(dst_scale,
+                                                                  true);
+        CHECK_CUDNN(cudnnConvolutionBackwardBias(
+                      cudnn::get_handle(),
+                      &gradient_scale,
+                      m_tensors_cudnn_desc.get_prev_error_signals(),
+                      local_gradient_wrt_output.LockedBuffer(),
+                      &dst_scale,
+                      m_bias_cudnn_desc,
+                      bias_gradient.Buffer()));
       } else {
-        CHECK_CUDNN(cudnnConvolutionBackwardBias(cudnn::get_handle(),
-                                                 &one,
-                                                 m_tensors_cudnn_desc.get_prev_error_signals(),
-                                                 local_gradient_wrt_output.LockedBuffer(),
-                                                 &zero,
-                                                 m_bias_cudnn_desc,
-                                                 m_bias_gradient.Buffer()));
+        // Ensure we participate in the allreduce.
+        bias_optimizer->get_gradient_buffer(true);
       }
-      bias_optimizer->add_to_gradient(m_bias_gradient,
-                                      m_bias_scaling_factor / effective_mini_batch_size,
-                                      true);
     }
 
     // Compute kernel gradient
     optimizer* kernel_optimizer = m_weights[0]->get_optimizer();
     if (kernel_optimizer != nullptr) {
-      if (!has_local_data) {
-        El::Zero(m_kernel_gradient);
-      } else {
-
+      if (has_local_data) {
+        DataType dst_scale = DataType(0);
+        auto& kernel_gradient = kernel_optimizer->get_gradient_buffer(dst_scale,
+                                                                      true);
         // Initialize GPU workspace
         GPUMat workspace;
 #ifdef HYDROGEN_HAVE_CUB
@@ -712,63 +688,61 @@ protected:
         #endif
         if (using_transposed_convolution) {
           #ifndef LBANN_DETERMINISTIC
-          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(cudnn::get_handle(),
-                                                                 gradient_wrt_output_desc,
-                                                                 input_desc,
-                                                                 m_convolution_cudnn_desc,
-                                                                 m_kernel_cudnn_desc,
-                                                                 CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-                                                                 workspace_size,
-                                                                 &kernel_gradient_cudnn_algorithm));
+          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(
+                        cudnn::get_handle(),
+                        gradient_wrt_output_desc,
+                        input_desc,
+                        m_convolution_cudnn_desc,
+                        m_kernel_cudnn_desc,
+                        CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                        workspace_size,
+                        &kernel_gradient_cudnn_algorithm));
           #endif
-          CHECK_CUDNN(cudnnConvolutionBackwardFilter(cudnn::get_handle(),
-                                                     &one,
-                                                     gradient_wrt_output_desc,
-                                                     local_gradient_wrt_output.LockedBuffer(),
-                                                     input_desc,
-                                                     local_input.LockedBuffer(),
-                                                     m_convolution_cudnn_desc,
-                                                     kernel_gradient_cudnn_algorithm,
-                                                     workspace.Buffer(),
-                                                     workspace_size,
-                                                     &zero,
-                                                     m_kernel_cudnn_desc,
-                                                     m_kernel_gradient.Buffer()));
-        }
-        else {
+          CHECK_CUDNN(cudnnConvolutionBackwardFilter(
+                        cudnn::get_handle(),
+                        &gradient_scale,
+                        gradient_wrt_output_desc,
+                        local_gradient_wrt_output.LockedBuffer(),
+                        input_desc,
+                        local_input.LockedBuffer(),
+                        m_convolution_cudnn_desc,
+                        kernel_gradient_cudnn_algorithm,
+                        workspace.Buffer(),
+                        workspace_size,
+                        &dst_scale,
+                        m_kernel_cudnn_desc,
+                        kernel_gradient.Buffer()));
+        } else {
           #ifndef LBANN_DETERMINISTIC
-          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(cudnn::get_handle(),
-                                                                 input_desc,
-                                                                 gradient_wrt_output_desc,
-                                                                 m_convolution_cudnn_desc,
-                                                                 m_kernel_cudnn_desc,
-                                                                 CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-                                                                 workspace_size,
-                                                                 &kernel_gradient_cudnn_algorithm));
+          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(
+                        cudnn::get_handle(),
+                        input_desc,
+                        gradient_wrt_output_desc,
+                        m_convolution_cudnn_desc,
+                        m_kernel_cudnn_desc,
+                        CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                        workspace_size,
+                        &kernel_gradient_cudnn_algorithm));
           #endif
-          CHECK_CUDNN(cudnnConvolutionBackwardFilter(cudnn::get_handle(),
-                                                     &one,
-                                                     input_desc,
-                                                     local_input.LockedBuffer(),
-                                                     gradient_wrt_output_desc,
-                                                     local_gradient_wrt_output.LockedBuffer(),
-                                                     m_convolution_cudnn_desc,
-                                                     kernel_gradient_cudnn_algorithm,
-                                                     workspace.Buffer(),
-                                                     workspace_size,
-                                                     &zero,
-                                                     m_kernel_cudnn_desc,
-                                                     m_kernel_gradient.Buffer()));
-
+          CHECK_CUDNN(cudnnConvolutionBackwardFilter(
+                        cudnn::get_handle(),
+                        &gradient_scale,
+                        input_desc,
+                        local_input.LockedBuffer(),
+                        gradient_wrt_output_desc,
+                        local_gradient_wrt_output.LockedBuffer(),
+                        m_convolution_cudnn_desc,
+                        kernel_gradient_cudnn_algorithm,
+                        workspace.Buffer(),
+                        workspace_size,
+                        &dst_scale,
+                        m_kernel_cudnn_desc,
+                        kernel_gradient.Buffer()));
         }
-
+      } else {
+        // Ensure we participate in the allreduce.
+        kernel_optimizer->get_gradient_buffer(true);
       }
-
-      // Add gradient contribution
-      kernel_optimizer->add_to_gradient(m_kernel_gradient,
-                                        one / effective_mini_batch_size,
-                                        true);
-
     }
 
 #endif // LBANN_HAS_CUDNN
@@ -932,8 +906,10 @@ protected:
     // Local matrices
     const DMat<Device>& local_input = get_local_prev_activations();
     const DMat<Device>& local_gradient_wrt_output = get_local_prev_error_signals();
-    auto& local_kernel_gradient = m_kernel_gradient.Matrix();
-    auto& local_bias_gradient = m_bias_gradient.Matrix();
+    const bool has_local_data = (local_input.Height() > 0
+                                 && local_input.Width() > 0
+                                 && local_gradient_wrt_output.Height() > 0
+                                 && local_gradient_wrt_output.Width() > 0);
 
     // Get convolution parameters
     const El::Int local_width = local_input.Width();
@@ -943,6 +919,7 @@ protected:
     const int num_output_channels = output_dims[0];
     const int num_per_output_channel = get_output_size() / num_output_channels;
     const int effective_mini_batch_size = this->m_model->get_effective_mini_batch_size();
+    const DataType gradient_scale = DataType(1) / effective_mini_batch_size;
     const auto& kernel_dims = get_kernel_dims();
     const auto& kernel_size = std::accumulate(kernel_dims.begin(),
                                               kernel_dims.end(),
@@ -952,25 +929,33 @@ protected:
     // Note: Sum is computed with Kahan summation
     optimizer* bias_optimizer = this->m_weights[1]->get_optimizer();
     if (m_bias_scaling_factor != DataType(0) && bias_optimizer != nullptr) {
-      LBANN_OMP_PARALLEL_FOR
-      for (int channel = 0; channel < num_output_channels; ++channel) {
-        const El::Int row_start = channel * num_per_output_channel;
-        const El::Int row_end = (channel+1) * num_per_output_channel;
-        DataType sum = 0;
-        DataType correction = 0;
-        for (El::Int col = 0; col < local_width; ++col) {
-          for (El::Int row = row_start; row < row_end; ++row) {
-            DataType term = local_gradient_wrt_output(row, col);
-            term += correction;
-            const DataType next_sum = sum + term;
-            correction = term - (next_sum - sum);
-            sum = next_sum;
+      if (has_local_data) {
+        DataType dst_scale = DataType(0);
+        auto& bias_gradient = bias_optimizer->get_gradient_buffer(
+          dst_scale, true);
+        auto& local_bias_gradient = bias_gradient.Matrix();
+        LBANN_OMP_PARALLEL_FOR
+        for (int channel = 0; channel < num_output_channels; ++channel) {
+          const El::Int row_start = channel * num_per_output_channel;
+          const El::Int row_end = (channel+1) * num_per_output_channel;
+          DataType sum = 0;
+          DataType correction = 0;
+          for (El::Int col = 0; col < local_width; ++col) {
+            for (El::Int row = row_start; row < row_end; ++row) {
+              DataType term = local_gradient_wrt_output(row, col);
+              term += correction;
+              const DataType next_sum = sum + term;
+              correction = term - (next_sum - sum);
+              sum = next_sum;
+            }
           }
+          local_bias_gradient(channel, 0) = dst_scale*local_bias_gradient(channel, 0)
+            + gradient_scale*sum;
         }
-        local_bias_gradient(channel, 0) = m_bias_scaling_factor * sum;
+      } else {
+        // Ensure we participate in the allreduce.
+        bias_optimizer->get_gradient_buffer(true);
       }
-      const DataType bias_scale = m_bias_scaling_factor / effective_mini_batch_size;
-      bias_optimizer->add_to_gradient(m_bias_gradient, bias_scale, true);
     }
 
     // Stop early if kernel is not being optimized
@@ -988,51 +973,53 @@ protected:
                    get_input_size() / num_input_channels :
                    get_output_size() / num_output_channels);
     DMat<Device> im2col_matrix(m, k);
-    DMat<Device> kernel_gradient_matrix(m, n, local_kernel_gradient.Buffer(), m);
-    El::Zero(kernel_gradient_matrix);
 
-    // Compute kernel gradient contributions from each data sample
-    for (El::Int col = 0; col < local_width; ++col) {
-      if (using_transposed_convolution) {
-        const DMat<Device> input_col(k, n, local_input.LockedBuffer(0,col), k);
-        const DMat<Device> gradient_wrt_output_col =
-          El::LockedView(local_gradient_wrt_output, El::ALL, El::IR(col));
-        im2col(gradient_wrt_output_col,
-               im2col_matrix,
-               num_output_channels,
-               output_dims.size() - 1,
-               &output_dims[1],
-               m_pads.data(),
-               &kernel_dims[2],
-               m_strides.data());
-        El::Gemm(El::NORMAL, El::NORMAL,
-                 DataType(1), im2col_matrix, input_col,
-                 DataType(1), kernel_gradient_matrix);
+    if (has_local_data) {
+      DataType dst_scale = DataType(0);
+      auto& kernel_gradient = kernel_optimizer->get_gradient_buffer(
+        dst_scale, true);
+      auto& local_kernel_gradient = kernel_gradient.Matrix();
+      DMat<Device> kernel_gradient_matrix(m, n, local_kernel_gradient.Buffer(), m);
+
+      // Compute kernel gradient contributions from each data sample
+      for (El::Int col = 0; col < local_width; ++col) {
+        if (using_transposed_convolution) {
+          const DMat<Device> input_col(k, n, local_input.LockedBuffer(0,col), k);
+          const DMat<Device> gradient_wrt_output_col =
+            El::LockedView(local_gradient_wrt_output, El::ALL, El::IR(col));
+          im2col(gradient_wrt_output_col,
+                 im2col_matrix,
+                 num_output_channels,
+                 output_dims.size() - 1,
+                 &output_dims[1],
+                 m_pads.data(),
+                 &kernel_dims[2],
+                 m_strides.data());
+          El::Gemm(El::NORMAL, El::NORMAL,
+                   gradient_scale, im2col_matrix, input_col,
+                   dst_scale, kernel_gradient_matrix);
+        }
+        else {
+          const DMat<Device> input_col
+            = El::LockedView(local_input, El::ALL, El::IR(col));
+          const DMat<Device> gradient_wrt_output_col(k, n, local_gradient_wrt_output.LockedBuffer(0,col), k);
+          im2col(input_col,
+                 im2col_matrix,
+                 num_input_channels,
+                 input_dims.size() - 1,
+                 &input_dims[1],
+                 m_pads.data(),
+                 &kernel_dims[2],
+                 m_strides.data());
+          El::Gemm(El::NORMAL, El::NORMAL,
+                   gradient_scale, im2col_matrix, gradient_wrt_output_col,
+                   dst_scale, kernel_gradient_matrix);
+        }
       }
-      else {
-        const DMat<Device> input_col
-          = El::LockedView(local_input, El::ALL, El::IR(col));
-        const DMat<Device> gradient_wrt_output_col(k, n, local_gradient_wrt_output.LockedBuffer(0,col), k);
-        im2col(input_col,
-               im2col_matrix,
-               num_input_channels,
-               input_dims.size() - 1,
-               &input_dims[1],
-               m_pads.data(),
-               &kernel_dims[2],
-               m_strides.data());
-        El::Gemm(El::NORMAL, El::NORMAL,
-                 DataType(1), im2col_matrix, gradient_wrt_output_col,
-                 DataType(1), kernel_gradient_matrix);
-      }
+    } else {
+      // Ensure we participate in the allreduce.
+      kernel_optimizer->get_gradient_buffer(true);
     }
-
-    // Scale and accumulate gradients
-    const DataType kernel_scale = DataType(1) / effective_mini_batch_size;
-    kernel_optimizer->add_to_gradient(m_kernel_gradient,
-                                      kernel_scale,
-                                      true);
-
   }
 
 private:

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -48,7 +48,6 @@ public:
                         weights* weight = nullptr,
                         bool has_bias = true)
     : learning_layer(comm),
-      m_linearity_gradient(nullptr),
       m_bias_gradient(nullptr),
       m_transpose(transpose) {
 
@@ -66,11 +65,7 @@ public:
     m_transpose(other.m_transpose) {
 
     // Deep matrix copies
-    m_linearity_gradient = other.m_linearity_gradient;
     m_bias_gradient = other.m_bias_gradient;
-    if (m_linearity_gradient != nullptr) {
-      m_linearity_gradient = m_linearity_gradient->Copy();
-    }
     if (m_bias_gradient != nullptr) {
       m_bias_gradient = m_bias_gradient->Copy();
     }
@@ -84,11 +79,7 @@ public:
 
     // Deep matrix copies
     deallocate_matrices();
-    m_linearity_gradient = other.m_linearity_gradient;
     m_bias_gradient = other.m_bias_gradient;
-    if (m_linearity_gradient != nullptr) {
-      m_linearity_gradient = m_linearity_gradient->Copy();
-    }
     if (m_bias_gradient != nullptr) {
       m_bias_gradient = m_bias_gradient->Copy();
     }
@@ -169,11 +160,6 @@ protected:
     }
     linearity_weights.set_matrix_distribution(linearity_dist);
 
-    // Setup weight gradients
-    El::Zeros(*m_linearity_gradient,
-              linearity_weights.get_matrix_height(),
-              linearity_weights.get_matrix_width());
-
     // Set up bias if needed.
     if (m_bias_scaling_factor != DataType(0)) {
       if (this->m_weights[1] == nullptr) {
@@ -190,9 +176,11 @@ protected:
       bias_dist.rowDist = El::STAR;
       bias_weights.set_dims(get_output_dims());
       bias_weights.set_matrix_distribution(bias_dist);
-      El::Zeros(*this->m_bias_gradient,
-              bias_weights.get_matrix_height(),
-              bias_weights.get_matrix_width());
+      if (this->m_bias_gradient != nullptr) {
+        El::Zeros(*this->m_bias_gradient,
+                  bias_weights.get_matrix_height(),
+                  bias_weights.get_matrix_width());
+      }
     }
 
     // Initialize freeze state
@@ -226,11 +214,6 @@ private:
    */
   DataType m_bias_scaling_factor;
 
-  /** Linearity gradient.
-   *  This is this layer's contribution to the objective function
-   *  gradient w.r.t. the linearity weights (i.e. its matrix weights).
-   */
-  AbsDistMat* m_linearity_gradient;
   /** Bias weights gradient.
    *  This is this layer's contribution to the objective function
    *  gradient w.r.t. the bias weights.
@@ -242,7 +225,6 @@ private:
 
   /** Deallocate distributed matrices. */
   void deallocate_matrices() {
-    if (m_linearity_gradient != nullptr) delete m_linearity_gradient;
     if (m_bias_gradient != nullptr) delete m_bias_gradient;
   }
 

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -123,6 +123,32 @@ public:
                        bool allreduce_needed = false);
   /** @brief Zero out the objective function gradient w.r.t. the weights. */
   void clear_gradient();
+  /** @brief Get the gradient buffer.
+   *
+   *  This provides access to the underlying gradient buffer, which may be
+   *  directly summed into. This buffer should be considered ephemeral and not
+   *  stored. The caller must also ensure the buffer has an appropriate
+   *  distribution. buf_scale provides the caller with a scale factor that must
+   *  be applied to the gradient buffer before writing to it. Essentially, this
+   *  enables computations of the form
+   *  gradient = buf_scale*gradient + new_gradient
+   *  This is an expert-mode function and is intended to help eliminate copies
+   *  and facilitate kernel fusion.
+   *
+   *  @param buf_scale A scale factor provided to the caller to scale the
+   *  returned buffer by.
+   *  @param allreduce_needed Whether this gradient contribution will need to
+   *  be allreduced.
+   */
+  AbsDistMat& get_gradient_buffer(DataType& buf_scale,
+                                  bool allreduce_needed = false);
+  /**
+   *  @brief Get the gradient buffer.
+   *
+   *  This is the same as the other get_gradient_buffer, but does all needed
+   *  scaling of the gradient buffer. 
+   */
+  AbsDistMat& get_gradient_buffer(bool allreduce_needed = false);
 
   /** @brief Objects that are expected to contribute to the gradient. */
   El::Int get_num_gradient_sources() const;

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -129,18 +129,22 @@ public:
    *  directly summed into. This buffer should be considered ephemeral and not
    *  stored. The caller must also ensure the buffer has an appropriate
    *  distribution. buf_scale provides the caller with a scale factor that must
-   *  be applied to the gradient buffer before writing to it. Essentially, this
-   *  enables computations of the form
-   *  gradient = buf_scale*gradient + new_gradient
+   *  be applied to the gradient buffer before writing to it, and in_scale
+   *  provides a scaling factor that must be applied to the user's data.
+   *  Essentially, this enables computations of the form
+   *  gradient = buf_scale*gradient + in_scale*new_gradient
    *  This is an expert-mode function and is intended to help eliminate copies
    *  and facilitate kernel fusion.
    *
    *  @param buf_scale A scale factor provided to the caller to scale the
    *  returned buffer by.
+   *  @param in_scale A scale factor provided to the caller to scale their
+   *  gradient contributions by.
    *  @param allreduce_needed Whether this gradient contribution will need to
    *  be allreduced.
    */
   AbsDistMat& get_gradient_buffer(DataType& buf_scale,
+                                  DataType& in_scale,
                                   bool allreduce_needed = false);
 
   /** @brief Objects that are expected to contribute to the gradient. */

--- a/include/lbann/optimizers/optimizer.hpp
+++ b/include/lbann/optimizers/optimizer.hpp
@@ -142,13 +142,6 @@ public:
    */
   AbsDistMat& get_gradient_buffer(DataType& buf_scale,
                                   bool allreduce_needed = false);
-  /**
-   *  @brief Get the gradient buffer.
-   *
-   *  This is the same as the other get_gradient_buffer, but does all needed
-   *  scaling of the gradient buffer. 
-   */
-  AbsDistMat& get_gradient_buffer(bool allreduce_needed = false);
 
   /** @brief Objects that are expected to contribute to the gradient. */
   El::Int get_num_gradient_sources() const;

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -239,17 +239,6 @@ AbsDistMat& optimizer::get_gradient_buffer(DataType& buf_scale,
   return *m_gradient;
 }
 
-AbsDistMat& optimizer::get_gradient_buffer(bool allreduce_needed) {
-  DataType buf_scale;
-  auto& buf = get_gradient_buffer(buf_scale, allreduce_needed);
-  if (buf_scale == DataType(0)) {
-    El::Zero(buf);
-  } else if (buf_scale != DataType(1)) {
-    El::Scale(buf_scale, buf);
-  }
-  return buf;
-}
-
 El::Int optimizer::get_num_gradient_sources() const {
   return m_gradient_sources.size();
 }

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -162,6 +162,8 @@ void optimizer::add_to_gradient(const AbsDistMat& gradient,
   switch (m_gradient_status) {
   case optimizer_gradient_status::ready:
     if (allreduce_needed) {
+      // Properly scale contributions that have already been allreduced or that
+      // do not need allreduces.
       El::Scale(DataType(1) / m_gradient->RedundantSize(), *m_gradient);
       m_gradient_status = optimizer_gradient_status::allreduce_needed;
     }
@@ -176,6 +178,7 @@ void optimizer::add_to_gradient(const AbsDistMat& gradient,
     break;
   case optimizer_gradient_status::allreduce_needed:
     {
+      // Properly scale data that does not need to be allreduced.
       const auto& scale_ = (allreduce_needed ?
                             scale :
                             scale / m_gradient->RedundantSize());
@@ -231,6 +234,7 @@ AbsDistMat& optimizer::get_gradient_buffer(DataType& buf_scale,
     break;
   case optimizer_gradient_status::allreduce_needed:
     buf_scale = DataType(1);
+    // Properly scale data that does not need to be allreduced.
     in_scale = (allreduce_needed ?
                 DataType(1) :
                 DataType(1) / m_gradient->RedundantSize());


### PR DESCRIPTION
This adds support for doing gradient computations in-place.

The problem with the current `add_to_gradient` method:
* We store two copies of gradient buffers, one within a layer and one within the optimizer. This uses a lot of excess memory when a layer many parameters (big fully-connected layers, wide convolutional layers).
* We perform a bunch of copies and scalings of gradient matrices, which involves excess data movement and computation (ideally: we fuse the scaling).

The solution: An expert-mode interface in optimizers (`get_gradient_buffer`) to get direct access to the underlying gradient buffer, as well as whatever scaling factors need to be applied to it. The contract for using this is that the caller must apply the scaling factor to the buffer before writing to it. The existing `add_to_gradient` method remains in place with no changes.

Layer modifications:
* Convolutional layers now use this for both kernel and bias gradients. cuDNN supports scaling parameters for buffers that we now use to completely fuse the scaling operations. `GEMM` has similar parameters that are used for CPU im2col convolution. Convolutional layers now no longer have their own gradient buffers.
* Fully-connected layers use this for linearity gradients, and bias gradients when the layer is on GPU. (The method used to compute bias gradients on CPU does not let us fuse the scale factors.) Fully-connected layers now no longer have their own linearity gradient buffers (or a bias gradient buffer when using GPUs).

Passes `model_mnist_conv_graph`, `model_mnist_ridge_regression`, and `model_mnist_softmax_classifier` tests. Initial ResNet-50 training also looks good. (I tested the `softmax_classifier` on CPU, and it seemed fine, but the tests were too slow to run to completion.)

Notes on other layers that compute gradients:
* I would like to apply this to batchnorm in order to fuse the copy/scaling. This will require modification to our custom batchnorm kernels, which we should do as part of our general batchnorm optimization.
* L2 weight regularization is currently fine as-is: it just does an Axpy into the gradient buffer via `add_to_gradient`. (But in the future we may want to clean up the order in which weight regularizations are done WRT other computations, and so this might change.)