### PR TITLE
include protobuf in the spack environment

### DIFF
--- a/spack_environments/developer_release_ppc64le_cuda_spack.yaml
+++ b/spack_environments/developer_release_ppc64le_cuda_spack.yaml
@@ -34,6 +34,7 @@ spack:
   - py-matplotlib
   - py-onnx
   - py-pandas
+  - protobuf
   - py-protobuf+cpp
   - py-setuptools
   - py-texttable

--- a/spack_environments/developer_release_x86_64_cuda_spack.yaml
+++ b/spack_environments/developer_release_x86_64_cuda_spack.yaml
@@ -34,6 +34,7 @@ spack:
   - py-matplotlib
   - py-onnx
   - py-pandas
+  - protobuf
   - py-protobuf+cpp
   - py-setuptools
   - py-texttable


### PR DESCRIPTION
the spack environment you get when running `spack env loads; source loads` contained `py-protobuf` but not `protobuf` itself.  This caused the configure step of `aluminum` to fail.  Adding these lines ensures that the environment contains the `protobuf` module too.   