### PR TITLE
Moving "check gradients" callback to end of test phase

### DIFF
--- a/include/lbann/callbacks/callback_check_gradients.hpp
+++ b/include/lbann/callbacks/callback_check_gradients.hpp
@@ -31,10 +31,11 @@
 
 namespace lbann {
 
-/** Gradient checking callback.
- *  Gradient checking is performed at the beginning of the test
- *  phase. Using a fourth-order finite difference scheme, a numerical
- *  partial derivative is computed for every weight parameter. If the
+/** @brief Gradient checking callback.
+ *
+ *  Gradient checking is performed at the end of the test phase. Using
+ *  a fourth-order finite difference scheme, a numerical partial
+ *  derivative is computed for every weight parameter. If the
  *  numerical derivative differs signifcantly from the analytical
  *  derivative computed during backprop, the gradient check has
  *  failed.
@@ -42,10 +43,10 @@ namespace lbann {
 class lbann_callback_check_gradients : public lbann_callback {
 public:
 
-  /** Constructor.
+  /**
    *  @param step_size          Step size for numerical
    *                            differentiation (with a step size of
-   *                            zero, the step size is chosen to
+   *                            zero, the step size is estimated to
    *                            minimize the numerical error).
    *  @param verbose            Whether to print results for each
    *                            parameter.
@@ -58,14 +59,8 @@ public:
   lbann_callback_check_gradients* copy() const override {
     return new lbann_callback_check_gradients(*this);
   }
-  void on_test_begin(model *m) override;
+  void on_test_end(model *m) override;
   std::string name() const override { return "check gradients"; }
-
-  /** Compute objective function value.
-   *  It is assumed that input data has already been loaded into the
-   *  activations of the first layer.
-   */
-  DataType compute_objective_function(model *m);
 
 private:
 

--- a/src/callbacks/callback_check_gradients.cpp
+++ b/src/callbacks/callback_check_gradients.cpp
@@ -25,8 +25,35 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/callback_check_gradients.hpp"
+#include "lbann/layers/io/input/generic_input_layer.hpp"
+#include "lbann/data_readers/data_reader.hpp"
 
 namespace lbann {
+
+namespace {
+
+/** @details Forward prop is applied to all layers, except input
+ *  layers. It is assumed that input layers have already loaded data.
+ */
+DataType compute_objective_function(model& m) {
+
+  // Forward prop, skipping input layers
+  for (auto&& l : m.get_layers()) {
+    if (dynamic_cast<generic_input_layer*>(l) == nullptr) {
+      l->forward_prop();
+    }
+  }
+
+  // Get objective function value
+  auto&& obj = m.get_objective_function();
+  const auto mode = m.get_execution_mode();
+  const auto mini_batch_size = m.get_current_mini_batch_size();
+  obj->start_evaluation(mode, mini_batch_size);
+  return obj->finish_evaluation(mode, mini_batch_size);
+
+}
+
+} // namespace
 
 lbann_callback_check_gradients
   ::lbann_callback_check_gradients(DataType step_size,
@@ -36,21 +63,32 @@ lbann_callback_check_gradients
     m_verbose(verbose),
     m_error_on_failure(error_on_failure) {}
 
-void lbann_callback_check_gradients::on_test_begin(model *m) {
+void lbann_callback_check_gradients::on_test_end(model *m) {
 
-  // Get model members
+  // Get objects from model
   lbann_comm *comm = m->get_comm();
-  const std::vector<Layer*>& layers = m->get_layers();
+  auto mode = m->get_execution_mode();
+  const auto& layers = m->get_layers();
 
-  // Initialize network for testing
+  // Reset statistics and gradients
+  m->get_objective_function()->reset_statistics(mode);
+  for (auto&& met : m->get_metrics()) {
+    met->reset_statistics(mode);
+  }
   for (auto&& w : m->get_weights()) {
     auto&& opt = w->get_optimizer();
     if (opt != nullptr) { opt->clear_gradient(); }
   }
-  layers[0]->forward_prop();
+
+  // Load data in input layers
+  for (auto&& l : m->get_layers()) {
+    if (dynamic_cast<generic_input_layer*>(l) != nullptr) {
+      l->forward_prop();
+    }
+  }
 
   // Compute objective function
-  const DataType objective = compute_objective_function(m);
+  const DataType objective = compute_objective_function(*m);
 
   // Choose finite difference step
   // Note: Consider a central difference scheme:
@@ -80,11 +118,11 @@ void lbann_callback_check_gradients::on_test_begin(model *m) {
 
   // Print objective function value
   if (comm->am_world_master()) {
-    std::cout << "--------------------------------------------------------------------------------" << std::endl
-              << "Gradient checking..." << std::endl
-              << "  Objective function value = " << objective << std::endl
-              << "  Step size                = " << step_size << std::endl
-              << "  Expected gradient error  = " << expected_error << std::endl;
+    std::cout << "----------------------------------------------------------------\n"
+              << "Gradient checking...\n"
+              << "  Objective function value = " << objective << "\n"
+              << "  Step size                = " << step_size << "\n"
+              << "  Expected gradient error  = " << expected_error << "\n";
   }
 
   for (weights *w : m->get_weights()) {
@@ -118,13 +156,13 @@ void lbann_callback_check_gradients::on_test_begin(model *m) {
         // Note: matrix entry is reset after computing objective
         // function values
         w->set_value(initial_weight + 2 * step_size, row, col);
-        const DataType f_2h = compute_objective_function(m);
+        const DataType f_2h = compute_objective_function(*m);
         w->set_value(initial_weight + step_size, row, col);
-        const DataType f_h = compute_objective_function(m);
+        const DataType f_h = compute_objective_function(*m);
         w->set_value(initial_weight - step_size, row, col);
-        const DataType f_nh = compute_objective_function(m);
+        const DataType f_nh = compute_objective_function(*m);
         w->set_value(initial_weight - 2 * step_size, row, col);
-        const DataType f_n2h = compute_objective_function(m);
+        const DataType f_n2h = compute_objective_function(*m);
         w->set_value(initial_weight, row, col);
 
         // Compute relative error in gradient.
@@ -168,23 +206,24 @@ void lbann_callback_check_gradients::on_test_begin(model *m) {
     }
 
   }
-
   if (comm->am_world_master()) {
-    std::cout << "--------------------------------------------------------------------------------" << std::endl;
+    std::cout << "----------------------------------------------------------------\n";
+  }
+
+  // Clean up
+  /// @todo tym: I'm not sure if data readers are properly reset
+  for (auto&& l : m->get_layers()) {
+    auto&& input = dynamic_cast<generic_input_layer*>(l);
+    if (input != nullptr) {
+      auto&& reader = input->get_data_reader(mode);
+      reader->set_initial_position();
+    }
+  }
+  m->get_objective_function()->reset_statistics(mode);
+  for (auto&& met : m->get_metrics()) {
+    met->reset_statistics(mode);
   }
 
 }
 
-DataType lbann_callback_check_gradients::compute_objective_function(model *m) {
-  const std::vector<Layer*>& layers = m->get_layers();
-  objective_function* obj_fn = m->get_objective_function();
-  for (size_t l = 1; l < layers.size(); l++) {
-    layers[l]->forward_prop();
-  }
-  obj_fn->start_evaluation(m->get_execution_mode(),
-                           m->get_current_mini_batch_size());
-  return obj_fn->finish_evaluation(m->get_execution_mode(),
-                                   m->get_current_mini_batch_size());
-}
-
-}  // namespace lbann
+} // namespace lbann


### PR DESCRIPTION
### Goal

Lately I've been working on implementing some unit tests for individual layers and the Python data reader (related: PRs #1105 and #1106). I'm particularly interested in using the "check metric" callback to verify correctness of forward prop and the "check gradients" callback to verify backprop. This combination would have allowed our unit tests to catch some errors they had missed before. 

### Problem

The metric checking happens at the end of the test phase and the gradient checking at the beginning. However, there are problems since the gradient checking will load in a mini-batch worth of data in the input layer and repeat forward prop many times to compute numerical gradients. After gradient checking has finished and evaluation on the test set begins, the data reader thinks that the first mini-batch has already completed, so the computed test metrics don't include the first mini-batch. I am also worried that all the forward prop passes from gradient checking could be messing up the metric statistics.

### Solution

As far as I can tell, data readers are automatically reset when they reach the end of an epoch and are immediately ready for a new epoch. Thus, gradient checking should use the same mini-batch of data whether it is performed at the beginning or end of the test phase (assuming samples are not shuffled between epochs). Note that we need to be careful that gradient checking is performed after metric checking, since gradient checking will reset the metrics when it is done. I have a unit test for the slice layer that passes both gradient checking and metric checking, although I am waiting for PR #1105 to see how best to integrate it into Bamboo.