### PR TITLE
Bugfix HDF5 PQ stale data

### DIFF
--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -150,7 +150,6 @@ class sample_list_jag {
   void delete_hdf5_handle_pq_entry(sample_file_id_t id) {
     for (std::deque<fd_use_map_t>::iterator it = m_open_fd_pq.begin(); it!=m_open_fd_pq.end(); ++it) {
       if(it->first == id) {
-        std::cout << "I have found the entry for " << id << std::endl;
         it = m_open_fd_pq.erase(it);
         break;
       }

--- a/include/lbann/data_readers/sample_list_jag.hpp
+++ b/include/lbann/data_readers/sample_list_jag.hpp
@@ -147,6 +147,17 @@ class sample_list_jag {
     manage_open_hdf5_handles(id, true);
   }
 
+  void delete_hdf5_handle_pq_entry(sample_file_id_t id) {
+    for (std::deque<fd_use_map_t>::iterator it = m_open_fd_pq.begin(); it!=m_open_fd_pq.end(); ++it) {
+      if(it->first == id) {
+        std::cout << "I have found the entry for " << id << std::endl;
+        it = m_open_fd_pq.erase(it);
+        break;
+      }
+    }
+    return;
+  }
+
   void manage_open_hdf5_handles(sample_file_id_t id, bool pre_open_fd = false) {
     /// When we enter this function the priority queue is either empty or a heap
     if(!m_open_fd_pq.empty()) {
@@ -234,6 +245,7 @@ class sample_list_jag {
       if(file_access_queue.empty()) {
         conduit::relay::io::hdf5_close_file(std::get<1>(e));
         std::get<1>(e) = 0;
+        delete_hdf5_handle_pq_entry(id);
       }
     }
   }

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -327,7 +327,7 @@ inline void sample_list_jag::read_exclusive_list(std::istream& istrm, size_t str
 }
 
 
-  inline void sample_list_jag::read_inclusive_list(std::istream& istrm, size_t stride, size_t offset) {
+inline void sample_list_jag::read_inclusive_list(std::istream& istrm, size_t stride, size_t offset) {
   const std::string whitespaces(" \t\f\v\n\r");
   size_t cnt_files = 0u;
   std::string line;
@@ -567,6 +567,8 @@ inline void sample_list_jag::compute_epochs_file_usage(const std::vector<int>& s
     }
     std::get<2>(e).clear();
   }
+  // Once all of the file handles are closed, clear the priority queue
+  m_open_fd_pq.clear();
 
   for (size_t i = 0; i < shuffled_indices.size(); i++) {
     int idx = shuffled_indices[i];

--- a/include/lbann/data_readers/sample_list_jag_impl.hpp
+++ b/include/lbann/data_readers/sample_list_jag_impl.hpp
@@ -58,6 +58,7 @@ inline sample_list_jag::~sample_list_jag() {
       conduit::relay::io::hdf5_close_file(std::get<1>(f));
     }
     std::get<1>(f) = 0;
+    std::get<2>(f).clear();
   }
   m_file_id_stats_map.clear();
   m_open_fd_pq.clear();
@@ -563,8 +564,8 @@ inline void sample_list_jag::compute_epochs_file_usage(const std::vector<int>& s
   for (auto&& e : m_file_id_stats_map) {
     if(std::get<1>(e) > 0) {
       conduit::relay::io::hdf5_close_file(std::get<1>(e));
-      std::get<1>(e) = 0;
     }
+    std::get<1>(e) = 0;
     std::get<2>(e).clear();
   }
   // Once all of the file handles are closed, clear the priority queue

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1021,7 +1021,6 @@ void model::make_data_store_preloaded(execution_mode mode) {
     if (input != nullptr) {
       auto *data_store = input->get_data_reader(mode)->get_data_store_ptr();
       if(data_store != nullptr && !data_store->is_preloaded()) {
-        std::cout << "I am going to mark the validation data reader as loaded" << std::endl;
         input->get_data_reader(mode)->get_data_store_ptr()->set_preload();
       }
     }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1019,7 +1019,8 @@ void model::make_data_store_preloaded(execution_mode mode) {
   for (El::Int i = 0; i < get_num_layers(); ++i) {
     auto *input = dynamic_cast<generic_input_layer*>(&get_layer(i));
     if (input != nullptr) {
-      if(!input->get_data_reader(mode)->get_data_store_ptr()->is_preloaded()) {
+      auto *data_store = input->get_data_reader(mode)->get_data_store_ptr();
+      if(data_store != nullptr && !data_store->is_preloaded()) {
         std::cout << "I am going to mark the validation data reader as loaded" << std::endl;
         input->get_data_reader(mode)->get_data_store_ptr()->set_preload();
       }


### PR DESCRIPTION
Fixed a bug where sample IDs were not removed from the HDF5 handle
priority queue when they were closed.  This could cause spurious
closures of the file.  This closes bug #1002 .