### PR TITLE
Autotune cuDNN convolution algorithms

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -80,6 +80,12 @@ protected:
   cudnnTensorDescriptor_t m_bias_cudnn_desc = nullptr;
   /** Tensor cuDNN descriptors. */
   cudnn::data_parallel_layer_tensor_manager m_tensors_cudnn_desc;
+  /** Forward algorithm cache (mini-batch size -> algo). */
+  std::unordered_map<int, cudnnConvolutionFwdAlgo_t> m_fwd_cudnn_algos;
+  /** Backward data algorithm cache (mini-batch size -> algo). */
+  std::unordered_map<int, cudnnConvolutionBwdDataAlgo_t> m_bwd_data_cudnn_algos;
+  /** Backward filter algorithm cache (mini-batch size -> algo). */
+  std::unordered_map<int, cudnnConvolutionBwdFilterAlgo_t> m_bwd_filter_cudnn_algos;
 
 #endif // LBANN_HAS_CUDNN
 
@@ -117,7 +123,10 @@ public:
       m_groups(other.m_groups),
       m_bias_scaling_factor(other.m_bias_scaling_factor)
 #ifdef LBANN_HAS_CUDNN
-    , m_tensors_cudnn_desc(other.m_tensors_cudnn_desc)
+    , m_tensors_cudnn_desc(other.m_tensors_cudnn_desc),
+      m_fwd_cudnn_algos(other.m_fwd_cudnn_algos),
+      m_bwd_data_cudnn_algos(other.m_bwd_data_cudnn_algos),
+      m_bwd_filter_cudnn_algos(other.m_bwd_filter_cudnn_algos)
 #endif // LBANN_HAS_CUDNN
   {
 #ifdef LBANN_HAS_CUDNN
@@ -155,6 +164,9 @@ public:
     }
     m_tensors_cudnn_desc = other.m_tensors_cudnn_desc;
     m_tensors_cudnn_desc.set_layer(this);
+    m_fwd_cudnn_algos = other.m_fwd_cudnn_algos;
+    m_bwd_data_cudnn_algos = other.m_bwd_data_cudnn_algos;
+    m_bwd_filter_cudnn_algos = other.m_bwd_filter_cudnn_algos;
 #endif // LBANN_HAS_CUDNN
 
     return *this;
@@ -498,15 +510,11 @@ protected:
     // Perform convolution on the GPU
     // Determine convolution algorithm
     cudnnConvolutionFwdAlgo_t convolution_cudnn_algorithm
-      = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-    CHECK_CUDNN(cudnnGetConvolutionForwardAlgorithm(cudnn::get_handle(),
-                                                    input_desc,
-                                                    m_kernel_cudnn_desc,
-                                                    m_convolution_cudnn_desc,
-                                                    output_desc,
-                                                    CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-                                                    workspace_size,
-                                                    &convolution_cudnn_algorithm));
+      = get_forward_algo_cudnn(input.Width(), input_desc, input.LockedBuffer(),
+                               m_kernel_cudnn_desc, kernel.LockedBuffer(),
+                               m_convolution_cudnn_desc,
+                               output_desc, output.Buffer(),
+                               workspace_size, workspace.Buffer());
 
     // Apply convolution
     CHECK_CUDNN(cudnnConvolutionForward(cudnn::get_handle(),
@@ -579,21 +587,13 @@ protected:
 
     // Perform transposed convolution on the GPU
     // Determine transposed convolution algorithm
-    #ifndef LBANN_DETERMINISTIC
     cudnnConvolutionBwdDataAlgo_t transposed_convolution_cudnn_algorithm
-      = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
-    CHECK_CUDNN(cudnnGetConvolutionBackwardDataAlgorithm(cudnn::get_handle(),
-                                                         m_kernel_cudnn_desc,
-                                                         input_desc,
-                                                         m_convolution_cudnn_desc,
-                                                         output_desc,
-                                                         CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-                                                         workspace_size,
-                                                         &transposed_convolution_cudnn_algorithm));
-    #else
-    cudnnConvolutionBwdDataAlgo_t transposed_convolution_cudnn_algorithm
-      = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
-    #endif
+      = get_backward_data_algo_cudnn(input.Width(),
+                                     m_kernel_cudnn_desc, kernel.LockedBuffer(),
+                                     input_desc, input.LockedBuffer(),
+                                     m_convolution_cudnn_desc,
+                                     output_desc, output.Buffer(),
+                                     workspace_size, workspace.Buffer());
     // Perform transposed convolution
     CHECK_CUDNN(cudnnConvolutionBackwardData(cudnn::get_handle(),
                                              &one,
@@ -694,25 +694,15 @@ protected:
         auto&& gradient_wrt_output_desc = m_tensors_cudnn_desc.get_prev_error_signals();
 
         // Determine algorithm and compute kernel gradient
-        #ifndef LBANN_DETERMINISTIC
-        cudnnConvolutionBwdFilterAlgo_t kernel_gradient_cudnn_algorithm
-          = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
-        #else
-        cudnnConvolutionBwdFilterAlgo_t kernel_gradient_cudnn_algorithm
-          = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
-        #endif
         if (using_transposed_convolution) {
-          #ifndef LBANN_DETERMINISTIC
-          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(
-                        cudnn::get_handle(),
-                        gradient_wrt_output_desc,
-                        input_desc,
-                        m_convolution_cudnn_desc,
-                        m_kernel_cudnn_desc,
-                        CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-                        workspace_size,
-                        &kernel_gradient_cudnn_algorithm));
-          #endif
+          cudnnConvolutionBwdFilterAlgo_t kernel_gradient_cudnn_algorithm
+            = get_backward_filter_algo_cudnn(
+              local_input.Width(),
+              gradient_wrt_output_desc, local_gradient_wrt_output.LockedBuffer(),
+              input_desc, local_input.LockedBuffer(),
+              m_convolution_cudnn_desc,
+              m_kernel_cudnn_desc,
+              workspace_size, workspace.Buffer());
           CHECK_CUDNN(cudnnConvolutionBackwardFilter(
                         cudnn::get_handle(),
                         &gradient_scale,
@@ -728,17 +718,14 @@ protected:
                         m_kernel_cudnn_desc,
                         kernel_gradient.Buffer()));
         } else {
-          #ifndef LBANN_DETERMINISTIC
-          CHECK_CUDNN(cudnnGetConvolutionBackwardFilterAlgorithm(
-                        cudnn::get_handle(),
-                        input_desc,
-                        gradient_wrt_output_desc,
-                        m_convolution_cudnn_desc,
-                        m_kernel_cudnn_desc,
-                        CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-                        workspace_size,
-                        &kernel_gradient_cudnn_algorithm));
-          #endif
+          cudnnConvolutionBwdFilterAlgo_t kernel_gradient_cudnn_algorithm
+            = get_backward_filter_algo_cudnn(
+              local_input.Width(),
+              input_desc, local_input.LockedBuffer(),
+              gradient_wrt_output_desc, local_gradient_wrt_output.LockedBuffer(),
+              m_convolution_cudnn_desc,
+              m_kernel_cudnn_desc,
+              workspace_size, workspace.Buffer());
           CHECK_CUDNN(cudnnConvolutionBackwardFilter(
                         cudnn::get_handle(),
                         &gradient_scale,
@@ -1128,6 +1115,105 @@ private:
                                                 num_groups));
     }
 
+  }
+
+  /** Get the cuDNN algorithm to use for forward prop. */
+  cudnnConvolutionFwdAlgo_t get_forward_algo_cudnn(
+    const int local_mini_batch_size,
+    const cudnnTensorDescriptor_t& input_desc,
+    const DataType* input,
+    const cudnnFilterDescriptor_t& filter_desc,
+    const DataType* filter,
+    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnnTensorDescriptor_t& output_desc,
+    DataType* output,
+    size_t ws_size,
+    DataType* ws) {
+    if (m_fwd_cudnn_algos.count(local_mini_batch_size) == 0) {
+#ifdef LBANN_DETERMINISTIC
+      bool deterministic = true;
+#else
+      bool deterministic = false;
+#endif
+      m_fwd_cudnn_algos[local_mini_batch_size] =
+        cudnn::get_fwd_algorithm(
+          true, deterministic,
+          input_desc, input,
+          filter_desc, filter,
+          conv_desc,
+          output_desc, output,
+          ws_size, ws);
+    }
+    return m_fwd_cudnn_algos[local_mini_batch_size];
+  }
+
+  /** Get the cuDNN algorithm to use for backward-data. */
+  cudnnConvolutionBwdDataAlgo_t get_backward_data_algo_cudnn(
+    const int local_mini_batch_size,
+    const cudnnFilterDescriptor_t& filter_desc,
+    const DataType* filter,
+    const cudnnTensorDescriptor_t& d_output_desc,
+    const DataType* d_output,
+    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnnTensorDescriptor_t& d_input_desc,
+    DataType* d_input,
+    size_t ws_size,
+    DataType* ws) {
+    if (m_bwd_data_cudnn_algos.count(local_mini_batch_size) == 0) {
+#ifdef LBANN_DETERMINISTIC
+      bool deterministic = true;
+#else
+      bool deterministic = false;
+#endif
+      m_bwd_data_cudnn_algos[local_mini_batch_size] =
+        cudnn::get_bwd_data_algorithm(
+          true, deterministic,
+          filter_desc, filter,
+          d_output_desc, d_output,
+          conv_desc,
+          d_input_desc, d_input,
+          ws_size, ws);
+    }
+    return m_bwd_data_cudnn_algos[local_mini_batch_size];
+  }
+
+  /**
+   * Get the cuDNN algorithm to use for backward-filter.
+   * Buffer space for d_filter is allocated via temporary workspace.
+   */
+  cudnnConvolutionBwdFilterAlgo_t get_backward_filter_algo_cudnn(
+    const int local_mini_batch_size,
+    const cudnnTensorDescriptor_t& input_desc,
+    const DataType* input,
+    const cudnnTensorDescriptor_t& d_output_desc,
+    const DataType* d_output,
+    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnnFilterDescriptor_t& d_filter_desc,
+    size_t ws_size,
+    DataType* ws) {
+    if (m_bwd_filter_cudnn_algos.count(local_mini_batch_size) == 0) {
+#ifdef LBANN_DETERMINISTIC
+      bool deterministic = true;
+#else
+      bool deterministic = false;
+#endif
+      // Temporary filter gradient buffer.
+      GPUMat d_filter;
+#ifdef HYDROGEN_HAVE_CUB
+      d_filter.SetMemoryMode(1);
+#endif
+      d_filter.Resize(this->m_weights[0]->get_matrix_height(),
+                      this->m_weights[0]->get_matrix_width());
+      m_bwd_filter_cudnn_algos[local_mini_batch_size] =
+        cudnn::get_bwd_filter_algorithm(
+          true, deterministic,
+          input_desc, input,
+          d_output_desc, d_output,
+          conv_desc,
+          d_filter_desc, d_filter.Buffer(),
+          ws_size, ws);
+    }
+    return m_bwd_filter_cudnn_algos[local_mini_batch_size];
   }
 
 #endif // LBANN_HAS_CUDNN

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -217,39 +217,53 @@ cudnnConvolutionFwdAlgo_t get_fwd_algorithm(
   bool deterministic,
   const cudnnTensorDescriptor_t& input_desc,
   const void* input,
-  const cudnnFilterDescriptor_t& filter_desc,
-  const void* filter,
+  const cudnnFilterDescriptor_t& kernel_desc,
+  const void* kernel,
   const cudnnConvolutionDescriptor_t& conv_desc,
   const cudnnTensorDescriptor_t& output_desc,
   void* output,
   size_t ws_size,
   void* ws);
 
-/** Select a backward data convolution algorithm. */
+/** Select a backward data convolution algorithm.
+ *
+ * If autotuning, memory for cuDNN algorithm runs is needed and should be
+ * provided via the pointer arguments.
+ *
+ * @param autotune True to attempt all cuDNN algorithms and select the fastest.
+ * @param deterministic True to require deterministic algorithms.
+ */
 cudnnConvolutionBwdDataAlgo_t get_bwd_data_algorithm(
   bool autotune,
   bool deterministic,
-  const cudnnFilterDescriptor_t& filter_desc,
-  const void* filter,
-  const cudnnTensorDescriptor_t& d_output_desc,
-  const void* d_output,
+  const cudnnFilterDescriptor_t& kernel_desc,
+  const void* kernel,
+  const cudnnTensorDescriptor_t& prev_error_signal_desc,
+  const void* prev_error_signal,
   const cudnnConvolutionDescriptor_t& conv_desc,
-  const cudnnTensorDescriptor_t& d_input_desc,
-  void* d_input,
+  const cudnnTensorDescriptor_t& error_signal_desc,
+  void* error_signal,
   size_t ws_size,
   void* ws);
 
-/** Select a backward filter convolution algorithm. */
+/** Select a backward filter convolution algorithm.
+ *
+ * If autotuning, memory for cuDNN algorithm runs is needed and should be
+ * provided via the pointer arguments.
+ *
+ * @param autotune True to attempt all cuDNN algorithms and select the fastest.
+ * @param deterministic True to require deterministic algorithms.
+ */
 cudnnConvolutionBwdFilterAlgo_t get_bwd_filter_algorithm(
   bool autotune,
   bool deterministic,
   const cudnnTensorDescriptor_t& input_desc,
   const void* input,
-  const cudnnTensorDescriptor_t& d_output_desc,
-  const void* d_output,
+  const cudnnTensorDescriptor_t& prev_error_signal_desc,
+  const void* prev_error_signal,
   const cudnnConvolutionDescriptor_t& conv_desc,
-  const cudnnFilterDescriptor_t& d_filter_desc,
-  void* d_filter,
+  const cudnnFilterDescriptor_t& kernel_gradient_desc,
+  void* kernel_gradient,
   size_t ws_size,
   void* ws);
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -199,6 +199,60 @@ public:
   cudnnTensorDescriptor_t& get_error_signals(int parent_index = 0) override;
 };
 
+////////////////////////////////////////////////////////////
+// cuDNN algorithm selection
+////////////////////////////////////////////////////////////
+
+/**
+ * Select a forward convolution algorithm.
+ *
+ * If autotuning, memory for cuDNN algorithm runs is needed and should be
+ * provided via the pointer arguments.
+ *
+ * @param autotune True to attempt all cuDNN algorithms and select the fastest.
+ * @param deterministic True to require deterministic algorithms.
+ */
+cudnnConvolutionFwdAlgo_t get_fwd_algorithm(
+  bool autotune,
+  bool deterministic,
+  const cudnnTensorDescriptor_t& input_desc,
+  const void* input,
+  const cudnnFilterDescriptor_t& filter_desc,
+  const void* filter,
+  const cudnnConvolutionDescriptor_t& conv_desc,
+  const cudnnTensorDescriptor_t& output_desc,
+  void* output,
+  size_t ws_size,
+  void* ws);
+
+/** Select a backward data convolution algorithm. */
+cudnnConvolutionBwdDataAlgo_t get_bwd_data_algorithm(
+  bool autotune,
+  bool deterministic,
+  const cudnnFilterDescriptor_t& filter_desc,
+  const void* filter,
+  const cudnnTensorDescriptor_t& d_output_desc,
+  const void* d_output,
+  const cudnnConvolutionDescriptor_t& conv_desc,
+  const cudnnTensorDescriptor_t& d_input_desc,
+  void* d_input,
+  size_t ws_size,
+  void* ws);
+
+/** Select a backward filter convolution algorithm. */
+cudnnConvolutionBwdFilterAlgo_t get_bwd_filter_algorithm(
+  bool autotune,
+  bool deterministic,
+  const cudnnTensorDescriptor_t& input_desc,
+  const void* input,
+  const cudnnTensorDescriptor_t& d_output_desc,
+  const void* d_output,
+  const cudnnConvolutionDescriptor_t& conv_desc,
+  const cudnnFilterDescriptor_t& d_filter_desc,
+  void* d_filter,
+  size_t ws_size,
+  void* ws);
+
 } // namespace cudnn
 } // namespace lbann
 


### PR DESCRIPTION
* Adds support for autotuning the cuDNN convolution algorithm selection using `cudnnFindConvolutionForwardAlgorithmEx` (etc.).
* Switches the heuristic algorithm selection from the deprecated `cudnnGetConvolutionForwardAlgorithm` (etc.) to `cudnnGetConvolutionForwardAlgorithm_v7` (etc.).

The implementation is adapted from distconv LBANN.

A layer selects an algorithm once for each unique mini-batch size it sees.

Right now, this always autotunes the algorithm. However, for some networks/datasets (e.g. 3D data), autotuning can take an excessive amount of time. We should find a nice way to enable/disable this without requiring a rebuild. Either environment variables or a command-line flag should work, but we need to come up with a reasonable interface for these sorts of tuning flags.