### PR TITLE
Minor changes

### DIFF
--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -35,19 +35,19 @@ fi
 if [ "${CLUSTER}" = 'lassen' ]; then
     ALLOCATION_TIME_LIMIT=600
     if [ ${WEEKLY} -ne 0 ]; then
-        timeout 24h bsub -G guests -Is -q pbatch -nnodes 16 -W $ALLOCATION_TIME_LIMIT ./run.sh --weekly
+        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 16 -W $ALLOCATION_TIME_LIMIT ./run.sh --weekly
     else
-        timeout 24h bsub -G guests -Is -q pbatch -nnodes 16 -W $ALLOCATION_TIME_LIMIT ./run.sh
+        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 16 -W $ALLOCATION_TIME_LIMIT ./run.sh
     fi
 elif [ "${CLUSTER}" = 'catalyst' ] || [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTER}" = 'pascal' ]; then
     if [ ${WEEKLY} -ne 0 ]; then
         ALLOCATION_TIME_LIMIT=720
-        timeout 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh --weekly
+        timeout -k 5 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh --weekly
         if [ "${CLUSTER}" = 'catalyst' ]; then
             cd integration_tests
-            python -m pytest -s test_integration_performance_full_alexnet_clang6 --weekly --run --junitxml=alexnet_clang6_results.xml
-            python -m pytest -s test_integration_performance_full_alexnet_gcc7 --weekly --run --junitxml=alexnet_gcc7_results.xml
-            # python -m pytest -s test_integration_performance_full_alexnet_intel19 --weekly --run --junitxml=alexnet_intel19_results.xml
+            python -m pytest -s test_integration_performance_full_alexnet_clang6 --weekly --run --junitxml=../full_alexnet_clang6/results.xml
+            python -m pytest -s test_integration_performance_full_alexnet_gcc7 --weekly --run --junitxml=../full_alexnet_gcc7/results.xml
+            # python -m pytest -s test_integration_performance_full_alexnet_intel19 --weekly --run --junitxml=../full_alexnet_intel19/results.xml
             cd ..
         fi
     else
@@ -56,6 +56,6 @@ elif [ "${CLUSTER}" = 'catalyst' ] || [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTE
         elif [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTER}" = 'pascal' ]; then
             ALLOCATION_TIME_LIMIT=660
         fi
-        timeout 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh
+        timeout -k 5 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh
     fi
 fi

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -72,7 +72,7 @@ def get_command(cluster,
     else:
         raise Exception('Unsupported Cluster: %s' % cluster)
 
-    MAX_TIME = 60
+    MAX_TIME = 600
     # Description of command line options are from the appropriate command's
     # man pages
     if scheduler == 'slurm':

--- a/bamboo/full_alexnet_clang6/README.md
+++ b/bamboo/full_alexnet_clang6/README.md
@@ -1,0 +1,1 @@
+Directory for results.xml for full_alexnet_clang6.

--- a/bamboo/full_alexnet_gcc7/README.md
+++ b/bamboo/full_alexnet_gcc7/README.md
@@ -1,0 +1,1 @@
+Directory for results.xml for full_alexnet_gcc7.

--- a/bamboo/full_alexnet_intel19/README.md
+++ b/bamboo/full_alexnet_intel19/README.md
@@ -1,0 +1,1 @@
+Directory for results.xml for full_alexnet_intel19.

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -8,14 +8,16 @@ import collections, csv, os, pprint, re, time
 def get_command(cluster, dir_name, model_folder, model_name, executable,
                 output_file_name, error_file_name, compiler_name, weekly=False):
     if model_name in ['alexnet', 'conv_autoencoder_imagenet']:
-        data_reader_percent = 0.01
-        # If doing weekly testing, increase data_reader_percent
         if weekly:
             data_reader_percent = 0.10
+            time_limit = 600
+        else:
+            data_reader_percent = 0.01
+            time_limit = 60
         if cluster == 'lassen':
             command = tools.get_command(
                 cluster=cluster, executable=executable, num_nodes=16,
-                partition='pbatch', time_limit=600, num_processes=32,
+                partition='pbatch', time_limit=time_limit, num_processes=32,
                 dir_name=dir_name,
                 data_filedir_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/train/',
                 data_filename_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/train.txt',
@@ -28,7 +30,7 @@ def get_command(cluster, dir_name, model_folder, model_name, executable,
         else:
             command = tools.get_command(
                 cluster=cluster, executable=executable, num_nodes=16,
-                partition='pbatch', time_limit=600, num_processes=32,
+                partition='pbatch', time_limit=time_limit, num_processes=32,
                 dir_name=dir_name,
                 data_filedir_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/train/',
                 data_filename_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/train.txt',

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -125,7 +125,7 @@ def test_unit_lbann2_reload_clang6(cluster, exes, dirname):
 
 
 def test_unit_lbann2_reload_gcc7(cluster, exes, dirname):
-    if cluster in ['catalyst', 'lassen', 'pascal']:  # STILL ERRORS
+    if cluster in ['catalyst', 'corona', 'lassen', 'pascal']:  # STILL ERRORS
         pytest.skip('FIXME')
     skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7')
 

--- a/docs/continuous_integration.rst
+++ b/docs/continuous_integration.rst
@@ -165,7 +165,7 @@ Bamboo agent properties are used to specify requirements for each job.
 +--------------------------------+-------------+--------------+----------+------------------+------------------------+
 | Pascal Agents (x86_gpu_pascal) | lbannusr    | x86_64       | pascal   | pascal           | chaos_6_x86_64_ib      |
 +--------------------------------+-------------+--------------+----------+------------------+------------------------+
-| Ray Agents (ppc64le_gpu)       | lbannusr    | ppc64_le     | ray      | pascal           | blueos_3_ppc64le_ib    |
+| Ray Agents (ppc64le_gpu)       | lbannusr    | ppc64le      | ray      | pascal           | blueos_3_ppc64le_ib    |
 +--------------------------------+-------------+--------------+----------+------------------+------------------------+
 
 Currently, "agent_owner", "architecture", and "gpu_architecture" are used to


### PR DESCRIPTION
- Updated `timeout` command to send `KILL` signal after 5 minutes if the process hasn't been stopped already, to make sure a build will stop if it isn't finished within 24 hours (including queue time).
- Updated `full_alexnet` test commands to use `results.xml` in other directories to make sure those results are included in Bamboo.
- Updated `MAX_TIME` to be 600 minutes to reflect duration of weekly tests.
- Updated time limits for integration tests.
- Added Corona to list of clusters that should skip the `lbann2_reload` test for now.
- Updated Ray's architecture from `ppc64_le` to `ppc64le`.