### PR TITLE
Mixup preprocessing

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -21,6 +21,7 @@ set_full_path(THIS_DIR_HEADERS
   callback_io.hpp
   callback_learning_rate.hpp
   callback_ltfb.hpp
+  callback_mixup.hpp
   callback_perturb_adam.hpp
   callback_print.hpp
   callback_save_images.hpp

--- a/include/lbann/callbacks/callback_mixup.hpp
+++ b/include/lbann/callbacks/callback_mixup.hpp
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_MIXUP_HPP
+#define LBANN_CALLBACKS_MIXUP_HPP
+
+#include <unordered_set>
+#include <string>
+
+#include "lbann/callbacks/callback.hpp"
+
+namespace lbann {
+
+/**
+ * Apply mixup to named input layers.
+ * See:
+ *     Zhang, H. et al. "mixup: Beyond Empirical Risk Minimization." ICLR, 2018.
+ *
+ * This implementation does mixup within a single batch, per the recommendation
+ * within the paper.
+ * This approach may create duplicate images, and so uses
+ *     lambda = max(lambda, 1 - lambda)
+ * for the mixing value.
+ * This recommendation comes from https://docs.fast.ai/callbacks.mixup.html
+ *
+ * The recommended default alpha (from the paper) is 0.4.
+ */
+class callback_mixup : public lbann_callback {
+public:
+  /** Apply mixup to layers named in layers with mixup parameter alpha. */
+  callback_mixup(std::unordered_set<std::string> layers, float alpha) :
+    lbann_callback(), m_layers(layers), m_alpha(alpha) {
+    if (alpha < 0.0f) {
+      LBANN_ERROR("Mixup alpha must be non-negative.");
+    }
+  }
+
+  callback_mixup* copy() const override { return new callback_mixup(*this); }
+  std::string name() const override { return "mixup"; }
+
+  void on_forward_prop_end(model *m, Layer *l) override;
+
+private:
+  /** Names of input layers to apply mixup to. */
+  std::unordered_set<std::string> m_layers;
+  /** mixup parameter. */
+  float m_alpha;
+};
+
+}  // namespace lbann
+
+#endif  // LBANN_CALLBACKS_MIXUP_HPP

--- a/include/lbann/callbacks/callback_mixup.hpp
+++ b/include/lbann/callbacks/callback_mixup.hpp
@@ -36,14 +36,20 @@ namespace lbann {
 
 /**
  * Apply mixup to named input layers.
+ * 
  * See:
+ * 
  *     Zhang, H. et al. "mixup: Beyond Empirical Risk Minimization." ICLR, 2018.
  *
  * This implementation does mixup within a single batch, per the recommendation
  * within the paper.
+ * 
  * This approach may create duplicate images, and so uses
+ * 
  *     lambda = max(lambda, 1 - lambda)
+ * 
  * for the mixing value.
+ * 
  * This recommendation comes from https://docs.fast.ai/callbacks.mixup.html
  *
  * The recommended default alpha (from the paper) is 0.4.

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -148,6 +148,7 @@
 #include "lbann/callbacks/callback_dump_minibatch_sample_indices.hpp"
 #include "lbann/callbacks/callback_early_stopping.hpp"
 #include "lbann/callbacks/callback_ltfb.hpp"
+#include "lbann/callbacks/callback_mixup.hpp"
 #include "lbann/callbacks/callback_save_images.hpp"
 #include "lbann/callbacks/callback_save_model.hpp"
 #include "lbann/callbacks/callback_save_topk_models.hpp"

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -20,6 +20,7 @@ set_full_path(THIS_DIR_SOURCES
   callback_io.cpp
   callback_learning_rate.cpp
   callback_ltfb.cpp
+  callback_mixup.cpp
   callback_perturb_adam.cpp
   callback_print.cpp
   callback_save_images.cpp

--- a/src/callbacks/callback_mixup.cpp
+++ b/src/callbacks/callback_mixup.cpp
@@ -1,0 +1,83 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <algorithm>
+#include "lbann/callbacks/callback_mixup.hpp"
+#include "lbann/utils/beta.hpp"
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/image.hpp"
+
+namespace lbann {
+
+void callback_mixup::on_forward_prop_end(model *m, Layer *l) {
+  if (!m_layers.count(l->get_name())) {
+    return;
+  }
+  if (m->get_execution_mode() != execution_mode::training) {
+    return;  // No mixup outside of training.
+  }
+
+  auto& samples = l->get_local_activations(0);
+  auto& targets = l->get_local_activations(1);
+  El::Int mbsize = samples.Width();
+  const El::Int samples_height = samples.Height();
+  const El::Int targets_height = targets.Height();
+  auto& gen = get_fast_generator();
+  beta_distribution<float> dist(m_alpha, m_alpha);
+
+  // For now, data must be on the CPU.
+  if (samples.GetDevice() != El::Device::CPU ||
+      targets.GetDevice() != El::Device::CPU) {
+    LBANN_ERROR("mixup only works with CPU data");
+  }
+
+  // Decide how to mix the mini-batch.
+  std::vector<El::Int> shuffled_indices(mbsize);
+  std::iota(shuffled_indices.begin(), shuffled_indices.end(), 0);
+  std::shuffle(shuffled_indices.begin(), shuffled_indices.end(), gen);
+
+  for (El::Int i = 0; i < mbsize; ++i) {
+    const El::Int j = shuffled_indices[i];
+    if (i == j) {
+      continue;
+    }
+    float lambda = dist(gen);
+    lambda = std::max(lambda, 1.0f - lambda);
+    const float lambda_sub = 1.0f - lambda;
+    DataType* __restrict__ x1_buf = samples.Buffer() + i*samples.LDim();
+    const DataType* __restrict__ x2_buf = samples.LockedBuffer() + j*samples.LDim();
+    DataType* __restrict__ y1_buf = targets.Buffer() + i*targets.LDim();
+    const DataType* __restrict__ y2_buf = targets.LockedBuffer() + j*targets.LDim();
+    for (El::Int k = 0; k < samples_height; ++k) {
+      x1_buf[k] = lambda*x1_buf[k] + lambda_sub*x2_buf[k];
+    }
+    for (El::Int k = 0; k < targets_height; ++k) {
+      y1_buf[k] = lambda*y1_buf[k] + lambda_sub*y2_buf[k];
+    }
+  }
+}
+
+}  // namespace lbann

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -435,6 +435,18 @@ lbann_callback* construct_callback(lbann_comm* comm,
                  params.keep_dropout_factor(),
                  parse_set<std::string>(params.layers()));
   }
+
+  //////////////////////////////////////////////////////////////
+  // Data augmentation
+  //////////////////////////////////////////////////////////////
+  if (proto_cb.has_mixup()) {
+    const auto& params = proto_cb.mixup();
+    const auto& layers_list = parse_list<std::string>(params.layers());
+    std::unordered_set<std::string> layers(layers_list.begin(),
+                                           layers_list.end());
+    return new callback_mixup(layers, params.alpha());
+  }
+
   return nullptr;
 }
 

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -439,6 +439,7 @@ message Callback {
    CallbackPerturbAdam perturb_adam = 38;
    CallbackPerturbDropout perturb_dropout = 39;
    CallbackSaveTopKModels save_topk_models = 40;
+   CallbackMixup mixup = 41;
 }
 
 message CallbackLTFB {
@@ -692,6 +693,12 @@ message CallbackSaveTopKModels {
   string metric = 3; //metrics to use in evaluating models
   bool  ascending_ordering = 4; //whether to sort metrics per model in ascending order, descending order is default
 }
+
+message CallbackMixup {
+  string layers = 1;
+  float alpha = 2;
+}
+
 //========================================================================
 // Weights
 //========================================================================


### PR DESCRIPTION
This re-creates #1071, which fell victim to far too much rewriting of history, rebasing, cherry-picking, force-pushing, and other Things One Should Not Do™.

This adds support for mixup preprocessing, implemented as a callback. @timmoon10 and I discussed the best way to do this, and decided it fit better as a callback, rather than as a layer or transform.

I have done basic tests of this, but have not yet done training to convergence.