### PR TITLE
Clean up tests

### DIFF
--- a/bamboo/common_python/test_tools.py
+++ b/bamboo/common_python/test_tools.py
@@ -4,158 +4,204 @@ import tools
 # This test isn't in a directory to be run from Bamboo
 # Run locally with python -m pytest -s
 
+d = dict(
+    executable='exe',
+    num_nodes=20,
+    partition='pdebug',
+    time_limit=30,
+    num_processes=40,
+    dir_name='dir',
+    data_filedir_default='lscratchh/filedir',
+    data_reader_name='mnist',
+    data_reader_percent=0.10,
+    exit_after_setup=True,
+    mini_batch_size=15,
+    model_folder='models/folder',
+    model_name='lenet',
+    num_epochs=7,
+    optimizer_name='adagrad',
+    processes_per_model=10,
+    output_file_name='output_file',
+    error_file_name='error_file',
+    check_executable_existence=False)
+
+
 def test_command_catalyst():
-    actual = tools.get_command(cluster='catalyst', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_default='lscratchh/filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existence=False)
-    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
+    actual = tools.get_command(cluster='catalyst', **d)
+    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --mpibind=off --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
+
 
 def test_command_pascal():
-    actual = tools.get_command(cluster='pascal', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_default='lscratchh/filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existence=False)
-    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
+    actual = tools.get_command(cluster='pascal', **d)
+    expected = 'salloc --nodes=20 --partition=pbatch --time=30 srun --mpibind=off --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
-def test_command_quartz():
-    actual = tools.get_command(cluster='quartz', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_default='lscratchh/filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existence=False)
-    expected = 'salloc --nodes=20 --partition=pdebug --time=30 srun --ntasks=40 exe --data_filedir=lscratchh/filedir --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
-    assert actual == expected
     
-def test_command_surface():
-    actual = tools.get_command(cluster='surface', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_default='lscratchh/filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existence=False)
-    expected = 'salloc --nodes=20 --partition=pbatch --time=30 srun --ntasks=40 exe --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
-    assert actual == expected
-
 def test_command_ray():
-    actual = tools.get_command(cluster='ray', executable='exe', num_nodes=20, partition='pdebug', time_limit=30, num_processes=40, dir_name='dir', data_filedir_default='lscratchh/filedir', data_reader_name='mnist', data_reader_percent=0.10, exit_after_setup=True, mini_batch_size=15, model_folder='models/folder', model_name='lenet', num_epochs=7, optimizer_name='adagrad', processes_per_model=10, output_file_name='output_file', error_file_name='error_file', check_executable_existence=False)
+    actual = tools.get_command(cluster='ray', **d)
     expected = 'bsub -x -G guests -Is -n 40 -q pdebug -R "span[ptile=2]" -W 30 mpirun -np 40 -N 2 exe --data_filedir=gscratchr/filedir --reader=dir/model_zoo/data_readers/data_reader_mnist.prototext --data_reader_percent=0.100000 --exit_after_setup --mini_batch_size=15 --model=dir/model_zoo/models/folder/model_lenet.prototext --num_epochs=7 --optimizer=dir/model_zoo/optimizers/opt_adagrad.prototext --procs_per_model=10 > output_file 2> error_file'
     assert actual == expected
 
 # Test error cases ############################################################
 
+
 def test_blacklisted_substrings():
     try:
         tools.get_command('ray', 'exe', partition=';', optimizer_path='--model=new_model', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid character(s): ; contains ; , --model=new_model contains --'
         assert actual == expected
 
+
 def test_unsupported_cluster():
     try:
-        tools.get_command('quartz', 'exe', check_executable_existence=False)
+        tools.get_command('q', 'exe', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
-        expected = 'Unsupported Cluster: quartz'
+        expected = 'Unsupported Cluster: q'
         assert actual == expected
+
 
 def test_bad_model_1():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_name='name', model_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
         assert actual == expected
+
 
 def test_bad_model_2():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', model_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
         assert actual == expected
+
 
 def test_bad_model_3():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', model_name='name',  model_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: model_path is set but so is at least one of model folder and model_name'
         assert actual == expected
 
+
 def test_bad_model_4():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', model_folder='folder', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: model_folder set but not model_name.'
         assert actual == expected
 
+
 def test_bad_model_5():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', model_name='name', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: model_name set but not model_folder.'
         assert actual == expected
 
+
 def test_bad_data_reader():
     try:
         tools.get_command('catalyst', 'exe', dir_name='dir', data_reader_name='name', data_reader_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_path is set but so is data_reader_name , data_reader_name or data_reader_path is set but not data_filedir_default. If a data reader is provided, the default filedir must be set. This allows for determining what the filedir should be on each cluster. Alternatively, some or all of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] can be set.'
         assert actual == expected
 
+
 def test_bad_optimizer():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', optimizer_name='name', optimizer_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: optimizer_path is set but so is optimizer_name'
         assert actual == expected
 
+
 def test_bad_dir_name_1():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', check_executable_existence=False)
+        assert False
     except Exception as e:
-	actual = str(e)
-	expected = 'Invalid Usage: dir_name set but none of model_folder, model_name, data_reader_name, optimizer_name are.'
+        actual = str(e)
+        expected = 'Invalid Usage: dir_name set but none of model_folder, model_name, data_reader_name, optimizer_name are.'
         assert actual == expected
+
 
 def test_bad_dir_name_2():
     try:
         tools.get_command('ray', 'exe', model_folder='folder', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
         assert actual == expected
 
+
 def test_bad_dir_name_3():
     try:
         tools.get_command('ray', 'exe', model_name='name', check_executable_existence=False)
+        assert False
     except Exception as e:
-	actual = str(e)
-	expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
+        actual = str(e)
+        expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
         assert actual == expected
+
 
 def test_bad_dir_name_4():
     try:
         tools.get_command('catalyst', 'exe', data_reader_name='name', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is. , data_reader_name or data_reader_path is set but not data_filedir_default. If a data reader is provided, the default filedir must be set. This allows for determining what the filedir should be on each cluster. Alternatively, some or all of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] can be set.'
         assert actual == expected
 
+
 def test_bad_dir_name_5():
     try:
         tools.get_command('ray', 'exe', optimizer_name='name', check_executable_existence=False)
+        assert False
     except Exception as e:
-	actual = str(e)
-	expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
+        actual = str(e)
+        expected = 'Invalid Usage: dir_name is not set but at least one of model_folder, model_name, data_reader_name, optimizer_name is.'
         assert actual == expected
+
 
 def test_bad_data_filedir_1():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_default='filedir', data_filedir_train_default='a',
                           check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
 
+
 def test_bad_data_filedir_2():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_default='filedir', data_filename_train_default='b',
                           check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
@@ -166,31 +212,38 @@ def test_bad_data_filedir_3():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_default='filedir', data_filedir_test_default='c',
                           check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
+
 
 def test_bad_data_filedir_4():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', data_filedir_default='filedir', data_filename_test_default='d',
                           check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
+
 
 def test_bad_data_filedir_5():
     try:
         tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_default='filedir', data_filedir_train_default='e', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
 
+
 def test_bad_data_filedir_6():
     try:
         tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_default='filedir', data_filename_train_default='f', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
@@ -200,46 +253,57 @@ def test_bad_data_filedir_6():
 def test_bad_data_filedir_7():
     try:
         tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_default='filedir', data_filedir_test_default='g', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
+
 
 def test_bad_data_filedir_8():
     try:
         tools.get_command('ray', 'exe', data_reader_path='path', data_filedir_default='filedir', data_filename_test_default='h', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_fildir_default set but so is at least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default]'
         assert actual == expected
 
+
 def test_bad_data_filedir_9():
     try:
         tools.get_command('ray', 'exe', dir_name='dir', data_reader_name='name', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_name or data_reader_path is set but not data_filedir_default. If a data reader is provided, the default filedir must be set. This allows for determining what the filedir should be on each cluster. Alternatively, some or all of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] can be set.'
         assert actual == expected
+
 
 def test_bad_data_filedir_10():
     try:
         tools.get_command('ray', 'exe', data_reader_path='path', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_reader_name or data_reader_path is set but not data_filedir_default. If a data reader is provided, the default filedir must be set. This allows for determining what the filedir should be on each cluster. Alternatively, some or all of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] can be set.'
         assert actual == expected
 
+
 def test_bad_data_filedir_11():
     try:
         tools.get_command('ray', 'exe', data_filedir_default='filedir', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: data_filedir_default set but neither data_reader_name or data_reader_path are.'
-	assert actual == expected
+        assert actual == expected
+
 
 def test_bad_data_filedir_12():
     try:
         tools.get_command('ray', 'exe', data_filedir_train_default='a', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] is set, but neither data_reader_name or data_reader_path are.'
@@ -249,6 +313,7 @@ def test_bad_data_filedir_12():
 def test_bad_data_filedir_13():
     try:
         tools.get_command('ray', 'exe', data_filename_train_default='b', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] is set, but neither data_reader_name or data_reader_path are.'
@@ -258,6 +323,7 @@ def test_bad_data_filedir_13():
 def test_bad_data_filedir_14():
     try:
         tools.get_command('ray', 'exe', data_filedir_test_default='c', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] is set, but neither data_reader_name or data_reader_path are.'
@@ -267,6 +333,7 @@ def test_bad_data_filedir_14():
 def test_bad_data_filedir_15():
     try:
         tools.get_command('ray', 'exe', data_filename_test_default='e', check_executable_existence=False)
+        assert False
     except Exception as e:
         actual = str(e)
         expected = 'Invalid Usage: At least one of [data_filedir_train_default, data_filename_train_default, data_filedir_test_default, data_filename_test_default] is set, but neither data_reader_name or data_reader_path are.'

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -57,7 +57,7 @@ def get_command(cluster,
 
     # Never give lbannusr an allocation for over 12 hours though.
     strict_time_limit = 60*6  # 6 hours.
-    if time_limit > strict_time_limit:
+    if (time_limit is None) or (time_limit > strict_time_limit):
         time_limit = strict_time_limit
 
     # Check executable existence
@@ -65,7 +65,7 @@ def get_command(cluster,
         process_executable_existence(executable, skip_no_exe)
 
     # Determine scheduler
-    if cluster in ['catalyst', 'pascal', 'quartz', 'surface']:
+    if cluster in ['catalyst', 'pascal']:
         scheduler = 'slurm'
     elif cluster == 'ray':
         scheduler = 'lsf'
@@ -90,8 +90,8 @@ def get_command(cluster,
                 # maxnodes.
                 option_num_nodes = ' --nodes=%d' % num_nodes
             if partition is not None:
-                # Surface does not have pdebug, so switch to pbatch
-                if (cluster in ['surface', 'pascal']) and \
+                # If cluster doesn't have pdebug switch to pbatch.
+                if (cluster in ['pascal']) and \
                         (partition == 'pdebug'):
                     partition = 'pbatch'
                 # --partition => Request a specific partition for the resource
@@ -249,27 +249,19 @@ def get_command(cluster,
     # Determine data file paths
     # If there is no regex match, then re.sub keeps the original string
     if data_filedir_default is not None:
-        if cluster in ['catalyst', 'pascal', 'surface']:
+        if cluster in ['catalyst', 'pascal',]:
             # option_data_filedir = data_filedir_default # lscratchh, presumably
             pass  # No need to pass in a parameter
-        elif cluster == 'quartz':
-            option_data_filedir = ' --data_filedir=%s' % re.sub(
-                '[a-z]scratch[a-z]', 'lscratchh', data_filedir_default)
         elif cluster == 'ray':
             option_data_filedir = ' --data_filedir=%s' % re.sub(
                 '[a-z]scratch[a-z]', 'gscratchr', data_filedir_default)
     elif None not in data_file_parameters:
-        if cluster in ['catalyst', 'pascal', 'surface']:
+        if cluster in ['catalyst', 'pascal']:
             # option_data_filedir_train = data_filedir_train_default
             # option_data_filename_train = data_filename_train_default
             # option_data_filedir_test = data_filedir_test_default
             # option_data_filename_train = data_filename_test_default
             pass # No need to pass in a parameter
-        elif cluster == 'quartz':
-            option_data_filedir_train  = ' --data_filedir_train=%s'  % re.sub('[a-z]scratch[a-z]', 'lscratchh', data_filedir_train_default)
-            option_data_filename_train = ' --data_filename_train=%s' % re.sub('[a-z]scratch[a-z]', 'lscratchh', data_filename_train_default)
-            option_data_filedir_test   = ' --data_filedir_test=%s'   % re.sub('[a-z]scratch[a-z]', 'lscratchh', data_filedir_test_default)
-            option_data_filename_train = ' --data_filename_test=%s'  % re.sub('[a-z]scratch[a-z]', 'lscratchh', data_filename_test_default)
         elif cluster == 'ray':
             option_data_filedir_train  = ' --data_filedir_train=%s'  % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filedir_train_default)
             option_data_filename_train = ' --data_filename_train=%s' % re.sub('[a-z]scratch[a-z]', 'gscratchr', data_filename_train_default)
@@ -303,7 +295,7 @@ def get_command(cluster,
             lbann_errors.append(
                 ('data_filedir_default set but neither data_reader_name'
                  ' or data_reader_path are.'))
-        elif filter(lambda x: x is not None, data_file_parameters) != []:
+        elif list(filter(lambda x: x is not None, data_file_parameters)) != []:
             # If the list of non-None data_file parameters is not empty
             lbann_errors.append(
                 ('At least one of [data_filedir_train_default, data_filename'
@@ -369,14 +361,12 @@ def get_spack_exes(default_dirname, cluster):
     exes = {}
 
     exes['clang4'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-    exes['gcc4'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (default_dirname, cluster)
     exes['gcc7'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
-    exes['intel18'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
+    exes['intel19'] = '%s/bamboo/compiler_tests/builds/%s_intel-19.0.0_rel/build/model_zoo/lbann' % (default_dirname, cluster)
 
     exes['clang4_debug'] = '%s/bamboo/compiler_tests/builds/%s_clang-4.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-    exes['gcc4_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (default_dirname, cluster)
     exes['gcc7_debug'] = '%s/bamboo/compiler_tests/builds/%s_gcc-7.1.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
-    exes['intel18_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
+    exes['intel19_debug'] = '%s/bamboo/compiler_tests/builds/%s_intel-19.0.0_debug/build/model_zoo/lbann' % (default_dirname, cluster)
 
     return exes
 
@@ -388,34 +378,28 @@ def get_default_exes(default_dirname, cluster):
         exes['clang4'] = '%s/build/clang.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if not os.path.exists(exes['gcc7']):
         exes['gcc7'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
-    if not os.path.exists(exes['intel18']):
-        exes['intel18'] = '%s/build/intel.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
+    if not os.path.exists(exes['intel19']):
+        exes['intel19'] = '%s/build/intel.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
 
     if not os.path.exists(exes['clang4_debug']):
         exes['clang4_debug'] = '%s/build/clang.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
     if not os.path.exists(exes['gcc7_debug']):
         exes['gcc7_debug'] = '%s/build/gnu.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
-    if not os.path.exists(exes['intel18_debug']):
-        exes['intel18_debug'] = '%s/build/intel.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
+    if not os.path.exists(exes['intel19_debug']):
+        exes['intel19_debug'] = '%s/build/intel.Debug.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
 
     default_exes = {}
     default_exes['default'] = '%s/build/gnu.Release.%s.llnl.gov/install/bin/lbann' % (default_dirname, cluster)
-    if cluster in ['catalyst', 'quartz', 'pascal']:
-        # x86_cpu - catalyst, quartz
+    if cluster in ['catalyst', 'pascal']:
+        # x86_cpu - catalyst
         # x86_gpu_pascal - pascal
         default_exes['clang4'] = exes['clang4']
-        default_exes['gcc4'] = exes['gcc4']
         default_exes['gcc7'] = exes['gcc7']
-        default_exes['intel18'] = exes['intel18']
+        default_exes['intel19'] = exes['intel19']
 
         default_exes['clang4_debug'] = exes['clang4_debug']
-        default_exes['gcc4_debug'] = exes['gcc4_debug']
         default_exes['gcc7_debug'] = exes['gcc7_debug']
-        default_exes['intel18_debug'] = exes['intel18_debug']
-    elif cluster in ['surface']:
-        # x86_gpu - surface
-        default_exes['gcc4'] = exes['gcc4']
-        default_exes['gcc4_debug'] = exes['gcc4_debug']
+        default_exes['intel19_debug'] = exes['intel19_debug']
 
     print('default_exes={d}'.format(d=default_exes))
     return default_exes

--- a/bamboo/compiler_tests/build_script.sh
+++ b/bamboo/compiler_tests/build_script.sh
@@ -1,7 +1,4 @@
-CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
-if [ "${CLUSTER}" != 'surface' ]; then
-    source /usr/share/lmod/lmod/init/bash
-    source /etc/profile.d/00-modulepath.sh
-fi
+source /usr/share/lmod/lmod/init/bash
+source /etc/profile.d/00-modulepath.sh
 LBANN_DIR=$(git rev-parse --show-toplevel)
 ${LBANN_DIR}/scripts/build_lbann_lc.sh --with-conduit

--- a/bamboo/compiler_tests/build_script_specific.sh
+++ b/bamboo/compiler_tests/build_script_specific.sh
@@ -2,10 +2,8 @@ set -e
 CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
 LBANN_DIR=$(git rev-parse --show-toplevel)
 DEBUG=''
-if [ "${CLUSTER}" != 'surface' ]; then
-    source /usr/share/lmod/lmod/init/bash
-    source /etc/profile.d/00-modulepath.sh
-fi
+source /usr/share/lmod/lmod/init/bash
+source /etc/profile.d/00-modulepath.sh
 
 while :; do
     case ${1} in
@@ -37,17 +35,13 @@ if [ "${COMPILER}" == 'clang4' ]; then
     ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler clang ${DEBUG} --reconfigure --with-conduit
 fi
 
-if [ "${COMPILER}" == 'intel18' ]; then
-    module load intel/18.0.0
-    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler intel ${DEBUG} --reconfigure --with-conduit
-fi
-
-if [ "${COMPILER}" == 'gcc4' ]; then
-    module load gcc/4.9.3
-    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler gnu ${DEBUG} --reconfigure --with-conduit
-fi
 
 if [ "${COMPILER}" == 'gcc7' ]; then
     module load gcc/7.1.0
     ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler gnu ${DEBUG} --reconfigure --with-conduit
+fi
+
+if [ "${COMPILER}" == 'intel19' ]; then
+    module load intel/19.0.0
+    ${LBANN_DIR}/scripts/build_lbann_lc.sh --compiler intel ${DEBUG} --reconfigure --with-conduit
 fi

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -50,26 +50,6 @@ def test_compiler_clang4_debug(cluster, dirname):
         assert os.path.exists(path)
 
 
-def test_compiler_gcc4_release(cluster, dirname):
-    try:
-        skeleton_gcc4(cluster, dirname, False)
-    except AssertionError as e:
-        print(e)
-        build_script(cluster, dirname, 'gcc4', False)
-    path = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_rel/build/model_zoo/lbann' % (dirname, cluster)
-    assert os.path.exists(path)
-
-
-def test_compiler_gcc4_debug(cluster, dirname):
-    try:
-        skeleton_gcc4(cluster, dirname, True)
-    except AssertionError as e:
-        print(e)
-        build_script(cluster, dirname, 'gcc4', True)
-    path = '%s/bamboo/compiler_tests/builds/%s_gcc-4.9.3_debug/build/model_zoo/lbann' % (dirname, cluster)
-    assert os.path.exists(path)
-
-
 def test_compiler_gcc7_release(cluster, dirname):
     try:
         skeleton_gcc7(cluster, dirname, False)
@@ -94,32 +74,32 @@ def test_compiler_gcc7_debug(cluster, dirname):
         assert os.path.exists(path)
 
 
-def test_compiler_intel18_release(cluster, dirname):
+def test_compiler_intel19_release(cluster, dirname):
     try:
-        skeleton_intel18(cluster, dirname, False)
+        skeleton_intel19(cluster, dirname, False)
     except AssertionError as e:
         print(e)
-        build_script(cluster, dirname, 'intel18', False)
-    path = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_rel/build/model_zoo/lbann' % (dirname, cluster)
+        build_script(cluster, dirname, 'intel19', False)
+    path = '%s/bamboo/compiler_tests/builds/%s_intel-19.0.0_rel/build/model_zoo/lbann' % (dirname, cluster)
     if not os.path.exists(path):
         path = '%s/build/intel.Release.%s.llnl.gov/install/bin/lbann' % (dirname, cluster)
         assert os.path.exists(path)
 
 
-def test_compiler_intel18_debug(cluster, dirname):
+def test_compiler_intel19_debug(cluster, dirname):
     try:
-        skeleton_intel18(cluster, dirname, True)
+        skeleton_intel19(cluster, dirname, True)
     except AssertionError as e:
         print(e)
-        build_script(cluster, dirname, 'intel18', True)
-    path = '%s/bamboo/compiler_tests/builds/%s_intel-18.0.0_debug/build/model_zoo/lbann' % (dirname, cluster)
+        build_script(cluster, dirname, 'intel19', True)
+    path = '%s/bamboo/compiler_tests/builds/%s_intel-19.0.0_debug/build/model_zoo/lbann' % (dirname, cluster)
     if not os.path.exists(path):
         path = '%s/build/intel.Debug.%s.llnl.gov/install/bin/lbann' % (dirname, cluster)
         assert os.path.exists(path)
 
 
 def skeleton_clang4(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['catalyst']:
         spack_skeleton(dir_name, 'clang@4.0.0', 'mvapich2@2.2', debug, should_log)
         build_skeleton(dir_name, 'clang@4.0.0', debug, should_log)
     else:
@@ -128,23 +108,8 @@ def skeleton_clang4(cluster, dir_name, debug, should_log=False):
         pytest.skip(e)
 
 
-def skeleton_gcc4(cluster, dir_name, debug, should_log=False):
-    if cluster in ['quartz']:  # Taking out 'catalyst'
-        mpi = 'mvapich2@2.2'
-    elif cluster in ['surface']:  # Taking out 'pascal'
-        mpi = 'mvapich2@2.2+cuda'
-    elif cluster == 'ray':
-        mpi = 'spectrum-mpi@2018.04.27'
-    else:
-        e = 'skeleton_gcc4: Unsupported Cluster %s' % cluster
-        print('Skip - ' + e)
-        pytest.skip(e)
-    spack_skeleton(dir_name, 'gcc@4.9.3', mpi, debug, should_log)
-    build_skeleton(dir_name, 'gcc@4.9.3', debug, should_log)
-
-
 def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
-    if cluster in ['catalyst', 'quartz']:
+    if cluster in ['catalyst']:
         spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
         build_skeleton(dir_name, 'gcc@7.1.0', debug, should_log)
     else:
@@ -153,12 +118,12 @@ def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
         pytest.skip(e)
 
 
-def skeleton_intel18(cluster, dir_name, debug, should_log=False):
-    if cluster in ['quartz']:  # Taking out 'catalyst'
-        spack_skeleton(dir_name, 'intel@18.0.0', 'mvapich2@2.2', debug, should_log)
-        build_skeleton(dir_name, 'intel@18.0.0', debug, should_log)
+def skeleton_intel19(cluster, dir_name, debug, should_log=False):
+    if cluster in []:  # ['catalyst']:
+        spack_skeleton(dir_name, 'intel@19.0.0', 'mvapich2@2.2', debug, should_log)
+        build_skeleton(dir_name, 'intel@19.0.0', debug, should_log)
     else:
-        e = 'skeleton_intel18: Unsupported Cluster %s' % cluster
+        e = 'skeleton_intel19: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)
         pytest.skip(e)
 
@@ -203,15 +168,13 @@ def build_skeleton(dir_name, compiler, debug, should_log):
     # For reference:
     # Commenting out for now. These additions to path name will likely return
     # one day, so I am not removing them entirely.
-    # x86_64 <=> catalyst, pascal, quartz, surface
+    # x86_64 <=> catalyst, pascal
     # ppc64le <=> ray
     #architecture = subprocess.check_output('uname -m'.split()).strip()
     #if cluster == 'ray':
     #    architecture += '_gpu_cuda-9.2.64_cudnn-7.0'
     #elif cluster == 'pascal':
     #    architecture += '_gpu_cuda-9.1.85_cudnn-7.1'
-    #elif cluster == 'surface':
-    #    architecture += '_gpu'
     os.chdir('%s/bamboo/compiler_tests/builds/%s_%s_%s/build' % (dir_name, cluster, compiler, build_type))
     command = 'make -j all > %s 2> %s' % (output_file_name, error_file_name)
     return_code = os.system(command)

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -26,7 +26,7 @@ def get_command(cluster, dir_name, model_folder, model_name, executable,
             error_file_name=error_file_name)
     elif model_name in ['conv_autoencoder_mnist', 'lenet_mnist']:
         if (model_name == 'lenet_mnist') and \
-                (compiler_name in ['clang4', 'intel18']):
+                (compiler_name in ['clang4', 'intel19']):
             partition = 'pbatch'
             time_limit = 600
         else:

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -13,12 +13,12 @@ def pytest_addoption(parser):
 
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
+    parser.addoption('--debug_build', action='store_true', default=False,
+                      help='--debug_build specifies that debug tests should be run, even without doing a --weekly build. Default False')
     parser.addoption('--dirname', action='store', default=default_dirname,
                      help='--dirname=<path_to_dir> to specify the top-level directory. Default directory of build_lbann_lc executable')
     parser.addoption('--exes', action='store', default=default_exes,
                      help='--exes={compiler_name: path}')
-    parser.addoption('--log', action='store', default=0,
-                     help='--log=1 to keep trimmed accuracy files. Default (--log=0) removes files')
     parser.addoption('--run', action='store_true', default=False,
                      help='--run specifies that a test normally ignored should be run. Default False')
     parser.addoption('--weekly', action='store_true', default=False,
@@ -33,8 +33,8 @@ def cluster(request):
 
 
 @pytest.fixture
-def debug(request):
-    return request.config.getoption('--debug')
+def debug_build(request):
+    return request.config.getoption('--debug_build')
 
 
 @pytest.fixture

--- a/bamboo/integration_tests/test_integration_autoencoders.py
+++ b/bamboo/integration_tests/test_integration_autoencoders.py
@@ -53,7 +53,7 @@ DATA_FIELDS = [
 
 def skeleton_autoencoder_imagenet(cluster, dir_name, executables, compiler_name,
                                   weekly):
-  if cluster in ['surface', 'pascal']:
+  if cluster in ['pascal']:
       e = 'skeleton_autoencoder_imagenet: does not run on GPU'
       print('Skip - ' + e)
       pytest.skip(e)
@@ -79,17 +79,13 @@ def test_integration_autoencoder_imagenet_clang4(cluster, dirname, exes,
     skeleton_autoencoder_imagenet(cluster, dirname, exes, 'clang4', weekly)
 
 
-def test_integration_autoencoder_imagenet_gcc4(cluster, dirname, exes, weekly):
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'gcc4', weekly)
-
-
 def test_integration_autoencoder_imagenet_gcc7(cluster, dirname, exes, weekly):
     skeleton_autoencoder_imagenet(cluster, dirname, exes, 'gcc7', weekly)
 
 
-def test_integration_autoencoder_imagenet_intel18(cluster, dirname, exes,
+def test_integration_autoencoder_imagenet_intel19(cluster, dirname, exes,
                                                   weekly):
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'intel18', weekly)
+    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'intel19', weekly)
 
 
 # Run with python -m pytest -s test_integration_autoencoder.py -k 'test_integration_autoencoder_imagenet_exe' --exe=<executable>

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -6,10 +6,10 @@ import common_code
 
 
 def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
-                         debug, should_log=False):
-    # If weekly or debug are true, then run the test.
-    if (not weekly) and (not debug):
-        e = 'skeleton_mnist_debug: Not doing weekly or debug testing'
+                         debug_build, should_log=False):
+    # If weekly or debug_build are true, then run the test.
+    if not (weekly or debug_build):
+        e = 'skeleton_mnist_debug: Not doing weekly or debug_build testing'
         print('Skip - ' + e)
         pytest.skip(e)
     if compiler_name not in executables:
@@ -26,15 +26,15 @@ def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='mnist', model_folder='models/' + model_name,
         model_name=model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name)
+    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
     assert output_value == 0
 
 
 def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
-                         debug, should_log=False):
-    # If weekly or debug are true, then run the test.
-    if (not weekly) and (not debug):
-        e = 'skeleton_cifar_debug: Not doing weekly or debug testing'
+                         debug_build, should_log=False):
+    # If weekly or debug_build are true, then run the test.
+    if not (weekly or debug_build):
+        e = 'skeleton_cifar_debug: Not doing weekly or debug_build testing'
         print('Skip - ' + e)
         pytest.skip(e)
     if cluster == 'ray':
@@ -56,40 +56,32 @@ def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='cifar10', data_reader_percent=0.01, model_folder='models/' + model_name,
         model_name='conv_' + model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name)
+    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
     assert output_value == 0
 
 
-def test_integration_mnist_clang4_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_mnist_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug)
+def test_integration_mnist_clang4_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_mnist_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug_build)
 
 
-def test_integration_cifar_clang4_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_cifar_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug)
+def test_integration_cifar_clang4_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_cifar_debug(cluster, dirname, exes, 'clang4_debug', weekly, debug_build)
 
 
-def test_integration_mnist_gcc4_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_mnist_debug(cluster, dirname, exes, 'gcc4_debug', weekly, debug)
+def test_integration_mnist_gcc7_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_mnist_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug_build)
 
 
-def test_integration_cifar_gcc4_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_cifar_debug(cluster, dirname, exes, 'gcc4_debug', weekly, debug)
+def test_integration_cifar_gcc7_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_cifar_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug_build)
 
 
-def test_integration_mnist_gcc7_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_mnist_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug)
+def test_integration_mnist_intel19_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_mnist_debug(cluster, dirname, exes, 'intel19_debug', weekly, debug_build)
 
 
-def test_integration_cifar_gcc7_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_cifar_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug)
-
-
-def test_integration_mnist_intel18_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_mnist_debug(cluster, dirname, exes, 'intel18_debug', weekly, debug)
-
-
-def test_integration_cifar_intel18_debug(cluster, dirname, exes, weekly, debug):
-    skeleton_cifar_debug(cluster, dirname, exes, 'intel18_debug', weekly, debug)
+def test_integration_cifar_intel19_debug(cluster, dirname, exes, weekly, debug_build):
+    skeleton_cifar_debug(cluster, dirname, exes, 'intel19_debug', weekly, debug_build)
 
 
 # Run with python -m pytest -s test_integration_debug.py -k 'test_integration_mnist_exe' --exe=<executable>

--- a/bamboo/integration_tests/test_integration_performance.py
+++ b/bamboo/integration_tests/test_integration_performance.py
@@ -158,7 +158,7 @@ def skeleton_performance_full_alexnet(cluster, dir_name, executables,
   should_log = True
   output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
   error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name) 
-  if cluster in ['catalyst', 'surface']:
+  if cluster in ['catalyst']:
     command = 'salloc --nodes 128 %s/bamboo/integration_tests/%s.sh > %s 2> %s' % (dir_name, model_name, output_file_name, error_file_name)
   elif cluster in ['pascal', 'ray']:
     e = 'skeleton_performance_full_alexnet: Pascal, Ray are unsupported for skeleton_performance_full_alexnet'
@@ -188,19 +188,6 @@ def test_integration_performance_full_alexnet_clang4(cluster, dirname, exes,
                                     run)
 
 
-def test_integration_performance_lenet_mnist_gcc4(cluster, dirname, exes):
-  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'gcc4')
-
-
-def test_integration_performance_alexnet_gcc4(cluster, dirname, exes, weekly):
-  skeleton_performance_alexnet(cluster, dirname, exes, 'gcc4', weekly)
-
-
-def test_integration_performance_full_alexnet_gcc4(cluster, dirname, exes,
-                                                   weekly, run):
-  skeleton_performance_full_alexnet(cluster, dirname, exes, 'gcc4', weekly, run)
-
-
 def test_integration_performance_lenet_mnist_gcc7(cluster, dirname, exes):
   skeleton_performance_lenet_mnist(cluster, dirname, exes, 'gcc7')
 
@@ -214,18 +201,18 @@ def test_integration_performance_full_alexnet_gcc7(cluster, dirname, exes,
   skeleton_performance_full_alexnet(cluster, dirname, exes, 'gcc7', weekly, run)
 
 
-def test_integration_performance_lenet_mnist_intel18(cluster, dirname, exes):
-  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'intel18')
+def test_integration_performance_lenet_mnist_intel19(cluster, dirname, exes):
+  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'intel19')
 
 
-def test_integration_performance_alexnet_intel18(cluster, dirname, exes,
+def test_integration_performance_alexnet_intel19(cluster, dirname, exes,
                                                  weekly):
-  skeleton_performance_alexnet(cluster, dirname, exes, 'intel18', weekly)
+  skeleton_performance_alexnet(cluster, dirname, exes, 'intel19', weekly)
 
 
-def test_integration_performance_full_alexnet_intel18(cluster, dirname, exes,
+def test_integration_performance_full_alexnet_intel19(cluster, dirname, exes,
                                                       weekly, run):
-  skeleton_performance_full_alexnet(cluster, dirname, exes, 'intel18', weekly,
+  skeleton_performance_full_alexnet(cluster, dirname, exes, 'intel19', weekly,
                                     run)
 
 

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -19,17 +19,21 @@ def pytest_addoption(parser):
     # For local testing only
     parser.addoption('--exe', action='store', help='--exe=<hand-picked executable>')
 
+
 @pytest.fixture
 def cluster(request):
     return request.config.getoption('--cluster')
+
 
 @pytest.fixture
 def dirname(request):
     return request.config.getoption('--dirname')
 
+
 @pytest.fixture
 def exes(request):
     return request.config.getoption('--exes')
+
 
 @pytest.fixture
 def exe(request):

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -122,16 +122,12 @@ def test_unit_models_clang4(cluster, dirname, exes):
     skeleton_models(cluster, dirname, exes, 'clang4')
 
 
-def test_unit_models_gcc4(cluster, dirname, exes):
-    skeleton_models(cluster, dirname, exes, 'gcc4')
-
-
 def test_unit_models_gcc7(cluster, dirname, exes):
     skeleton_models(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_models_intel18(cluster, dirname, exes):
-    skeleton_models(cluster, dirname, exes, 'intel18')
+def test_unit_models_intel19(cluster, dirname, exes):
+    skeleton_models(cluster, dirname, exes, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_check_proto_models.py -k 'test_unit_models_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -128,19 +128,14 @@ def test_unit_checkpoint_lenet_clang4(cluster, exes, dirname):
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_checkpoint_lenet_gcc4(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc4')
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_checkpoint_lenet_gcc7(cluster, exes, dirname):
     skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc7')
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_checkpoint_lenet_intel18(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'intel18')
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel18')
+def test_unit_checkpoint_lenet_intel19(cluster, exes, dirname):
+    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'intel19')
+    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_clamp.py
+++ b/bamboo/unit_tests/test_unit_layer_clamp.py
@@ -27,16 +27,12 @@ def test_unit_layer_clamp_clang4(cluster, exes, dirname):
     skeleton_layer_clamp(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_clamp_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_clamp(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_clamp_gcc7(cluster, exes, dirname):
     skeleton_layer_clamp(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_clamp_intel18(cluster, exes, dirname):
-    skeleton_layer_clamp(cluster, exes, dirname, 'intel18')
+def test_unit_layer_clamp_intel19(cluster, exes, dirname):
+    skeleton_layer_clamp(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_clamp.py -k 'test_unit_layer_clamp_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_covariance.py
+++ b/bamboo/unit_tests/test_unit_layer_covariance.py
@@ -27,16 +27,12 @@ def test_unit_layer_covariance_clang4(cluster, exes, dirname):
     skeleton_layer_covariance(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_covariance_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_covariance(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_covariance_gcc7(cluster, exes, dirname):
     skeleton_layer_covariance(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_covariance_intel18(cluster, exes, dirname):
-    skeleton_layer_covariance(cluster, exes, dirname, 'intel18')
+def test_unit_layer_covariance_intel19(cluster, exes, dirname):
+    skeleton_layer_covariance(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_covariance_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_elu.py
+++ b/bamboo/unit_tests/test_unit_layer_elu.py
@@ -27,16 +27,12 @@ def test_unit_layer_elu_clang4(cluster, exes, dirname):
     skeleton_layer_elu(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_elu_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_elu(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_elu_gcc7(cluster, exes, dirname):
     skeleton_layer_elu(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_elu_intel18(cluster, exes, dirname):
-    skeleton_layer_elu(cluster, exes, dirname, 'intel18')
+def test_unit_layer_elu_intel19(cluster, exes, dirname):
+    skeleton_layer_elu(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_elu.py -k 'test_unit_layer_elu_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_identity.py
+++ b/bamboo/unit_tests/test_unit_layer_identity.py
@@ -27,16 +27,12 @@ def test_unit_layer_identity_clang4(cluster, exes, dirname):
     skeleton_layer_identity(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_identity_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_identity(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_identity_gcc7(cluster, exes, dirname):
     skeleton_layer_identity(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_identity_intel18(cluster, exes, dirname):
-    skeleton_layer_identity(cluster, exes, dirname, 'intel18')
+def test_unit_layer_identity_intel19(cluster, exes, dirname):
+    skeleton_layer_identity(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_identity.py -k 'test_unit_layer_identity_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_l1_norm.py
+++ b/bamboo/unit_tests/test_unit_layer_l1_norm.py
@@ -27,16 +27,12 @@ def test_unit_layer_l1_norm_clang4(cluster, exes, dirname):
     skeleton_layer_l1_norm(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_l1_norm_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_l1_norm_gcc7(cluster, exes, dirname):
     skeleton_layer_l1_norm(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_l1_norm_intel18(cluster, exes, dirname):
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'intel18')
+def test_unit_layer_l1_norm_intel19(cluster, exes, dirname):
+    skeleton_layer_l1_norm(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l1_norm_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_l2_norm2.py
+++ b/bamboo/unit_tests/test_unit_layer_l2_norm2.py
@@ -26,17 +26,12 @@ def skeleton_layer_l2_norm2(cluster, executables, dir_name, compiler_name):
 def test_unit_layer_l2_norm2_clang4(cluster, exes, dirname):
     skeleton_layer_l2_norm2(cluster, exes, dirname, 'clang4')
 
-
-def test_unit_layer_l2_norm2_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_l2_norm2_gcc7(cluster, exes, dirname):
     skeleton_layer_l2_norm2(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_l2_norm2_intel18(cluster, exes, dirname):
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'intel18')
+def test_unit_layer_l2_norm2_intel19(cluster, exes, dirname):
+    skeleton_layer_l2_norm2(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l2_norm2_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu.py
@@ -27,16 +27,12 @@ def test_unit_layer_leaky_relu_clang4(cluster, exes, dirname):
     skeleton_layer_leaky_relu(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_leaky_relu_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_leaky_relu_gcc7(cluster, exes, dirname):
     skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_leaky_relu_intel18(cluster, exes, dirname):
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel18')
+def test_unit_layer_leaky_relu_intel19(cluster, exes, dirname):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_leaky_relu_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
@@ -27,16 +27,12 @@ def test_unit_layer_log_sigmoid_clang4(cluster, exes, dirname):
     skeleton_layer_log_sigmoid(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_log_sigmoid_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_log_sigmoid_gcc7(cluster, exes, dirname):
     skeleton_layer_log_sigmoid(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_log_sigmoid_intel18(cluster, exes, dirname):
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'intel18')
+def test_unit_layer_log_sigmoid_intel19(cluster, exes, dirname):
+    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_log_sigmoid.py -k 'test_unit_layer_log_sigmoid_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_log_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_log_softmax.py
@@ -27,16 +27,12 @@ def test_unit_layer_log_softmax_clang4(cluster, exes, dirname):
     skeleton_layer_log_softmax(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_log_softmax_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_log_softmax_gcc7(cluster, exes, dirname):
     skeleton_layer_log_softmax(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_log_softmax_intel18(cluster, exes, dirname):
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'intel18')
+def test_unit_layer_log_softmax_intel19(cluster, exes, dirname):
+    skeleton_layer_log_softmax(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_log_softmax_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
+++ b/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
@@ -27,16 +27,12 @@ def test_unit_layer_mean_absolute_error_clang4(cluster, exes, dirname):
     skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_mean_absolute_error_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_mean_absolute_error_gcc7(cluster, exes, dirname):
     skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_mean_absolute_error_intel18(cluster, exes, dirname):
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'intel18')
+def test_unit_layer_mean_absolute_error_intel19(cluster, exes, dirname):
+    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_mean_absolute_error_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_relu.py
@@ -27,16 +27,12 @@ def test_unit_layer_relu_clang4(cluster, exes, dirname):
     skeleton_layer_relu(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_relu_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_relu(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_relu_gcc7(cluster, exes, dirname):
     skeleton_layer_relu(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_relu_intel18(cluster, exes, dirname):
-    skeleton_layer_relu(cluster, exes, dirname, 'intel18')
+def test_unit_layer_relu_intel19(cluster, exes, dirname):
+    skeleton_layer_relu(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_relu.py -k 'test_unit_layer_relu_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_selu.py
+++ b/bamboo/unit_tests/test_unit_layer_selu.py
@@ -27,16 +27,12 @@ def test_unit_layer_selu_clang4(cluster, exes, dirname):
     skeleton_layer_selu(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_selu_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_selu(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_selu_gcc7(cluster, exes, dirname):
     skeleton_layer_selu(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_selu_intel18(cluster, exes, dirname):
-    skeleton_layer_selu(cluster, exes, dirname, 'intel18')
+def test_unit_layer_selu_intel19(cluster, exes, dirname):
+    skeleton_layer_selu(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_selu.py -k 'test_unit_layer_selu_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_sigmoid.py
@@ -27,16 +27,12 @@ def test_unit_layer_sigmoid_clang4(cluster, exes, dirname):
     skeleton_layer_sigmoid(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_sigmoid_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_sigmoid_gcc7(cluster, exes, dirname):
     skeleton_layer_sigmoid(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_sigmoid_intel18(cluster, exes, dirname):
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'intel18')
+def test_unit_layer_sigmoid_intel19(cluster, exes, dirname):
+    skeleton_layer_sigmoid(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_sigmoid.py -k 'test_unit_layer_sigmoid_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_softmax.py
@@ -27,16 +27,12 @@ def test_unit_layer_softmax_clang4(cluster, exes, dirname):
     skeleton_layer_softmax(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_softmax_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_softmax(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_softmax_gcc7(cluster, exes, dirname):
     skeleton_layer_softmax(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_softmax_intel18(cluster, exes, dirname):
-    skeleton_layer_softmax(cluster, exes, dirname, 'intel18')
+def test_unit_layer_softmax_intel19(cluster, exes, dirname):
+    skeleton_layer_softmax(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_softmax_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_softplus.py
+++ b/bamboo/unit_tests/test_unit_layer_softplus.py
@@ -27,16 +27,12 @@ def test_unit_layer_softplus_clang4(cluster, exes, dirname):
     skeleton_layer_softplus(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_softplus_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_softplus(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_softplus_gcc7(cluster, exes, dirname):
     skeleton_layer_softplus(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_softplus_intel18(cluster, exes, dirname):
-    skeleton_layer_softplus(cluster, exes, dirname, 'intel18')
+def test_unit_layer_softplus_intel19(cluster, exes, dirname):
+    skeleton_layer_softplus(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_softplus.py -k 'test_unit_layer_softplus_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_softsign.py
+++ b/bamboo/unit_tests/test_unit_layer_softsign.py
@@ -27,16 +27,16 @@ def test_unit_layer_softsign_clang4(cluster, exes, dirname):
     skeleton_layer_softsign(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_softsign_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_softsign_gcc7(cluster, exes, dirname):
     skeleton_layer_softsign(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_softsign_intel18(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'intel18')
+def test_unit_layer_softsign_intel19(cluster, exes, dirname):
+    skeleton_layer_softsign(cluster, exes, dirname, 'intel19')
+
+
+def test_unit_layer_softsign_intel19(cluster, exes, dirname):
+    skeleton_layer_softsign(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_softsign.py -k 'test_unit_layer_softsign_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_squared_difference.py
+++ b/bamboo/unit_tests/test_unit_layer_squared_difference.py
@@ -27,16 +27,12 @@ def test_unit_layer_squared_difference_clang4(cluster, exes, dirname):
     skeleton_layer_squared_difference(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_squared_difference_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_squared_difference_gcc7(cluster, exes, dirname):
     skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_squared_difference_intel18(cluster, exes, dirname):
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'intel18')
+def test_unit_layer_squared_difference_intel19(cluster, exes, dirname):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_squared_difference.py -k 'test_unit_layer_squared_difference_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_tessellate.py
+++ b/bamboo/unit_tests/test_unit_layer_tessellate.py
@@ -27,16 +27,12 @@ def test_unit_layer_tessellate_clang4(cluster, exes, dirname):
     skeleton_layer_tessellate(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_tessellate_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_tessellate(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_tessellate_gcc7(cluster, exes, dirname):
     skeleton_layer_tessellate(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_tessellate_intel18(cluster, exes, dirname):
-    skeleton_layer_tessellate(cluster, exes, dirname, 'intel18')
+def test_unit_layer_tessellate_intel19(cluster, exes, dirname):
+    skeleton_layer_tessellate(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_layer_tessellate.py -k 'test_unit_layer_tessellate_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_layer_variance.py
+++ b/bamboo/unit_tests/test_unit_layer_variance.py
@@ -27,16 +27,12 @@ def test_unit_layer_variance_clang4(cluster, exes, dirname):
     skeleton_layer_variance(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_layer_variance_gcc4_check(cluster, exes, dirname):
-    skeleton_layer_variance(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_layer_variance_gcc7(cluster, exes, dirname):
     skeleton_layer_variance(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_layer_variance_intel18(cluster, exes, dirname):
-    skeleton_layer_variance(cluster, exes, dirname, 'intel18')
+def test_unit_layer_variance_intel19(cluster, exes, dirname):
+    skeleton_layer_variance(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_variance_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -124,18 +124,14 @@ def test_unit_lbann2_reload_clang4(cluster, exes, dirname):
     skeleton_lbann2_reload(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_lbann2_reload_gcc4(cluster, exes, dirname):
-  skeleton_lbann2_reload(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_lbann2_reload_gcc7(cluster, exes, dirname):
     if cluster in ['catalyst', 'pascal']:  # STILL ERRORS
         pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_lbann2_reload_intel18(cluster, exes, dirname):
-    skeleton_lbann2_reload(cluster, exes, dirname, 'intel18')
+def test_unit_lbann2_reload_intel19(cluster, exes, dirname):
+    skeleton_lbann2_reload(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_lbann_invocation.py
+++ b/bamboo/unit_tests/test_unit_lbann_invocation.py
@@ -4,7 +4,7 @@ import tools
 import os, sys
 
 def test_unit_no_params_bad(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with no params; lbann should throw exception\n')
     command = tools.get_command(
         cluster=cluster, executable=exe, exit_after_setup=True)
@@ -13,7 +13,7 @@ def test_unit_no_params_bad(cluster, exes):
 
 
 def test_unit_one_model_bad(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with no optimizer or reader; lbann should throw exception\n')
     model_path = 'prototext/model_mnist_simple_1.prototext'
     command = tools.get_command(
@@ -24,7 +24,7 @@ def test_unit_one_model_bad(cluster, exes):
 
 
 def test_unit_two_models_bad(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with two models but no optimizer or reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -35,7 +35,7 @@ def test_unit_two_models_bad(cluster, exes):
 
 
 def test_unit_two_models_bad2(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with two models with missing {; lbann should throw exception\n')
     model_path='prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -46,7 +46,7 @@ def test_unit_two_models_bad2(cluster, exes):
 
 
 def test_unit_missing_optimizer(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with two models, reader, but no optimizer; lbann should throw exception\n')
     model_path='{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path='prototext/data_reader_mnist.prototext'
@@ -59,7 +59,7 @@ def test_unit_missing_optimizer(cluster, exes):
 
 
 def test_unit_missing_reader(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with two models, reader, but no reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     optimizer_path = 'prototext/opt_sgd.prototext'
@@ -71,7 +71,7 @@ def test_unit_missing_reader(cluster, exes):
 
 
 def test_unit_bad_params(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with ill-formed param (missing -) lbann should throw exception\n')
     (command_allocate, command_run, _, _) = tools.get_command(cluster=cluster, executable=exe, return_tuple=True)
     return_code = os.system('%s%s %s -exit_after_setup --reader=prototext/data_reader_mnist.prototext --model={prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext} --optimizer=prototext/opt_sgd.prototext' % (command_allocate, command_run, exe))
@@ -79,7 +79,7 @@ def test_unit_bad_params(cluster, exes):
 
 
 def test_unit_should_work(cluster, exes):
-    exe = exes['gcc4']
+    exe = exes['gcc7']
     sys.stderr.write('TESTING: run lbann with two models, reader, and optimizer; lbann should NOT throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path = 'prototext/data_reader_mnist.prototext'

--- a/bamboo/unit_tests/test_unit_mnist_conv_graph.py
+++ b/bamboo/unit_tests/test_unit_mnist_conv_graph.py
@@ -34,16 +34,12 @@ def test_unit_mnist_conv_graph_clang4(cluster, exes, dirname):
     skeleton_mnist_conv_graph(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_mnist_conv_graph_gcc4(cluster, exes, dirname):
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_mnist_conv_graph_gcc7(cluster, exes, dirname):
     skeleton_mnist_conv_graph(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_mnist_conv_graph_intel18(cluster, exes, dirname):
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'intel18')
+def test_unit_mnist_conv_graph_intel19(cluster, exes, dirname):
+    skeleton_mnist_conv_graph(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_conv_graph.py -k 'test_unit_mnist_conv_graph_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
+++ b/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
@@ -28,16 +28,12 @@ def test_unit_mnist_ridge_regression_clang4(cluster, exes, dirname):
     skeleton_mnist_ridge_regression(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_mnist_ridge_regression_gcc4(cluster, exes, dirname):
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_mnist_ridge_regression_gcc7(cluster, exes, dirname):
     skeleton_mnist_ridge_regression(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_mnist_ridge_regression_intel18(cluster, exes, dirname):
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'intel18')
+def test_unit_mnist_ridge_regression_intel19(cluster, exes, dirname):
+    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_mnist_ridge_regression_exe' --exe=<executable>

--- a/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
+++ b/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
@@ -28,16 +28,12 @@ def test_unit_mnist_softmax_classifier_clang4(cluster, exes, dirname):
     skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'clang4')
 
 
-def test_unit_mnist_softmax_classifier_gcc4(cluster, exes, dirname):
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'gcc4')
-
-
 def test_unit_mnist_softmax_classifier_gcc7(cluster, exes, dirname):
     skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'gcc7')
 
 
-def test_unit_mnist_softmax_classifier_intel18(cluster, exes, dirname):
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'intel18')
+def test_unit_mnist_softmax_classifier_intel19(cluster, exes, dirname):
+    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'intel19')
 
 
 # Run with python -m pytest -s test_unit_softmax_classifier.py -k 'test_unit_mnist_softmax_classifier_exe' --exe=<executable>

--- a/docs/continuous_integration.rst
+++ b/docs/continuous_integration.rst
@@ -155,11 +155,7 @@ Bamboo agent properties are used to specify requirements for each job.
 +--------------------------------+-------------+--------------+----------+------------------+---------------------+
 | Pascal Agents (x86_gpu_pascal) | lbannusr    | x86_64       | pascal   | pascal           | chaos_6_x86_64_ib   |
 +--------------------------------+-------------+--------------+----------+------------------+---------------------+
-| Quartz Agents (x86_cpu)        | lbannusr    | x86_64       | quartz   | none	            | toss_3_x86_64_ib    |
-+--------------------------------+-------------+--------------+----------+------------------+---------------------+
 | Ray Agents (ppc64le_gpu)       | lbannusr    | ppc64_le     | ray      | pascal           | blueos_3_ppc64le_ib |
-+--------------------------------+-------------+--------------+----------+------------------+---------------------+
-| Surface Agents (x86_gpu)       | lbannusr    | x86_64       | surface  | kepler           | chaos_5_x86_64_ib   |
 +--------------------------------+-------------+--------------+----------+------------------+---------------------+
 
 Currently, "agent_owner", "architecture", and "gpu_architecture" are used to


### PR DESCRIPTION
Cleaned up testing code:
- Cleaned up spacing.
- Factored out common parameters in `test_tools.py`.
- Added assertions to error tests in `test_tools.py` to make sure we enter the `except` blocks.
- Updated `time_limit` handling in `tools.py`.
- Removed references to surface or quartz (including from the documentation).
- Removed references to gcc4.
- Replaced references to intel18 with intel19.
- Updated `integration_tests/conftest.py` by adding `debug_build` option and removing the `log` option.
- Updated `test_integration_debug.py` by changing if-statement logic and adding `should_log` option.