### PR TITLE
Template JAG data reader to use DataType format

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -343,7 +343,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   bool has_conduit_path(const size_t i, const std::string& key) const;
 
   /// Obtain image data
-  std::vector< std::vector<ch_t> > get_image_data(const size_t i, conduit::Node& sample) const;
+  std::vector< std::vector<DataType> > get_image_data(const size_t i, conduit::Node& sample) const;
 
   bool data_store_active() const {
     bool flag = generic_data_reader::data_store_active();

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -1184,9 +1184,9 @@ bool data_reader_jag_conduit::check_non_numeric(const std::string key) {
 }
 
 
-std::vector< std::vector<data_reader_jag_conduit::ch_t> >
+std::vector< std::vector<DataType> >
 data_reader_jag_conduit::get_image_data(const size_t sample_id, conduit::Node& sample) const {
-  std::vector< std::vector<ch_t> > image_ptrs;
+  std::vector< std::vector<DataType> > image_ptrs;
   image_ptrs.reserve(m_emi_image_keys.size());
 
   for (const auto& emi_tag : m_emi_image_keys) {
@@ -1208,6 +1208,7 @@ data_reader_jag_conduit::get_image_data(const size_t sample_id, conduit::Node& s
     conduit_ch_t emi = sample[conduit_obj].value();
     const size_t num_vals = emi.number_of_elements();
     const ch_t* emi_data = sample[conduit_obj].value();
+    // Note that data will be cast from ch_t to DataType format
     image_ptrs.emplace_back(emi_data, emi_data + num_vals);
   }
 
@@ -1325,7 +1326,7 @@ bool data_reader_jag_conduit::fetch(CPUMat& X, int data_id, conduit::Node& sampl
       const size_t image_size = get_linearized_image_size();
       const std::vector<size_t> sizes(num_images, image_size);
       std::vector<CPUMat> X_v = create_datum_views(X, sizes, mb_idx);
-      std::vector< std::vector<ch_t> > img_data(get_image_data(data_id, sample));
+      std::vector< std::vector<DataType> > img_data(get_image_data(data_id, sample));
 
       if (img_data.size() != num_images) {
         _THROW_LBANN_EXCEPTION2_(_CN_, "fetch() : the number of images is not as expected ", \

--- a/src/transforms/repack_HWC_to_CHW_layout.cpp
+++ b/src/transforms/repack_HWC_to_CHW_layout.cpp
@@ -38,7 +38,7 @@ void repack_HWC_to_CHW_layout::apply(utils::type_erased_matrix& data, std::vecto
 
 void repack_HWC_to_CHW_layout::apply(utils::type_erased_matrix& data, CPUMat& out,
                             std::vector<size_t>& dims) {
-  CPUMat &src = data.template get<float>();
+  CPUMat &src = data.template get<DataType>();
   if (!src.Contiguous()) {
     LBANN_ERROR("RepackHWCtoCHWLayout does not support non-contiguous src.");
   }


### PR DESCRIPTION
Updated the JAG data reader and repack transform layer to use DataType
format internally.  The JAG data reader will now cast the images from
ch_t to DataType during ingestion.