### PR TITLE
Fixing the warnings raised by latest clang

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -189,24 +189,6 @@ static void __attribute__((used)) _print_local_matrix_dims(AbsMat *m, const char
 }
 #define PRINT_LOCAL_MATRIX_DIMS(x) _print_local_matrix_dims(x, #x);
 
-// FIXME
-#if 1
-// __FILE__
-#define log_msg(...) {\
-  char str[256];\
-  sprintf(str, __VA_ARGS__);\
-  std::cout << "[" << m_comm->get_trainer_rank() << "." << m_comm->get_rank_in_trainer() << "][" << __FUNCTION__ << "][Line " << __LINE__ << "]" << str << std::endl; \
-  }
-#define log_simple_msg(...) {\
-  char str[256];\
-  sprintf(str, __VA_ARGS__);\
-  std::cout << "[" << __FUNCTION__ << "][Line " << __LINE__ << "]" << str << std::endl; \
-  }
-#else
-#define log_msg(...)
-#define log_simple_msg(...)
-#endif
-
 #define LBANN_MAKE_STR(x) _LBANN_MAKE_STR(x)
 #define _LBANN_MAKE_STR(x) #x
 

--- a/include/lbann/callbacks/callback_checksmall.hpp
+++ b/include/lbann/callbacks/callback_checksmall.hpp
@@ -49,7 +49,7 @@ class lbann_callback_checksmall : public lbann_callback {
   lbann_callback_checksmall() : lbann_callback() {}
   lbann_callback_checksmall(const lbann_callback_checksmall&) = default;
   lbann_callback_checksmall& operator=(
-    const lbann_callback_checksmall&) = default;
+    const lbann_callback_checksmall&) = delete;
   lbann_callback_checksmall* copy() const override {
     return new lbann_callback_checksmall(*this);
   }

--- a/include/lbann/callbacks/callback_checksmall.hpp
+++ b/include/lbann/callbacks/callback_checksmall.hpp
@@ -49,7 +49,7 @@ class lbann_callback_checksmall : public lbann_callback {
   lbann_callback_checksmall() : lbann_callback() {}
   lbann_callback_checksmall(const lbann_callback_checksmall&) = default;
   lbann_callback_checksmall& operator=(
-    const lbann_callback_checksmall&) = delete;
+    const lbann_callback_checksmall&) = default;
   lbann_callback_checksmall* copy() const override {
     return new lbann_callback_checksmall(*this);
   }
@@ -62,7 +62,7 @@ class lbann_callback_checksmall : public lbann_callback {
   std::string name() const override { return "checksmall"; }
  private:
   /** Smallest allowable value. */
-  const DataType m_threshold = std::sqrt(std::numeric_limits<DataType>::min());
+  static const DataType m_threshold;
   /** Return true if there are no problems with m. */
   bool is_good(const AbsDistMat& m);
 };

--- a/include/lbann/callbacks/callback_perturb_adam.hpp
+++ b/include/lbann/callbacks/callback_perturb_adam.hpp
@@ -77,8 +77,8 @@ public:
   lbann_callback_perturb_adam* copy() const override { return new lbann_callback_perturb_adam(*this); }
   std::string name() const override { return "perturb Adam"; }
 
-  void setup(model* m);
-  void on_batch_begin(model* m);
+  void setup(model* m) override;
+  void on_batch_begin(model* m) override;
 
 private:
 

--- a/include/lbann/callbacks/callback_perturb_dropout.hpp
+++ b/include/lbann/callbacks/callback_perturb_dropout.hpp
@@ -52,7 +52,7 @@ public:
   lbann_callback_perturb_dropout* copy() const override { return new lbann_callback_perturb_dropout(*this); }
   std::string name() const override { return "perturb dropout"; }
 
-  void setup(model* m);
+  void setup(model* m) override;
 
 private:
 
@@ -67,9 +67,9 @@ private:
    *  If empty, all dropout layers  in the model will be perturbed.
    */
   std::set<std::string> m_layer_names;
-  
+
   template <data_layout T_layout, El::Device Dev>
-  dropout<T_layout, Dev>* get_dropout_layer(Layer* l); 
+  dropout<T_layout, Dev>* get_dropout_layer(Layer* l);
 
   /** Perturb dropout keep prob in model. */
   void perturb(model& m);

--- a/include/lbann/callbacks/callback_variable_minibatch.hpp
+++ b/include/lbann/callbacks/callback_variable_minibatch.hpp
@@ -44,7 +44,7 @@ class lbann_callback_variable_minibatch : public lbann_callback {
   lbann_callback_variable_minibatch(
     const lbann_callback_variable_minibatch&) = default;
   lbann_callback_variable_minibatch& operator=(
-    const lbann_callback_variable_minibatch&) = delete;
+    const lbann_callback_variable_minibatch&) = default;
   /// Set the initial mini-batch size.
   void on_train_begin(model *m) override;
   /// Potentially change the mini-batch size.
@@ -71,7 +71,7 @@ class lbann_callback_variable_minibatch : public lbann_callback {
   float get_current_learning_rate(model *m) const;
 
   /// Initial mini-batch size.
-  const int m_starting_mbsize;
+  int m_starting_mbsize;
   /**
    * The current mini-batch size for this epoch.
    * This is kept separately from the model's get_current_mini_batch_size()

--- a/include/lbann/callbacks/callback_variable_minibatch.hpp
+++ b/include/lbann/callbacks/callback_variable_minibatch.hpp
@@ -44,7 +44,7 @@ class lbann_callback_variable_minibatch : public lbann_callback {
   lbann_callback_variable_minibatch(
     const lbann_callback_variable_minibatch&) = default;
   lbann_callback_variable_minibatch& operator=(
-    const lbann_callback_variable_minibatch&) = default;
+    const lbann_callback_variable_minibatch&) = delete;
   /// Set the initial mini-batch size.
   void on_train_begin(model *m) override;
   /// Potentially change the mini-batch size.
@@ -69,6 +69,7 @@ class lbann_callback_variable_minibatch : public lbann_callback {
   void change_learning_rate(model *m, float new_lr) const;
   /// Get the current learning rate (assumes every layer has the same one).
   float get_current_learning_rate(model *m) const;
+
   /// Initial mini-batch size.
   const int m_starting_mbsize;
   /**
@@ -94,13 +95,14 @@ class lbann_callback_step_minibatch : public lbann_callback_variable_minibatch {
                                 int ramp_time = 0);
   lbann_callback_step_minibatch(const lbann_callback_step_minibatch&) = default;
   lbann_callback_step_minibatch& operator=(
-    const lbann_callback_step_minibatch&) = default;
+    const lbann_callback_step_minibatch&) = delete;
   lbann_callback_step_minibatch* copy() const override {
     return new lbann_callback_step_minibatch(*this);
   }
   std::string name() const override { return "step minibatch"; }
  protected:
   bool schedule(model *m, int& new_mbsize, float& new_lr, int& ramp_time) override;
+
   /// Number of epochs between mini-batch size increases.
   int m_step;
   /// Number of steps to ramp the learning rate over.
@@ -128,7 +130,7 @@ class lbann_callback_minibatch_schedule : public lbann_callback_variable_minibat
   lbann_callback_minibatch_schedule(
     const lbann_callback_minibatch_schedule&) = default;
   lbann_callback_minibatch_schedule& operator=(
-    const lbann_callback_minibatch_schedule&) = default;
+    const lbann_callback_minibatch_schedule&) = delete;
   lbann_callback_minibatch_schedule* copy() const override {
     return new lbann_callback_minibatch_schedule(*this);
   }

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -175,8 +175,8 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// Set every reader instances in a model to have an independent index list
   void set_list_per_model(bool flag) { m_list_per_model = flag; };
 
-  bool has_list_per_model() const { return m_list_per_model; }
-  bool has_list_per_trainer() const { return m_list_per_trainer; }
+  bool has_list_per_model() const override { return m_list_per_model; }
+  bool has_list_per_trainer() const override { return m_list_per_trainer; }
 
 
   /// Fetch data of a mini-batch or reuse it from the cache of the leading reader
@@ -361,12 +361,12 @@ class data_reader_jag_conduit : public generic_data_reader {
   /// Obtain image data
   std::vector< std::vector<DataType> > get_image_data(const size_t i, conduit::Node& sample) const;
 
-  bool data_store_active() const {
+  bool data_store_active() const override {
     bool flag = generic_data_reader::data_store_active();
     return (m_data_store != nullptr && flag);
   }
 
-  bool priming_data_store() const {
+  bool priming_data_store() const override {
     bool flag = generic_data_reader::priming_data_store();
     return (m_data_store != nullptr && flag);
   }

--- a/include/lbann/data_readers/data_reader_numpy_npz_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_numpy_npz_conduit.hpp
@@ -73,7 +73,7 @@ namespace lbann {
   const std::vector<int> get_data_dims() const override { return m_data_dims; }
 
   protected:
-    void preload_data_store();
+    void preload_data_store() override;
 
     bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
     bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;

--- a/include/lbann/layers/activations/elu.hpp
+++ b/include/lbann/layers/activations/elu.hpp
@@ -57,7 +57,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("alpha", m_alpha);
     return desc;
   }

--- a/include/lbann/layers/activations/leaky_relu.hpp
+++ b/include/lbann/layers/activations/leaky_relu.hpp
@@ -57,7 +57,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("Negative slope", m_negative_slope);
     return desc;
   }

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -129,7 +129,7 @@ class generic_input_layer : public io_layer {
   std::string get_type() const override { return "generic_input"; }
 
   description get_description() const override {
-    auto&& desc = io_layer::get_description();
+    auto desc = io_layer::get_description();
     desc.add("Buffer", m_io_buffers[0]->get_type());
     desc.add("Background I/O", this->m_model->background_io_activity_allowed());
     return desc;

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -187,7 +187,7 @@ public:
   }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     std::ostringstream ss;
 
     // Convolution dimensions

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -123,7 +123,7 @@ protected:
 
   }
 
-  std::vector<int> get_kernel_dims() const {
+  std::vector<int> get_kernel_dims() const override {
     std::vector<int> dims;
     dims.push_back(this->m_output_channels);
     dims.push_back(this->get_input_dims()[0] / this->m_groups);

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -142,7 +142,7 @@ public:
 
 protected:
 
-  std::vector<int> get_kernel_dims() const {
+  std::vector<int> get_kernel_dims() const override {
     std::vector<int> dims;
     dims.push_back(this->get_input_dims()[0]);
     dims.push_back(this->m_output_channels);

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -60,7 +60,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("Dictionary size", m_dictionary_size);
     desc.add("Embedding size", m_embedding_size);
     return desc;

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -100,7 +100,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = learning_layer::get_description();
+    auto desc = learning_layer::get_description();
     const auto& bias_str = (m_bias_scaling_factor == DataType(0) ?
                             "disabled" : "enabled");
     desc.add("Bias", bias_str);

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -59,7 +59,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("k", m_k);
     return desc;
   }

--- a/include/lbann/layers/math/clamp.hpp
+++ b/include/lbann/layers/math/clamp.hpp
@@ -59,7 +59,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     std::stringstream ss;
     ss << "[" << m_min << "," << m_max << "]";
     desc.add("Range", ss.str());

--- a/include/lbann/layers/misc/covariance.hpp
+++ b/include/lbann/layers/misc/covariance.hpp
@@ -72,7 +72,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("Biased", m_biased);
     return desc;
   }

--- a/include/lbann/layers/misc/variance.hpp
+++ b/include/lbann/layers/misc/variance.hpp
@@ -69,7 +69,7 @@ public:
   El::Device get_device_allocation() const override { return Device; }
 
   description get_description() const override {
-    auto&& desc = Layer::get_description();
+    auto desc = Layer::get_description();
     desc.add("Biased", m_biased);
     return desc;
   }

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -175,7 +175,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = regularizer_layer::get_description();
+    auto desc = regularizer_layer::get_description();
     desc.add("Decay", m_decay);
     desc.add("Epsilon", m_epsilon);
     switch (m_stats_aggregation) {

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -118,7 +118,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = regularizer_layer::get_description();
+    auto desc = regularizer_layer::get_description();
     desc.add("Keep probability", m_keep_prob);
     return desc;
   }

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -128,7 +128,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = regularizer_layer::get_description();
+    auto desc = regularizer_layer::get_description();
     desc.add("alpha", m_alpha);
     desc.add("beta", m_beta);
     desc.add("k", m_k);

--- a/include/lbann/layers/transform/bernoulli.hpp
+++ b/include/lbann/layers/transform/bernoulli.hpp
@@ -56,7 +56,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Probability", m_prob);
     return desc;
   }

--- a/include/lbann/layers/transform/concatenation.hpp
+++ b/include/lbann/layers/transform/concatenation.hpp
@@ -64,7 +64,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Concatenation dimension", m_concat_dim);
     return desc;
   }

--- a/include/lbann/layers/transform/constant.hpp
+++ b/include/lbann/layers/transform/constant.hpp
@@ -50,7 +50,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Value", m_value);
     return desc;
   }

--- a/include/lbann/layers/transform/gaussian.hpp
+++ b/include/lbann/layers/transform/gaussian.hpp
@@ -60,7 +60,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Mean", m_mean);
     desc.add("Standard deviation", m_stdev);
     return desc;

--- a/include/lbann/layers/transform/in_top_k.hpp
+++ b/include/lbann/layers/transform/in_top_k.hpp
@@ -57,7 +57,7 @@ class in_top_k_layer : public transform_layer {
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("k", m_k);
     return desc;
   }

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -163,7 +163,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     std::stringstream ss;
 
     // Pool mode

--- a/include/lbann/layers/transform/reduction.hpp
+++ b/include/lbann/layers/transform/reduction.hpp
@@ -67,7 +67,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     std::string mode_str;
     switch (m_mode) {
     case reduction_mode::SUM:     mode_str = "sum";     break;

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -84,7 +84,7 @@ public:
   std::vector<El::Int> get_slice_points() const { return m_slice_points; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Slice dimension", m_slice_dim);
     std::stringstream ss;
     for (size_t i = 0; i < m_slice_points.size(); ++i) {

--- a/include/lbann/layers/transform/sort.hpp
+++ b/include/lbann/layers/transform/sort.hpp
@@ -87,7 +87,7 @@ class sort_layer : public transform_layer {
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     desc.add("Descending", m_descending);
     return desc;
   }

--- a/include/lbann/layers/transform/uniform.hpp
+++ b/include/lbann/layers/transform/uniform.hpp
@@ -61,7 +61,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     std::stringstream ss;
     ss << "[" << m_min << "," << m_max << ")";
     desc.add("Range", ss.str());

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -55,7 +55,7 @@ public:
   El::Device get_device_allocation() const override { return Dev; }
 
   description get_description() const override {
-    auto&& desc = transform_layer::get_description();
+    auto desc = transform_layer::get_description();
     std::stringstream ss;
     for (size_t i = 0; i < m_scaling_factors.size(); ++i) {
       ss << (i > 0 ? ", " : "") << m_scaling_factors[i];

--- a/include/lbann/transforms/normalize.hpp
+++ b/include/lbann/transforms/normalize.hpp
@@ -54,7 +54,7 @@ public:
 
   std::string get_type() const override { return "normalize"; }
 
-  bool supports_non_inplace() const { return true; }
+  bool supports_non_inplace() const override { return true; }
 
   void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
   void apply(utils::type_erased_matrix& data, CPUMat& out,

--- a/include/lbann/transforms/repack_HWC_to_CHW_layout.hpp
+++ b/include/lbann/transforms/repack_HWC_to_CHW_layout.hpp
@@ -42,7 +42,7 @@ public:
 
   std::string get_type() const override { return "to_lbann_layout"; }
 
-  bool supports_non_inplace() const { return true; }
+  bool supports_non_inplace() const override { return true; }
 
   void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
 

--- a/include/lbann/transforms/vision/normalize_to_lbann_layout.hpp
+++ b/include/lbann/transforms/vision/normalize_to_lbann_layout.hpp
@@ -49,12 +49,12 @@ public:
       LBANN_ERROR("Normalize mean and std have different numbers of channels.");
     }
   }
-  
+
   transform* copy() const override { return new normalize_to_lbann_layout(*this); }
 
   std::string get_type() const override { return "normalize_to_lbann_layout"; }
 
-  bool supports_non_inplace() const { return true; }
+  bool supports_non_inplace() const override { return true; }
 
   void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
 

--- a/include/lbann/transforms/vision/to_lbann_layout.hpp
+++ b/include/lbann/transforms/vision/to_lbann_layout.hpp
@@ -43,7 +43,7 @@ public:
 
   std::string get_type() const override { return "to_lbann_layout"; }
 
-  bool supports_non_inplace() const { return true; }
+  bool supports_non_inplace() const override { return true; }
 
   void apply(utils::type_erased_matrix& data, std::vector<size_t>& dims) override;
 

--- a/include/lbann/weights/initializer.hpp
+++ b/include/lbann/weights/initializer.hpp
@@ -60,8 +60,8 @@ public:
   constant_initializer* copy() const override {
     return new constant_initializer(*this);
   }
-  std::string get_type() const { return "constant"; }
-  description get_description() const;
+  std::string get_type() const override { return "constant"; }
+  description get_description() const override;
   void fill(AbsDistMat& matrix) override;
 
 private:
@@ -83,7 +83,7 @@ public:
   value_initializer* copy() const override {
     return new value_initializer(*this);
   }
-  std::string get_type() const { return "value"; }
+  std::string get_type() const override { return "value"; }
   void fill(AbsDistMat& matrix) override;
 
 private:
@@ -102,8 +102,8 @@ class uniform_initializer : public weights_initializer {
   uniform_initializer* copy() const override {
     return new uniform_initializer(*this);
   }
-  std::string get_type() const { return "uniform"; }
-  description get_description() const;
+  std::string get_type() const override{ return "uniform"; }
+  description get_description() const override;
   void fill(AbsDistMat& matrix) override;
 
 private:
@@ -126,8 +126,8 @@ public:
   normal_initializer* copy() const override {
     return new normal_initializer(*this);
   }
-  std::string get_type() const { return "normal"; }
-  description get_description() const;
+  std::string get_type() const override { return "normal"; }
+  description get_description() const override;
   void fill(AbsDistMat& matrix) override;
 
 private:

--- a/include/lbann/weights/variance_scaling_initializers.hpp
+++ b/include/lbann/weights/variance_scaling_initializers.hpp
@@ -45,7 +45,7 @@ namespace lbann {
 class variance_scaling_initializer : public weights_initializer {
 public:
   variance_scaling_initializer(probability_distribution dist);
-  description get_description() const;
+  description get_description() const override;
   void fill(AbsDistMat& matrix) override;
 
   /** Set fan-in parameter. */
@@ -78,7 +78,7 @@ public:
   glorot_initializer* copy() const override {
     return new glorot_initializer(*this);
   }
-  std::string get_type() const { return "Glorot"; }
+  std::string get_type() const override { return "Glorot"; }
 protected:
   DataType get_variance(El::Int fan_in, El::Int fan_out) override;
 };
@@ -91,7 +91,7 @@ public:
   he_initializer* copy() const override {
     return new he_initializer(*this);
   }
-  std::string get_type() const { return "He"; }
+  std::string get_type() const override { return "He"; }
 protected:
   DataType get_variance(El::Int fan_in, El::Int fan_out) override;
 };
@@ -104,7 +104,7 @@ public:
   lecun_initializer* copy() const override {
     return new lecun_initializer(*this);
   }
-  std::string get_type() const { return "LeCun"; }
+  std::string get_type() const override { return "LeCun"; }
 protected:
   DataType get_variance(El::Int fan_in, El::Int fan_out) override;
 };

--- a/src/callbacks/callback_checksmall.cpp
+++ b/src/callbacks/callback_checksmall.cpp
@@ -85,4 +85,7 @@ bool lbann_callback_checksmall::is_good(const AbsDistMat& m) {
   return true;
 }
 
+const DataType lbann_callback_checksmall::m_threshold
+  = std::sqrt(std::numeric_limits<DataType>::min());
+
 }  // namespace lbann

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -1319,7 +1319,7 @@ data_reader_jag_conduit::create_datum_views(CPUMat& X, const std::vector<size_t>
     El::View(X_v[i], X, El::IR(h, h_end), El::IR(mb_idx, mb_idx + 1));
     h = h_end;
   }
-  return std::move(X_v);
+  return X_v;
 }
 
 bool data_reader_jag_conduit::fetch(CPUMat& X, int data_id, conduit::Node& sample, int mb_idx, int tid,

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -831,8 +831,10 @@ void data_reader_jag_conduit::load() {
   /// Merge all of the sample lists
   m_sample_list.all_gather_packed_lists(*m_comm);
   if (opts->has_string("write_sample_list") && m_comm->am_trainer_master()) {
-    const std::string msg = " writing sample list " + sample_list_file;
-    log_msg(msg.c_str());
+    {
+      const std::string msg = " writing sample list " + sample_list_file;
+      LBANN_WARNING(msg);
+    }
     std::stringstream s;
     std::string basename = get_basename_without_ext(sample_list_file);
     std::string ext = get_ext_name(sample_list_file);
@@ -866,7 +868,7 @@ void data_reader_jag_conduit::preload_data_store() {
       (opts->get_bool("ltfb_verbose") && get_comm()->am_trainer_master())) {
     std::stringstream msg;
     msg << " for role: " << get_role() << " starting preload";
-    log_msg(msg.str().c_str());
+    LBANN_WARNING(msg.str());
   }
 
   for (size_t idx=0; idx < m_shuffled_indices.size(); idx++) {
@@ -897,7 +899,7 @@ void data_reader_jag_conduit::preload_data_store() {
       (opts->get_bool("ltfb_verbose") && get_comm()->am_trainer_master())) {
     std::stringstream msg;
     msg << " loading data for role: " << get_role() << " took " << get_time() - tm1 << "s";
-    log_msg(msg.str().c_str());
+    LBANN_WARNING(msg.str());
   }
 }
 

--- a/src/optimizers/adagrad.cpp
+++ b/src/optimizers/adagrad.cpp
@@ -45,7 +45,7 @@ adagrad& adagrad::operator=(const adagrad& other) {
 }
 
 description adagrad::get_description() const {
-  auto&& desc = optimizer::get_description();
+  auto desc = optimizer::get_description();
   desc.add("eps", m_eps);
   return desc;
 }

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -62,7 +62,7 @@ adam& adam::operator=(const adam& other) {
 }
 
 description adam::get_description() const {
-  auto&& desc = optimizer::get_description();
+  auto desc = optimizer::get_description();
   desc.add("beta1", m_beta1);
   desc.add("beta2", m_beta2);
   desc.add("eps", m_eps);

--- a/src/optimizers/hypergradient_adam.cpp
+++ b/src/optimizers/hypergradient_adam.cpp
@@ -72,7 +72,7 @@ hypergradient_adam& hypergradient_adam::operator=(const hypergradient_adam& othe
 }
 
 description hypergradient_adam::get_description() const {
-  auto&& desc = optimizer::get_description();
+  auto desc = optimizer::get_description();
   desc.add("Hypergradient learning rate", m_hyper_learning_rate);
   desc.add("beta1", m_beta1);
   desc.add("beta2", m_beta2);

--- a/src/optimizers/rmsprop.cpp
+++ b/src/optimizers/rmsprop.cpp
@@ -52,7 +52,7 @@ rmsprop& rmsprop::operator=(const rmsprop& other) {
 }
 
 description rmsprop::get_description() const {
-  auto&& desc = optimizer::get_description();
+  auto desc = optimizer::get_description();
   desc.add("Decay rate", m_decay_rate);
   desc.add("eps", m_eps);
   return desc;

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -53,7 +53,7 @@ sgd& sgd::operator=(const sgd& other) {
 }
 
 description sgd::get_description() const {
-  auto&& desc = optimizer::get_description();
+  auto desc = optimizer::get_description();
   desc.add("Momentum", m_momentum);
   desc.add("Nesterov acceleration", m_nesterov);
   return desc;

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -250,7 +250,7 @@ void init_image_data_reader(const lbann_data::Reader& pb_readme, const lbann_dat
   }
 
   reader->set_transform_pipeline(
-    std::move(proto::construct_transform_pipeline(pb_readme)));
+    proto::construct_transform_pipeline(pb_readme));
 
   if (channels == 0) {
     channels = 3;
@@ -291,7 +291,7 @@ void init_org_image_data_reader(const lbann_data::Reader& pb_readme, const bool 
   }
 
   reader->set_transform_pipeline(
-    std::move(proto::construct_transform_pipeline(pb_readme)));
+    proto::construct_transform_pipeline(pb_readme));
 }
 
 }

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -345,7 +345,7 @@ void init_data_readers(
 
     if (set_transform_pipeline) {
       reader->set_transform_pipeline(
-        std::move(proto::construct_transform_pipeline(readme)));
+        proto::construct_transform_pipeline(readme));
     }
 
     if (readme.data_filename() != "") {

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -35,7 +35,7 @@ description weights_initializer::get_description() const {
 }
 
 description constant_initializer::get_description() const {
-  auto&& desc = weights_initializer::get_description();
+  auto desc = weights_initializer::get_description();
   desc.add("Value", m_value);
   return desc;
 }
@@ -91,7 +91,7 @@ void value_initializer::fill(AbsDistMat& matrix) {
 }
 
 description uniform_initializer::get_description() const {
-  auto&& desc = weights_initializer::get_description();
+  auto desc = weights_initializer::get_description();
   std::stringstream ss;
   ss << "[" << m_min << "," << m_max << ")";
   desc.add("Range", ss.str());
@@ -104,7 +104,7 @@ void uniform_initializer::fill(AbsDistMat& matrix) {
 }
 
 description normal_initializer::get_description() const {
-  auto&& desc = weights_initializer::get_description();
+  auto desc = weights_initializer::get_description();
   desc.add("Mean", m_mean);
   desc.add("Standard deviation", m_standard_deviation);
   return desc;

--- a/src/weights/variance_scaling_initializers.cpp
+++ b/src/weights/variance_scaling_initializers.cpp
@@ -45,7 +45,7 @@ variance_scaling_initializer::variance_scaling_initializer(probability_distribut
 }
 
 description variance_scaling_initializer::get_description() const {
-  auto&& desc = weights_initializer::get_description();
+  auto desc = weights_initializer::get_description();
   std::string dist_str;
   switch (m_prob_dist) {
   case probability_distribution::gaussian:


### PR DESCRIPTION
Nothing major here, just slight cleanup.

The major points:

- No universal references returned by name.
- Mark everything that overrides `override`.
- Don't have `const` data members and defaulted copy assignment (can't assign `const` members).
- Probably don't have `const` data members.