### PR TITLE
Support specifying random seeds in Python

### DIFF
--- a/model_zoo/vision/resnet.py
+++ b/model_zoo/vision/resnet.py
@@ -52,6 +52,9 @@ parser.add_argument(
 parser.add_argument(
     '--num-labels', action='store', default=1000, type=int,
     help='number of data classes (default: 1000)', metavar='NUM')
+parser.add_argument(
+    '--random-seed', action='store', default=0, type=int,
+    help='random seed for LBANN RNGs', metavar='NUM')
 lbann.contrib.args.add_optimizer_arguments(parser, default_learning_rate=0.1)
 parser.add_argument(
     '--data-reader', action='store',
@@ -145,7 +148,8 @@ model = lbann.Model(args.mini_batch_size,
                     layers=layers,
                     objective_function=obj,
                     metrics=metrics,
-                    callbacks=callbacks)
+                    callbacks=callbacks,
+                    random_seed=args.random_seed)
 
 # Setup optimizer
 opt = lbann.contrib.args.create_optimizer(args)

--- a/python/lbann/model.py
+++ b/python/lbann/model.py
@@ -10,7 +10,7 @@ class Model:
 
     def __init__(self, mini_batch_size, epochs,
                  layers=[], weights=[], objective_function=None,
-                 metrics=[], callbacks=[]):
+                 metrics=[], callbacks=[], random_seed=None):
 
         # Scalar fields
         self.mini_batch_size = mini_batch_size
@@ -18,6 +18,7 @@ class Model:
         self.block_size = 256           # TODO: Make configurable
         self.num_parallel_readers = 0   # TODO: Make configurable
         self.procs_per_trainer = 0      # TODO: Make configurable
+        self.random_seed = random_seed
 
         # Get connected layers
         self.layers = list(lbann.layer.traverse_layer_graph(layers))
@@ -49,6 +50,8 @@ class Model:
         model.block_size = self.block_size
         model.num_parallel_readers = self.num_parallel_readers
         model.procs_per_trainer = self.procs_per_trainer
+        if self.random_seed is not None:
+            model.random_seed = self.random_seed
 
         # Add model components
         model.layer.extend([l.export_proto() for l in self.layers])


### PR DESCRIPTION
For `resnet.py` this adds a `--random-seed` argument.