### PR TITLE
Disable signal handler in Python worker processes

### DIFF
--- a/src/data_readers/data_reader_python.cpp
+++ b/src/data_readers/data_reader_python.cpp
@@ -290,8 +290,8 @@ def @init_func@():
 
     """
 
-    # Disable LBANN signal handler for SIGTERM
-    #import signal
+    # Disable LBANN signal handler
+    import signal
     for sig in range(signal.NSIG):
         try:
             signal.signal(sig, signal.SIG_DFL)


### PR DESCRIPTION
In the Python data reader's destructor, the master process kills its worker processes by sending a `SIGTERM`. Sometimes this is caught by LBANN's signal handler, which prints out an error message and calls `MPI_Abort`. This is inconsistent, so it seems to be a race condition.

See #1111. This PR fixes my original diagnosis of the problem, but does not address the weird subsequent behavior with PyTorch.