### PR TITLE
change a constructor that was causing clang to throw an error

### DIFF
--- a/include/lbann/utils/any.hpp
+++ b/include/lbann/utils/any.hpp
@@ -64,7 +64,7 @@ public:
   ///@{
 
   /** @brief Default construct an empty "any" */
-  any() noexcept = default;
+  any() noexcept {}
 
   /** @brief Construct an object holding a T */
   template <typename T>


### PR DESCRIPTION
The original code is correct; the bug is in clang. It appears fixed in trunk.