### PR TITLE
update the proto inputs

### DIFF
--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -21,8 +21,8 @@ if (LBANN_HAS_PROTOBUF)
     "-I" "${CMAKE_CURRENT_SOURCE_DIR}"
     "${PROTO_INPUTS}"
     OUTPUT ${PROTO_SRCS} ${PROTO_HDRS} ${PROTO_PY}
-    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/lbann.proto" protobuf::protoc
-    COMMENT "Running protoc on lbann.proto"
+    DEPENDS ${PROTO_INPUTS} protobuf::protoc
+    COMMENT "Running protoc on LBANN protobuf sources."
     COMMAND_EXPAND_LISTS
     VERBATIM)
 


### PR DESCRIPTION
There was an issue where the proto library would not update if the `callbacks.proto` file changed. This should address that by adding it as a formal dependency. 