### PR TITLE
Fix build error from #1009

### DIFF
--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -29,6 +29,7 @@
 
 #include "El.hpp"
 #include <iostream>
+#include <map>
 #include <unordered_map>
 #include <tuple>
 
@@ -151,7 +152,7 @@ void set_tensor_desc(cudnnTensorDescriptor_t& desc,
     }
   }
 #endif // LBANN_DEBUG
-  
+
   // Set cuDNN tensor descriptor
   // Note: cuDNN tensors should have at least 4 dimensions
   /// @todo Think about 1D convolution
@@ -270,7 +271,7 @@ layer_tensor_manager& layer_tensor_manager::operator=(const layer_tensor_manager
 
   // Set layer being managed
   m_layer = other.m_layer;
-  
+
   // Destroy tensor descriptors
   set_num_parents(0);
   set_num_children(0);
@@ -577,7 +578,7 @@ AlgoType find_best_algorithm(
   const std::vector<AlgoType>& nondeterministic_algos,
   bool deterministic,
   size_t max_ws_size) {
-  std::unordered_map<AlgoType, float> time_map;
+  std::map<AlgoType, float> time_map;
   for (const auto& p : perf_results) {
     if (p.status != CUDNN_STATUS_SUCCESS) {
       // If an algorithm fails, we still add it in case the failure is


### PR DESCRIPTION
When I type `scripts/build_lbann_lc.sh --clean-build` on Pascal, I get the following error:
```
/usr/WS1/moon13/src/lbann/src/utils/cudnn.cpp:580:39:   required from 'AlgoType lbann::cudnn::{anonymous}::find_best_algorithm(const std::vector<F2>&, const std::vector<_RealType>&, bool, size_t) [with AlgoType = cudnnConvolutionFwdAlgo_t; PerfType = cudnnConvolutionFwdAlgoPerf_t; size_t = long unsigned int]'
/usr/WS1/moon13/src/lbann/src/utils/cudnn.cpp:711:52:   required from here
/usr/tce/packages/gcc/gcc-4.9.3/include/c++/4.9.3/bits/hashtable_policy.h:85:33: error: no match for call to '(const std::hash<cudnnConvolutionFwdAlgo_t>) (const cudnnConvolutionFwdAlgo_t&)'
  noexcept(declval<const _Hash&>()(declval<const _Key&>()))>
```
This bug seems to be from PR #1009. I fixed it by changing an `unordered_map` to a `map`. It looks like cuDNN algorithms aren't hashable by default, at least with the default configuration on Pascal.