### PR TITLE
Color jitter transforms

### DIFF
--- a/include/lbann/transforms/vision/CMakeLists.txt
+++ b/include/lbann/transforms/vision/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
+  adjust_brightness.hpp
+  adjust_contrast.hpp
+  adjust_saturation.hpp
   center_crop.hpp
   colorize.hpp
+  color_jitter.hpp
   grayscale.hpp
   horizontal_flip.hpp
   normalize_to_lbann_layout.hpp

--- a/include/lbann/transforms/vision/adjust_brightness.hpp
+++ b/include/lbann/transforms/vision/adjust_brightness.hpp
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_TRANSFORMS_ADJUST_BRIGHTNESS_HPP_INCLUDED
+#define LBANN_TRANSFORMS_ADJUST_BRIGHTNESS_HPP_INCLUDED
+
+#include "lbann/transforms/transform.hpp"
+
+namespace lbann {
+namespace transform {
+
+/** Adjust the brightness of an image. */
+class adjust_brightness : public transform {
+public:
+  /**
+   * Adjust brightness with given factor.
+   * @param factor A non-negative factor. 0 gives a black image, 1 the original.
+   */
+  adjust_brightness(float factor) : transform(), m_factor(factor) {
+    if (factor < 0.0f) {
+      LBANN_ERROR("Brightness factor must be non-negative.");
+    }
+  }
+  
+  transform* copy() const override { return new adjust_brightness(*this); }
+
+  std::string get_type() const override { return "adjust_brightness"; }
+
+  void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
+
+private:
+  /** Factor to adjust brightness by. */
+  float m_factor;
+};
+
+}  // namespace transform
+}  // namespace lbann
+
+#endif  // LBANN_TRANSFORMS_ADJUST_BRIGHTNESS_HPP_INCLUDED

--- a/include/lbann/transforms/vision/adjust_contrast.hpp
+++ b/include/lbann/transforms/vision/adjust_contrast.hpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_TRANSFORMS_ADJUST_CONTRAST_HPP_INCLUDED
+#define LBANN_TRANSFORMS_ADJUST_CONTRAST_HPP_INCLUDED
+
+#include "lbann/transforms/transform.hpp"
+
+namespace lbann {
+namespace transform {
+
+/**
+ * Adjust the contrast of an image.
+ * This operates similarly to the contrast control on a television.
+ */
+class adjust_contrast : public transform {
+public:
+  /**
+   * Adjust contrast with given factor.
+   * @param factor A non-negative factor. 0 gives a solid grey image,
+   *     1 the original.
+   */
+  adjust_contrast(float factor) : transform(), m_factor(factor) {
+    if (factor < 0.0f) {
+      LBANN_ERROR("Contrast factor must be non-negative.");
+    }
+  }
+  
+  transform* copy() const override { return new adjust_contrast(*this); }
+
+  std::string get_type() const override { return "adjust_contrast"; }
+
+  void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
+
+private:
+  /** Factor to adjust contrast by. */
+  float m_factor;
+};
+
+}  // namespace transform
+}  // namespace lbann
+
+#endif  // LBANN_TRANSFORMS_ADJUST_CONTRAST_HPP_INCLUDED

--- a/include/lbann/transforms/vision/adjust_contrast.hpp
+++ b/include/lbann/transforms/vision/adjust_contrast.hpp
@@ -34,6 +34,7 @@ namespace transform {
 
 /**
  * Adjust the contrast of an image.
+ * 
  * This operates similarly to the contrast control on a television.
  */
 class adjust_contrast : public transform {

--- a/include/lbann/transforms/vision/adjust_saturation.hpp
+++ b/include/lbann/transforms/vision/adjust_saturation.hpp
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_TRANSFORMS_ADJUST_SATURATION_HPP_INCLUDED
+#define LBANN_TRANSFORMS_ADJUST_SATURATION_HPP_INCLUDED
+
+#include "lbann/transforms/transform.hpp"
+
+namespace lbann {
+namespace transform {
+
+/**
+ * Adjust the saturation of an image.
+ * This operates similarly to the controls on a color television
+ * (as opposed to a direct adjustment of saturation).
+ */
+class adjust_saturation : public transform {
+public:
+  /**
+   * Adjust saturation with given factor.
+   * @param factor A non-negative factor. 0 gives a grayscale image,
+   *     1 the original.
+   */
+  adjust_saturation(float factor) : transform(), m_factor(factor) {
+    if (factor < 0.0f) {
+      LBANN_ERROR("Saturation factor must be non-negative.");
+    }
+  }
+  
+  transform* copy() const override { return new adjust_saturation(*this); }
+
+  std::string get_type() const override { return "adjust_saturation"; }
+
+  void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
+
+private:
+  /** Factor to adjust saturation by. */
+  float m_factor;
+};
+
+}  // namespace transform
+}  // namespace lbann
+
+#endif  // LBANN_TRANSFORMS_ADJUST_SATURATION_HPP_INCLUDED

--- a/include/lbann/transforms/vision/adjust_saturation.hpp
+++ b/include/lbann/transforms/vision/adjust_saturation.hpp
@@ -34,8 +34,10 @@ namespace transform {
 
 /**
  * Adjust the saturation of an image.
+ *
  * This operates similarly to the controls on a color television
- * (as opposed to a direct adjustment of saturation).
+ * (as opposed to a direct adjustment of saturation) by interpolating
+ * between the original value and its grayscale value.
  */
 class adjust_saturation : public transform {
 public:

--- a/include/lbann/transforms/vision/color_jitter.hpp
+++ b/include/lbann/transforms/vision/color_jitter.hpp
@@ -51,33 +51,7 @@ public:
    */
   color_jitter(float min_brightness_factor, float max_brightness_factor,
                float min_contrast_factor, float max_contrast_factor,
-               float min_saturation_factor, float max_saturation_factor) :
-    transform(),
-    m_min_brightness_factor(min_brightness_factor),
-    m_max_brightness_factor(max_brightness_factor),
-    m_min_contrast_factor(min_contrast_factor),
-    m_max_contrast_factor(max_contrast_factor),
-    m_min_saturation_factor(min_saturation_factor),
-    m_max_saturation_factor(max_saturation_factor) {
-    if (min_brightness_factor < 0.0f ||
-        max_brightness_factor < min_brightness_factor) {
-      LBANN_ERROR("Min/max brightness factors out of range: "
-                  + std::to_string(min_brightness_factor) + " "
-                  + std::to_string(max_brightness_factor));
-    }
-    if (min_contrast_factor < 0.0f ||
-        max_contrast_factor < min_contrast_factor) {
-      LBANN_ERROR("Min/max contrast factors out of range: "
-                  + std::to_string(min_contrast_factor) + " "
-                  + std::to_string(max_contrast_factor));
-    }
-    if (min_saturation_factor < 0.0f ||
-        max_saturation_factor < min_saturation_factor) {
-      LBANN_ERROR("Min/max saturation factors out of range: "
-                  + std::to_string(min_saturation_factor) + " "
-                  + std::to_string(max_saturation_factor));
-    }
-  }
+               float min_saturation_factor, float max_saturation_factor);
   
   transform* copy() const override { return new color_jitter(*this); }
 

--- a/include/lbann/transforms/vision/color_jitter.hpp
+++ b/include/lbann/transforms/vision/color_jitter.hpp
@@ -1,0 +1,106 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_TRANSFORMS_COLOR_JITTER_HPP_INCLUDED
+#define LBANN_TRANSFORMS_COLOR_JITTER_HPP_INCLUDED
+
+#include "lbann/transforms/transform.hpp"
+
+namespace lbann {
+namespace transform {
+
+/**
+ * Randomly change brightness, contrast, and saturation.
+ * This randomly adjusts brightness, contrast, and saturation, in a random
+ * order.
+ */
+class color_jitter : public transform {
+public:
+  /**
+   * Randomly adjust brightness, contrast, and saturation within given ranges.
+   * Set both min and max to 0 to disable that adjustment.
+   * @param min_brightness_factor Minimum brightness adjustment (>= 0).
+   * @param max_brightness_factor Maximum brightness adjustment.
+   * @param min_contrast_factor Minimum contrast adjustment (>= 0).
+   * @param max_contrast_factor Maximum contrast adjustment.
+   * @param min_saturation_factor Minimum saturation adjustment (>= 0).
+   * @param max_saturation_factor Maximum saturation adjustment.
+   */
+  color_jitter(float min_brightness_factor, float max_brightness_factor,
+               float min_contrast_factor, float max_contrast_factor,
+               float min_saturation_factor, float max_saturation_factor) :
+    transform(),
+    m_min_brightness_factor(min_brightness_factor),
+    m_max_brightness_factor(max_brightness_factor),
+    m_min_contrast_factor(min_contrast_factor),
+    m_max_contrast_factor(max_contrast_factor),
+    m_min_saturation_factor(min_saturation_factor),
+    m_max_saturation_factor(max_saturation_factor) {
+    if (min_brightness_factor < 0.0f ||
+        max_brightness_factor < min_brightness_factor) {
+      LBANN_ERROR("Min/max brightness factors out of range: "
+                  + std::to_string(min_brightness_factor) + " "
+                  + std::to_string(max_brightness_factor));
+    }
+    if (min_contrast_factor < 0.0f ||
+        max_contrast_factor < min_contrast_factor) {
+      LBANN_ERROR("Min/max contrast factors out of range: "
+                  + std::to_string(min_contrast_factor) + " "
+                  + std::to_string(max_contrast_factor));
+    }
+    if (min_saturation_factor < 0.0f ||
+        max_saturation_factor < min_saturation_factor) {
+      LBANN_ERROR("Min/max saturation factors out of range: "
+                  + std::to_string(min_saturation_factor) + " "
+                  + std::to_string(max_saturation_factor));
+    }
+  }
+  
+  transform* copy() const override { return new color_jitter(*this); }
+
+  std::string get_type() const override { return "color_jitter"; }
+
+  void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
+
+private:
+  /** Minimum brightness factor. */
+  float m_min_brightness_factor;
+  /** Maximum brightness factor. */
+  float m_max_brightness_factor;
+  /** Minimum contrast factor. */
+  float m_min_contrast_factor;
+  /** Maximum contrast factor. */
+  float m_max_contrast_factor;
+  /** Minimum saturation factor. */
+  float m_min_saturation_factor;
+  /** Maximum saturation factor. */
+  float m_max_saturation_factor;
+};
+
+}  // namespace transform
+}  // namespace lbann
+
+#endif  // LBANN_TRANSFORMS_COLOR_JITTER_HPP_INCLUDED

--- a/src/proto/factories/transform_factory.cpp
+++ b/src/proto/factories/transform_factory.cpp
@@ -28,9 +28,13 @@
 #include "lbann/transforms/normalize.hpp"
 #include "lbann/transforms/sample_normalize.hpp"
 #include "lbann/transforms/scale.hpp"
+#include "lbann/transforms/vision/adjust_brightness.hpp"
+#include "lbann/transforms/vision/adjust_contrast.hpp"
+#include "lbann/transforms/vision/adjust_saturation.hpp"
 #include "lbann/transforms/vision/center_crop.hpp"
-#include "lbann/transforms/vision/grayscale.hpp"
 #include "lbann/transforms/vision/colorize.hpp"
+#include "lbann/transforms/vision/color_jitter.hpp"
+#include "lbann/transforms/vision/grayscale.hpp"
 #include "lbann/transforms/vision/horizontal_flip.hpp"
 #include "lbann/transforms/vision/normalize_to_lbann_layout.hpp"
 #include "lbann/transforms/vision/random_affine.hpp"
@@ -114,6 +118,21 @@ std::unique_ptr<transform::transform> construct_transform(
   } else if (trans.has_vertical_flip()) {
     return make_unique<transform::horizontal_flip>(
       trans.vertical_flip().p());
+  } else if (trans.has_adjust_brightness()) {
+    return make_unique<transform::adjust_brightness>(
+      trans.adjust_brightness().factor());
+  } else if (trans.has_adjust_contrast()) {
+    return make_unique<transform::adjust_contrast>(
+      trans.adjust_contrast().factor());
+  } else if (trans.has_adjust_saturation()) {
+    return make_unique<transform::adjust_saturation>(
+      trans.adjust_saturation().factor());
+  } else if (trans.has_color_jitter()) {
+    auto& pb_trans = trans.color_jitter();
+    return make_unique<transform::color_jitter>(
+      pb_trans.min_brightness_factor(), pb_trans.max_brightness_factor(),
+      pb_trans.min_contrast_factor(), pb_trans.max_contrast_factor(),
+      pb_trans.min_saturation_factor(), pb_trans.max_saturation_factor());
   }
 
   LBANN_ERROR("Unknown transform");

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -101,6 +101,18 @@ message Transform {
   }
 
   // Transforms that apply to images.
+  // Adjust the brightness of an image.
+  message AdjustBrightness {
+    float factor = 1;
+  }
+  // Adjust the contrast of an image.
+  message AdjustContrast {
+    float factor = 1;
+  }
+  // Adjust the saturation of an image.
+  message AdjustSaturation {
+    float factor = 1;
+  }
   // Crop of size height x width from the center.
   message CenterCrop {
     uint64 height = 1;
@@ -108,6 +120,15 @@ message Transform {
   }
   // Convert to color.
   message Colorize {}
+  // Randomly jitter brightness/contrast/saturation.
+  message ColorJitter {
+    float min_brightness_factor = 1;
+    float max_brightness_factor = 2;
+    float min_contrast_factor = 3;
+    float max_contrast_factor = 4;
+    float min_saturation_factor = 5;
+    float max_saturation_factor = 6;
+  }
   // Convert to grayscale.
   message Grayscale {}
   // Horizontal flip with probability p.
@@ -190,6 +211,10 @@ message Transform {
     ResizedCenterCrop resized_center_crop = 110;
     ToLBANNLayout to_lbann_layout = 111;
     VerticalFlip vertical_flip = 112;
+    AdjustBrightness adjust_brightness = 113;
+    AdjustContrast adjust_contrast = 114;
+    AdjustSaturation adjust_saturation = 115;
+    ColorJitter color_jitter = 116;
   }
 }
 

--- a/src/transforms/vision/CMakeLists.txt
+++ b/src/transforms/vision/CMakeLists.txt
@@ -1,7 +1,11 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  adjust_brightness.cpp
+  adjust_contrast.cpp
+  adjust_saturation.cpp
   center_crop.cpp
   colorize.cpp
+  color_jitter.cpp
   grayscale.cpp
   horizontal_flip.cpp
   normalize_to_lbann_layout.cpp

--- a/src/transforms/vision/adjust_brightness.cpp
+++ b/src/transforms/vision/adjust_brightness.cpp
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/transforms/vision/adjust_brightness.hpp"
+#include "lbann/utils/opencv.hpp"
+
+namespace lbann {
+namespace transform {
+
+void adjust_brightness::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
+  // Adjusting the brightness is simply scaling by a constant value
+  // taking care to saturate.
+  cv::Mat src = utils::get_opencv_mat(data, dims);
+  if (!src.isContinuous()) {
+    // This should not occur, but just in case.
+    LBANN_ERROR("Do not support non-contiguous OpenCV matrices.");
+  }
+  uint8_t* __restrict__ src_buf = src.ptr();
+  const size_t size = utils::get_linearized_size(dims);
+  for (size_t i = 0; i < size; ++i) {
+    src_buf[i] = cv::saturate_cast<uint8_t>(src_buf[i]*m_factor);
+  }
+}
+
+}  // namespace transform
+}  // namespace lbann

--- a/src/transforms/vision/adjust_contrast.cpp
+++ b/src/transforms/vision/adjust_contrast.cpp
@@ -1,0 +1,84 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <opencv2/imgproc.hpp>
+#include "lbann/transforms/vision/adjust_contrast.hpp"
+#include "lbann/utils/opencv.hpp"
+
+namespace lbann {
+namespace transform {
+
+void adjust_contrast::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
+  // To adjust contrast, we essentially add the mean of the grayscale version
+  // of the image, scaled by (1 - m_factor) to each pixel.
+  cv::Mat src = utils::get_opencv_mat(data, dims);
+  if (!src.isContinuous()) {
+    // This should not occur, but just in case.
+    LBANN_ERROR("Do not support non-contiguous OpenCV matrices.");
+  }
+  // Get the grayscale version and compute its mean value.
+  // If need be, we could do this computation in-place by manually computing
+  // the grayscale value of each pixel.
+  uint8_t gray_mean = 0.0;
+  if (dims[0] == 1) {
+    // Already grayscale, just compute the mean.
+    uint64_t sum = 0;
+    const size_t size = utils::get_linearized_size(dims);
+    const uint8_t* __restrict__ gray_buf = src.ptr();
+    for (size_t i = 0; i < size; ++i) {
+      sum += gray_buf[i];
+    }
+    gray_mean = static_cast<uint8_t>(
+      std::round(static_cast<double>(sum) / static_cast<double>(size)));
+  } else {
+    std::vector<size_t> gray_dims = {1, dims[1], dims[2]};
+    const size_t size = utils::get_linearized_size(gray_dims);
+    auto gray_real = El::Matrix<uint8_t>(size, 1);
+    cv::Mat gray = utils::get_opencv_mat(gray_real, gray_dims);
+    cv::cvtColor(src, gray, cv::COLOR_BGR2GRAY);
+    const uint8_t* __restrict__ gray_buf = gray.ptr();
+    // We sum integers, so accumulate into an integer.
+    // This should be large enough to avoid overflow, provided we have less than
+    // 2^56 pixels or so.
+    uint64_t sum = 0;
+    for (size_t i = 0; i < size; ++i) {
+      sum += gray_buf[i];
+    }
+    gray_mean = static_cast<uint8_t>(
+      std::round(static_cast<double>(sum) / static_cast<double>(size)));
+  }
+  // Mix the gray mean with the original image.
+  uint8_t* __restrict__ src_buf = src.ptr();
+  const float one_minus_factor = 1.0f - m_factor;
+  const size_t size = utils::get_linearized_size(dims);
+  for (size_t i = 0; i < size; ++i) {
+    src_buf[i] = cv::saturate_cast<uint8_t>(
+      src_buf[i]*m_factor + gray_mean*one_minus_factor);
+  }
+}
+
+}  // namespace transform
+}  // namespace lbann

--- a/src/transforms/vision/adjust_saturation.cpp
+++ b/src/transforms/vision/adjust_saturation.cpp
@@ -1,0 +1,72 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <opencv2/imgproc.hpp>
+#include "lbann/transforms/vision/adjust_saturation.hpp"
+#include "lbann/utils/opencv.hpp"
+
+namespace lbann {
+namespace transform {
+
+void adjust_saturation::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
+  // To adjust contrast, we essentially blend between the grayscale and
+  // original image based on the given factor.
+  cv::Mat src = utils::get_opencv_mat(data, dims);
+  if (!src.isContinuous()) {
+    // This should not occur, but just in case.
+    LBANN_ERROR("Do not support non-contiguous OpenCV matrices.");
+  }
+  if (dims[0] == 1) {
+    // Already grayscale, nothing to do.
+  } else {
+    // Handle RGB.
+    // Get the grayscaled image.
+    // If need be, we could do this computation in-place by manually computing
+    // the grayscale value of each pixel.
+    std::vector<size_t> gray_dims = {1, dims[1], dims[2]};
+    const size_t gray_size = utils::get_linearized_size(gray_dims);
+    auto gray_real = El::Matrix<uint8_t>(gray_size, 1);
+    cv::Mat gray = utils::get_opencv_mat(gray_real, gray_dims);
+    cv::cvtColor(src, gray, cv::COLOR_BGR2GRAY);
+    const uint8_t* __restrict__ gray_buf = gray.ptr();
+    // Mix the grayscale image with the original.
+    uint8_t* __restrict__ src_buf = src.ptr();
+    const float one_minus_factor = 1.0f - m_factor;
+    for (size_t i = 0; i < gray_size; ++i) {
+      // Handle the three channels, in OpenCV format.
+      const size_t src_base = 3*i;
+      src_buf[src_base] = cv::saturate_cast<uint8_t>(
+        src_buf[src_base]*m_factor + gray_buf[i]*one_minus_factor);
+      src_buf[src_base+1] = cv::saturate_cast<uint8_t>(
+        src_buf[src_base+1]*m_factor + gray_buf[i]*one_minus_factor);
+      src_buf[src_base+2] = cv::saturate_cast<uint8_t>(
+        src_buf[src_base+2]*m_factor + gray_buf[i]*one_minus_factor);
+    }
+  }
+}
+
+}  // namespace transform
+}  // namespace lbann

--- a/src/transforms/vision/color_jitter.cpp
+++ b/src/transforms/vision/color_jitter.cpp
@@ -35,6 +35,36 @@
 namespace lbann {
 namespace transform {
 
+color_jitter::color_jitter(float min_brightness_factor, float max_brightness_factor,
+                           float min_contrast_factor, float max_contrast_factor,
+                           float min_saturation_factor, float max_saturation_factor) :
+  transform(),
+  m_min_brightness_factor(min_brightness_factor),
+  m_max_brightness_factor(max_brightness_factor),
+  m_min_contrast_factor(min_contrast_factor),
+  m_max_contrast_factor(max_contrast_factor),
+  m_min_saturation_factor(min_saturation_factor),
+  m_max_saturation_factor(max_saturation_factor) {
+  if (min_brightness_factor < 0.0f ||
+      max_brightness_factor < min_brightness_factor) {
+    LBANN_ERROR("Min/max brightness factors out of range: "
+                + std::to_string(min_brightness_factor) + " "
+                + std::to_string(max_brightness_factor));
+  }
+  if (min_contrast_factor < 0.0f ||
+      max_contrast_factor < min_contrast_factor) {
+    LBANN_ERROR("Min/max contrast factors out of range: "
+                + std::to_string(min_contrast_factor) + " "
+                + std::to_string(max_contrast_factor));
+  }
+  if (min_saturation_factor < 0.0f ||
+      max_saturation_factor < min_saturation_factor) {
+    LBANN_ERROR("Min/max saturation factors out of range: "
+                + std::to_string(min_saturation_factor) + " "
+                + std::to_string(max_saturation_factor));
+  }
+}
+
 void color_jitter::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
   fast_rng_gen& gen = get_fast_generator();
   // Determine the order to apply transforms.

--- a/src/transforms/vision/color_jitter.cpp
+++ b/src/transforms/vision/color_jitter.cpp
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include "lbann/transforms/vision/color_jitter.hpp"
+#include "lbann/transforms/vision/adjust_brightness.hpp"
+#include "lbann/transforms/vision/adjust_contrast.hpp"
+#include "lbann/transforms/vision/adjust_saturation.hpp"
+#include "lbann/utils/random.hpp"
+#include "lbann/utils/opencv.hpp"
+
+namespace lbann {
+namespace transform {
+
+void color_jitter::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
+  fast_rng_gen& gen = get_fast_generator();
+  // Determine the order to apply transforms.
+  // Unused transforms will be skipped.
+  // 1 == brightness, 2 == contrast, 3 == saturation.
+  std::vector<int> transform_order = {1, 2, 3};
+  std::shuffle(transform_order.begin(), transform_order.end(), gen);
+  // Now apply the random adjustments.
+  for (const auto& t : transform_order) {
+    switch (t) {
+    case 1:
+      // Brightness.
+      if (!(m_min_brightness_factor == 0.0f &&
+            m_min_brightness_factor == m_max_brightness_factor)) {
+        std::uniform_real_distribution<float> dist(
+          m_min_brightness_factor, m_max_brightness_factor);
+        adjust_brightness trans = adjust_brightness(dist(gen));
+        trans.apply(data, dims);
+      }
+      break;
+    case 2:
+      // Contrast.
+      if (!(m_min_contrast_factor == 0.0f &&
+            m_min_contrast_factor == m_max_contrast_factor)) {
+        std::uniform_real_distribution<float> dist(
+          m_min_contrast_factor, m_max_contrast_factor);
+        adjust_contrast trans = adjust_contrast(dist(gen));
+        trans.apply(data, dims);
+      }
+      break;
+    case 3:
+      // Saturation.
+      if (!(m_min_saturation_factor == 0.0f &&
+            m_min_saturation_factor == m_max_saturation_factor)) {
+        std::uniform_real_distribution<float> dist(
+          m_min_saturation_factor, m_max_saturation_factor);
+        adjust_saturation trans = adjust_saturation(dist(gen));
+        trans.apply(data, dims);
+      }
+      break;
+    default:
+      LBANN_ERROR("Unexpected transform number");
+    }
+  }
+}
+
+}  // namespace transform
+}  // namespace lbann


### PR DESCRIPTION
This depends on #1014.

This adds four new transforms:
* `adjust_brightness`, to adjust the brightness of images by a fixed factor.
* `adjust_contrast`, to adjust the contrast of images by a fixed factor.
* `adjust_saturation`, to adjust the saturation of images by a fixed factor.
* `color_jitter`, to randomly jitter brightness, contrast, and saturation within a given range.

The `color_jitter` is analogous to the PyTorch `ColorJitter` transform (except we don't support jittering hue yet-- but this doesn't seem to be used as much). The `adjust_brightness`/`contrast`/`saturation` are analogous to the (functional-only) transforms in PyTorch with the same name.

Note that these do not operate by e.g. adjusting the saturation in HSV color space. Think of them as adjusting knobs on a television. Or at least that's the analogy Pillow gives. 📺 🤷‍♂