### PR TITLE
Bugfix for model zoo Python scripts

### DIFF
--- a/model_zoo/vision/alexnet.py
+++ b/model_zoo/vision/alexnet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import argparse
-from os.path import dirname, join
+from os.path import abspath, dirname, join
 import google.protobuf.text_format as txtf
 import lbann
 import lbann.models
@@ -8,7 +8,7 @@ import lbann.proto
 import lbann.contrib.args
 
 # Default data reader
-model_zoo_dir = dirname(dirname(__file__))
+model_zoo_dir = dirname(dirname(abspath(__file__)))
 data_reader_prototext = join(model_zoo_dir,
                              'data_readers',
                              'data_reader_imagenet.prototext')

--- a/model_zoo/vision/lenet.py
+++ b/model_zoo/vision/lenet.py
@@ -86,7 +86,7 @@ model = lbann.Model(mini_batch_size,
 opt = lbann.SGD(learn_rate=0.01, momentum=0.9)
 
 # Load data reader from prototext
-model_zoo_dir = os.path.dirname(os.path.dirname(__file__))
+model_zoo_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 data_reader_file = os.path.join(model_zoo_dir,
                                 'data_readers',
                                 'data_reader_mnist.prototext')

--- a/model_zoo/vision/resnet.py
+++ b/model_zoo/vision/resnet.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import argparse
-from os.path import dirname, join
+from os.path import abspath, dirname, join
 import google.protobuf.text_format as txtf
 import lbann
 import lbann.models
@@ -10,7 +10,7 @@ import lbann.contrib.args
 import lbann.contrib.models.wide_resnet
 
 # Default data reader
-model_zoo_dir = dirname(dirname(__file__))
+model_zoo_dir = dirname(dirname(abspath(__file__)))
 data_reader_prototext = join(model_zoo_dir,
                              'data_readers',
                              'data_reader_imagenet.prototext')


### PR DESCRIPTION
We had some issues loading the data reader prototext when the scripts were run from within the `model_zoo` directory. This is fixed by making sure we use absolute paths.