### PR TITLE
Fuse batchnorm allreduces in FP/BP

### DIFF
--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -50,8 +50,8 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
   if (is_training) {
 
     // Local matrices
-    auto& local_mean = m_mean->Matrix();
-    auto& local_var = m_var->Matrix();
+    auto& local_mean = m_mean_v->Matrix();
+    auto& local_var = m_var_v->Matrix();
     auto& local_running_mean = this->m_weights[2]->get_values().Matrix();
     auto& local_running_var = this->m_weights[3]->get_values().Matrix();
 
@@ -75,13 +75,14 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
     El::Int num_per_sum;
     switch (m_stats_aggregation) {
     case batch_normalization_stats_aggregation::global:
-      m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
-      m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var, m_mean_and_var->RedundantComm(),
+                        El::mpi::SUM);
       num_per_sum = channel_size * width;
       break;
     case batch_normalization_stats_aggregation::node_local:
-      m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
-      m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
         num_per_sum = channel_size * local_width;
         num_per_sum = m_comm->allreduce(num_per_sum, m_comm->get_node_comm());
@@ -122,10 +123,10 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
   const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
   const auto& local_bias = this->m_weights[1]->get_values().LockedMatrix();
   const auto& local_mean = (is_training ?
-                            m_mean->LockedMatrix() :
+                            m_mean_v->LockedMatrix() :
                             this->m_weights[2]->get_values().LockedMatrix());
   const auto& local_var = (is_training ?
-                           m_var->LockedMatrix() :
+                           m_var_v->LockedMatrix() :
                            this->m_weights[3]->get_values().LockedMatrix());
 
   // Iterate through channels
@@ -163,17 +164,17 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
   // Matrices
   const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
   const auto& local_mean = (is_training ?
-                            m_mean->LockedMatrix() :
+                            m_mean_v->LockedMatrix() :
                             this->m_weights[2]->get_values().LockedMatrix());
   const auto& local_var = (is_training ?
-                           m_var->LockedMatrix() :
+                           m_var_v->LockedMatrix() :
                            this->m_weights[3]->get_values().LockedMatrix());
   const auto& input = get_prev_activations();
   const auto& local_input = input.LockedMatrix();
   const auto& local_gradient_wrt_output = get_local_prev_error_signals();
   auto& local_gradient_wrt_input = get_local_error_signals();
-  auto& local_mean_gradient = m_mean_gradient->Matrix();
-  auto& local_var_gradient = m_var_gradient->Matrix();
+  auto& local_mean_gradient = m_mean_gradient_v->Matrix();
+  auto& local_var_gradient = m_var_gradient_v->Matrix();
   auto& local_scale_gradient = m_scale_gradient->Matrix();
   auto& local_bias_gradient = m_bias_gradient->Matrix();
 
@@ -225,23 +226,19 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
   // Accumulate gradients
   if (is_training) {
     if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
-      m_comm->allreduce(*m_mean_gradient,
-                        m_mean_gradient->RedundantComm(),
-                        El::mpi::SUM);
-      m_comm->allreduce(*m_var_gradient,
-                        m_var_gradient->RedundantComm(),
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var_gradient,
+                        m_mean_and_var_gradient->RedundantComm(),
                         El::mpi::SUM);
     } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
-      m_comm->allreduce(*m_mean_gradient,
-                        m_comm->get_node_comm(),
-                        El::mpi::SUM);
-      m_comm->allreduce(*m_var_gradient,
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
     }
   } else {
-    El::Zero(*m_mean_gradient);
-    El::Zero(*m_var_gradient);
+    // Zero fused buffer.
+    El::Zero(*m_mean_and_var_gradient);
   }
   optimizer* scale_optimizer = m_weights[0]->get_optimizer();
   if (scale_optimizer != nullptr) {

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -318,8 +318,8 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
   if (is_training) {
 
     // Local matrices
-    auto& local_mean = m_mean->Matrix();
-    auto& local_var = m_var->Matrix();
+    auto& local_mean = m_mean_v->Matrix();
+    auto& local_var = m_var_v->Matrix();
     auto& local_running_mean = this->m_weights[2]->get_values().Matrix();
     auto& local_running_var = this->m_weights[3]->get_values().Matrix();
 
@@ -341,13 +341,14 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
     El::Int num_per_sum;
     switch (m_stats_aggregation) {
     case batch_normalization_stats_aggregation::global:
-      m_comm->allreduce(*m_mean, m_mean->RedundantComm(), El::mpi::SUM);
-      m_comm->allreduce(*m_var, m_var->RedundantComm(), El::mpi::SUM);
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var, m_mean_and_var->RedundantComm(),
+                        El::mpi::SUM);
       num_per_sum = channel_size * width;
       break;
     case batch_normalization_stats_aggregation::node_local:
-      m_comm->allreduce(*m_mean, m_comm->get_node_comm(), El::mpi::SUM);
-      m_comm->allreduce(*m_var, m_comm->get_node_comm(), El::mpi::SUM);
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var, m_comm->get_node_comm(), El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
         num_per_sum = channel_size * local_width;
         num_per_sum = m_comm->allreduce(num_per_sum, m_comm->get_node_comm());
@@ -382,10 +383,10 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_
   const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
   const auto& local_bias = this->m_weights[1]->get_values().LockedMatrix();
   const auto& local_mean = (is_training ?
-                            m_mean->LockedMatrix() :
+                            m_mean_v->LockedMatrix() :
                             this->m_weights[2]->get_values().LockedMatrix());
   const auto& local_var = (is_training ?
-                           m_var->LockedMatrix() :
+                           m_var_v->LockedMatrix() :
                            this->m_weights[3]->get_values().LockedMatrix());
   if (!local_input.IsEmpty()) {
     const El::Int block_size = 256;
@@ -416,17 +417,17 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
   // Matrices
   const auto& local_scale = this->m_weights[0]->get_values().LockedMatrix();
   const auto& local_mean = (is_training ?
-                            m_mean->LockedMatrix() :
+                            m_mean_v->LockedMatrix() :
                             this->m_weights[2]->get_values().LockedMatrix());
   const auto& local_var = (is_training ?
-                           m_var->LockedMatrix() :
+                           m_var_v->LockedMatrix() :
                            this->m_weights[3]->get_values().LockedMatrix());
   const auto& input = get_prev_activations();
   const auto& local_input = input.LockedMatrix();
   const auto& local_gradient_wrt_output = get_local_prev_error_signals();
   auto& local_gradient_wrt_input = get_local_error_signals();
-  auto& local_mean_gradient = m_mean_gradient->Matrix();
-  auto& local_var_gradient = m_var_gradient->Matrix();
+  auto& local_mean_gradient = m_mean_gradient_v->Matrix();
+  auto& local_var_gradient = m_var_gradient_v->Matrix();
   auto& local_scale_gradient = m_scale_gradient->Matrix();
   auto& local_bias_gradient = m_bias_gradient->Matrix();
 
@@ -464,23 +465,19 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_
   // Accumulate gradients
   if (is_training) {
     if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
-      m_comm->allreduce(*m_mean_gradient,
-                        m_mean_gradient->RedundantComm(),
-                        El::mpi::SUM);
-      m_comm->allreduce(*m_var_gradient,
-                        m_var_gradient->RedundantComm(),
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var_gradient,
+                        m_mean_and_var_gradient->RedundantComm(),
                         El::mpi::SUM);
     } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
-      m_comm->allreduce(*m_mean_gradient,
-                        m_comm->get_node_comm(),
-                        El::mpi::SUM);
-      m_comm->allreduce(*m_var_gradient,
+      // Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var_gradient,
                         m_comm->get_node_comm(),
                         El::mpi::SUM);
     }
   } else {
-    El::Zero(*m_mean_gradient);
-    El::Zero(*m_var_gradient);
+    // Zero fused buffer.
+    El::Zero(*m_mean_and_var_gradient);
   }
   optimizer* scale_optimizer = m_weights[0]->get_optimizer();
   if (scale_optimizer != nullptr) {


### PR DESCRIPTION
This replaces the separate mean and variance (and associated gradients) buffers with fused buffers. This enables the allreduces during forward/backprop when doing node-local/global statistics to be fused into a single allreduce. Since the size of these buffers is the number of channels in the layer being normalized, these allreduces are likely latency-bound, so doing fewer of them improves performance.

Tested that it could train Wide ResNet-50-4 with node-local stats to convergence without issue. Also tested gradient checking.

Benchmarked with global stats at small scale and observed a minor but consistent performance improvement.