### PR TITLE
Save model callback

### DIFF
--- a/include/lbann/callbacks/callback_save_model.hpp
+++ b/include/lbann/callbacks/callback_save_model.hpp
@@ -63,7 +63,11 @@ class lbann_callback_save_model : public lbann_callback {
   void on_train_end(model *m) override;
   bool save_model(model *m);
   bool save_model_weights(model *m);
-  static bool load_model_weights(std::string ckpt_dir, model *m);
+  /* ckptdir_is_fullpath flag if true
+ * allow user to specify full path to model weights to load
+ * and allow system to ignore appending trainer id, num of epochs/steps
+ * to default ckpt_dir*/
+  static bool load_model_weights(std::string ckpt_dir, model *m, bool ckptdir_is_fullpath=false);
 
   std::string name() const override { return "save model"; }
  private:

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -60,11 +60,16 @@ int main(int argc, char *argv[]) {
         build_model_from_prototext(argc, argv, *pb_model,
                                    comm.get(), io_thread_pool, models.size() == 0));
     }
+      for(auto&& m : models) {
+        bool loaded = lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), m.get());
+        if(!loaded)  LBANN_ERROR("Unable to reload model"); 
+      }
 
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
       for(auto&& m : models) {
-        lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), m.get());
+        bool loaded = lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), m.get());
+        if(!loaded)  LBANN_ERROR("Unable to reload model"); 
       }
     }else {
       LBANN_ERROR("Unable to reload model");

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -60,15 +60,13 @@ int main(int argc, char *argv[]) {
         build_model_from_prototext(argc, argv, *pb_model,
                                    comm.get(), io_thread_pool, models.size() == 0));
     }
-      for(auto&& m : models) {
-        bool loaded = lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), m.get());
-        if(!loaded)  LBANN_ERROR("Unable to reload model"); 
-      }
 
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
       for(auto&& m : models) {
-        bool loaded = lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), m.get());
+        bool loaded = lbann_callback_save_model::load_model_weights(opts->get_string("ckpt_dir"), 
+                                                                    m.get(),
+                                                                    opts->get_bool("ckptdir_is_fullpath"));
         if(!loaded)  LBANN_ERROR("Unable to reload model"); 
       }
     }else {

--- a/src/callbacks/callback_save_model.cpp
+++ b/src/callbacks/callback_save_model.cpp
@@ -133,18 +133,23 @@ bool lbann_callback_save_model::save_model_weights(model *m) {
   return true;
 }
 
-bool lbann_callback_save_model::load_model_weights(std::string ckpt_dir, model * m) {
+bool lbann_callback_save_model::load_model_weights(std::string ckpt_dir, model * m, bool ckptdir_is_fullpath) {
   std::vector<std::string> weight_list = std::vector<std::string>();
-  int epochLast = -1;
-  int stepLast = -1;
-  std::string active_ckpt_dir = get_last_shared_checkpoint_filename(m, ckpt_dir);
+  std::string active_ckpt_dir;
+  if(ckptdir_is_fullpath) {
+    active_ckpt_dir = ckpt_dir;
+  }else {
+    int epochLast = -1;
+    int stepLast = -1;
+    active_ckpt_dir = get_last_shared_checkpoint_filename(m, ckpt_dir);
 
-  // get last epoch and step saved.
-  int success = read_latest(active_ckpt_dir, &epochLast, &stepLast);
-  if(!success) {
-    return false;
+    // get last epoch and step saved.
+    int success = read_latest(active_ckpt_dir, &epochLast, &stepLast);
+    if(!success) {
+      return false;
+    }
+    active_ckpt_dir = get_shared_checkpoint_dirname(m, ckpt_dir, epochLast, stepLast);
   }
-  active_ckpt_dir = get_shared_checkpoint_dirname(m, ckpt_dir, epochLast, stepLast);
   lbann_comm *comm = m->get_comm();
   if(comm->am_trainer_master()) {
     std::cout << "Loading model weights from " << active_ckpt_dir << std::endl;


### PR DESCRIPTION
This PR fixes bug related to not specifying ckpt directory and also allow user to use fullpath for saved/trained weights. 