### PR TITLE
Cleanup exception handling

### DIFF
--- a/include/lbann/utils/opencv.hpp
+++ b/include/lbann/utils/opencv.hpp
@@ -38,7 +38,7 @@ namespace utils {
  * Check whether data is an image.
  * Currently requires data to be a uint8_t CPUMat, with 3 dimensions, the first
  * (channel) being 1 or 3.
- * 
+ *
  * @param data The data to check.
  * @param dims The dimensions associated with data.
  */
@@ -48,7 +48,7 @@ inline bool check_is_image(const utils::type_erased_matrix& data,
     // Check if we can do the conversion.
     const auto& unused = data.template get<uint8_t>();
     (void) unused;
-  } catch (utils::bad_any_cast) {
+  } catch (const utils::bad_any_cast&) {
     return false;
   }
   if (dims.size() != 3 || (dims[0] != 1 && dims[0] != 3)) {
@@ -62,7 +62,7 @@ inline bool check_is_image(const utils::type_erased_matrix& data,
  * Currently requires data to be a uint8_t CPUMat, with 3 dimensions, the first
  * (channel) being 1 or 3.
  * Also throws an error if OpenCV is not supported.
- * 
+ *
  * @param data The data to check.
  * @param dims The dimensions associated with data.
  */
@@ -72,7 +72,7 @@ inline void assert_is_image(const utils::type_erased_matrix& data,
     // Check if we can do the conversion.
     const auto& unused = data.template get<uint8_t>();
     (void) unused;
-  } catch (utils::bad_any_cast) {
+  } catch (const utils::bad_any_cast&) {
     LBANN_ERROR("Data is not an image: not uint8_t.");
   }
   if (dims.size() != 3 || (dims[0] != 1 && dims[0] != 3)) {

--- a/model_zoo/jag_utils/check_for_duplicate_samples.cpp
+++ b/model_zoo/jag_utils/check_for_duplicate_samples.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
       std::vector<std::string> cnames;
       try {
         conduit::relay::io::hdf5_group_list_child_names(hdf5_file_hnd, "/", cnames);
-      } catch (std::exception e) {
+      } catch (const std::exception&) {
         throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + " :: hdf5_group_list_child_names failed; " + files[j]);
       }
 
@@ -137,10 +137,7 @@ int main(int argc, char *argv[]) {
         testme.insert(the_test);
       }
     }
-  } catch (exception const &e) {
-    El::ReportException(e);
-    return EXIT_FAILURE;
-  } catch (std::exception const &e) {
+  } catch (const std::exception& e) {
     El::ReportException(e);
     return EXIT_FAILURE;
   }
@@ -156,4 +153,3 @@ void get_input_names(std::unordered_set<std::string> &s) {
   s.insert("shape_model_initial_modes:(2,1)");
   s.insert("shape_model_initial_modes:(1,0)");
 }
-

--- a/model_zoo/jag_utils/check_images.cpp
+++ b/model_zoo/jag_utils/check_images.cpp
@@ -85,9 +85,6 @@ int main(int argc, char *argv[]) {
       if (h % 10 == 0) std::cout << rank << " :: processed " << h << " files\n";
       try {
         hdf5_file_hnd = conduit::relay::io::hdf5_open_file_for_read( files[j] );
-      } catch (std::exception e) {
-        std::cerr << rank << " :: exception hdf5_open_file_for_read: " << files[j] << "\n";
-        continue;
       } catch (...) {
         std::cerr << rank << " :: exception hdf5_open_file_for_read: " << files[j] << "\n";
         continue;
@@ -96,7 +93,7 @@ int main(int argc, char *argv[]) {
       std::vector<std::string> cnames;
       try {
         conduit::relay::io::hdf5_group_list_child_names(hdf5_file_hnd, "/", cnames);
-      } catch (std::exception e) {
+      } catch (const std::exception&) {
         std::cerr << rank << " :: exception hdf5_group_list_child_names: " << files[j] << "\n";
         continue;
       }
@@ -106,7 +103,7 @@ int main(int argc, char *argv[]) {
         key = "/" + cnames[i] + "/performance/success";
         try {
           conduit::relay::io::hdf5_read(hdf5_file_hnd, key, n_ok);
-        } catch (exception const &e) {
+        } catch (const exception& e) {
           throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + " :: caught exception reading success flag for child " + std::to_string(i) + " of " + std::to_string(cnames.size()) + "; " + e.what());
         }
         int success = n_ok.to_int64();
@@ -116,17 +113,14 @@ int main(int argc, char *argv[]) {
           std::vector<std::string> image_names;
           try {
             conduit::relay::io::hdf5_group_list_child_names(hdf5_file_hnd, key, image_names);
-          } catch (std::exception const &e) {
+          } catch (const std::exception&) {
             std::cerr << rank << " :: exception :hdf5_group_list_child_names for images: " << files[j] << "\n";
             continue;
           }
         }
       }
     }
-  } catch (exception const &e) {
-    El::ReportException(e);
-    return EXIT_FAILURE;
-  } catch (std::exception const &e) {
+  } catch (const std::exception& e) {
     El::ReportException(e);
     return EXIT_FAILURE;
   }

--- a/model_zoo/jag_utils/extract_random_samples.cpp
+++ b/model_zoo/jag_utils/extract_random_samples.cpp
@@ -148,11 +148,11 @@ int main(int argc, char *argv[]) {
 
     extract_samples(comm.get(), rank, np, conduit_filenames, samples);
 
-  } catch (exception& e) {
+  } catch (const exception& e) {
     std::cerr << "\n\n" << rank << " ::::: caught exception, outer try/catch: " << e.what() << "\n\n";
     El::ReportException(e);
     return EXIT_FAILURE;
-  } catch (std::exception& e) {
+  } catch (const std::exception& e) {
     El::ReportException(e);
     return EXIT_FAILURE;
   }
@@ -413,7 +413,7 @@ std::cerr << rank << " samples.size: " << samples.size() << " np: " << np << "\n
 
     try {
       conduit::relay::io::hdf5_close_file( hdf5_file_hnd );
-    } catch (exception e) {
+    } catch (const exception& e) {
        throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + " :: exception hdf5_close_file; " + filenames[j] + "; " + e.what());
     }
 
@@ -432,7 +432,7 @@ std::cerr << rank << " samples.size: " << samples.size() << " np: " << np << "\n
               << "_" << file_id++ << ".bundle";
     try {
       conduit::relay::io::save(save_me, fn.str(), "hdf5");
-    } catch (exception e) {
+    } catch (const exception& e) {
       throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + " :: exception conduit::relay::save(); what: " + e.what());
     }
   }

--- a/model_zoo/jag_utils/generate_corrupt_samples.cpp
+++ b/model_zoo/jag_utils/generate_corrupt_samples.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) {
     std::vector<std::string> cnames;
     try {
       hndl.list_child_names(cnames);
-    } catch (std::exception e) {
+    } catch (const std::exception&) {
       err << "list_child_names failed for this file: " << files[j];
       LBANN_ERROR(err.str());
     }

--- a/model_zoo/jag_utils/load_balance.cpp
+++ b/model_zoo/jag_utils/load_balance.cpp
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]) {
       try {
 
         hdf5_file_hnd = conduit::relay::io::hdf5_open_file_for_read( files[j].c_str() );
-      } catch (std::exception e) {
+      } catch (const std::exception&) {
         std::cerr << rank << " :: exception hdf5_open_file_for_read: " << files[j] << "\n";
         continue;
       }
@@ -143,7 +143,7 @@ int main(int argc, char *argv[]) {
       std::vector<std::string> cnames;
       try {
         conduit::relay::io::hdf5_group_list_child_names(hdf5_file_hnd, "/", cnames);
-      } catch (std::exception e) {
+      } catch (const std::exception&) {
         std::cerr << rank << " :: exception hdf5_group_list_child_names; " << files[j] << "\n";
         continue;
       }
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
         key = "/" + cnames[i] + "/performance/success";
         try {
           conduit::relay::io::hdf5_read(hdf5_file_hnd, key, n_ok);
-        } catch (std::exception e) {
+        } catch (const std::exception&) {
           std::cerr << rank << " :: exception reading success flag: " << files[j] << "\n";
           continue;
         }
@@ -166,7 +166,7 @@ int main(int argc, char *argv[]) {
                 conduit::relay::io::hdf5_read(hdf5_file_hnd, key, node);
                 save_me["/" + cnames[i]] = node;
 
-            } catch (std::exception e) {
+            } catch (const std::exception&) {
               throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + " :: rank " + std::to_string(rank) + " :: " + "exception reading sample: " + cnames[i] + " which is " + std::to_string(i) + " of " + std::to_string(cnames[i].size()) + "; " + files[j]);
             }
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
             if (sample_count == samples_per_file) {
               try {
                 conduit::relay::io::save(save_me, output_fn, "hdf5");
-              } catch (exception const &e) {
+              } catch (const std::exception& e) {
                 std::cerr << rank << " :: exception: failed to save conduit node to disk; what: " << e.what() << "\n";
                 continue;
               } catch (...) {
@@ -195,14 +195,14 @@ int main(int argc, char *argv[]) {
       if (sample_count) {
         try {
           conduit::relay::io::save(save_me, output_fn, "hdf5");
-        } catch (exception const &e) {
+        } catch (exception const& e) {
           std::cerr << rank << " :: exception: failed to save conduit node to disk; what: " << e.what() << "\n";
         } catch (...) {
           std::cerr << rank << " :: exception: failed to save conduit node to disk; FINAL FILE\n";
         }
       }
 
-  } catch (std::exception const &e) {
+  } catch (std::exception const& e) {
     El::ReportException(e);
     return EXIT_FAILURE;
   }
@@ -210,4 +210,3 @@ int main(int argc, char *argv[]) {
   // Clean up
   return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
This cleans up a bunch of warnings about catching polymorphic exception types by value. Generally, exceptions should be caught by const-reference unless there's a compelling reason not to do that (not typing "SHIFT+7" is not a compelling reason).

I also swept through the files that were afflicted by catch-by-value and cleaned up a few other things. Notably, `lbann::exception` is-a `std::exception`, so code like this:
```cpp
try {...}
catch (const exception& e) {
    El::ReportException(e);
    continue;
} catch (const std::exception& e) {
    El::ReportException(e);
    continue;
}
```
is just redundant since nothing special happens for the `lbann::exception` that doesn't happen for the `std::exception` and vice versa.

I also changed the "const-reference style" to be more consistent with the rest of LBANN, which prefers `const type&`.