### PR TITLE
Fix grouped convolution.

### DIFF
--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -126,7 +126,7 @@ protected:
   std::vector<int> get_kernel_dims() const {
     std::vector<int> dims;
     dims.push_back(this->m_output_channels);
-    dims.push_back(this->get_input_dims()[0]);
+    dims.push_back(this->get_input_dims()[0] / this->m_groups);
     dims.insert(dims.end(),
                 this->m_conv_dims.begin(),
                 this->m_conv_dims.end());


### PR DESCRIPTION
cuDNN expects the number of channels per group. This was the case before
commit 310f4b4e222728c5bb14a8cf9594589ecb7a5db0.