### PR TITLE
Grouped batchnorm statistics

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -998,6 +998,16 @@ class lbann_comm {
     return node_comm;
   }
 
+  /**
+   * Return a communicator containing num_per_group processors.
+   *
+   * This will attempt to pack processes so that the processes in each group
+   * are physically close together on the system.
+   *
+   * num_per_group must evenly divide the number of processors in the world.
+   */
+  const El::mpi::Comm& get_packed_group_comm(int num_per_group) const;
+
   /** Return true if rank (in comm) is on the local node. */
   bool is_rank_node_local(int rank, const El::mpi::Comm& comm) const {
     // Translating to COMM_WORLD is typically constant time.
@@ -1017,6 +1027,8 @@ class lbann_comm {
   El::mpi::Comm intertrainer_comm;
   /** Communicator for every process in the same compute node. */
   El::mpi::Comm node_comm;
+  /** Packed group communicators. */
+  mutable std::unordered_map<int, El::mpi::Comm> group_communicators;
   /** Grid for this trainer. */
   Grid *grid;
   /** Number of trainers. */

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -224,7 +224,8 @@ protected:
             << "may be too small to get good statistics";
         std::cerr << err.str() << std::endl;
       }
-    } else if (m_statistics_group_size*local_mini_batch_size <= 4) {
+    } else if (m_statistics_group_size != 0 &&
+               m_statistics_group_size*local_mini_batch_size <= 4) {
       // This possibly underestimates the aggregation size for processors with
       // smaller local mini-batch sizes.
       if (output.DistRank() == 0) {

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -63,8 +63,12 @@ private:
   DataType m_decay;
   /** Small number to avoid division by zero. */
   DataType m_epsilon;
-  /** Type of statistics aggregation to use. */
-  batch_normalization_stats_aggregation m_stats_aggregation;
+  /** @brief Size of group to aggregate statistics over.
+   *
+   * If this is 1, the group consists of one process and aggregation
+   * is local. If it is 0, statistics are aggregated globally.
+   */
+  int m_statistics_group_size;
   /**
    * Cache of node-local num_per_sum results for node-local stats.
    * Indexed by effective mini-batch size.
@@ -101,22 +105,22 @@ public:
    *  @param decay Controls the momentum of the running mean/standard
    *         deviation averages.
    *  @param epsilon A small number to avoid division by zero.
-   *  @param stats_aggregation The type of statistics to use when training.
+   *  @param statistics_group_size Number of processors to aggregate
+   *         statistics over. Defaults to 1 (i.e. local aggregation).
    */
   batch_normalization_layer(lbann_comm *comm,
                             DataType decay=0.9,
                             DataType epsilon=1e-5,
-                            batch_normalization_stats_aggregation stats_aggregation =
-                            batch_normalization_stats_aggregation::local)
+                            int statistics_group_size=1)
     : regularizer_layer(comm),
       m_decay(decay),
       m_epsilon(epsilon),
-      m_stats_aggregation(stats_aggregation) {
+      m_statistics_group_size(statistics_group_size) {
     static_assert(T_layout == data_layout::DATA_PARALLEL,
                   "batch normalization only supports DATA_PARALLEL");
 #ifdef LBANN_DETERMINISTIC
     // Force global computation.
-    m_stats_aggregation = batch_normalization_stats_aggregation::global;
+    m_statistics_group_size = 0;
 #endif
   }
 
@@ -124,7 +128,7 @@ public:
     : regularizer_layer(other),
       m_decay(other.m_decay),
       m_epsilon(other.m_epsilon),
-      m_stats_aggregation(other.m_stats_aggregation),
+      m_statistics_group_size(other.m_statistics_group_size),
       m_num_per_sum_cache(other.m_num_per_sum_cache),
       m_mean_and_var(other.m_mean_and_var ?
                      other.m_mean_and_var->Copy() : nullptr),
@@ -145,7 +149,7 @@ public:
     regularizer_layer::operator=(other);
     m_decay = other.m_decay;
     m_epsilon = other.m_epsilon;
-    m_stats_aggregation = other.m_stats_aggregation;
+    m_statistics_group_size = other.m_statistics_group_size;
     m_num_per_sum_cache = other.m_num_per_sum_cache;
 
     // Deep copy matrices
@@ -178,17 +182,7 @@ public:
     auto&& desc = regularizer_layer::get_description();
     desc.add("Decay", m_decay);
     desc.add("Epsilon", m_epsilon);
-    switch (m_stats_aggregation) {
-    case batch_normalization_stats_aggregation::local:
-      desc.add("Statistics aggregation", "local");
-      break;
-    case batch_normalization_stats_aggregation::node_local:
-      desc.add("Statistics aggregation", "node-local");
-      break;
-    case batch_normalization_stats_aggregation::global:
-      desc.add("Statistics aggregation", "global");
-      break;
-    }
+    desc.add("Statistics group size", m_statistics_group_size);
     return desc;
   }
 
@@ -220,38 +214,28 @@ protected:
     const auto& output = get_activations();
     const auto& mini_batch_size = output.Width();
     const auto& local_mini_batch_size = mini_batch_size / output.DistSize();
-    if (m_stats_aggregation == batch_normalization_stats_aggregation::global
-        && mini_batch_size <= 4) {
-      std::stringstream err;
-      err << "LBANN warning: "
-          << get_type() << " layer \"" << get_name() << "\" "
-          << "is using global statistics and "
-          << "the mini-batch size (" << mini_batch_size << ") "
-          << "may be too small to get good statistics";
+    if (m_statistics_group_size == 0 && mini_batch_size <= 4) {
       if (output.DistRank() == 0) {
+        std::stringstream err;
+        err << "LBANN warning: "
+            << get_type() << " layer \"" << get_name() << "\" "
+            << "is using global statistics and "
+            << "the mini-batch size (" << mini_batch_size << ") "
+            << "may be too small to get good statistics";
         std::cerr << err.str() << std::endl;
       }
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local
-               && local_mini_batch_size*m_comm->get_procs_per_node() <= 4) {
-      std::stringstream err;
+    } else if (m_statistics_group_size*local_mini_batch_size <= 4) {
+      // This possibly underestimates the aggregation size for processors with
+      // smaller local mini-batch sizes.
+      if (output.DistRank() == 0) {
+        std::stringstream err;
       err << "LBANN warning: "
           << get_type() << " layer \"" << get_name() << "\" "
-          << "is using node-local statistics and "
-          << "the node-local mini-batch size ("
-          << (local_mini_batch_size*m_comm->get_procs_per_node()) << ") "
+          << "is aggregating statistics over "
+          << m_statistics_group_size
+          << "processors and the aggregated mini-batch size ("
+          << (m_statistics_group_size*local_mini_batch_size) << ") "
           << "may be too small to get good statistics";
-      if (output.DistRank() == 0) {
-        std::cerr << err.str() << std::endl;
-      }
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::local
-               && local_mini_batch_size <= 4) {
-      std::stringstream err;
-      err << "LBANN warning: "
-          << get_type() << " layer \"" << get_name() << "\" "
-          << "is using local statistics and "
-          << "the local mini-batch size (" << local_mini_batch_size << ") "
-          << "may be too small to get good statistics";
-      if (output.DistRank() == 0) {
         std::cerr << err.str() << std::endl;
       }
     }

--- a/model_zoo/vision/resnet.py
+++ b/model_zoo/vision/resnet.py
@@ -38,9 +38,13 @@ parser.add_argument(
     '--block-channels', action='store', default=None, type=str,
     help='Internal channels in each ResNet block (comma-separated list)')
 parser.add_argument(
-    '--bn-stats-aggregation', action='store', default='local', type=str,
+    '--bn-stats-aggregation', action='store', type=str,
     help=('aggregation mode for batch normalization statistics '
-          '(default: "local")'))
+          '(default: "local") (DEPRECATED)'))
+parser.add_argument(
+    '--bn-statistics-group-size', action='store', default=1, type=int,
+    help=('Group size for aggregating batch normalization statistics '
+          '(default: 1)'))
 parser.add_argument(
     '--warmup', action='store_true', help='use a linear warmup')
 parser.add_argument(
@@ -70,6 +74,19 @@ args = parser.parse_args()
 # hardcoded to 1000 labels for ImageNet.
 imagenet_labels = 1000
 
+# Handle old-style batchnorm aggregation.
+if args.bn_stats_aggregation is not None:
+    print('--bn-stats-aggregation is deprected, use --bn-statistics-group-size')
+    if args.bn_stats_aggregation == 'local':
+        args.bn_statistics_group_size = 1
+    elif args.bn_stats_aggregation == 'node_local':
+        raise RuntimeError('Cannot translate node_local stats aggregation')
+    elif args.bn_stats_aggregation == 'global':
+        args.bn_statistics_group_size = 0
+    else:
+        raise RuntimeError('Unknown stats aggregation '
+                           + args.bn_stats_aggregation)
+
 # Choose ResNet variant
 resnet_variant_dict = {18: lbann.models.ResNet18,
                        34: lbann.models.ResNet34,
@@ -93,24 +110,24 @@ if args.block_type and args.blocks and args.block_channels:
         list(map(int, args.blocks.split(','))),
         list(map(int, args.block_channels.split(','))),
         zero_init_residual=True,
-        bn_stats_aggregation=args.bn_stats_aggregation,
+        bn_statistics_group_size=args.bn_statistics_group_size,
         name='custom_resnet',
         width=args.width)
 elif args.width == 1:
     # Vanilla ResNet.
     resnet = resnet_variant_dict[args.resnet](
         imagenet_labels,
-        bn_stats_aggregation=args.bn_stats_aggregation)
+        bn_statistics_group_size=args.bn_statistics_group_size)
 elif args.width == 2 and args.resnet == 50:
     # Use pre-defined WRN-50-2.
     resnet = wide_resnet_variant_dict[args.resnet](
         imagenet_labels,
-        bn_stats_aggregation=args.bn_stats_aggregation)
+        bn_statistics_group_size=args.bn_statistics_group_size)
 else:
     # Some other Wide ResNet.
     resnet = resnet_variant_dict[args.resnet](
         imagenet_labels,
-        bn_stats_aggregation=args.bn_stats_aggregation,
+        bn_statistics_group_size=args.bn_statistics_group_size,
         width=args.width)
 
 # Construct layer graph

--- a/python/lbann/contrib/models/wide_resnet.py
+++ b/python/lbann/contrib/models/wide_resnet.py
@@ -13,7 +13,7 @@ class WideResNet50_2(lbann.models.resnet.ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None):
         """Initialize WRN-50-2.
 
@@ -22,8 +22,8 @@ class WideResNet50_2(lbann.models.resnet.ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name.
                 (default: 'wide_resnet50_module<index>')
 
@@ -33,5 +33,5 @@ class WideResNet50_2(lbann.models.resnet.ResNet):
             WideResNet50_2.global_count)
         super().__init__(lbann.models.resnet.BottleneckBlock,
                          output_size, (3,4,6,3), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation, name,
+                         zero_init_residual, bn_statistics_group_size, name,
                          width=2)

--- a/python/lbann/models/resnet.py
+++ b/python/lbann/models/resnet.py
@@ -61,8 +61,8 @@ class ConvBNRelu(lbann.modules.Module):
         conv = self.conv(x)
         bn = lbann.BatchNormalization(
             conv, weights=self.bn_weights,
-            statistics_group_size=self.bn_statistics_group_size,
-            global_statistics=True if self.bn_statistics_group_size == 0 else None,
+            statistics_group_size=(-1 if self.bn_statistics_group_size == 0
+                                   else self.bn_statistics_group_size),
             name='{0}_bn_instance{1}'.format(self.name,self.instance))
         if self.relu:
             return lbann.Relu(

--- a/python/lbann/models/resnet.py
+++ b/python/lbann/models/resnet.py
@@ -13,7 +13,7 @@ class ConvBNRelu(lbann.modules.Module):
     """
 
     def __init__(self, out_channels, kernel_size, stride, padding,
-                 bn_zero_init, bn_stats_aggregation,
+                 bn_zero_init, bn_statistics_group_size,
                  relu, name):
         """Initialize ConvBNRelu module.
 
@@ -25,8 +25,8 @@ class ConvBNRelu(lbann.modules.Module):
             padding (int): Convolution padding.
             bn_zero_init (bool): Zero-initialize batch normalization
                 scale.
-            bn_stats_aggregation (str): Aggregation mode for batch
-                normalization statistics.
+            bn_statistics_group_size (int): Group size for aggregating
+                batch normalization statistics.
             relu (bool): Apply ReLU activation.
             name (str): Module name.
 
@@ -51,7 +51,7 @@ class ConvBNRelu(lbann.modules.Module):
             initializer=lbann.ConstantInitializer(value=0.0),
             name=self.name + '_bn_bias')
         self.bn_weights = [bn_scale, bn_bias]
-        self.bn_stats_aggregation = bn_stats_aggregation
+        self.bn_statistics_group_size = bn_statistics_group_size
 
         # Initialize ReLU
         self.relu = relu
@@ -61,7 +61,8 @@ class ConvBNRelu(lbann.modules.Module):
         conv = self.conv(x)
         bn = lbann.BatchNormalization(
             conv, weights=self.bn_weights,
-            stats_aggregation=self.bn_stats_aggregation,
+            statistics_group_size=self.bn_statistics_group_size,
+            global_statistics=True if self.bn_statistics_group_size == 0 else None,
             name='{0}_bn_instance{1}'.format(self.name,self.instance))
         if self.relu:
             return lbann.Relu(
@@ -80,7 +81,7 @@ class BasicBlock(lbann.modules.Module):
 
     def __init__(self, in_channels, mid_channels,
                  downsample, zero_init_residual,
-                 bn_stats_aggregation, name, width=1):
+                 bn_statistics_group_size, name, width=1):
         """Initialize residual block.
 
         Args:
@@ -90,8 +91,8 @@ class BasicBlock(lbann.modules.Module):
                 factor of 2 in each spatial dimension).
             zero_init_residual (bool): Zero-initialize the scale in
                 the final batch normalization in the residual branch.
-            bn_stats_aggregation (str): Aggregation mode for batch
-                normalization statistics.
+            bn_statistics_group_size (int): Group size for aggregating
+                batch normalization statistics.
             name (str): Module name.
             width (float, optional): Width growth factor for 3x3
                 convolutions.
@@ -106,11 +107,11 @@ class BasicBlock(lbann.modules.Module):
         # Skip connection
         if downsample:
             self.branch1 = ConvBNRelu(self.out_channels, 1, 2, 0,
-                                      False, bn_stats_aggregation,
+                                      False, bn_statistics_group_size,
                                       False, self.name + '_branch1')
         elif in_channels != self.out_channels:
             self.branch1 = ConvBNRelu(self.out_channels, 1, 1, 0,
-                                      False, bn_stats_aggregation,
+                                      False, bn_statistics_group_size,
                                       False, self.name + '_branch1')
         else:
             self.branch1 = None
@@ -118,11 +119,11 @@ class BasicBlock(lbann.modules.Module):
         # Residual branch
         self.branch2a = ConvBNRelu(mid_channels, 3,
                                    (2 if downsample else 1), 1,
-                                   False, bn_stats_aggregation,
+                                   False, bn_statistics_group_size,
                                    True, self.name + '_branch2a')
         self.branch2b = ConvBNRelu(self.out_channels, 3, 1, 1,
                                    zero_init_residual,
-                                   bn_stats_aggregation,
+                                   bn_statistics_group_size,
                                    False, self.name + '_branch2b')
 
     def forward(self, x):
@@ -144,7 +145,7 @@ class BottleneckBlock(lbann.modules.Module):
 
     def __init__(self, in_channels, mid_channels,
                  downsample, zero_init_residual,
-                 bn_stats_aggregation, name, width=1):
+                 bn_statistics_group_size, name, width=1):
         """Initialize residual block.
 
         Args:
@@ -154,8 +155,8 @@ class BottleneckBlock(lbann.modules.Module):
                 factor of 2 in each spatial dimension).
             zero_init_residual (bool): Zero-initialize the scale in
                 the final batch normalization in the residual branch.
-            bn_stats_aggregation (str): Aggregation mode for batch
-                normalization statistics.
+            bn_statistics_group_size (int): Group size for aggregating
+                batch normalization statistics.
             name (str): Module name.
             width (float, optional): Width growth factor for 3x3
                 convolutions.
@@ -171,26 +172,26 @@ class BottleneckBlock(lbann.modules.Module):
         # Skip connection
         if downsample:
             self.branch1 = ConvBNRelu(self.out_channels, 1, 2, 0,
-                                      False, bn_stats_aggregation,
+                                      False, bn_statistics_group_size,
                                       False, self.name + '_branch1')
         elif in_channels != self.out_channels:
             self.branch1 = ConvBNRelu(self.out_channels, 1, 1, 0,
-                                      False, bn_stats_aggregation,
+                                      False, bn_statistics_group_size,
                                       False, self.name + '_branch1')
         else:
             self.branch1 = None
 
         # Residual branch
         self.branch2a = ConvBNRelu(mid_channels, 1, 1, 0,
-                                   False, bn_stats_aggregation,
+                                   False, bn_statistics_group_size,
                                    True, self.name + '_branch2a')
         self.branch2b = ConvBNRelu(mid_channels, 3,
                                    (2 if downsample else 1), 1,
-                                   False, bn_stats_aggregation,
+                                   False, bn_statistics_group_size,
                                    True, self.name + '_branch2b')
         self.branch2c = ConvBNRelu(self.out_channels, 1, 1, 0,
                                    zero_init_residual,
-                                   bn_stats_aggregation,
+                                   bn_statistics_group_size,
                                    False, self.name + '_branch2c')
 
     def forward(self, x):
@@ -228,7 +229,7 @@ class ResNet(lbann.modules.Module):
 
     def __init__(self, block, output_size,
                  layer_sizes, layer_channels,
-                 zero_init_residual, bn_stats_aggregation,
+                 zero_init_residual, bn_statistics_group_size,
                  name, width=1):
         """Initialize ResNet.
 
@@ -242,8 +243,8 @@ class ResNet(lbann.modules.Module):
                 internal channels in each ResNet layer.
             zero_init_residual (bool): Whether to initialize the final
                 batch normalization in residual branches with zeros.
-            bn_stats_aggregation (str): Aggregation mode for batch
-                normalization statistics.
+            bn_statistics_group_size (int): Group size for aggregating
+                batch normalization statistics.
             name (str): Module name.
             width (float, optional): Width growth factor.
 
@@ -252,7 +253,7 @@ class ResNet(lbann.modules.Module):
         self.name = name
         self.instance = 0
         self.conv1 = ConvBNRelu(layer_channels[0], 7, 2, 3,
-                                False, bn_stats_aggregation,
+                                False, bn_statistics_group_size,
                                 True, self.name + '_conv1')
         self.blocks = []
         for layer in range(len(layer_sizes)):
@@ -264,7 +265,7 @@ class ResNet(lbann.modules.Module):
                 downsample = (i == 0 and layer > 0)
                 b = block(in_channels, mid_channels,
                           downsample, zero_init_residual,
-                          bn_stats_aggregation,
+                          bn_statistics_group_size,
                           '{0}_layer{1}_block{2}'.format(self.name, layer, i),
                           width=width)
                 self.blocks.append(b)
@@ -300,7 +301,7 @@ class ResNet18(ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None, width=1):
         """Initialize ResNet-18.
 
@@ -309,8 +310,8 @@ class ResNet18(ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name
                 (default: 'resnet18_module<index>')
             width (float, optional): Width growth factor.
@@ -321,7 +322,7 @@ class ResNet18(ResNet):
             name = 'resnet18_module{0}'.format(ResNet18.global_count)
         super().__init__(BasicBlock, output_size,
                          (2,2,2,2), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation,
+                         zero_init_residual, bn_statistics_group_size,
                          name, width=width)
 
 class ResNet34(ResNet):
@@ -341,7 +342,7 @@ class ResNet34(ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None, width=1):
         """Initialize ResNet-34.
 
@@ -350,8 +351,8 @@ class ResNet34(ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name
                 (default: 'resnet34_module<index>')
             width (float, optional): Width growth factor.
@@ -362,7 +363,7 @@ class ResNet34(ResNet):
             name = 'resnet34_module{0}'.format(ResNet34.global_count)
         super().__init__(BasicBlock, output_size,
                          (3,4,6,3), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation,
+                         zero_init_residual, bn_statistics_group_size,
                          name, width=width)
 
 class ResNet50(ResNet):
@@ -382,7 +383,7 @@ class ResNet50(ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None, width=1):
         """Initialize ResNet-50.
 
@@ -391,8 +392,8 @@ class ResNet50(ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name
                 (default: 'resnet50_module<index>')
             width (float, optional): Width growth factor.
@@ -403,7 +404,7 @@ class ResNet50(ResNet):
             name = 'resnet50_module{0}'.format(ResNet50.global_count)
         super().__init__(BottleneckBlock, output_size,
                          (3,4,6,3), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation,
+                         zero_init_residual, bn_statistics_group_size,
                          name, width=width)
 
 class ResNet101(ResNet):
@@ -423,7 +424,7 @@ class ResNet101(ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None, width=1):
         """Initialize ResNet-101.
 
@@ -432,8 +433,8 @@ class ResNet101(ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name
                 (default: 'resnet101_module<index>')
             width (float, optional): Width growth factor.
@@ -444,7 +445,7 @@ class ResNet101(ResNet):
             name = 'resnet101_module{0}'.format(ResNet101.global_count)
         super().__init__(BottleneckBlock, output_size,
                          (3,4,23,3), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation,
+                         zero_init_residual, bn_statistics_group_size,
                          name, width=width)
 
 class ResNet152(ResNet):
@@ -464,7 +465,7 @@ class ResNet152(ResNet):
 
     def __init__(self, output_size,
                  zero_init_residual=True,
-                 bn_stats_aggregation='local',
+                 bn_statistics_group_size=1,
                  name=None, width=1):
         """Initialize ResNet-152.
 
@@ -473,8 +474,8 @@ class ResNet152(ResNet):
             zero_init_residual (bool, optional): Whether to initialize
                 the final batch normalization in residual branches
                 with zeros.
-            bn_stats_aggregation (str, optional): Aggregation mode for
-                batch normalization statistics.
+            bn_statistics_group_size (str, optional): Group size for
+                aggregating batch normalization statistics.
             name (str, optional): Module name
                 (default: 'resnet152_module<index>')
             width (float, optional): Width growth factor.
@@ -485,5 +486,5 @@ class ResNet152(ResNet):
             name = 'resnet152_module{0}'.format(ResNet152.global_count)
         super().__init__(BottleneckBlock, output_size,
                          (3,8,36,3), (64,128,256,512),
-                         zero_init_residual, bn_stats_aggregation,
+                         zero_init_residual, bn_statistics_group_size,
                          name, width=width)

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -73,29 +73,27 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_
       local_var(channel, 0) = sqsum;
     }
     El::Int num_per_sum;
-    switch (m_stats_aggregation) {
-    case batch_normalization_stats_aggregation::global:
-      // Allreduce on fused buffer.
+    if (m_statistics_group_size == 0) {
+      // Global statistics aggregation; allreduce on fused buffer.
       m_comm->allreduce(*m_mean_and_var, m_mean_and_var->RedundantComm(),
                         El::mpi::SUM);
       num_per_sum = channel_size * width;
-      break;
-    case batch_normalization_stats_aggregation::node_local:
-      // Allreduce on fused buffer.
-      m_comm->allreduce(*m_mean_and_var, m_comm->get_node_comm(), El::mpi::SUM);
+    } else if (m_statistics_group_size == 1) {
+      // Local aggregation, no allreduce needed.
+      num_per_sum = channel_size * local_width;
+    } else {
+      // Grouped batchnorm. Allreduce on fused buffer.
+      m_comm->allreduce(*m_mean_and_var,
+                        m_comm->get_packed_group_comm(m_statistics_group_size),
+                        El::mpi::SUM);
       if (m_num_per_sum_cache.count(width) == 0) {
         num_per_sum = channel_size * local_width;
-        num_per_sum = m_comm->allreduce(num_per_sum, m_comm->get_node_comm());
+        num_per_sum = m_comm->allreduce(
+          num_per_sum, m_comm->get_packed_group_comm(m_statistics_group_size));
         m_num_per_sum_cache[width] = num_per_sum;
       } else {
         num_per_sum = m_num_per_sum_cache[width];
       }
-      break;
-    case batch_normalization_stats_aggregation::local:
-      num_per_sum = channel_size * local_width;
-      break;
-    default:
-      LBANN_ERROR("Unknown batch normalization stats aggregation");
     }
 
     // Compute minibatch statistics
@@ -225,15 +223,15 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
 
   // Accumulate gradients
   if (is_training) {
-    if (m_stats_aggregation == batch_normalization_stats_aggregation::global) {
-      // Allreduce on fused buffer.
+    if (m_statistics_group_size == 0) {
+      // Global aggregation; allreduce on fused buffer.
       m_comm->allreduce(*m_mean_and_var_gradient,
                         m_mean_and_var_gradient->RedundantComm(),
                         El::mpi::SUM);
-    } else if (m_stats_aggregation == batch_normalization_stats_aggregation::node_local) {
-      // Allreduce on fused buffer.
+    } else if (m_statistics_group_size > 1) {
+      // Grouped batchnorm; allreduce on fused buffer.
       m_comm->allreduce(*m_mean_and_var_gradient,
-                        m_comm->get_node_comm(),
+                        m_comm->get_packed_group_comm(m_statistics_group_size),
                         El::mpi::SUM);
     }
   } else {
@@ -255,18 +253,15 @@ void batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_
 
   // Compute error signal
   El::Int num_per_sum;
-  switch (m_stats_aggregation) {
-  case batch_normalization_stats_aggregation::global:
+  if (m_statistics_group_size == 0) {
+    // Global statistics aggregation.
     num_per_sum = channel_size * width;
-    break;
-  case batch_normalization_stats_aggregation::node_local:
-    num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
-    break;
-  case batch_normalization_stats_aggregation::local:
+  } else if (m_statistics_group_size == 1) {
+    // Local aggregation.
     num_per_sum = channel_size * local_width;
-    break;
-  default:
-    LBANN_ERROR("Unknown batch normalization stats aggregation");
+  } else {
+    // Grouped batchnorm.
+    num_per_sum = m_num_per_sum_cache[width];  // This was computed in FP.
   }
   if (num_per_sum <= 1) {
     El::Zero(local_gradient_wrt_input);

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -421,19 +421,26 @@ std::unique_ptr<Layer> construct_layer(
   if (proto_layer.has_batch_normalization()) {
     const auto& params = proto_layer.batch_normalization();
     if (Layout == data_layout::DATA_PARALLEL) {
+      int statistics_group_size = params.statistics_group_size();
+      if (params.global_statistics()) {
+        statistics_group_size = 0;
+      } else if (statistics_group_size == 0) {
+        statistics_group_size = 1;  // Default to local.
+      }
       const auto& aggr_str = params.stats_aggregation();
-      batch_normalization_stats_aggregation aggr =
-        batch_normalization_stats_aggregation::local;
-      if (aggr_str == "local" || aggr_str.empty()) {
-        aggr = batch_normalization_stats_aggregation::local;
-      } else if (aggr_str == "node_local") {
-        aggr = batch_normalization_stats_aggregation::node_local;
-      } else if (aggr_str == "global") {
-        aggr = batch_normalization_stats_aggregation::global;
-      } else {
-        err << "Invalid batch normalization stats aggregation " << aggr_str;
-        LBANN_ERROR(err.str());
-        return nullptr;
+      if (!aggr_str.empty()) {
+        LBANN_WARNING("stats_aggregation field for BatchNormalization is deprecated");
+        if (aggr_str == "local") {
+          statistics_group_size = 1;
+        } else if (aggr_str == "node_local") {
+          statistics_group_size = comm->get_procs_per_node();
+        } else if (aggr_str == "global") {
+          statistics_group_size = 0;
+        } else {
+          err << "Invalid batch normalization stats aggregation " << aggr_str;
+          LBANN_ERROR(err.str());
+          return nullptr;
+        }
       }
       // Set defaults if not given.
       auto decay = params.decay();
@@ -448,7 +455,7 @@ std::unique_ptr<Layer> construct_layer(
         comm,
         decay,
         epsilon,
-        aggr);
+        statistics_group_size);
     } else {
       LBANN_ERROR("batch normalization layer is only supported with "
                   "a data-parallel layout");

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -422,8 +422,8 @@ std::unique_ptr<Layer> construct_layer(
     const auto& params = proto_layer.batch_normalization();
     if (Layout == data_layout::DATA_PARALLEL) {
       int statistics_group_size = params.statistics_group_size();
-      if (params.global_statistics()) {
-        statistics_group_size = 0;
+      if (statistics_group_size < 0) {
+        statistics_group_size = 0;  // Global statistics.
       } else if (statistics_group_size == 0) {
         statistics_group_size = 1;  // Default to local.
       }

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1060,7 +1060,9 @@ message BatchNormalization {
   double scale_init = 2;     //default: 1.0
   double bias_init = 3;      //default: 0.0
   double epsilon = 4;        //default: 1e-5
-  string stats_aggregation = 5; // default: local
+  string stats_aggregation = 5; // default: local; deprecated
+  int64 statistics_group_size = 6;  // default: 1 (local)
+  bool global_statistics = 7;
 }
 
 message SeluDropout {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -1061,8 +1061,8 @@ message BatchNormalization {
   double bias_init = 3;      //default: 0.0
   double epsilon = 4;        //default: 1e-5
   string stats_aggregation = 5; // default: local; deprecated
-  int64 statistics_group_size = 6;  // default: 1 (local)
-  bool global_statistics = 7;
+  // default: 1 (local aggregation); set to a negative value for global stats.
+  int64 statistics_group_size = 6;
 }
 
 message SeluDropout {


### PR DESCRIPTION
This makes the specification of batchnorm statistics aggregation more general. Instead of just supporting local, node-local, and global statistics, you now specify the number of processors to aggregate statistics over. This makes rather more sense than just having a limited set of options, so you can aggregate over as many processors as needed to get good statistics, and not more.

For backwards compatibility, this still supports the old method of specifying aggregation in the prototext, but will issue a warning about it. The Python ResNet modules have been switched to exclusively use the new method, but the `model_zoo/vision/resnet.py` still supports the old argument for backwards compatibility (except node-local statistics).