### PR TITLE
Add callback for dropout perturbation

### DIFF
--- a/include/lbann/callbacks/callback_dump_outputs.hpp
+++ b/include/lbann/callbacks/callback_dump_outputs.hpp
@@ -79,7 +79,11 @@ public:
   std::string name() const override { return "dump outputs"; }
 
   void on_forward_prop_end(model* m, Layer* l) override          { dump_outputs(*m, *l); }
-  void on_evaluate_forward_prop_end(model* m, Layer* l) override { dump_outputs(*m, *l); }
+  void on_evaluate_forward_prop_end(model* m, Layer* l) override {
+       if(m->get_step() % m_batch_interval == 0) { 
+         dump_outputs(*m, *l); 
+       }
+  }
 
 private:
 

--- a/include/lbann/callbacks/callback_ltfb.hpp
+++ b/include/lbann/callbacks/callback_ltfb.hpp
@@ -120,6 +120,7 @@ public:
     std::set<std::string> weights_names = std::set<std::string>(),
     bool low_score_wins = false,
     communication_algorithm comm_algo = communication_algorithm::sendrecv_weights,
+    bool exchange_hyperparameters = false,
     lbann_summary *summarizer = nullptr);
   lbann_callback_ltfb(const lbann_callback_ltfb& other);
   lbann_callback_ltfb& operator=(const lbann_callback_ltfb& other);
@@ -154,6 +155,10 @@ private:
 
   /** Inter-trainer communication scheme. */
   communication_algorithm m_comm_algo;
+ 
+  /** Whether to exchange training hyperparameters between trainers
+  */
+  bool m_exchange_hyperparameters;
 
   /** Workspace weights.
    *

--- a/include/lbann/callbacks/callback_perturb_dropout.hpp
+++ b/include/lbann/callbacks/callback_perturb_dropout.hpp
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_PERTURB_DROPOUT_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_PERTURB_DROPOUT_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+#include "lbann/layers/regularizers/dropout.hpp"
+#include <set>
+
+namespace lbann {
+
+/** @brief Hyperparameter exploration with dropouts.
+ *
+ *  Goes through the dropout layers in a model and perturbs keep probability
+ */
+class lbann_callback_perturb_dropout : public lbann_callback {
+public:
+
+  /** @param keep_prob_factor   Standard deviation of learning rate
+   *                                perturbation (in log space).
+   *  @param layer_names  Names of layers with dropout keep prob to perturb. If
+   *                        empty, all dropout layers  in the model are
+   *                        perturbed.
+   */
+  lbann_callback_perturb_dropout(EvalType keep_prob_factor,
+                              std::set<std::string> layer_names
+                              = std::set<std::string>());
+  lbann_callback_perturb_dropout* copy() const override { return new lbann_callback_perturb_dropout(*this); }
+  std::string name() const override { return "perturb dropout"; }
+
+  void setup(model* m);
+
+private:
+
+  /** Standard deviation of keep probability  perturbation.
+   *
+   *  In log space.
+   */
+  EvalType m_keep_prob_factor;
+
+  /** Keep prob for these layers will be perturbed.
+   *
+   *  If empty, all dropout layers  in the model will be perturbed.
+   */
+  std::set<std::string> m_layer_names;
+  
+  template <data_layout T_layout, El::Device Dev>
+  dropout<T_layout, Dev>* get_dropout_layer(Layer* l); 
+
+  /** Perturb dropout keep prob in model. */
+  void perturb(model& m);
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_CALLBACKS_CALLBACK_PERTURB_DROPOUT_HPP_INCLUDED

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/regularizers/regularizer.hpp"
 #include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/random.hpp"
 
 namespace lbann {
 
@@ -120,6 +121,14 @@ public:
     auto&& desc = regularizer_layer::get_description();
     desc.add("Keep probability", m_keep_prob);
     return desc;
+  }
+  /** @brief get prob for keep each unit. */
+  EvalType get_keep_prob() const {
+    return m_keep_prob;
+  }
+  /** @brief set prob for keep each unit. */
+  void set_keep_prob(EvalType keep_prob) {
+    m_keep_prob = keep_prob;
   }
 
 protected:

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -166,6 +166,7 @@
 #include "lbann/callbacks/callback_check_gradients.hpp"
 #include "lbann/callbacks/callback_check_metric.hpp"
 #include "lbann/callbacks/callback_perturb_adam.hpp"
+#include "lbann/callbacks/callback_perturb_dropout.hpp"
 
 /// Weights and weight initializers
 #include "lbann/weights/weights.hpp"

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -33,6 +33,7 @@ set_full_path(THIS_DIR_SOURCES
   profiler.cpp
   callback_replace_weights.cpp
   callback_gpu_memory_usage.cpp
+  callback_perturb_dropout.cpp
 )
 
 # Propagate the files up the tree

--- a/src/callbacks/callback_perturb_dropout.cpp
+++ b/src/callbacks/callback_perturb_dropout.cpp
@@ -1,0 +1,120 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback_perturb_dropout.hpp"
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+
+lbann_callback_perturb_dropout::lbann_callback_perturb_dropout(EvalType keep_prob_factor,
+                                                         std::set<std::string> layer_names)
+  : lbann_callback(1),
+    m_keep_prob_factor(keep_prob_factor),
+    m_layer_names(std::move(layer_names)) {}
+
+void lbann_callback_perturb_dropout::setup(model* m) {
+  perturb(*m);
+}
+
+template <data_layout T_layout, El::Device Dev>
+dropout<T_layout, Dev>* lbann_callback_perturb_dropout::get_dropout_layer(Layer* l) {
+  if(auto d_layer = dynamic_cast<dropout<T_layout, Dev>*>(l)) return d_layer;
+  else return nullptr;
+}
+
+void lbann_callback_perturb_dropout::perturb(model& m) {
+  auto* comm = m.get_comm();
+  for (auto* l : m.get_layers()) {
+    if (l == nullptr) {
+      std::stringstream err;
+      err << "callback \"" << name() << "\" "
+          << "got a layer pointer that is a null pointer";
+      LBANN_ERROR(err.str());
+    }
+    if (m_layer_names.empty()
+        || m_layer_names.count(l->get_name()) > 0) {
+      
+      auto d_dp_cpu = get_dropout_layer<data_layout::DATA_PARALLEL, El::Device::CPU>(l);
+      auto d_mp_cpu = get_dropout_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>(l);
+      #ifdef LBANN_HAS_GPU
+      auto d_dp_gpu = get_dropout_layer<data_layout::DATA_PARALLEL, El::Device::GPU>(l);
+      auto d_mp_gpu = get_dropout_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>(l);
+      #endif
+      // Perturb dropout layer
+        if(d_dp_cpu != nullptr || d_mp_cpu != nullptr 
+           #ifdef LBANN_HAS_GPU
+           || d_dp_gpu != nullptr || d_mp_gpu != nullptr
+           #endif
+          ) {
+        EvalType new_keep_prob;
+        if (comm->am_trainer_master()) {
+
+          // Useful constants
+          constexpr EvalType zero = 0;
+          constexpr EvalType one = 1;
+          constexpr EvalType min_val = std::numeric_limits<EvalType>::min();
+
+          // RNG
+          auto& gen = get_generator();
+          std::normal_distribution<EvalType> dist(zero, one);
+
+          // Perturb log(keep_prob)
+          EvalType old_keep_prob = 0;
+          if (d_dp_cpu) old_keep_prob = d_dp_cpu->get_keep_prob();
+          if (d_mp_cpu) old_keep_prob = d_mp_cpu->get_keep_prob();
+          #ifdef LBANN_HAS_GPU
+          if (d_dp_gpu) old_keep_prob = d_dp_gpu->get_keep_prob();
+          if (d_mp_gpu) old_keep_prob = d_mp_gpu->get_keep_prob();
+          #endif
+          if (m_keep_prob_factor != zero && old_keep_prob >= zero) {
+            auto log_val = std::log(std::max(old_keep_prob, min_val));
+            log_val += m_keep_prob_factor * dist(gen);
+            new_keep_prob = std::max(EvalType(0.5), std::min(std::exp(log_val),EvalType(1.0)));
+            std::cout << "Trainer [ " << comm->get_trainer_rank() << " ] keep prob changed from "
+                << old_keep_prob << " to " << new_keep_prob << std::endl;
+          }
+
+        }
+
+        // Communicate new keep prob from trainer master processes
+        comm->trainer_broadcast(comm->get_trainer_master(), new_keep_prob);
+
+        // Update keep prob
+        if (d_dp_cpu) d_dp_cpu->set_keep_prob(new_keep_prob);
+        if (d_mp_cpu) d_mp_cpu->set_keep_prob(new_keep_prob);
+        #ifdef LBANN_HAS_GPU
+        if (d_dp_gpu) d_dp_gpu->set_keep_prob(new_keep_prob);
+        if (d_mp_gpu) d_mp_gpu->set_keep_prob(new_keep_prob);
+        #endif
+
+      }
+
+    }
+  }
+}
+
+
+} // namespace lbann

--- a/src/callbacks/callback_perturb_dropout.cpp
+++ b/src/callbacks/callback_perturb_dropout.cpp
@@ -89,10 +89,10 @@ void lbann_callback_perturb_dropout::perturb(model& m) {
           if (d_dp_gpu) old_keep_prob = d_dp_gpu->get_keep_prob();
           if (d_mp_gpu) old_keep_prob = d_mp_gpu->get_keep_prob();
           #endif
-          if (m_keep_prob_factor != zero && old_keep_prob >= zero) {
-            auto log_val = std::log(std::max(old_keep_prob, min_val));
+          if (m_keep_prob_factor > zero) {
+            auto log_val = std::log(one - std::max(old_keep_prob, min_val));
             log_val += m_keep_prob_factor * dist(gen);
-            new_keep_prob = std::max(EvalType(0.5), std::min(std::exp(log_val),EvalType(1.0)));
+            new_keep_prob = std::max(EvalType(0.5), std::min(std::exp(one - log_val),one));
             std::cout << "Trainer [ " << comm->get_trainer_rank() << " ] keep prob changed from "
                 << old_keep_prob << " to " << new_keep_prob << std::endl;
           }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -104,6 +104,7 @@ lbann_callback* construct_callback(lbann_comm* comm,
                                    parse_set<std::string>(params.weights()),
                                    params.low_score_wins(),
                                    lbann_callback_ltfb::string_to_comm_algo(params.communication_algorithm()),
+                                   params.exchange_hyperparameters(),
                                    summarizer);
   }
   /// @todo
@@ -420,6 +421,12 @@ lbann_callback* construct_callback(lbann_comm* comm,
                  parse_set<std::string>(params.weights()));
   }
 
+  if (proto_cb.has_perturb_dropout()) {
+    const auto& params = proto_cb.perturb_dropout();
+    return new lbann_callback_perturb_dropout(
+                 params.keep_dropout_factor(),
+                 parse_set<std::string>(params.layers()));
+  }
   return nullptr;
 }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -412,6 +412,7 @@ message Callback {
    CallbackConfusionMatrix confusion_matrix = 36;
    CallbackCheckMetric check_metric = 37;
    CallbackPerturbAdam perturb_adam = 38;
+   CallbackPerturbDropout perturb_dropout = 39;
 }
 
 message CallbackLTFB {
@@ -420,6 +421,7 @@ message CallbackLTFB {
   string weights = 3;       // default: all weights
   bool low_score_wins = 4;
   string communication_algorithm = 5;   // default: "sendrecv_weights"
+  bool exchange_hyperparameters = 6;
 }
 
 message CallbackStepLearningRate {
@@ -653,6 +655,10 @@ message CallbackPerturbAdam {
   string weights = 7;               // Weights with Adam optimizer
 }
 
+message CallbackPerturbDropout {
+  float keep_dropout_factor = 1; //Keep dropout prob perturbation (in log space)
+  string layers = 2; // dropout layers to perturb keep prob, all dropout layers by default
+}
 //========================================================================
 // Weights
 //========================================================================


### PR DESCRIPTION
This PR adds callback for dropout perturbation, and a flag to determine whether LTFB exchange hyperparameter.