### PR TITLE
Channel-wise scale/bias layer

### DIFF
--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_LEARNING_CHANNELWISE_SCALE_BIAS_HPP_INCLUDED
+#define LBANN_LAYER_LEARNING_CHANNELWISE_SCALE_BIAS_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+template <data_layout Layout = data_layout::DATA_PARALLEL,
+          El::Device Device = El::Device::CPU>
+class channelwise_scale_bias_layer : public Layer {
+public:
+
+  channelwise_scale_bias_layer(lbann_comm *comm)
+    : Layer(comm) {
+    static_assert(Layout == data_layout::DATA_PARALLEL,
+                  "channelwise_mean_layer only supports "
+                  "data-parallel data layout");
+  }
+
+  channelwise_scale_bias_layer(const channelwise_scale_bias_layer& other)
+    : Layer(other),
+      m_weights_gradient(other.m_weights_gradient ?
+                         other.m_weights_gradient->Copy() : nullptr) {}
+  channelwise_scale_bias_layer& operator=(const channelwise_scale_bias_layer& other) {
+    Layer::operator=(other);
+    m_weights_gradient.reset(other.m_weights_gradient ?
+                             other.m_weights_gradient->Copy() :
+                             nullptr);
+    return *this;
+  }
+
+  channelwise_scale_bias_layer* copy() const override {
+    return new channelwise_scale_bias_layer(*this);
+  }
+  std::string get_type() const override { return "channel-wise scale/bias"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
+
+  void setup_matrices(const El::Grid& grid) override {
+    Layer::setup_matrices(grid);
+    m_weights_gradient.reset(new StarMat<Device>(grid));
+  }
+
+  void setup_data() override {
+    Layer::setup_data();
+    const El::Int num_channels = get_output_dims()[0];
+
+    // Construct default weights if needed
+    if (this->m_weights.size() < 1) {
+      this->m_weights.push_back(new weights(get_comm()));
+      std::vector<DataType> vals(2*num_channels, DataType{0});
+      std::fill(vals.begin(), vals.begin()+num_channels, DataType{1});
+      std::unique_ptr<weights_initializer> init(new value_initializer(vals));
+      std::unique_ptr<optimizer> opt(m_model->create_optimizer());
+      this->m_weights[0]->set_name(get_name() + "_weights");
+      this->m_weights[0]->set_initializer(init);
+      this->m_weights[0]->set_optimizer(opt);
+      this->m_model->add_weights(this->m_weights[0]);
+    }
+    if (this->m_weights.size() != 1) {
+      std::ostringstream err;
+      err << "attempted to setup "
+          << this->get_type() << " layer \"" << this->get_name() << "\" "
+          << "with an invalid number of weights "
+          << "(expected 1, "
+          << "found " << this->m_weights.size() << ")";
+      LBANN_ERROR(err.str());
+    }
+
+    // Setup weights
+    auto matrix_dist = get_prev_activations().DistData();
+    matrix_dist.colDist = El::STAR;
+    matrix_dist.rowDist = El::STAR;
+    m_weights[0]->set_dims({static_cast<int>(num_channels)},
+                           {static_cast<int>(2)});
+    m_weights[0]->set_matrix_distribution(matrix_dist);
+
+    // Setup gradient w.r.t. weights
+    m_weights_gradient->Resize(num_channels, 2);
+
+  }
+
+protected:
+  void fp_compute() override;
+  void bp_compute() override;
+
+private:
+
+  std::unique_ptr<AbsDistMat> m_weights_gradient;
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_LEARNING_CHANNELWISE_SCALE_BIAS_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -46,6 +46,7 @@
 #include "lbann/layers/learning/convolution.hpp"
 #include "lbann/layers/learning/deconvolution.hpp"
 #include "lbann/layers/learning/embedding.hpp"
+#include "lbann/layers/learning/channelwise_scale_bias.hpp"
 
 /// Loss layers
 #include "lbann/layers/loss/categorical_accuracy.hpp"

--- a/src/layers/learning/CMakeLists.txt
+++ b/src/layers/learning/CMakeLists.txt
@@ -5,5 +5,13 @@ set_full_path(THIS_DIR_SOURCES
   fully_connected.cpp
   )
 
+if (LBANN_HAS_CUDA)
+  # Add the CUDA source files for this directory
+  set_full_path(THIS_DIR_CU_SOURCES
+    channelwise_scale_bias.cu
+    )
+endif ()
+
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)
+set(CUDA_SOURCES "${CUDA_SOURCES}" "${THIS_DIR_CU_SOURCES}" PARENT_SCOPE)

--- a/src/layers/learning/CMakeLists.txt
+++ b/src/layers/learning/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  channelwise_scale_bias.cpp
   embedding.cpp
   fully_connected.cpp
   )

--- a/src/layers/learning/channelwise_scale_bias.cpp
+++ b/src/layers/learning/channelwise_scale_bias.cpp
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/learning/channelwise_scale_bias.hpp"
+
+namespace lbann {
+
+template <>
+void channelwise_scale_bias_layer<data_layout::DATA_PARALLEL,El::Device::CPU>
+     ::fp_compute() {
+
+  // Local matrices
+  const auto& local_input = get_local_prev_activations();
+  auto& local_output = get_local_activations();
+  const auto& local_weights = m_weights[0]->get_values().LockedMatrix();
+
+  // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
+  const auto dims = get_output_dims();
+  const El::Int num_channels = dims[0];
+  const El::Int channel_size = std::accumulate(dims.begin() + 1,
+                                               dims.end(),
+                                               1, std::multiplies<int>());
+  const El::Int local_width = local_input.Width();
+
+  // Apply channel-wise scale and bias
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int col = 0; col < local_width; ++col) {
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      const auto s = local_weights(channel, 0);
+      const auto b = local_weights(channel, 1);
+      const auto* x = local_input.LockedBuffer(channel * channel_size, col);
+      auto* y = local_output.Buffer(channel * channel_size, col);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        y[i] = s * x[i] + b;
+      }
+    }
+  }
+
+}
+
+template <>
+void channelwise_scale_bias_layer<data_layout::DATA_PARALLEL,El::Device::CPU>
+     ::bp_compute() {
+
+  // Local matrices
+  const auto& local_input = get_local_prev_activations();
+  const auto& local_weights = m_weights[0]->get_values().LockedMatrix();
+  const auto& local_gradient_wrt_output = get_local_prev_error_signals();
+  auto& local_gradient_wrt_input = get_local_error_signals();
+  auto& local_gradient_wrt_weights = m_weights_gradient->Matrix();
+
+  // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
+  const auto dims = get_output_dims();
+  const El::Int num_channels = dims[0];
+  const El::Int channel_size = std::accumulate(dims.begin() + 1,
+                                               dims.end(),
+                                               1, std::multiplies<int>());
+  const El::Int local_width = local_input.Width();
+
+  // Compute gradients
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int channel = 0; channel < num_channels; ++channel) {
+    const auto s = local_weights(channel, 0);
+    auto& ds = local_gradient_wrt_weights(channel, 0);
+    auto& db = local_gradient_wrt_weights(channel, 1);
+    ds = DataType{0};
+    db = DataType{0};
+    for (El::Int col = 0; col < local_width; ++col) {
+      const El::Int offset = channel * channel_size;
+      const auto* x = local_input.LockedBuffer(offset, col);
+      const auto* dy = local_gradient_wrt_output.LockedBuffer(offset, col);
+      auto* dx = local_gradient_wrt_input.Buffer(offset, col);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        ds += x[i] * dy[i];
+        db += dy[i];
+        dx[i] = s * dy[i];
+      }
+    }
+  }
+
+  // Update optimizer with gradient
+  auto* opt = m_weights[0]->get_optimizer();
+  if (opt != nullptr) {
+    const El::Int mini_batch_size = this->m_model->get_effective_mini_batch_size();
+    opt->add_to_gradient(*m_weights_gradient,
+                         DataType{1} / mini_batch_size,
+                         true);
+  }
+
+}
+
+} // namespace lbann

--- a/src/layers/learning/channelwise_scale_bias.cu
+++ b/src/layers/learning/channelwise_scale_bias.cu
@@ -1,0 +1,251 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/learning/channelwise_scale_bias.hpp"
+#include "cub/block/block_reduce.cuh"
+
+namespace lbann {
+
+namespace {
+
+/**
+ *  Block dimensions: bsizex x bsizey x 1
+ *
+ *  Grid dimensions: (channel_size / bsizex) x (width / bsizey) x num_channels
+ */
+__global__ void fp_kernel(size_t num_channels,
+                          size_t channel_size,
+                          size_t width,
+                          const DataType* __restrict__ input,
+                          size_t input_ldim,
+                          DataType* __restrict__ output,
+                          size_t output_ldim,
+                          const DataType* __restrict__ scale,
+                          const DataType* __restrict__ bias) {
+
+  // Indices
+  const size_t bidz = blockIdx.z;
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nblocksz = gridDim.z;
+
+  // Apply channel-wise scale/bias
+  for (size_t channel = bidz; channel < num_channels; channel += nblocksz) {
+    const auto a = scale[channel];
+    const auto b = bias[channel];
+    const size_t row_start = channel * channel_size;
+    const size_t row_end = (channel + 1) * channel_size;
+    const size_t col_start = 0;
+    const size_t col_end = width;
+    for (size_t col = col_start+gidy; col < col_end; col += nthreadsy) {
+      for (size_t row = row_start+gidx; row < row_end; row += nthreadsx) {
+        const auto& x = input[row + col*input_ldim];
+        auto& y = output[row + col*output_ldim];
+        y = a * x + b;
+      }
+    }
+  }
+
+}
+
+/**
+ *  Block dimensions: bsizex x bsizey x 1
+ *
+ *  Grid dimensions: (channel_size / bsizex) x (width / bsizey) x num_channels
+ */
+template <size_t bsizex, size_t bsizey>
+__global__ void bp_kernel(size_t num_channels,
+                          size_t channel_size,
+                          size_t width,
+                          const DataType* __restrict__ input,
+                          size_t input_ldim,
+                          const DataType* __restrict__ gradient_wrt_output,
+                          size_t gradient_wrt_output_ldim,
+                          DataType* __restrict__ gradient_wrt_input,
+                          size_t gradient_wrt_input_ldim,
+                          const DataType* __restrict__ scale,
+                          DataType* __restrict__ gradient_wrt_scale,
+                          DataType* __restrict__ gradient_wrt_bias) {
+
+  // Indices
+  const size_t tid = threadIdx.x + threadIdx.y * blockDim.x;
+  const size_t bidz = blockIdx.z;
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nblocksz = gridDim.z;
+
+  for (size_t channel = bidz; channel < num_channels; channel += nblocksz) {
+
+    // Accumulate gradient contributions for thread in private memory
+    DataType private_da{0}, private_db{0};
+    const auto a = scale[channel];
+    const size_t row_start = channel * channel_size;
+    const size_t row_end = (channel + 1) * channel_size;
+    const size_t col_start = 0;
+    const size_t col_end = width;
+    for (size_t col = col_start+gidy; col < col_end; col += nthreadsy) {
+      for (size_t row = row_start+gidx; row < row_end; row += nthreadsx) {
+        const auto& x = input[row + col*input_ldim];
+        const auto& dy = gradient_wrt_output[row + col*gradient_wrt_output_ldim];
+        auto& dx = gradient_wrt_input[row + col*gradient_wrt_input_ldim];
+        private_da += x * dy;
+        private_db += dy;
+        dx = a * dy;
+      }
+    }
+
+    // Accumulate gradient contributions for block and add to result
+    // Note: Perform block reduction with CUB
+    constexpr auto reduce_algo = cub::BLOCK_REDUCE_WARP_REDUCTIONS;
+    using BlockReduce = cub::BlockReduce<DataType, bsizex, reduce_algo, bsizey>;
+    __shared__ typename BlockReduce::TempStorage workspace;
+    __syncthreads();
+    const auto da = BlockReduce(workspace).Sum(private_da);
+    if (tid == 0) {
+      cuda::atomic_add(&gradient_wrt_scale[channel], da);
+    }
+    __syncthreads();
+    const auto db = BlockReduce(workspace).Sum(private_db);
+    if (tid == 0) {
+      cuda::atomic_add(&gradient_wrt_bias[channel], db);
+    }
+
+  }
+
+}
+
+} // namespace
+
+template <>
+void channelwise_scale_bias_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::fp_compute() {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const GPUMat&>(get_local_prev_activations());
+  auto& local_output = dynamic_cast<GPUMat&>(get_local_activations());
+  const auto& local_weights = dynamic_cast<const GPUMat&>(m_weights[0]->get_values().LockedMatrix());
+  const auto local_scale = El::LockedView(local_weights,
+                                          El::ALL, El::IR(0));
+  const auto local_bias = El::LockedView(local_weights,
+                                         El::ALL, El::IR(1));
+
+  // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
+  const auto dims = get_output_dims();
+  const El::Int num_channels = dims[0];
+  const El::Int channel_size = std::accumulate(dims.begin() + 1,
+                                               dims.end(),
+                                               1, std::multiplies<int>());
+  const El::Int local_width = local_input.Width();
+
+  // Apply channel-wise scale and bias
+  if (!local_input.IsEmpty()) {
+    constexpr size_t block_size_x = 256;
+    constexpr size_t block_size_y = 1;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size_x;
+    block_dims.y = block_size_y;
+    grid_dims.x = (channel_size + block_size_x - 1) / block_size_x;
+    grid_dims.y = (local_width + block_size_y - 1) / block_size_y;
+    grid_dims.z = num_channels;
+    fp_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        num_channels, channel_size, local_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_output.Buffer(), local_output.LDim(),
+        local_scale.LockedBuffer(),
+        local_bias.LockedBuffer());
+  }
+
+}
+
+template <>
+void channelwise_scale_bias_layer<data_layout::DATA_PARALLEL, El::Device::GPU>
+     ::bp_compute() {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const GPUMat&>(get_local_prev_activations());
+  const auto& local_gradient_wrt_output = dynamic_cast<const GPUMat&>(get_local_prev_error_signals());
+  auto& local_gradient_wrt_input = dynamic_cast<GPUMat&>(get_local_error_signals());
+  const auto& local_weights = dynamic_cast<const GPUMat&>(m_weights[0]->get_values().LockedMatrix());
+  auto& local_gradient_wrt_weights = dynamic_cast<GPUMat&>(m_weights_gradient->Matrix());
+  const auto local_scale = El::LockedView(local_weights,
+                                          El::ALL, El::IR(0));
+  auto local_gradient_wrt_scale = El::View(local_gradient_wrt_weights,
+                                           El::ALL, El::IR(0));
+  auto local_gradient_wrt_bias = El::View(local_gradient_wrt_weights,
+                                          El::ALL, El::IR(1));
+
+  // Dimensions
+  // Note: channel_size is the number of input entries per channel and
+  // local_width is the number of local mini-batch samples.
+  const auto dims = get_output_dims();
+  const El::Int num_channels = dims[0];
+  const El::Int channel_size = std::accumulate(dims.begin() + 1,
+                                               dims.end(),
+                                               1, std::multiplies<int>());
+  const El::Int local_width = local_input.Width();
+
+  // Compute gradients
+  El::Zero(local_gradient_wrt_weights);
+  if (!local_input.IsEmpty()) {
+    constexpr size_t block_size_x = 256;
+    constexpr size_t block_size_y = 1;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size_x;
+    block_dims.y = block_size_y;
+    grid_dims.x = (channel_size + block_size_x - 1) / block_size_x;
+    grid_dims.y = (local_width + block_size_y - 1) / block_size_y;
+    grid_dims.z = num_channels;
+    bp_kernel<block_size_x, block_size_y>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        num_channels, channel_size, local_width,
+        local_input.LockedBuffer(), local_input.LDim(),
+        local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
+        local_gradient_wrt_input.Buffer(), local_gradient_wrt_input.LDim(),
+        local_scale.LockedBuffer(),
+        local_gradient_wrt_scale.Buffer(),
+        local_gradient_wrt_bias.Buffer());
+  }
+
+  // Update optimizer with gradient
+  auto* opt = m_weights[0]->get_optimizer();
+  if (opt != nullptr) {
+    const El::Int mini_batch_size = this->m_model->get_effective_mini_batch_size();
+    opt->add_to_gradient(*m_weights_gradient,
+                         DataType{1} / mini_batch_size,
+                         true);
+  }
+
+
+}
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -211,6 +211,16 @@ std::unique_ptr<Layer> construct_layer(
     }
   }
 
+  // Channel-wise scale/bias layer
+  if (proto_layer.has_channelwise_scale_bias()) {
+    if (Layout == data_layout::DATA_PARALLEL) {
+      return lbann::make_unique<channelwise_scale_bias_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(comm);
+    } else {
+      LBANN_ERROR("channel-wise scale/bias layer is only supported "
+                  "with data-parallel data layout");
+    }
+  }
+
   // Transform layers
   if (proto_layer.has_reshape()) {
     const auto& params = proto_layer.reshape();

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -214,7 +214,7 @@ std::unique_ptr<Layer> construct_layer(
   // Channel-wise scale/bias layer
   if (proto_layer.has_channelwise_scale_bias()) {
     if (Layout == data_layout::DATA_PARALLEL) {
-      return lbann::make_unique<channelwise_scale_bias_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(comm);
+      return lbann::make_unique<channelwise_scale_bias_layer<data_layout::DATA_PARALLEL,Device>>(comm);
     } else {
       LBANN_ERROR("channel-wise scale/bias layer is only supported "
                   "with data-parallel data layout");

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -857,6 +857,7 @@ message Layer {
    Convolution convolution = 13;
    Deconvolution deconvolution = 305;
    Embedding embedding = 328;
+   ChannelwiseScaleBias channelwise_scale_bias = 329;
 
    // Loss layers
    CrossEntropy cross_entropy = 60;
@@ -1287,6 +1288,8 @@ message Embedding {
   int64 dictionary_size = 1;
   int64 embedding_size = 2;
 }
+
+message ChannelwiseScaleBias {}
 
 //////////////////
 // Image layers //


### PR DESCRIPTION
The channel-wise scale/bias layer is equivalent to the second stage of batchnorm. It maintains the scaling and bias terms in a single weights tensor, which has the effect of halving the number of gradient allreduces (mostly latency-bound) and shifting each gradient allreduce slightly toward the bandwidth-bound regime.

It passes metric checking and gradient checking on Pascal and Catalyst. However, I'm not entirely pleased with the name. I was thinking "channel-wise affine layer", but that's not quite accurate since it implies an affine transformation on each channel. Also, DeepAI uses the term "affine layer" to refer to what we call a "fully-connected layer".

This makes progress toward Issue #618.