### PR TITLE
Beta distributions

### DIFF
--- a/include/lbann/utils/beta.hpp
+++ b/include/lbann/utils/beta.hpp
@@ -1,0 +1,220 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_BETA_HPP
+#define LBANN_UTILS_BETA_HPP
+
+#include <random>
+#include <ostream>
+#include <istream>
+#include <cmath>
+
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+
+/**
+ * Produces random floating point values drawn from a Beta distribution with
+ * parameters a > 0 and b > 0.
+ * See:
+ *     https://en.wikipedia.org/wiki/Beta_distribution
+ * for more details.
+ */
+template <typename RealType = double>
+class beta_distribution {
+public:
+  using result_type = RealType;
+
+  class param_type {
+  public:
+    using distribution_type = beta_distribution;
+
+    explicit param_type(RealType a, RealType b) :
+      m_a(a), m_b(b) {}
+
+    RealType a() const { return m_a; }
+    RealType b() const { return m_b; }
+
+    bool operator==(const param_type& other) const {
+      return m_a == other.m_a && m_b == other.m_b;
+    }
+    bool operator!=(const param_type& other) const {
+      return m_a != other.m_a || m_b != other.m_b;
+    }
+  private:
+    RealType m_a, m_b;
+  };
+
+  explicit beta_distribution(RealType a, RealType b) :
+    m_params(a, b), m_gamma_a(a), m_gamma_b(b) {}
+  explicit beta_distribution(const param_type& p) :
+    m_params(p), m_gamma_a(p.a()), m_gamma_b(p.b()) {}
+
+  result_type a() const { return m_params.a(); }
+  result_type b() const { return m_params.b(); }
+
+  void reset() {}
+
+  param_type param() const { return m_params; }
+  void param(const param_type& p) {
+    m_params = p;
+    m_gamma_a = gamma_dist(p.a());
+    m_gamma_b = gamma_dist(p.b());
+  }
+
+  template <typename Generator>
+  result_type operator()(Generator& g) {
+    return generate(g);
+  }
+  template <typename Generator>
+  result_type operator()(Generator& g, const param_type& p) {
+    return generate(g, p);
+  }
+
+  result_type min() const { return result_type(0); }
+  result_type max() const { return result_type(1); }
+
+  bool operator==(const beta_distribution<result_type>& other) const {
+    return param() == other.param();
+  }
+  bool operator!=(const beta_distribution<result_type>& other) const {
+    return param() != other.param();
+  }
+
+private:
+  param_type m_params;
+
+  using gamma_dist = std::gamma_distribution<RealType>;
+  gamma_dist m_gamma_a, m_gamma_b;
+
+  // Generator for when we use the distribution's parameters.
+  template <typename Generator>
+  result_type generate(Generator& g) {
+    if (a() <= result_type(1) && b() <= result_type(1)) {
+      return generate_johnk(g, m_params.a(), m_params.b());
+    } else {
+      return generate_gamma(g, m_gamma_a, m_gamma_b);
+    }
+  }
+  // Generator for when we use specified parameters.
+  template <typename Generator>
+  result_type generate(Generator& g, const param_type& p) {
+    if (p.a() <= result_type(1) && p.b() <= result_type(1)) {
+      return generate_johnk(p.a(), p.b());
+    } else {
+      gamma_dist gamma_a(p.a()), gamma_b(p.b());
+      return generate_gamma(g, gamma_a, gamma_b);
+    }
+  }
+
+  /**
+   * Generate Beta-distributed values using Johnk's algorithm.
+   * This is a rejection-sampling algorithm that only needs a few
+   * uniformly random values.
+   * 
+   * See:
+   *     Johnk, H. D. "Erzeugung von betaverteilten und gammaverteilten
+   *     Zufallszahlen." Metrika 8, no. 1 (1964).
+   * For an English-language presentation, see:
+   *     Atkinson, A. C. and M. C. Pearce. "The computer generation of beta,
+   *     gamma and normal random variables." Journal of the Royal Statistical
+   *     Society: Series A (General) 139, no. 4 (1976).
+   *
+   * This includes fixes for numerical stability when the parameters are small,
+   * see:
+   *     https://github.com/numpy/numpy/issues/5851
+   * for discussion there; and a catch for the (extremely rare) case of the RNG
+   * giving us U and V both exactly 0.
+   *
+   * Note: There should be an umlaut on the "o" in "Johnk", but blame poor
+   * unicode support.
+   */
+  template <typename Generator>
+  result_type generate_johnk(Generator& g, result_type a, result_type b) {
+    while (true) {
+      const result_type U = fast_random_uniform<result_type>(g);
+      const result_type V = fast_random_uniform<result_type>(g);
+      const result_type X = std::pow(U, result_type(1) / a);
+      const result_type Y = std::pow(V, result_type(1) / b);
+      const result_type XplusY = X + Y;
+      if (XplusY <= result_type(1.0)) {
+        if (XplusY > result_type(0)) {
+          return X / XplusY;
+        } else if (U != result_type(0) && V != result_type(0)) {
+          // Work with logs instead if a/b is too small.
+          result_type logX = std::log(U) / a;
+          result_type logY = std::log(V) / b;
+          const result_type log_max = std::max(logX, logY);
+          logX -= log_max;
+          logY -= log_max;
+          return std::exp(logX - std::log(std::exp(logX) + std::exp(logY)));
+        }
+      }
+    }
+  }
+
+  /**
+   * Generate Beta-distributed values based on Gamma distributions.
+   * See:
+   *     https://en.wikipedia.org/wiki/Beta_distribution#Generating_beta-distributed_random_variates
+   * for details.
+   */
+  template <typename Generator>
+  result_type generate_gamma(Generator& g, gamma_dist& gamma_a,
+                             gamma_dist& gamma_b) {
+    const result_type Ga = gamma_a(g);
+    const result_type Gb = gamma_b(g);
+    return Ga / (Ga + Gb);
+  }
+};
+
+template <typename CharT, typename RealType>
+std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os,
+                                      const beta_distribution<RealType>& d) {
+  os << "~Beta(" << d.a() << "," << d.b() << ")";
+  return os;
+}
+
+template <typename CharT, typename RealType>
+std::basic_istream<CharT>& operator<<(std::basic_istream<CharT>& is,
+                                      beta_distribution<RealType>& d) {
+  std::string s;
+  RealType a, b;
+  if (std::getline(is, s, '(') && s == "~Beta"
+      && is >> a
+      && is.get() == ','
+      && is >> b
+      && is.get() == ')') {
+    d = beta_distribution<RealType>(a, b);
+  } else {
+    is.setstate(std::ios::failbit);
+  }
+  return is;
+}
+
+}  // namespace lbann
+
+#endif  // LBANN_UTILS_BETA_HPP

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -113,6 +113,86 @@ inline T fast_rand_int_pow2(Generator& g, T max) {
   return x & ((typename Generator::result_type) max);
 }
 
+// Methods for quickly generating uniformly random values in [0, 1).
+
+namespace details {
+
+// See section on converting uint64_ts to doubles in:
+// http://xoshiro.di.unimi.it/
+
+template <typename Generator>
+inline float random_float_32(Generator& g) {
+  const uint32_t r = g() >> 9;
+  return r * (1.0f / 8388608.0f);
+}
+
+template <typename Generator>
+inline float random_float_64(Generator& g) {
+  const uint32_t r = uint32_t(g()) >> 9;  // Truncate.
+  return r * (1.0f / 8388608.0f);
+}
+
+template <typename Generator>
+inline float random_float(Generator& g) {
+  // TODO: Replace with if constexpr when possible.
+  if (sizeof(typename Generator::result_type) == 4) {
+    return random_float_32(g);
+  } else if (sizeof(typename Generator::result_type) == 8) {
+    return random_float_64(g);
+  } else {
+    LBANN_ERROR("Unsupported generator type");
+  }
+}
+
+template <typename Generator>
+inline double random_double_32(Generator& g) {
+  const uint32_t r1 = g() >> 5;
+  const uint32_t r2 = g() >> 6;
+  return (r1 * 67108864.0 + r2) * (1.0 / 9007199254740992.0);
+}
+
+template <typename Generator>
+inline double random_double_64(Generator& g) {
+  const uint64_t r = g() >> 11;
+  return r * (1.0 / 9007199254740992.0);
+}
+
+template <typename Generator>
+inline double random_double(Generator& g) {
+  // TODO: Replace with if constexpr when possible.
+  if (sizeof(typename Generator::result_type) == 4) {
+    return random_double_32(g);
+  } else if (sizeof(typename Generator::result_type) == 8) {
+    return random_double_64(g);
+  } else {
+    LBANN_ERROR("Unsupported generator type");
+  }
+}
+
+template <typename Generator, typename T>
+struct random_uniform_impl {
+  static T generate(Generator&);
+};
+template <typename Generator>
+struct random_uniform_impl<Generator, float> {
+  static float generate(Generator& g) { return random_float(g); }
+};
+template <typename Generator>
+struct random_uniform_impl<Generator, double> {
+  static float generate(Generator& g) { return random_double(g); }
+};
+
+}  // namespace details
+
+/** Generate uniformly random values in the range (0, 1]. */
+template <typename T, typename Generator>
+inline T fast_random_uniform(Generator& g) {
+  static_assert(sizeof(typename Generator::result_type) == 4 ||
+                sizeof(typename Generator::result_type) == 8,
+                "Invalid generator result_type.");
+  return details::random_uniform_impl<Generator, T>::generate(g);
+}
+
 /** @brief Initialize the random number generator (with optional seed).
  *
  *  @param seed Seed value for the random number generator

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -121,27 +121,9 @@ namespace details {
 // http://xoshiro.di.unimi.it/
 
 template <typename Generator>
-inline float random_float_32(Generator& g) {
-  const uint32_t r = g() >> 9;
-  return r * (1.0f / 8388608.0f);
-}
-
-template <typename Generator>
-inline float random_float_64(Generator& g) {
-  const uint32_t r = uint32_t(g()) >> 9;  // Truncate.
-  return r * (1.0f / 8388608.0f);
-}
-
-template <typename Generator>
 inline float random_float(Generator& g) {
-  // TODO: Replace with if constexpr when possible.
-  if (sizeof(typename Generator::result_type) == 4) {
-    return random_float_32(g);
-  } else if (sizeof(typename Generator::result_type) == 8) {
-    return random_float_64(g);
-  } else {
-    LBANN_ERROR("Unsupported generator type");
-  }
+  const uint32_t r = uint32_t(g()) >> 9;  // Truncate if needed.
+  return r * (1.0f / 8388608.0f);
 }
 
 template <typename Generator>
@@ -184,7 +166,7 @@ struct random_uniform_impl<Generator, double> {
 
 }  // namespace details
 
-/** Generate uniformly random values in the range (0, 1]. */
+/** Generate uniformly random values in the range [0, 1). */
 template <typename T, typename Generator>
 inline T fast_random_uniform(Generator& g) {
   static_assert(sizeof(typename Generator::result_type) == 4 ||

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set_full_path(_DIR_LBANN_CATCH2_TEST_FILES
   any_test.cpp
+  beta_distribution_test.cpp
   factory_test.cpp
   image_test.cpp
   random_test.cpp

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -2,6 +2,7 @@ set_full_path(_DIR_LBANN_CATCH2_TEST_FILES
   any_test.cpp
   factory_test.cpp
   image_test.cpp
+  random_test.cpp
   type_erased_matrix_test.cpp
   )
 

--- a/src/utils/unit_test/beta_distribution_test.cpp
+++ b/src/utils/unit_test/beta_distribution_test.cpp
@@ -1,0 +1,46 @@
+// MUST include this
+#include <catch2/catch.hpp>
+
+// File being tested
+#include <lbann/utils/beta.hpp>
+
+#include <cmath>
+
+constexpr size_t num_tests = 1000;
+
+template <typename RealType, typename Generator>
+void test_dist(Generator& g, RealType a, RealType b) {
+  lbann::beta_distribution<RealType> dist(a, b);
+  for (size_t i = 0; i < num_tests; ++i) {
+    RealType val = dist(g);
+    REQUIRE(std::isfinite(val));
+    REQUIRE(val >= RealType(0));
+    REQUIRE(val <= RealType(1));
+  }
+}
+
+TEST_CASE("Testing beta_distribution", "[random][utilities]") {
+  std::mt19937 gen;
+  SECTION("float") {
+    SECTION("a=0.5 b=0.5") {
+      test_dist<float>(gen, 0.5f, 0.5f);
+    }
+    SECTION("a=0.001 b=0.001") {
+      test_dist<float>(gen, 0.001f, 0.001f);
+    }
+    SECTION("a=1.5 b=1.5") {
+      test_dist<float>(gen, 1.5f, 1.5f);
+    }
+  }
+  SECTION("double") {
+    SECTION("a=0.5 b=0.5") {
+      test_dist<double>(gen, 0.5, 0.5);
+    }
+    SECTION("a=0.001 b=0.001") {
+      test_dist<double>(gen, 0.001, 0.001);
+    }
+    SECTION("a=1.5 b=1.5") {
+      test_dist<double>(gen, 1.5, 1.5);
+    }
+  }
+}

--- a/src/utils/unit_test/random_test.cpp
+++ b/src/utils/unit_test/random_test.cpp
@@ -13,7 +13,7 @@ TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
       for (size_t i = 0; i < num_tests; ++i) {
         float val = lbann::fast_random_uniform<float>(gen);
         REQUIRE(val >= 0.0f);
-        REQUIRE(val <= 1.0f);
+        REQUIRE(val < 1.0f);
       }
     }
 
@@ -21,7 +21,7 @@ TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
       for (size_t i = 0; i < num_tests; ++i) {
         double val = lbann::fast_random_uniform<double>(gen);
         REQUIRE(val >= 0.0);
-        REQUIRE(val <= 1.0);
+        REQUIRE(val < 1.0);
       }
     }
   }
@@ -31,7 +31,7 @@ TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
       for (size_t i = 0; i < num_tests; ++i) {
         float val = lbann::fast_random_uniform<float>(gen);
         REQUIRE(val >= 0.0f);
-        REQUIRE(val <= 1.0f);
+        REQUIRE(val < 1.0f);
       }
     }
 
@@ -39,7 +39,7 @@ TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
       for (size_t i = 0; i < num_tests; ++i) {
         double val = lbann::fast_random_uniform<double>(gen);
         REQUIRE(val >= 0.0);
-        REQUIRE(val <= 1.0);
+        REQUIRE(val < 1.0);
       }
     }
   }

--- a/src/utils/unit_test/random_test.cpp
+++ b/src/utils/unit_test/random_test.cpp
@@ -1,0 +1,46 @@
+// MUST include this
+#include <catch2/catch.hpp>
+
+// File being tested
+#include <lbann/utils/random.hpp>
+
+constexpr size_t num_tests = 1000;
+
+TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
+  SECTION("32-bit generator") {
+    std::mt19937 gen;
+    SECTION("floats") {
+      for (size_t i = 0; i < num_tests; ++i) {
+        float val = lbann::fast_random_uniform<float>(gen);
+        REQUIRE(val >= 0.0f);
+        REQUIRE(val <= 1.0f);
+      }
+    }
+
+    SECTION("doubles") {
+      for (size_t i = 0; i < num_tests; ++i) {
+        double val = lbann::fast_random_uniform<double>(gen);
+        REQUIRE(val >= 0.0);
+        REQUIRE(val <= 1.0);
+      }
+    }
+  }
+  SECTION("64-bit generator") {
+    std::mt19937_64 gen;
+    SECTION("floats") {
+      for (size_t i = 0; i < num_tests; ++i) {
+        float val = lbann::fast_random_uniform<float>(gen);
+        REQUIRE(val >= 0.0f);
+        REQUIRE(val <= 1.0f);
+      }
+    }
+
+    SECTION("doubles") {
+      for (size_t i = 0; i < num_tests; ++i) {
+        double val = lbann::fast_random_uniform<double>(gen);
+        REQUIRE(val >= 0.0);
+        REQUIRE(val <= 1.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
(Note: This depends on #1046.)

This adds a [`RandomNumberDistribution`](https://en.cppreference.com/w/cpp/named_req/RandomNumberDistribution)-compatible implementation of the Beta distribution. This will be needed for Mixup.

This uses two algorithms to generate values from the Beta distribution, depending on the distribution parameters. When `a <= 1 && b <= 1`, it uses Jöhnk's algorithm, or a variant of that using logarithms for more stability when `a` or `b` are small (adapted from the NumPy implementation). Otherwise, it generates them from the Gamma distribution (which is slower).

I would most like comments on the `fast_random_uniform` implementation in `random.hpp`, and the `generate` implementations in `beta.hpp`.