### PR TITLE
Cutout preprocessing

### DIFF
--- a/include/lbann/transforms/vision/CMakeLists.txt
+++ b/include/lbann/transforms/vision/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_HEADERS
   center_crop.hpp
   colorize.hpp
   color_jitter.hpp
+  cutout.hpp
   grayscale.hpp
   horizontal_flip.hpp
   normalize_to_lbann_layout.hpp

--- a/include/lbann/transforms/vision/cutout.hpp
+++ b/include/lbann/transforms/vision/cutout.hpp
@@ -34,7 +34,9 @@ namespace transform {
 
 /**
  * Cutout data augmentation which randomly masks out square regions of input.
+ * 
  * See:
+ * 
  *     DeVries and Taylor. "Improved Regularization of Convolutional Neural
  *     Networks with Cutout". arXiv preprint arXiv:1708.04552 (2017).
  *

--- a/include/lbann/transforms/vision/cutout.hpp
+++ b/include/lbann/transforms/vision/cutout.hpp
@@ -51,7 +51,7 @@ public:
   /**
    * Cutout with a given number of squares of a given size.
    * @param num_holes Number of squares to mask out (must be positive).
-   * @param size Length of a side of the square (must be positive).
+   * @param length Length of a side of the square (must be positive).
    */
   cutout(size_t num_holes, size_t length) :
     transform(), m_num_holes(num_holes), m_length(length) {

--- a/include/lbann/transforms/vision/cutout.hpp
+++ b/include/lbann/transforms/vision/cutout.hpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_TRANSFORMS_CUTOUT_HPP_INCLUDED
+#define LBANN_TRANSFORMS_CUTOUT_HPP_INCLUDED
+
+#include "lbann/transforms/transform.hpp"
+
+namespace lbann {
+namespace transform {
+
+/**
+ * Cutout data augmentation which randomly masks out square regions of input.
+ * See:
+ *     DeVries and Taylor. "Improved Regularization of Convolutional Neural
+ *     Networks with Cutout". arXiv preprint arXiv:1708.04552 (2017).
+ *
+ * This will randomly select a center pixel for each square and set all pixels
+ * within that square to 0. It is permissible for portions of the masks to lie
+ * outside of the image.
+ *
+ * Normalization about 0 should be applied after applying cutout.
+ */
+class cutout : public transform {
+public:
+  /**
+   * Cutout with a given number of squares of a given size.
+   * @param num_holes Number of squares to mask out (must be positive).
+   * @param size Length of a side of the square (must be positive).
+   */
+  cutout(size_t num_holes, size_t length) :
+    transform(), m_num_holes(num_holes), m_length(length) {
+    if (num_holes == 0) {
+      LBANN_ERROR("num_holes must be positive, got 0");
+    }
+    if (length == 0) {
+      LBANN_ERROR("length must be positive, got 0");
+    }
+  }
+
+  transform* copy() const override { return new cutout(*this); }
+
+  std::string get_type() const override { return "cutout"; }
+
+  void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
+
+private:
+  /** Number of squares that will be masked out. */
+  size_t m_num_holes;
+  /** Length of a side of each square that will be masked out. */
+  size_t m_length;
+};
+
+}  // namespace transform
+}  // namespace lbann
+
+#endif  // LBANN_TRANSFORMS_CUTOUT_HPP_INCLUDED

--- a/src/proto/factories/transform_factory.cpp
+++ b/src/proto/factories/transform_factory.cpp
@@ -34,6 +34,7 @@
 #include "lbann/transforms/vision/center_crop.hpp"
 #include "lbann/transforms/vision/colorize.hpp"
 #include "lbann/transforms/vision/color_jitter.hpp"
+#include "lbann/transforms/vision/cutout.hpp"
 #include "lbann/transforms/vision/grayscale.hpp"
 #include "lbann/transforms/vision/horizontal_flip.hpp"
 #include "lbann/transforms/vision/normalize_to_lbann_layout.hpp"
@@ -133,6 +134,10 @@ std::unique_ptr<transform::transform> construct_transform(
       pb_trans.min_brightness_factor(), pb_trans.max_brightness_factor(),
       pb_trans.min_contrast_factor(), pb_trans.max_contrast_factor(),
       pb_trans.min_saturation_factor(), pb_trans.max_saturation_factor());
+  } else if (trans.has_cutout()) {
+    auto& pb_trans = trans.cutout();
+    return make_unique<transform::cutout>(
+      pb_trans.num_holes(), pb_trans.length());
   }
 
   LBANN_ERROR("Unknown transform");

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -129,6 +129,11 @@ message Transform {
     float min_saturation_factor = 5;
     float max_saturation_factor = 6;
   }
+  // Apply cutout augmentation.
+  message Cutout {
+    uint64 num_holes = 1;
+    uint64 length = 2;
+  }
   // Convert to grayscale.
   message Grayscale {}
   // Horizontal flip with probability p.
@@ -215,6 +220,7 @@ message Transform {
     AdjustContrast adjust_contrast = 114;
     AdjustSaturation adjust_saturation = 115;
     ColorJitter color_jitter = 116;
+    Cutout cutout = 117;
   }
 }
 

--- a/src/transforms/vision/CMakeLists.txt
+++ b/src/transforms/vision/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
   center_crop.cpp
   colorize.cpp
   color_jitter.cpp
+  cutout.cpp
   grayscale.cpp
   horizontal_flip.cpp
   normalize_to_lbann_layout.cpp

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/transforms/vision/cutout.hpp"
+#include "lbann/utils/opencv.hpp"
+
+namespace lbann {
+namespace transform {
+
+void cutout::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
+  cv::Mat src = utils::get_opencv_mat(data, dims);
+  for (size_t i = 0; i < m_num_holes; ++i) {
+    // Select the center of the hole.
+    const ssize_t center_x = transform::get_uniform_random_int(0, dims[2]);
+    const ssize_t center_y = transform::get_uniform_random_int(0, dims[1]);
+    // Compute top-left corner and bottom-right corners of the hole.
+    const ssize_t length = static_cast<ssize_t>(m_length);
+    const size_t x1 = std::max(center_x - length / 2, 0l);
+    const size_t x2 = std::min(center_x + length / 2,
+                               static_cast<ssize_t>(dims[2]) - 1);
+    const size_t y1 = std::max(center_y - length / 2, 0l);
+    const size_t y2 = std::min(center_y + length / 2,
+                               static_cast<ssize_t>(dims[1]) - 1);
+    // Convert to height/width.
+    const size_t h = y2 - y1;
+    const size_t w = x2 - x1;
+    // Sanity check.
+    if (x1 >= static_cast<size_t>(src.cols) ||
+        y1 >= static_cast<size_t>(src.rows) ||
+        (x1 + w) > static_cast<size_t>(src.cols) ||
+        (y1 + h) > static_cast<size_t>(src.rows)) {
+      std::stringstream ss;
+      ss << "Bad hole dimensions for " << src.rows << "x" << src.cols << ": "
+         << h << "x" << w << " at (" << x1 << "," << y1 << ")";
+      LBANN_ERROR(ss.str());
+    }
+    std::cout << "Cutout: " << x1 << " " << y1 << " " << w << " " << h << std::endl;
+    // This will be just a view into the original.
+    cv::Mat hole = src(cv::Rect(x1, y1, w, h));
+    hole = 0;
+  }
+}
+
+}  // namespace transform
+}  // namespace lbann

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -41,8 +41,8 @@ void cutout::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
     const size_t x1 = std::max(center_x - length / 2, 0);
     const size_t x2 = std::min(x1 + length,
                                static_cast<ssize_t>(dims[2]) - 1);
-    const size_t y1 = std::max(center_y - length / 2, 0l);
-    const size_t y2 = std::min(center_y + length / 2,
+    const size_t y1 = std::max(center_y - length / 2, 0);
+    const size_t y2 = std::min(y1 + length,
                                static_cast<ssize_t>(dims[1]) - 1);
     // Convert to height/width.
     const size_t h = y2 - y1;

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -38,8 +38,8 @@ void cutout::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
     const ssize_t center_y = transform::get_uniform_random_int(0, dims[1]);
     // Compute top-left corner and bottom-right corners of the hole.
     const ssize_t length = static_cast<ssize_t>(m_length);
-    const size_t x1 = std::max(center_x - length / 2, 0l);
-    const size_t x2 = std::min(center_x + length / 2,
+    const size_t x1 = std::max(center_x - length / 2, 0);
+    const size_t x2 = std::min(x1 + length,
                                static_cast<ssize_t>(dims[2]) - 1);
     const size_t y1 = std::max(center_y - length / 2, 0l);
     const size_t y2 = std::min(center_y + length / 2,

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -57,7 +57,6 @@ void cutout::apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) {
          << h << "x" << w << " at (" << x1 << "," << y1 << ")";
       LBANN_ERROR(ss.str());
     }
-    std::cout << "Cutout: " << x1 << " " << y1 << " " << w << " " << h << std::endl;
     // This will be just a view into the original.
     cv::Mat hole = src(cv::Rect(x1, y1, w, h));
     hole = 0;


### PR DESCRIPTION
Note: This depends on #1046.

This adds support for cutout preprocessing. This is used in many SOTA networks for CIFAR10/100.

I have done basic tests of this, but have not yet trained networks to convergence.