### PR TITLE
Reduce node allocation queueing

### DIFF
--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -1,0 +1,9 @@
+CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
+
+if [ "${CLUSTER}" = 'catalyst' ]; then
+    salloc -N16 -t 600 ./run.sh
+fi
+
+if [ "${CLUSTER}" = 'pascal' ]; then
+    salloc -N16 -t 600 ./run.sh
+fi

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -77,9 +77,8 @@ def get_command(cluster,
     if scheduler == 'slurm':
         # Create allocate command
         command_allocate = ''
-        # Allocate a node if we don't have one already
-        # Running the tests manually allows for already having a node allocated
-        if os.getenv('SLURM_JOB_NUM_NODES') == None:
+        # Allocate nodes only if we don't already have an allocation.
+        if os.getenv('SLURM_JOB_NUM_NODES') is None:
             command_allocate = 'salloc'
             option_num_nodes = ''
             option_partition = ''
@@ -122,8 +121,7 @@ def get_command(cluster,
     elif scheduler == 'lsf':
         # Create allocate command
         command_allocate = ''
-        # Allocate a node if we don't have one already
-        # Running the tests manually allows for already having a node allocated
+        # Allocate nodes only if we don't already have an allocation.
         if os.getenv('LSB_HOSTS') is None:
             command_allocate = 'bsub'
             # x => Puts the host running your job into exclusive execution

--- a/bamboo/integration_tests/expected_values/catalyst/clang4/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/clang4/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 56.00,             1.20,          5.00,         0.80,         0.40,           0.00
+alexnet_nightly, 117.00,            2.80,          9.00,         1.20,         2.00,           0.00
 alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
-lenet_mnist,     88.00,             0.12,          0.40,         0.10,         0.09,           98.40
+lenet_mnist,     100.00,            0.12,          0.40,         0.10,         0.09,           98.40

--- a/bamboo/integration_tests/expected_values/catalyst/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/gcc7/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
-alexnet_nightly, 57.00,             1.11,          4.80,        0.37,         1.20,           0.00
-alexnet_weekly,  0.00,              0.00,          0.00,        0.00,         0.00,           100.00
-cache_alexnet,   0.00,              0.00,          0.00,        0.00,         0.00,           100.00
-lenet_mnist,     64.00,             0.10,          0.40,        0.08,         0.04,           98.92
+alexnet_nightly, 65.00,             1.50,          8.30,         0.37,         1.70,           0.00
+alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
+cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
+lenet_mnist,     137.00,            0.18,          0.40,         0.15,         0.04,           98.92

--- a/bamboo/integration_tests/expected_values/pascal/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/pascal/gcc7/expected_performance.csv
@@ -2,4 +2,4 @@ Model_name,      training_run_time, training_mean, training_max, training_min, t
 alexnet_nightly, 51.00,             1.20,          4.00,         0.50,         0.40,           0.17
 alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
-lenet_mnist,     9.00,              0.01,          6.00,         0.01,         0.40,           98.40
+lenet_mnist,     12.00,              0.01,          6.00,         0.01,         0.40,           98.40

--- a/bamboo/run.sh
+++ b/bamboo/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -l
+
+echo "Task: Cleaning"
+./clean.sh
+
+echo "Task: Compiler Tests"
+cd compiler_tests
+module load cmake/3.9.2
+python -m pytest -s --junitxml=results.xml
+cd ..
+
+echo "Task: Integration Tests"
+cd integration_tests
+python -m pytest -s --junitxml=results.xml
+cd ..
+
+echo "Task: Unit Tests"
+cd unit_tests
+python -m pytest -s --junitxml=results.xml
+cd ..
+
+echo "Task: Finished"


### PR DESCRIPTION
Adding scripts to run all tests. Now, we just need Bamboo to run `./allocate_and_run.sh`. This means that most of the logic to run tests is now in git instead of the Bamboo web interface. This reduces the number of changes that would require duplication across every single Bamboo plan. Note that `tools.get_command` will discover we already have nodes allocated and thus will not queue for more nodes. Each build will consist of just one allocation. If it is cancelled, Bamboo will go on to the next build in the queue.

For some reason, performance tests seem to take longer, so we'll increase the expected performance values.

Note that running a batch job with`sbatch` will not work since after the job is submitted, Bamboo believes the test is finished immediately. 