### PR TITLE
Fixed a bug in how the data store is being loaded during the

### DIFF
--- a/include/lbann/callbacks/callback_debug_io.hpp
+++ b/include/lbann/callbacks/callback_debug_io.hpp
@@ -77,7 +77,7 @@ class lbann_callback_debug_io : public lbann_callback {
   /** Common format for printing I/O stats at the start of a phase */
   void print_phase_start(model *m, execution_mode mode);
 
-  std::string name() const override { return "debug"; }
+  std::string name() const override { return "debug_io"; }
  private:
   /** The phase to debug. */
   execution_mode m_debug_phase;

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -106,6 +106,10 @@ class data_store_conduit {
 
   bool is_preloaded() { return m_preload; }
 
+  void set_explicit_loading(bool flag) { m_explicit_loading = flag; }
+
+  bool is_explicitly_loading() { return m_explicit_loading; }
+
   /// fills in m_owner, which maps index -> owning processor
   void build_preloaded_owner_map(const std::vector<int>& per_rank_list_sizes);
 
@@ -155,6 +159,9 @@ protected :
 
   /// set to true if data_store is preloaded
   bool m_preload;
+
+  /// set to true if data_store is being explicitly loaded
+  bool m_explicit_loading;
 
   /// maps an index to the processor that owns the associated data
   mutable std::unordered_map<int, int> m_owner;

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -243,6 +243,8 @@ public:
 
   virtual void make_data_store_preloaded(execution_mode mode);
 
+  virtual void mark_data_store_explicitly_loading(execution_mode mode);
+
   // ===========================================
   // Summarizer
   // ===========================================

--- a/src/callbacks/callback_ltfb.cpp
+++ b/src/callbacks/callback_ltfb.cpp
@@ -279,6 +279,10 @@ EvalType evaluate(model& m, const std::string& metric_name) {
   const auto original_mode = m.get_execution_mode();
   m.collect_background_data_fetch(original_mode);
 
+  // Mark the data store as loading - Note that this is a temporary fix
+  // for the current use of the tournament
+  m.mark_data_store_explicitly_loading(execution_mode::validation);
+
   // Evaluate model on validation set
   m.evaluate(execution_mode::validation);
 

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -296,7 +296,6 @@ bool generic_data_reader::update(bool is_active_reader) {
     }
 
     set_initial_position();
-
   }
 
   post_update();
@@ -782,7 +781,8 @@ bool generic_data_reader::priming_data_store() const {
           && (((m_model->get_execution_mode() == execution_mode::training)
                && m_model->get_epoch() == 0)
               || ((m_model->get_execution_mode() == execution_mode::validation)
-                  && m_model->get_epoch() == 1)));
+                  && m_model->get_epoch() == 1)
+              || m_data_store->is_explicitly_loading()));
 }
 
 void generic_data_reader::set_data_store(data_store_conduit *g) {

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -43,6 +43,7 @@ data_store_conduit::data_store_conduit(
   m_is_setup(false),
   m_reader(reader),
   m_preload(false),
+  m_explicit_loading(false),
   m_owner_map_mb_size(0),
   m_super_node(false),
   m_compacted_sample_size(0) {
@@ -86,6 +87,7 @@ void data_store_conduit::copy_members(const data_store_conduit& rhs, const std::
   m_world_master = rhs.m_world_master;
   m_trainer_master = rhs.m_trainer_master;
   m_preload = rhs.m_preload;
+  m_explicit_loading = rhs.m_explicit_loading;
   m_owner = rhs.m_owner;
   m_shuffled_indices = rhs.m_shuffled_indices;
   m_owner_map_mb_size = rhs.m_owner_map_mb_size;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1022,6 +1022,19 @@ void model::make_data_store_preloaded(execution_mode mode) {
       auto *data_store = input->get_data_reader(mode)->get_data_store_ptr();
       if(data_store != nullptr && !data_store->is_preloaded()) {
         input->get_data_reader(mode)->get_data_store_ptr()->set_preload();
+        input->get_data_reader(mode)->get_data_store_ptr()->set_explicit_loading(false);
+      }
+    }
+  }
+}
+
+void model::mark_data_store_explicitly_loading(execution_mode mode) {
+  for (El::Int i = 0; i < get_num_layers(); ++i) {
+    auto *input = dynamic_cast<generic_input_layer*>(&get_layer(i));
+    if (input != nullptr) {
+      auto *data_store = input->get_data_reader(mode)->get_data_store_ptr();
+      if(data_store != nullptr && !data_store->is_preloaded()) {
+        input->get_data_reader(mode)->get_data_store_ptr()->set_explicit_loading(true);
       }
     }
   }


### PR DESCRIPTION
tournament use case of the validation data set.  There is now an
explicit flag that tells the data store to load the data and is used
in conjunction with explicitly setting the data store as preloaded
after the first tournament.  Note that this should be cleaned up with
the execution environment of the trainer refactor.