### PR TITLE
Fixing bug when parsing list of execution modes

### DIFF
--- a/src/base.cpp
+++ b/src/base.cpp
@@ -163,7 +163,7 @@ execution_mode exe_mode_from_string(std::string const& str) {
 std::istream& operator>>(std::istream& is, execution_mode& m) {
   std::string tmp;
   is >> tmp;
-  m = exe_mode_from_string(tmp);
+  m = is ? exe_mode_from_string(tmp) : execution_mode::invalid;
   return is;
 }
 


### PR DESCRIPTION
I notice that PR #1118 introduces a bug in `lbann::parse_set<lbann::execution_mode>`:

<details> <summary> Error message </summary>

```
****************************************************************
LBANN error on rank 4 (/usr/WS1/moon13/src/lbann/src/base.cpp:160): "" is not a valid execution mode.
Stack trace:
   0: lbann::stack_trace::get[abi:cxx11]()
   1: lbann::exception::exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)
   2: lbann::exe_mode_from_string(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
   3: lbann::operator>>(std::istream&, lbann::execution_mode&)
   4: std::set<lbann::execution_mode, std::less<lbann::execution_mode>, std::allocator<lbann::execution_mode> > lbann::parse_set<lbann::execution_mode>(std::__cxx\
11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
   5: lbann::build_callback_check_metric_from_pbuf(google::protobuf::Message const&, lbann::lbann_summary*)
   6: std::_Function_handler<std::unique_ptr<lbann::lbann_callback, std::default_delete<lbann::lbann_callback> > (google::protobuf::Message const&, lbann::lbann_s\
ummary*), std::unique_ptr<lbann::lbann_callback, std::default_delete<lbann::lbann_callback> > (*)(google::protobuf::Message const&, lbann::lbann_summary*)>::_M_in\
voke(std::_Any_data const&, google::protobuf::Message const&, lbann::lbann_summary*&&)
   7: lbann::proto::construct_callback(google::protobuf::Message const&, lbann::lbann_summary*)
   8: lbann::proto::construct_model(lbann::lbann_comm*, std::map<lbann::execution_mode, lbann::generic_data_reader*, std::less<lbann::execution_mode>, std::alloca\
tor<std::pair<lbann::execution_mode const, lbann::generic_data_reader*> > > const&, lbann_data::Optimizer const&, lbann_data::Model const&)
   9: lbann::build_model_from_prototext(int, char**, lbann_data::LbannPB&, lbann::lbann_comm*, std::shared_ptr<lbann::thread_pool>, bool)
  10: /usr/WS1/moon13/src/lbann/build/gnu.Release.catalyst.llnl.gov/install/bin/lbann() [0x4053c0] (could not find stack frame symbol)
  11: __libc_start_main (demangling failed)
  12: /usr/WS1/moon13/src/lbann/build/gnu.Release.catalyst.llnl.gov/install/bin/lbann() [0x405d70] (could not find stack frame symbol)
****************************************************************
```

</details>

The problem is that the stream extraction operator returns an empty string when it reaches the end. When it is fed into `lbann::exe_mode_from_string`, an exception is thrown. This can be fixed by checking whether the stream has finished before parsing it.