### PR TITLE
Bugfix for LTFB to mark data store loaded

### DIFF
--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -241,6 +241,8 @@ public:
       mode requested */
   virtual void collect_background_data_fetch(execution_mode mode);
 
+  virtual void make_data_store_preloaded(execution_mode mode);
+
   // ===========================================
   // Summarizer
   // ===========================================

--- a/src/callbacks/callback_ltfb.cpp
+++ b/src/callbacks/callback_ltfb.cpp
@@ -266,6 +266,10 @@ EvalType evaluate(model& m, const std::string& metric_name) {
     LBANN_ERROR(err.str());
   }
 
+  // Mark the data store as loaded - Note that this is a temporary fix
+  // for the current use of the tournament
+  m.make_data_store_preloaded(execution_mode::validation);
+
   // Clean up and return metric value
   m.set_execution_mode(original_mode);
   return metric_value;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -37,6 +37,7 @@
 #include "lbann/utils/random.hpp"
 #include "lbann/utils/omp_diagnostics.hpp"
 #include "lbann/utils/description.hpp"
+#include "lbann/data_store/data_store_conduit.hpp"
 #include <string>
 #include <unistd.h>
 #include <iomanip>
@@ -1010,6 +1011,18 @@ void model::collect_background_data_fetch(execution_mode mode) {
     auto *input = dynamic_cast<generic_input_layer*>(&get_layer(i));
     if (input != nullptr) {
       input->collect_background_data_fetch(mode);
+    }
+  }
+}
+
+void model::make_data_store_preloaded(execution_mode mode) {
+  for (El::Int i = 0; i < get_num_layers(); ++i) {
+    auto *input = dynamic_cast<generic_input_layer*>(&get_layer(i));
+    if (input != nullptr) {
+      if(!input->get_data_reader(mode)->get_data_store_ptr()->is_preloaded()) {
+        std::cout << "I am going to mark the validation data reader as loaded" << std::endl;
+        input->get_data_reader(mode)->get_data_store_ptr()->set_preload();
+      }
     }
   }
 }


### PR DESCRIPTION
Work around to let LTFB properly mark the data store as loaded during a tournament.