### PR TITLE
CIFAR10 data reader cleanup

### DIFF
--- a/include/lbann/data_readers/data_reader_cifar10.hpp
+++ b/include/lbann/data_readers/data_reader_cifar10.hpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 //
-// lbann_data_reader_cifar10 .hpp .cpp - generic_data_reader class for CIFAR10 dataset
+// data_reader_cifar10 .hpp .cpp - Data reader for CIFAR-10/100
 ////////////////////////////////////////////////////////////////////////////////
 
 #ifndef LBANN_DATA_READER_CIFAR10_HPP
@@ -33,14 +33,23 @@
 
 namespace lbann {
 
+/**
+ * A data reader for the CIFAR-10/100 datasets.
+ *
+ * This requires the binary distributions of the datasets, which
+ * must retain their original filenames.
+ * CIFAR-10 vs -100 is inferred by the number of labels set.
+ * @note This does not store the coarse labels from CIFAR-100.
+ *
+ * See:
+ *     https://www.cs.toronto.edu/~kriz/cifar.html
+ */
 class cifar10_reader : public image_data_reader {
  public:
-  /// constructor
   cifar10_reader(bool shuffle = true);
   cifar10_reader(const cifar10_reader&) = default;
   cifar10_reader& operator=(const cifar10_reader&) = default;
 
-  /// destructor
   ~cifar10_reader() override;
 
   cifar10_reader* copy() const override { return new cifar10_reader(*this); }
@@ -58,7 +67,13 @@ class cifar10_reader : public image_data_reader {
   bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;
 
  private:
-  std::vector<std::vector<unsigned char> > m_data;
+  /**
+   * Loaded image data.
+   * This will be stored in "OpenCV" format for ease of preprocessing.
+   */
+  std::vector<std::vector<unsigned char>> m_images;
+  /** Loaded label information. */
+  std::vector<uint8_t> m_labels;
 };
 
 }  // namespace lbann

--- a/model_zoo/data_readers/data_reader_cifar10.prototext
+++ b/model_zoo/data_readers/data_reader_cifar10.prototext
@@ -3,14 +3,20 @@ data_reader {
     name: "cifar10"
     role: "train"
     shuffle: true
-    data_filename: "/p/lscratchh/brainusr/datasets/cifar10-bin/data_all.bin"
-    label_filename: "/p/lscratchh/brainusr/datasets/cifar10-bin/data_all.bin"
+    data_filedir: "/p/lscratchh/brainusr/datasets/cifar10-bin/"
     validation_percent: 0.1
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
+
     transforms {
-      scale {
-        scale: 0.003921568627  # 1/255
+      horizontal_flip {
+        p: 0.5
+      }
+    }
+    transforms {
+      normalize_to_lbann_layout {
+        means: "0.44653 0.48216 0.4914"
+        stddevs: "0.26159 0.24349 0.24703"
       }
     }
   }
@@ -18,13 +24,19 @@ data_reader {
     name: "cifar10"
     role: "test"
     shuffle: true
-    data_filename: "/p/lscratchh/brainusr/datasets/cifar10-bin/test_batch.bin"
-    label_filename: "/p/lscratchh/brainusr/datasets/cifar10-bin/test_batch.bin"
+    data_filedir: "/p/lscratchh/brainusr/datasets/cifar10-bin/"
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
+
     transforms {
-      scale {
-        scale: 0.003921568627  # 1/255
+      horizontal_flip {
+        p: 0.5
+      }
+    }
+    transforms {
+      normalize_to_lbann_layout {
+        means: "0.44653 0.48216 0.4914"
+        stddevs: "0.26159 0.24349 0.24703"
       }
     }
   }

--- a/src/data_readers/data_reader_cifar10.cpp
+++ b/src/data_readers/data_reader_cifar10.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 //
-// lbann_data_reader_cifar10 .hpp .cpp - generic_data_reader class for CIFAR10 dataset
+// data_reader_cifar10 .hpp .cpp - Data reader for CIFAR-10/100
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/data_readers/data_reader_cifar10.hpp"
@@ -46,68 +46,96 @@ void cifar10_reader::set_defaults() {
 }
 
 void cifar10_reader::load() {
-  //open data file
-  std::string image_dir = get_file_dir();
-  std::string filename = get_data_filename();
-  std::string path = image_dir + "/" + filename;
-  std::ifstream in(path, std::ios::binary);
-  if (!in.good()) {
-    throw lbann_exception(
-      std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: failed to open " + path + " for reading");
+  // These are all specified by the CIFAR10/100 description.
+  constexpr size_t num_channels = 3;
+  constexpr size_t channel_size = 32*32;
+  constexpr size_t image_size = num_channels*channel_size;
+  constexpr size_t cifar10_label_size = 1;
+  constexpr size_t cifar100_label_size = 2;
+
+  if (m_num_labels != 10 && m_num_labels != 100) {
+    LBANN_ERROR("Unsupported number of labels for CIFAR10/100.");
   }
 
-  //get number of images, with error checking
-  int len = get_linearized_data_size() + 1;  //should be 3073
-  in.seekg(0, in.end);
-  std::streampos fs = in.tellg();
-  in.seekg(0, in.beg);
-  if (fs % len != 0) {
-    throw lbann_exception(
-      std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " ::  fs % len != 0; fs: " + std::to_string(fs) + " len: " +
-      std::to_string(len));
+  const bool cifar100 = m_num_labels == 100;
+
+  std::string path = get_file_dir();
+  // These filenames are specified by the CIFAR-10/100 dataset description.
+  std::vector<std::string> filenames;
+  size_t images_per_file = 10000;
+  if (this->get_role() == "train") {
+    if (cifar100) {
+      filenames = {"train.bin"};
+      images_per_file = 50000;
+    } else {
+      filenames = {
+        "data_batch_1.bin",
+        "data_batch_2.bin",
+        "data_batch_3.bin",
+        "data_batch_4.bin",
+        "data_batch_5.bin"
+      };
+    }
+  } else if (this->get_role() == "test") {
+    if (cifar100) {
+      filenames = {"test.bin"};
+    } else {
+      filenames = {"test_batch.bin"};
+    }
+  } else {
+    LBANN_ERROR("Unsupported training mode for CIFAR loading.");
   }
 
-  //reserve space for string images
-  int num_images = fs / len;
-  m_data.resize(num_images);
-  for (auto & h : m_data) {
-    h.resize(len);
+  for (const auto& filename : filenames) {
+    std::ifstream f(path + "/" + filename,
+                    std::ios::in | std::ios::binary);
+    if (!f.good()) {
+      LBANN_ERROR("Could not open " + path + "/" + filename);
+    }
+    // Temporary buffer to hold an image.
+    std::vector<uint8_t> buf(image_size + (cifar100 ?
+                                           cifar100_label_size :
+                                           cifar10_label_size), 0);
+    for (size_t i = 0; i < images_per_file; ++i) {
+      f.read(reinterpret_cast<char*>(buf.data()), buf.size());
+      if (static_cast<size_t>(f.gcount()) != buf.size()) {
+        LBANN_ERROR("Could not read from " + path + "/" + filename);
+      }
+      // CIFAR-10 has only one label; for CIFAR-100, the second byte is the
+      // fine label.
+      m_labels.push_back(buf[cifar100 ? 1 : 0]);
+      // Convert to OpenCV layout.
+      std::vector<uint8_t> image(image_size);
+      for (size_t channel = 0; channel < num_channels; ++channel) {
+        const size_t src_start = channel*channel_size;
+        for (size_t j = 0; j < channel_size; ++j) {
+          image[j*num_channels + channel] = buf[src_start + j];
+        }
+      }
+      m_images.push_back(std::move(image));
+    }
+    f.close();
   }
 
-  //read in the images; each image is 1 byte, which is the
-  //label (0-9), and 3072 pixels
-  for (auto & h : m_data) {
-    in.read((char *)&(h[0]), len);
-  }
-  in.close();
-
-  m_shuffled_indices.resize(m_data.size());
-  for (size_t n = 0; n < m_data.size(); n++) {
-    m_shuffled_indices[n] = n;
-  }
-
+  m_shuffled_indices.clear();
+  m_shuffled_indices.resize(m_images.size());
+  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
   select_subset_of_data();
 }
 
 bool cifar10_reader::fetch_datum(CPUMat& X, int data_id, int mb_idx) {
-  for (size_t p = 1; p<m_data[data_id].size(); p++) {
-    X.Set(p-1, mb_idx, m_data[data_id][p]);
-  }
-
-  auto pixel_col = X(El::IR(0, X.Height()), El::IR(mb_idx, mb_idx + 1));
-  std::vector<size_t> dims = {
-    static_cast<size_t>(m_image_num_channels),
-    static_cast<size_t>(m_image_height),
-    static_cast<size_t>(m_image_width)};
-  m_transform_pipeline.apply(pixel_col, dims);
+  // Copy to a matrix so we can do data augmentation.
+  // Sizes per CIFAR-10/100 dataset description.
+  El::Matrix<uint8_t> image(3*32*32, 1);
+  std::vector<size_t> dims = {size_t(3), size_t(32), size_t(32)};
+  std::copy_n(m_images[data_id].data(), 3*32*32, image.Buffer());
+  auto X_v = X(El::IR(0, X.Height()), El::IR(mb_idx, mb_idx + 1));
+  m_transform_pipeline.apply(image, X_v, dims);
   return true;
 }
 
 bool cifar10_reader::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
-  auto label = (int)m_data[data_id][0];
-  Y.Set(label, mb_idx, 1);
+  Y.Set(m_labels[data_id], mb_idx, 1);
   return true;
 }
 


### PR DESCRIPTION
_Note: This depends on #1014._

This is mostly a cleanup of the CIFAR-10 data reader so that it can use the full image preprocessing features of the new preprocessing pipeline.
* Now also supports CIFAR-100 by specifying the number of labels as 100. (I thought about renaming the data reader to just "CIFAR", but that would be unclear since CIFAR is a big organization.)
* We no longer require a custom repackaged version of the CIFAR-10 dataset that merges everything into a single file. Instead, the data reader now requires the files be as officially distributed. This should make it easy for other people to use it. (I thought about generalizing this, but the CIFAR-10/100 binary format is custom, and this is a data reader specifically for CIFAR-10/100, not other data sets.)
* I updated the CIFAR-10 data reader to use some new preprocessing (normalizing by the dataset means/standard deviations, random horizontal flips) that seem standard. There are some other standard preprocessing steps that we don't yet support (padded cropping, color jitter).

I tested on Lassen with `model_conv_autoencoder_cifar10` and it seems like it learned/generalized without issue. I don't believe we have any other models that use CIFAR-10.