### PR TITLE
Update test flags

### DIFF
--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -31,7 +31,8 @@ if [ "${CLUSTER}" = 'pascal' ]; then
 fi
 
 if [ ${WEEKLY} -ne 0 ]; then
-    salloc -N16 --partition=pbatch -t 1440 ./run.sh --weekly
+    ALLOCATION_TIME_LIMIT=720
+    timeout 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh --weekly
     if [ "${CLUSTER}" = 'catalyst' ]; then
         cd integration_tests
         python -m pytest -s test_integration_performance_full_alexnet_clang6 --weekly --run --junitxml=alexnet_clang6_results.xml
@@ -40,5 +41,10 @@ if [ ${WEEKLY} -ne 0 ]; then
         cd ..
     fi
 else
-    salloc -N16 --partition=pbatch -t 1440 ./run.sh
+    if [ "${CLUSTER}" = 'catalyst' ]; then
+        ALLOCATION_TIME_LIMIT=240
+    elif [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTER}" = 'pascal' ]; then
+        ALLOCATION_TIME_LIMIT=660
+    fi
+    timeout 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh
 fi

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -73,6 +73,7 @@ def get_command(cluster,
     else:
         raise Exception('Unsupported Cluster: %s' % cluster)
 
+    MAX_TIME = 60
     # Description of command line options are from the appropriate command's
     # man pages
     if scheduler == 'slurm':
@@ -112,9 +113,15 @@ def get_command(cluster,
 
         # Create run command
         if command_allocate == '':
-            command_run = 'srun --mpibind=off'
+            space = ''
+            # If nodes have already been allocated,
+            # then an individual test should not take longer than MAX_TIME.
+            if time_limit > MAX_TIME:
+                time_limit = MAX_TIME
         else:
-            command_run = ' srun --mpibind=off'
+            space = ' '
+        command_run = '{s}srun --mpibind=off --time={t}'.format(
+            s=space, t=time_limit)
         option_num_processes = ''
         if num_processes is not None:
             # --ntasks => Specify  the  number of tasks to run.
@@ -170,9 +177,14 @@ def get_command(cluster,
 
         # Create run command
         if command_allocate == '':
-            command_run = 'mpirun'
+            space = ''
+            # If nodes have already been allocated,
+            # then an individual test should not take longer than MAX_TIME.
+            if time_limit > MAX_TIME:
+                time_limit = MAX_TIME
         else:
-            command_run = ' mpirun'
+            space = ' '
+        command_run = '{s}mpirun --timeout {t}'.format(s=space, t=time_limit)
         option_num_processes = ''
         option_processes_per_node = ''
         if num_processes is not None:

--- a/bamboo/run.sh
+++ b/bamboo/run.sh
@@ -42,22 +42,22 @@ echo "Task: Cleaning"
 echo "Task: Compiler Tests"
 cd compiler_tests
 module load cmake/3.9.2
-$PYTHON -m pytest -s --junitxml=results.xml
+$PYTHON -m pytest -s -vv --durations=0 --junitxml=results.xml
 cd ..
 
 echo "Task: Integration Tests"
 cd integration_tests
 if [ ${WEEKLY} -ne 0 ]; then
-    $PYTHON -m pytest -s --weekly --junitxml=results.xml
+    $PYTHON -m pytest -s -vv --durations=0 --weekly --junitxml=results.xml
 else
-    $PYTHON -m pytest -s --junitxml=results.xml
+    $PYTHON -m pytest -s -vv --durations=0 --junitxml=results.xml
 fi
 
 cd ..
 
 echo "Task: Unit Tests"
 cd unit_tests
-$PYTHON -m pytest -s --junitxml=results.xml
+$PYTHON -m pytest -s -vv --durations=0 --junitxml=results.xml
 cd ..
 
 echo "Task: Finished"


### PR DESCRIPTION
Update test flags to include more verbosity and set time limits for individual tests.

Also update allocation command to timeout after 24 hours (including queue time) and further specify the time limit excluding queue time.