### PR TITLE
Sample list for image data reader

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -101,6 +101,7 @@ class generic_data_reader {
     m_procs_per_partition(1),
     m_io_thread_pool(nullptr),
     m_jag_partitioned(false),
+    m_keep_sample_order(false),
     m_model(nullptr),
     m_issue_warning(true)
   {}
@@ -172,6 +173,12 @@ class generic_data_reader {
    * Returns the complete sample list for your data set.
    */
   std::string get_data_sample_list() const;
+
+  /**
+   * To facilictate the testing, maintain the order of loaded samples
+   * in the sample list as it is in the list file.
+   */
+  void keep_sample_order(bool same_order = false);
 
   /**
    * Set the filename for your data (images, etc).
@@ -623,7 +630,7 @@ class generic_data_reader {
 
   void instantiate_data_store();
 
-  virtual void preload_data_store(); 
+  virtual void preload_data_store();
 
   void set_gan_labelling(bool has_gan_labelling) {
      m_gan_labelling = has_gan_labelling;
@@ -836,6 +843,10 @@ private:
   /// special handling for 1B jag; each reader
   /// owns a unique subset of the data
   bool m_jag_partitioned;
+
+  /** Whether to keep the order of loaded samples same as it is in the
+   *  file to make testing and validation easier */
+  bool m_keep_sample_order;
 
   /// called by fetch_data a single time if m_jag_partitioned = true;
   /// this sets various member variables (num_iterations, m_reset_mini_batch_index,

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -89,7 +89,7 @@ class generic_data_reader {
     m_world_master_mini_batch_adjustment(0),
     m_num_parallel_readers(0), m_rank_in_model(0),
     m_max_files_to_load(0),
-    m_file_dir(""), m_data_index_list(""), m_data_fn(""), m_label_fn(""),
+    m_file_dir(""), m_data_sample_list(""), m_data_fn(""), m_label_fn(""),
     m_shuffle(shuffle), m_absolute_sample_count(0), m_validation_percent(0.0),
     m_use_percent(1.0),
     m_master(false),
@@ -162,16 +162,16 @@ class generic_data_reader {
   std::string get_local_file_dir() const;
 
   /**
-   * Set the index list for your data (images, etc).
-   * The index lists contains an enumeration of all samples in the
+   * Set the sample list for your data (images, etc).
+   * The sample lists contains an enumeration of all samples in the
    * data set.
    */
-  void set_data_index_list(std::string s);
+  void set_data_sample_list(std::string s);
 
   /**
-   * Returns the complete index list for your data set.
+   * Returns the complete sample list for your data set.
    */
-  std::string get_data_index_list() const;
+  std::string get_data_sample_list() const;
 
   /**
    * Set the filename for your data (images, etc).
@@ -586,9 +586,9 @@ class generic_data_reader {
   /// returns true if the data set is partitioned
   bool is_partitioned() const { return m_is_partitioned; }
 
-  /// Does the data reader have a unqiue index list per model
+  /// Does the data reader have a unqiue sample list per model
   virtual bool has_list_per_model() const { return false; }
-  /// Does the data reader have a unqiue index list per trainer
+  /// Does the data reader have a unqiue sample list per trainer
   virtual bool has_list_per_trainer() const { return false; }
 
 
@@ -778,7 +778,7 @@ class generic_data_reader {
   size_t m_max_files_to_load;
   std::string m_file_dir;
   std::string m_local_file_dir;
-  std::string m_data_index_list;
+  std::string m_data_sample_list;
   std::string m_data_fn;
   std::string m_label_fn;
   bool m_shuffle;

--- a/include/lbann/data_readers/data_reader_image.hpp
+++ b/include/lbann/data_readers/data_reader_image.hpp
@@ -106,9 +106,11 @@ class image_data_reader : public generic_data_reader {
   void set_linearized_image_size();
 
   /// Rely on pre-determined list of samples.
-  void load_list_of_samples(const std::string filename, bool load_interleave = false);
+  void load_list_of_samples(const std::string filename);
   /// Load the sample list from a serialized archive from another rank
   void load_list_of_samples_from_archive(const std::string& sample_list_archive);
+  /// Load the labels for samples
+  void load_labels();
 
   std::string m_image_dir; ///< where images are stored
   int m_image_width; ///< image width

--- a/include/lbann/data_readers/data_reader_image.hpp
+++ b/include/lbann/data_readers/data_reader_image.hpp
@@ -39,9 +39,9 @@ class image_data_reader : public generic_data_reader {
   using img_src_t = std::string;
   using label_t = int;
   using sample_t = std::pair<img_src_t, label_t>;
-  //using sample_name_t = std::string;
-  using sample_name_t = size_t;
+  using sample_name_t = img_src_t;
   using sample_list_t = sample_list<sample_name_t>;
+  using labels_t = std::unordered_map<sample_name_t, label_t>;
 
   image_data_reader(bool shuffle = true);
   image_data_reader(const image_data_reader&);
@@ -82,21 +82,16 @@ class image_data_reader : public generic_data_reader {
     return {m_image_num_channels, m_image_height, m_image_width};
   }
 
-  /// Return the sample list of current minibatch
-  std::vector<sample_t> get_image_list_of_current_mb() const;
-
   /// Allow read-only access to the entire sample list
-  const std::vector<sample_t>& get_image_list() const {
-    return m_image_list;
+  const sample_list_t& get_sample_list() const {
+    return m_sample_list;
   }
 
   /**
    * Returns idx-th sample in the initial loading order.
    * The second argument is only to facilitate overloading, and not to be used by users.
    */
-  sample_t get_sample(const size_t idx) const {
-    return m_image_list.at(idx);
-  }
+  sample_t get_sample(const size_t idx) const;
 
   void do_preload_data_store() override;
 
@@ -116,7 +111,6 @@ class image_data_reader : public generic_data_reader {
   void load_list_of_samples_from_archive(const std::string& sample_list_archive);
 
   std::string m_image_dir; ///< where images are stored
-  std::vector<sample_t> m_image_list; ///< list of image files and labels
   int m_image_width; ///< image width
   int m_image_height; ///< image height
   int m_image_num_channels; ///< number of image channels
@@ -124,6 +118,7 @@ class image_data_reader : public generic_data_reader {
   int m_num_labels; ///< number of labels
 
   sample_list_t m_sample_list;
+  labels_t m_labels;
 
   bool load_conduit_nodes_from_file(const std::unordered_set<int> &data_ids);
 

--- a/include/lbann/data_readers/data_reader_image.hpp
+++ b/include/lbann/data_readers/data_reader_image.hpp
@@ -111,7 +111,7 @@ class image_data_reader : public generic_data_reader {
   void set_linearized_image_size();
 
   /// Rely on pre-determined list of samples.
-  void load_list_of_samples(const std::string filename, size_t stride=1, size_t offset=0);
+  void load_list_of_samples(const std::string filename, bool load_interleave = false);
   /// Load the sample list from a serialized archive from another rank
   void load_list_of_samples_from_archive(const std::string& sample_list_archive);
 

--- a/include/lbann/data_readers/data_reader_image.hpp
+++ b/include/lbann/data_readers/data_reader_image.hpp
@@ -30,6 +30,7 @@
 #define IMAGE_DATA_READER_HPP
 
 #include "data_reader.hpp"
+#include "sample_list.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
 
 namespace lbann {
@@ -38,6 +39,9 @@ class image_data_reader : public generic_data_reader {
   using img_src_t = std::string;
   using label_t = int;
   using sample_t = std::pair<img_src_t, label_t>;
+  //using sample_name_t = std::string;
+  using sample_name_t = size_t;
+  using sample_list_t = sample_list<sample_name_t>;
 
   image_data_reader(bool shuffle = true);
   image_data_reader(const image_data_reader&);
@@ -106,6 +110,11 @@ class image_data_reader : public generic_data_reader {
   bool fetch_label(Mat& Y, int data_id, int mb_idx) override;
   void set_linearized_image_size();
 
+  /// Rely on pre-determined list of samples.
+  void load_list_of_samples(const std::string filename, size_t stride=1, size_t offset=0);
+  /// Load the sample list from a serialized archive from another rank
+  void load_list_of_samples_from_archive(const std::string& sample_list_archive);
+
   std::string m_image_dir; ///< where images are stored
   std::vector<sample_t> m_image_list; ///< list of image files and labels
   int m_image_width; ///< image width
@@ -114,7 +123,9 @@ class image_data_reader : public generic_data_reader {
   int m_image_linearized_size; ///< linearized image size
   int m_num_labels; ///< number of labels
 
-  bool  load_conduit_nodes_from_file(const std::unordered_set<int> &data_ids);
+  sample_list_t m_sample_list;
+
+  bool load_conduit_nodes_from_file(const std::unordered_set<int> &data_ids);
 
 };
 

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -169,9 +169,9 @@ class data_reader_jag_conduit : public generic_data_reader {
   void check_image_data();
 #endif // _JAG_OFFLINE_TOOL_MODE_
 
-  /// Set every reader instances in a trainer to have an independent index list
+  /// Set every reader instances in a trainer to have an independent sample list
   void set_list_per_trainer(bool flag) { m_list_per_trainer = flag; };
-  /// Set every reader instances in a model to have an independent index list
+  /// Set every reader instances in a model to have an independent sample list
   void set_list_per_model(bool flag) { m_list_per_model = flag; };
 
   bool has_list_per_model() const override { return m_list_per_model; }

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -314,7 +314,7 @@ class data_reader_jag_conduit : public generic_data_reader {
    */
   bool check_num_parallel_readers(long data_set_size);
   /// Rely on pre-determined list of samples.
-  void load_list_of_samples(const std::string filename, size_t stride=1, size_t offset=0);
+  void load_list_of_samples(const std::string filename, bool load_interleave = false);
   /// Load the sample list from a serialized archive from another rank
   void load_list_of_samples_from_archive(const std::string& sample_list_archive);
 

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -115,6 +115,9 @@ class sample_list {
   template<typename T> size_t all_gather_field(T data, std::vector<T>& gathered_data, lbann_comm& comm);
   virtual void all_gather_packed_lists(lbann_comm& comm);
 
+  /// Set to maintain the original sample order as listed in the file
+  void keep_sample_order(bool keep);
+
  protected:
 
   /// Reads a header line from the sample list given as a stream, and use the info string for error message
@@ -149,6 +152,9 @@ class sample_list {
 
   /// The stride used in loading sample list file
   size_t m_stride;
+
+  /// maintain the original sample order as listed in the file
+  bool m_keep_order;
 
  private:
   /// List of all samples with a file identifier and sample name for each sample

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -18,10 +18,14 @@
 
 namespace lbann {
 
-static const std::string sample_exclusion_list = "CONDUIT_HDF5_EXCLUSION";
-static const std::string sample_inclusion_list = "CONDUIT_HDF5_INCLUSION";
+static const std::string multi_sample_exclusion = "MULTI-SAMPLE_EXCLUSION";
+static const std::string multi_sample_inclusion = "MULTI-SAMPLE_INCLUSION";
+static const std::string single_sample = "SINGLE-SAMPLE";
 
 struct sample_list_header {
+  /// Whether each data file includes multiple samples
+  bool m_is_multi_sample;
+  /// Whether to list the IDs of samples to exclude or to include
   bool m_is_exclusive;
   /// Number of included samples
   size_t m_included_sample_count;
@@ -30,16 +34,27 @@ struct sample_list_header {
   size_t m_num_files;
   std::string m_file_dir;
   std::string m_sample_list_filename;
+  std::string m_label_filename;
 
   sample_list_header();
 
+  void set_sample_list_type(const std::string& line1);
+  void set_sample_count(const std::string& line2);
+  void set_data_file_dir(const std::string& line3);
+  void set_label_filename(const std::string& line4);
+
+  bool is_multi_sample() const;
   bool is_exclusive() const;
   size_t get_sample_count() const;
   size_t get_num_files() const;
-  const std::string& get_sample_list_filename() const;
   const std::string& get_file_dir() const;
+  const std::string& get_sample_list_filename() const;
+  const std::string& get_label_filename() const;
   template <class Archive> void serialize( Archive & ar ) {
-    ar(m_is_exclusive, m_included_sample_count, m_excluded_sample_count, m_num_files, m_file_dir, m_sample_list_filename);
+    ar(m_is_multi_sample, m_is_exclusive,
+       m_included_sample_count, m_excluded_sample_count,
+       m_num_files, m_file_dir,
+       m_sample_list_filename, m_label_filename);
   }
 };
 
@@ -108,6 +123,7 @@ class sample_list {
   virtual const std::string& get_samples_filename(sample_file_id_t id) const;
 
   const std::string& get_samples_dirname() const;
+  const std::string& get_label_filename() const;
 
   void all_gather_archive(const std::string &archive, std::vector<std::string>& gathered_archive, lbann_comm& comm);
   void all_gather_archive_new(const std::string &archive, std::vector<std::string>& gathered_archive, lbann_comm& comm);

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -32,6 +32,8 @@ struct sample_list_header {
   /// Number of excluded samples
   size_t m_excluded_sample_count;
   size_t m_num_files;
+  /// whether file_dir is overriden, and not to be read from a file header
+  bool m_is_file_dir_overriden;
   std::string m_file_dir;
   std::string m_sample_list_filename;
   std::string m_label_filename;
@@ -40,6 +42,7 @@ struct sample_list_header {
 
   void set_sample_list_type(const std::string& line1);
   void set_sample_count(const std::string& line2);
+  void override_file_dir(const std::string& fdir);
   void set_data_file_dir(const std::string& line3);
   void set_label_filename(const std::string& line4);
 
@@ -122,6 +125,7 @@ class sample_list {
 
   virtual const std::string& get_samples_filename(sample_file_id_t id) const;
 
+  void override_samples_dirname(const std::string& fdir);
   const std::string& get_samples_dirname() const;
   const std::string& get_label_filename() const;
 

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -67,6 +67,11 @@ class sample_list {
   /// Load a sample list file
   void load(const std::string& samplelist_file, size_t stride=1, size_t offset=0);
 
+  /** Load a sample list file using the stride as the number of processes per
+   *  trainer and the offset as the current rank within the trainer.
+   */
+  void load(const std::string& samplelist_file, const lbann_comm& comm);
+
   /// Load the header of a sample list file
   sample_list_header load_header(const std::string& samplelist_file) const;
 
@@ -135,9 +140,15 @@ class sample_list {
 
   virtual void set_samples_filename(sample_file_id_t id, const std::string& filename);
 
+  /// Reorder the sample list to its initial order
+  virtual void reorder();
+
  protected:
   /// header info of sample list
   sample_list_header m_header;
+
+  /// The stride used in loading sample list file
+  size_t m_stride;
 
  private:
   /// List of all samples with a file identifier and sample name for each sample

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -307,7 +307,7 @@ inline void sample_list<sample_name_t>
 
     if (filename.empty() || !check_if_file_exists(file_path)) {
       throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__)
-                            + " :: data file '" + filename + "' does not exist.");
+                            + " :: data file '" + file_path + "' does not exist.");
     }
 
     const sample_file_id_t index = m_file_id_stats_map.size();

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -535,7 +535,7 @@ inline void sample_list<sample_name_t>
   size_t total, included, excluded;
   get_num_samples(total, included, excluded);
   /// TODO: clarify the comment below
-  /// Include the number of invalid samples, which for an inclusive index list is always 0
+  /// Include the number of invalid samples, which for an inclusive sample list is always 0
   sstr += std::to_string(included) + ' '  + std::to_string(excluded) + ' '  + std::to_string(num_files) + '\n';
   sstr += m_header.get_file_dir() + '\n';
 }
@@ -649,7 +649,7 @@ inline void sample_list<sample_name_t>
     }
   } else if constexpr (std::is_same<std::string, sample_name_t>::value) {
     for (auto& s: m_sample_list) {
-      s.second = s.first;
+      s.second = get_samples_filename(s.first);
     }
   } else {
     LBANN_ERROR(std::string{} + " :: base class does not implement this method"
@@ -686,7 +686,7 @@ template<> inline void sample_list<size_t>
 template<> inline void sample_list<std::string>
 ::assign_samples_name() {
   for (auto& s: m_sample_list) {
-    s.second = s.first;
+    s.second = get_samples_filename(s.first);
   }
 }
 

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -107,7 +107,7 @@ inline const std::string& sample_list_header::get_file_dir() const {
 
 template <typename sample_name_t>
 inline sample_list<sample_name_t>::sample_list()
-: m_stride(1ul) {
+: m_stride(1ul), m_keep_order(true) {
 }
 
 template <typename sample_name_t>
@@ -751,7 +751,9 @@ inline void sample_list<sample_name_t>
     }
   }
 
-  reorder();
+  if (m_keep_order) {
+    reorder();
+  }
 
   assign_samples_name();
 
@@ -781,6 +783,12 @@ inline void sample_list<sample_name_t>
     std::swap(m_sample_list, tmp_sample_list);
     m_stride = 1ul;
   }
+}
+
+template <typename sample_name_t>
+inline void sample_list<sample_name_t>
+::keep_sample_order(bool keep) {
+  m_keep_order = keep;
 }
 
 } // end of namespace lbann

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -761,18 +761,23 @@ inline void sample_list<sample_name_t>
 template <typename sample_name_t>
 inline void sample_list<sample_name_t>
 ::reorder() {
-  if (m_stride > 1ul) {
-    // undo interleaving
+  if (m_stride > 1ul) { // undo interleaving
     const size_t sz = m_sample_list.size();
-    samples_t tmp_sample_list;
-    tmp_sample_list.reserve(sz);
+    const size_t s = sz/m_stride;
+    const size_t s_more = (sz + m_stride - 1ul)/m_stride;
+    const size_t n_more = sz - s * m_stride;
 
-    const size_t s = (sz + m_stride - 1ul)/m_stride;
-    for (size_t i = 0ul; i < s; ++i) {
-      for (size_t j = i; j < sz; j += s) {
+    samples_t tmp_sample_list;
+    tmp_sample_list.reserve(s_more * m_stride);
+
+    for (size_t i = 0ul; i < s_more; ++i) {
+      for (size_t j = i, k = 0ul; j < sz; ++k) {
         tmp_sample_list.push_back(m_sample_list[j]);
+        //if (tmp_sample_list.size() == sz) break;
+        j += ((k < n_more)? s_more : s);
       }
     }
+    tmp_sample_list.resize(sz);
     std::swap(m_sample_list, tmp_sample_list);
     m_stride = 1ul;
   }

--- a/include/lbann/data_readers/sample_list_open_files.hpp
+++ b/include/lbann/data_readers/sample_list_open_files.hpp
@@ -107,6 +107,9 @@ class sample_list_open_files : public sample_list<sample_name_t> {
 
   void assign_samples_name() override {}
 
+  /// Reorder the sample list to its initial order
+  void reorder() override;
+
   /// Get the number of total/included/excluded samples
   void get_num_samples(size_t& total, size_t& included, size_t& excluded) const override;
 

--- a/include/lbann/data_readers/sample_list_open_files_impl.hpp
+++ b/include/lbann/data_readers/sample_list_open_files_impl.hpp
@@ -561,7 +561,31 @@ inline void sample_list_open_files<sample_name_t, file_handle_t>
     }
   }
 
+  // data_reader_jag_conduit does use any label. Thus, the information in
+  // sample list is self-contained requiring no reordering.
+  //reorder();
+
   return;
+}
+
+template <typename sample_name_t, typename file_handle_t>
+inline void sample_list_open_files<sample_name_t, file_handle_t>
+::reorder() {
+  if (this->m_stride > 1ul) {
+    // undo interleaving
+    const size_t sz = m_sample_list.size();
+    samples_t tmp_sample_list;
+    tmp_sample_list.reserve(sz);
+
+    const size_t s = (sz + this->m_stride - 1ul)/this->m_stride;
+    for (size_t i = 0ul; i < s; ++i) {
+      for (size_t j = i; j < sz; j += s) {
+        tmp_sample_list.push_back(m_sample_list[j]);
+      }
+    }
+    std::swap(m_sample_list, tmp_sample_list);
+    this->m_stride = 1ul;
+  }
 }
 
 template <typename sample_name_t, typename file_handle_t>

--- a/include/lbann/data_readers/sample_list_open_files_impl.hpp
+++ b/include/lbann/data_readers/sample_list_open_files_impl.hpp
@@ -561,9 +561,9 @@ inline void sample_list_open_files<sample_name_t, file_handle_t>
     }
   }
 
-  // data_reader_jag_conduit does use any label. Thus, the information in
-  // sample list is self-contained requiring no reordering.
-  //reorder();
+  if (this->m_keep_order) {
+    reorder();
+  }
 
   return;
 }

--- a/include/lbann/data_readers/sample_list_open_files_impl.hpp
+++ b/include/lbann/data_readers/sample_list_open_files_impl.hpp
@@ -574,15 +574,21 @@ inline void sample_list_open_files<sample_name_t, file_handle_t>
   if (this->m_stride > 1ul) {
     // undo interleaving
     const size_t sz = m_sample_list.size();
-    samples_t tmp_sample_list;
-    tmp_sample_list.reserve(sz);
+    const size_t s = sz/(this->m_stride);
+    const size_t s_more = (sz + this->m_stride - 1ul)/(this->m_stride);
+    const size_t n_more = sz - s * (this->m_stride);
 
-    const size_t s = (sz + this->m_stride - 1ul)/this->m_stride;
-    for (size_t i = 0ul; i < s; ++i) {
-      for (size_t j = i; j < sz; j += s) {
+    samples_t tmp_sample_list;
+    tmp_sample_list.reserve(s_more * (this->m_stride));
+
+    for (size_t i = 0ul; i < s_more; ++i) {
+      for (size_t j = i, k = 0ul; j < sz; ++k) {
         tmp_sample_list.push_back(m_sample_list[j]);
+        // if (tmp_sample_list.size() == sz) break;
+        j += ((k < n_more)? s_more : s);
       }
     }
+    tmp_sample_list.resize(sz);
     std::swap(m_sample_list, tmp_sample_list);
     this->m_stride = 1ul;
   }

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -37,19 +37,19 @@ class Trainer;
 
 namespace lbann {
 
-/** @brief Customize the name of the index list
+/** @brief Customize the name of the sample list
  *
  *  The following options are available
  *   - trainer ID
  *   - model name
  *
  *  The format for the naming convention if the provided name is
- *  \<index list\> is:
+ *  \<sample list\> is:
  *  @verbatim
-    <index list> == <basename>.<extension>
+    <sample list> == <basename>.<extension>
     <model name>_t<ID>_<basename>.<extension> @endverbatim
  */
-void customize_data_readers_index_list(const lbann_comm& comm,
+void customize_data_readers_sample_list(const lbann_comm& comm,
                                        ::lbann_data::LbannPB& p);
 
 /** @brief instantiates one or more generic_data_readers and inserts

--- a/model_zoo/data_readers/data_reader_imagenet.prototext
+++ b/model_zoo/data_readers/data_reader_imagenet.prototext
@@ -3,8 +3,7 @@ data_reader {
     name: "imagenet"
     role: "train"
     shuffle: true
-    data_filedir: "/p/lscratchh/brainusr/datasets/ILSVRC2012/original/train/"
-    data_filename: "/p/lscratchh/brainusr/datasets/ILSVRC2012/original/labels/train.txt"
+    sample_list:   "/p/lustre2/brainusr/datasets/ILSVRC2012/sample_list/train_sample_list.txt"
     label_filename: ""
     validation_percent: 0.0
     absolute_sample_count: 0
@@ -37,8 +36,7 @@ data_reader {
     name: "imagenet"
     role: "validate"
     shuffle: true
-    data_filedir: "/p/lscratchh/brainusr/datasets/ILSVRC2012/original/val/"
-    data_filename: "/p/lscratchh/brainusr/datasets/ILSVRC2012/original/labels/val.txt"
+    sample_list:  "/p/lustre2/brainusr/datasets/ILSVRC2012/sample_list/val_sample_list.txt"
     label_filename: ""
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0

--- a/model_zoo/data_readers/data_reader_imagenet_lassen.prototext
+++ b/model_zoo/data_readers/data_reader_imagenet_lassen.prototext
@@ -3,8 +3,7 @@ data_reader {
     name: "imagenet"
     role: "train"
     shuffle: true
-    data_filedir: "/p/gpfs1/brainusr/datasets/ILSVRC2012/original/train/"
-    data_filename: "/p/gpfs1/brainusr/datasets/ILSVRC2012/original/labels/train.txt"
+    sample_list:   "/p/gpfs1/brainusr/datasets/ILSVRC2012/sample_list/train_sample_list.txt"
     label_filename: ""
     validation_percent: 0.0
     absolute_sample_count: 0
@@ -37,8 +36,7 @@ data_reader {
     name: "imagenet"
     role: "validate"
     shuffle: true
-    data_filedir: "/p/gpfs1/brainusr/datasets/ILSVRC2012/original/val/"
-    data_filename: "/p/gpfs1/brainusr/datasets/ILSVRC2012/original/labels/val.txt"
+    sample_list:  "/p/gpfs1/brainusr/datasets/ILSVRC2012/sample_list/val_sample_list.txt"
     label_filename: ""
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0

--- a/model_zoo/data_readers/data_reader_jag.prototext
+++ b/model_zoo/data_readers/data_reader_jag.prototext
@@ -15,9 +15,9 @@ data_reader {
     role: "train"
     shuffle: true
     data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_A/100K4trainers/"
-    index_list: "100Kindex.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    sample_list: "100Kindex.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0
@@ -35,9 +35,9 @@ data_reader {
     shuffle: false
     # change to a lustre path
     data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_A/100K16trainers/"
-    index_list: "t1_sample_list.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    sample_list: "t1_sample_list.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0

--- a/model_zoo/models/jag/wae_cycle_gan/data_reader_jag_conduit_lassen.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/data_reader_jag_conduit_lassen.prototext
@@ -16,9 +16,9 @@ data_reader {
     shuffle: true
     # change to a lustre path
     data_filedir: "/p/gpfs1/brainusr/datasets/10MJAG/1M_A/"
-    index_list: "index.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    sample_list: "index.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0
@@ -35,9 +35,9 @@ data_reader {
     shuffle: true
     # change to a lustre path
     data_filedir: "/p/gpfs1/brainusr/datasets/10MJAG/1M_B"
-    index_list: "index.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    sample_list: "index.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0

--- a/model_zoo/models/jag/wae_cycle_gan/data_reader_jag_conduit_lustre.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/data_reader_jag_conduit_lustre.prototext
@@ -16,11 +16,11 @@ data_reader {
     shuffle: true
     # change to a lustre path
     #data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_A/"
-    #index_list: "index.txt"
+    #sample_list: "index.txt"
     data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_A/100K4trainers/"
-    index_list: "100Kindex.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    sample_list: "100Kindex.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0
@@ -38,11 +38,11 @@ data_reader {
     shuffle: true
     # change to a lustre path
     data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_B/"
-    index_list: "index.txt"
+    sample_list: "index.txt"
     #data_filedir: "/p/lustre2/brainusr/datasets/10MJAG/1M_A/100K16trainers/"
-    #index_list: "t1_sample_list.txt"
-    index_list_per_trainer: false
-    index_list_per_model: false
+    #sample_list: "t1_sample_list.txt"
+    sample_list_per_trainer: false
+    sample_list_per_model: false
 
     validation_percent: 0
     absolute_sample_count: 0

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -615,6 +615,14 @@ std::string generic_data_reader::get_data_sample_list() const {
   return m_data_sample_list;
 }
 
+void generic_data_reader::keep_sample_order(bool same_order) {
+  // The sample_list::keep_sample_order() should be called using this
+  // flag. By doing so, it will add additional step to re-shuffle the
+  // sample order to restore it to the original before the loading
+  // with interleaving accesses by multiple ranks in a trainer.
+  m_keep_sample_order = same_order;
+}
+
 void generic_data_reader::set_data_filename(std::string s) {
   m_data_fn = s;
 }

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -602,17 +602,17 @@ std::string generic_data_reader::get_local_file_dir() const {
   return m_local_file_dir;
 }
 
-void generic_data_reader::set_data_index_list(std::string s) {
-  m_data_index_list = s;
+void generic_data_reader::set_data_sample_list(std::string s) {
+  m_data_sample_list = s;
 }
 
-std::string generic_data_reader::get_data_index_list() const {
-  if (m_data_index_list == "") {
+std::string generic_data_reader::get_data_sample_list() const {
+  if (m_data_sample_list == "") {
     throw lbann_exception(
       std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: you apparently did not call set_data_index_list; error!");
+      " :: you apparently did not call set_data_sample_list; error!");
   }
-  return m_data_index_list;
+  return m_data_sample_list;
 }
 
 void generic_data_reader::set_data_filename(std::string s) {

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -288,6 +288,10 @@ void image_data_reader::load_conduit_node_from_file(int data_id, conduit::Node &
 void image_data_reader::load_list_of_samples(const std::string sample_list_file) {
   // load the sample list
   double tm1 = get_time();
+  if (! get_file_dir().empty()) {
+    m_sample_list.override_samples_dirname(get_file_dir());
+  }
+
   if (m_keep_sample_order) {
     m_sample_list.keep_sample_order(true);
     m_sample_list.load(sample_list_file, *m_comm);
@@ -302,6 +306,7 @@ void image_data_reader::load_list_of_samples(const std::string sample_list_file)
 
   /// Merge all of the sample lists
   m_sample_list.all_gather_packed_lists(*m_comm);
+  set_file_dir(m_sample_list.get_samples_dirname());
 
   double tm3 = get_time();
   if(is_master()) {

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -54,7 +54,7 @@ image_data_reader& image_data_reader::operator=(const image_data_reader& rhs) {
   }
   generic_data_reader::operator=(rhs);
   m_image_dir = rhs.m_image_dir;
-  m_image_list = rhs.m_image_list;
+  m_labels = rhs.m_labels;
   m_image_width = rhs.m_image_width;
   m_image_height = rhs.m_image_height;
   m_image_num_channels = rhs.m_image_num_channels;
@@ -76,7 +76,7 @@ void image_data_reader::copy_members(const image_data_reader &rhs) {
   }
 
   m_image_dir = rhs.m_image_dir;
-  m_image_list = rhs.m_image_list;
+  m_labels = rhs.m_labels;
   m_image_width = rhs.m_image_width;
   m_image_height = rhs.m_image_height;
   m_image_num_channels = rhs.m_image_num_channels;
@@ -126,7 +126,12 @@ void image_data_reader::set_input_params(const int width, const int height, cons
 }
 
 bool image_data_reader::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
-  const label_t label = m_image_list[data_id].second;
+  const auto sample_name = m_sample_list[data_id].second;
+  labels_t::const_iterator it = m_labels.find(sample_name);
+  if (it == m_labels.cend()) {
+    LBANN_ERROR("Cannot find label for sample '" + sample_name + "'.");
+  }
+  const label_t label = it->second;
   Y.Set(label, mb_idx, 1);
   return true;
 }
@@ -136,7 +141,7 @@ void image_data_reader::load() {
 
   // Load sample list
   const std::string data_dir = add_delimiter(get_file_dir());
-  const std::string sample_list_file = get_data_index_list();
+  const std::string sample_list_file = get_data_sample_list();
 
   load_list_of_samples(sample_list_file, true);
   if(is_master()) {
@@ -163,25 +168,25 @@ void image_data_reader::load() {
 
   const std::string imageListFile = get_data_filename();
 
-  // load image list
-  m_image_list.clear();
+  // load labels
+  m_labels.clear();
   FILE *fplist = fopen(imageListFile.c_str(), "rt");
   if (!fplist) {
     LBANN_ERROR("failed to open: " + imageListFile + " for reading");
   }
   while (!feof(fplist)) {
-    char imagepath[512];
+    char imagepath[512] = {'\0'};
     label_t imagelabel;
     if (fscanf(fplist, "%s%d", imagepath, &imagelabel) <= 1) {
       break;
     }
-    m_image_list.emplace_back(imagepath, imagelabel);
+    m_labels.insert(std::make_pair(sample_name_t(imagepath), imagelabel));
   }
   fclose(fplist);
 
   // reset indices
   m_shuffled_indices.clear();
-  m_shuffled_indices.resize(m_image_list.size());
+  m_shuffled_indices.resize(m_sample_list.size());
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
   resize_shuffled_indices();
 
@@ -189,6 +194,15 @@ void image_data_reader::load() {
   instantiate_data_store();
 
   select_subset_of_data();
+}
+
+image_data_reader::sample_t image_data_reader::get_sample(const size_t idx) const {
+  const auto sample_name = m_sample_list[idx].second;
+  labels_t::const_iterator it = m_labels.find(sample_name);
+  if (it == m_labels.cend()) {
+    LBANN_ERROR("Cannot find label for sample '" + sample_name + "'.");
+  }
+  return sample_t(sample_name, it->second);
 }
 
 void read_raw_data(const std::string &filename, std::vector<char> &data) {
@@ -267,12 +281,6 @@ void image_data_reader::setup(int num_io_threads, observer_ptr<thread_pool> io_t
      static_cast<size_t>(m_image_width)});
 }
 
-std::vector<image_data_reader::sample_t> image_data_reader::get_image_list_of_current_mb() const {
-  std::vector<sample_t> ret;
-  ret.reserve(m_mini_batch_size);
-  return ret;
-}
-
 bool image_data_reader::load_conduit_nodes_from_file(const std::unordered_set<int> &data_ids) {
   conduit::Node node;
   for (auto t : data_ids) {
@@ -284,8 +292,17 @@ bool image_data_reader::load_conduit_nodes_from_file(const std::unordered_set<in
 
 void image_data_reader::load_conduit_node_from_file(int data_id, conduit::Node &node) {
   node.reset();
-  const std::string filename = get_file_dir() + m_image_list[data_id].first;
-  int label = m_image_list[data_id].second;
+
+  const auto file_id = m_sample_list[data_id].first;
+  const std::string filename = get_file_dir() + m_sample_list.get_samples_filename(file_id);
+
+  const auto& sample_name = m_sample_list[data_id].second;
+  std::unordered_map<std::string, label_t>::const_iterator it = m_labels.find(sample_name);
+  if (it == m_labels.cend()) {
+    LBANN_ERROR("Cannot find label for sample '" + sample_name + "'.");
+  }
+  const label_t label = it->second;
+
   std::vector<char> data;
   read_raw_data(filename, data);
   node[LBANN_DATA_ID_STR(data_id) + "/label"].set(label);

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -135,13 +135,10 @@ void image_data_reader::load() {
   options *opts = options::get();
 
   // Load sample list
-  // TODO: use other ways to obtain the name of the directory that contains
-  // sample lists. Currently, the function get_file_dir() is used for both
-  // the directory of actual data files and for that of the sample list.
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string sample_list_file = get_data_index_list();
 
-  load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
+  load_list_of_samples(sample_list_file, true);
   if(is_master()) {
     std::cout << "Finished sample list, check data" << std::endl;
   }
@@ -298,10 +295,14 @@ void image_data_reader::load_conduit_node_from_file(int data_id, conduit::Node &
   node[LBANN_DATA_ID_STR(data_id) + "/buffer_size"] = data.size();
 }
 
-void image_data_reader::load_list_of_samples(const std::string sample_list_file, size_t stride, size_t offset) {
+void image_data_reader::load_list_of_samples(const std::string sample_list_file, bool load_interleave) {
   // load the sample list
   double tm1 = get_time();
-  m_sample_list.load(sample_list_file, stride, offset);
+  if (load_interleave) {
+    m_sample_list.load(sample_list_file, *m_comm);
+  } else {
+    m_sample_list.load(sample_list_file);
+  }
   double tm2 = get_time();
 
   if (is_master()) {

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -179,8 +179,6 @@ void image_data_reader::load() {
   }
   fclose(fplist);
 
-  // TODO: this will probably need to change after sample_list class
-  //       is modified
   // reset indices
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_image_list.size());

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -49,6 +49,9 @@ image_data_reader::image_data_reader(const image_data_reader& rhs)
 }
 
 image_data_reader& image_data_reader::operator=(const image_data_reader& rhs) {
+  if (this == &rhs) {
+    return (*this);
+  }
   generic_data_reader::operator=(rhs);
   m_image_dir = rhs.m_image_dir;
   m_image_list = rhs.m_image_list;
@@ -57,11 +60,15 @@ image_data_reader& image_data_reader::operator=(const image_data_reader& rhs) {
   m_image_num_channels = rhs.m_image_num_channels;
   m_image_linearized_size = rhs.m_image_linearized_size;
   m_num_labels = rhs.m_num_labels;
+  m_sample_list.copy(rhs.m_sample_list);
 
   return (*this);
 }
 
 void image_data_reader::copy_members(const image_data_reader &rhs) {
+  if (this == &rhs) {
+    return;
+  }
 
   if(rhs.m_data_store != nullptr) {
     m_data_store = new data_store_conduit(rhs.get_data_store());
@@ -75,6 +82,7 @@ void image_data_reader::copy_members(const image_data_reader &rhs) {
   m_image_num_channels = rhs.m_image_num_channels;
   m_image_linearized_size = rhs.m_image_linearized_size;
   m_num_labels = rhs.m_num_labels;
+  m_sample_list.copy(rhs.m_sample_list);
   //m_thread_cv_buffer = rhs.m_thread_cv_buffer
 }
 
@@ -125,6 +133,36 @@ bool image_data_reader::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
 
 void image_data_reader::load() {
   options *opts = options::get();
+
+  // Load sample list
+  // TODO: use other ways to obtain the name of the directory that contains
+  // sample lists. Currently, the function get_file_dir() is used for both
+  // the directory of actual data files and for that of the sample list.
+  const std::string data_dir = add_delimiter(get_file_dir());
+  const std::string sample_list_file = data_dir + get_data_index_list();
+
+  load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
+  if(is_master()) {
+    std::cout << "Finished sample list, check data" << std::endl;
+  }
+
+  /// Merge all of the sample lists
+  m_sample_list.all_gather_packed_lists(*m_comm);
+  if (opts->has_string("write_sample_list") && m_comm->am_trainer_master()) {
+    {
+      const std::string msg = " writing sample list " + sample_list_file;
+      LBANN_WARNING(msg);
+    }
+    std::stringstream s;
+    std::string basename = get_basename_without_ext(sample_list_file);
+    std::string ext = get_ext_name(sample_list_file);
+    s << basename << "." << ext;
+    m_sample_list.write(s.str());
+  }
+
+  if(is_master()) {
+    std::cout << "Sample lists have been gathered" << std::endl;
+  }
 
   const std::string imageListFile = get_data_filename();
 
@@ -260,5 +298,30 @@ void image_data_reader::load_conduit_node_from_file(int data_id, conduit::Node &
   node[LBANN_DATA_ID_STR(data_id) + "/buffer_size"] = data.size();
 }
 
+void image_data_reader::load_list_of_samples(const std::string sample_list_file, size_t stride, size_t offset) {
+  // load the sample list
+  double tm1 = get_time();
+  m_sample_list.load(sample_list_file, stride, offset);
+  double tm2 = get_time();
+
+  if (is_master()) {
+    std::cout << "Time to load sample list: " << tm2 - tm1 << std::endl;
+  }
+}
+
+void image_data_reader::load_list_of_samples_from_archive(const std::string& sample_list_archive) {
+  // load the sample list
+  double tm1 = get_time();
+  std::stringstream ss(sample_list_archive); // any stream can be used
+
+  cereal::BinaryInputArchive iarchive(ss); // Create an input archive
+
+  iarchive(m_sample_list); // Read the data from the archive
+  double tm2 = get_time();
+
+  if (is_master()) {
+    std::cout << "Time to load sample list from archive: " << tm2 - tm1 << std::endl;
+  }
+}
 
 }  // namespace lbann

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -166,7 +166,7 @@ void image_data_reader::load() {
     std::cout << "Sample lists have been gathered" << std::endl;
   }
 
-  const std::string imageListFile = get_data_filename();
+  const std::string imageListFile = m_sample_list.get_label_filename();
 
   // load labels
   m_labels.clear();

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -143,13 +143,8 @@ void image_data_reader::load() {
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string sample_list_file = get_data_sample_list();
 
-  load_list_of_samples(sample_list_file, true);
-  if(is_master()) {
-    std::cout << "Finished sample list, check data" << std::endl;
-  }
+  load_list_of_samples(sample_list_file);
 
-  /// Merge all of the sample lists
-  m_sample_list.all_gather_packed_lists(*m_comm);
   if (opts->has_string("write_sample_list") && m_comm->am_trainer_master()) {
     {
       const std::string msg = " writing sample list " + sample_list_file;
@@ -162,27 +157,7 @@ void image_data_reader::load() {
     m_sample_list.write(s.str());
   }
 
-  if(is_master()) {
-    std::cout << "Sample lists have been gathered" << std::endl;
-  }
-
-  const std::string imageListFile = m_sample_list.get_label_filename();
-
-  // load labels
-  m_labels.clear();
-  FILE *fplist = fopen(imageListFile.c_str(), "rt");
-  if (!fplist) {
-    LBANN_ERROR("failed to open: " + imageListFile + " for reading");
-  }
-  while (!feof(fplist)) {
-    char imagepath[512] = {'\0'};
-    label_t imagelabel;
-    if (fscanf(fplist, "%s%d", imagepath, &imagelabel) <= 1) {
-      break;
-    }
-    m_labels.insert(std::make_pair(sample_name_t(imagepath), imagelabel));
-  }
-  fclose(fplist);
+  load_labels();
 
   // reset indices
   m_shuffled_indices.clear();
@@ -310,10 +285,10 @@ void image_data_reader::load_conduit_node_from_file(int data_id, conduit::Node &
   node[LBANN_DATA_ID_STR(data_id) + "/buffer_size"] = data.size();
 }
 
-void image_data_reader::load_list_of_samples(const std::string sample_list_file, bool load_interleave) {
+void image_data_reader::load_list_of_samples(const std::string sample_list_file) {
   // load the sample list
   double tm1 = get_time();
-  if (load_interleave) {
+  if (m_keep_sample_order) {
     m_sample_list.keep_sample_order(true);
     m_sample_list.load(sample_list_file, *m_comm);
   } else {
@@ -323,6 +298,14 @@ void image_data_reader::load_list_of_samples(const std::string sample_list_file,
 
   if (is_master()) {
     std::cout << "Time to load sample list: " << tm2 - tm1 << std::endl;
+  }
+
+  /// Merge all of the sample lists
+  m_sample_list.all_gather_packed_lists(*m_comm);
+
+  double tm3 = get_time();
+  if(is_master()) {
+    std::cout << "Time to gather sample list: " << tm3 - tm2 << std::endl;
   }
 }
 
@@ -339,6 +322,26 @@ void image_data_reader::load_list_of_samples_from_archive(const std::string& sam
   if (is_master()) {
     std::cout << "Time to load sample list from archive: " << tm2 - tm1 << std::endl;
   }
+}
+
+void image_data_reader::load_labels() {
+  const std::string imageListFile = m_sample_list.get_label_filename();
+
+  // load labels
+  m_labels.clear();
+  FILE *fplist = fopen(imageListFile.c_str(), "rt");
+  if (!fplist) {
+    LBANN_ERROR("failed to open: " + imageListFile + " for reading");
+  }
+  while (!feof(fplist)) {
+    char imagepath[512] = {'\0'};
+    label_t imagelabel;
+    if (fscanf(fplist, "%s%d", imagepath, &imagelabel) <= 1) {
+      break;
+    }
+    m_labels.insert(std::make_pair(sample_name_t(imagepath), imagelabel));
+  }
+  fclose(fplist);
 }
 
 }  // namespace lbann

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -139,7 +139,7 @@ void image_data_reader::load() {
   // sample lists. Currently, the function get_file_dir() is used for both
   // the directory of actual data files and for that of the sample list.
   const std::string data_dir = add_delimiter(get_file_dir());
-  const std::string sample_list_file = data_dir + get_data_index_list();
+  const std::string sample_list_file = get_data_index_list();
 
   load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
   if(is_master()) {

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -297,6 +297,7 @@ void image_data_reader::load_list_of_samples(const std::string sample_list_file,
   // load the sample list
   double tm1 = get_time();
   if (load_interleave) {
+    m_sample_list.keep_sample_order(true);
     m_sample_list.load(sample_list_file, *m_comm);
   } else {
     m_sample_list.load(sample_list_file);

--- a/src/data_readers/data_reader_imagenet.cpp
+++ b/src/data_readers/data_reader_imagenet.cpp
@@ -54,7 +54,10 @@ CPUMat imagenet_reader::create_datum_view(CPUMat& X, const int mb_idx) const {
 bool imagenet_reader::fetch_datum(CPUMat& X, int data_id, int mb_idx) {
   El::Matrix<uint8_t> image;
   std::vector<size_t> dims;
-  const std::string image_path = get_file_dir() + m_image_list[data_id].first;
+  const auto file_id = m_sample_list[data_id].first;
+  const std::string filename = m_sample_list.get_samples_filename(file_id);
+  const std::string image_path = get_file_dir() + filename;
+
   if (m_data_store != nullptr) {
     bool have_node = true;
     conduit::Node node;

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -784,13 +784,13 @@ void data_reader_jag_conduit::load() {
     std::cout << "data_reader_jag_conduit - starting load" << std::endl;
   }
   const std::string data_dir = add_delimiter(get_file_dir());
-  const std::string sample_list_file = data_dir + get_data_index_list();
+  const std::string sample_list_file = data_dir + get_data_sample_list();
 
   options *opts = options::get();
   bool check_data = opts->get_bool("check_data");
 
   /// The use of these flags need to be updated to properly separate
-  /// how index lists are used between trainers and models
+  /// how sample lists are used between trainers and models
   /// @todo m_list_per_trainer || m_list_per_model
   load_list_of_samples(sample_list_file, true);
   if(is_master()) {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -925,6 +925,10 @@ void data_reader_jag_conduit::load_list_of_samples(const std::string sample_list
   // load the sample list
   double tm1 = get_time();
   if (load_interleave) {
+    // data_reader_jag_conduit does use any label. Thus, the information in
+    // sample list is self-contained and does not require maintaining the
+    // original sample order.
+    m_sample_list.keep_sample_order(false);
     m_sample_list.load(sample_list_file, *(this->m_comm));
   } else {
     m_sample_list.load(sample_list_file);

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -792,10 +792,8 @@ void data_reader_jag_conduit::load() {
   /// The use of these flags need to be updated to properly separate
   /// how index lists are used between trainers and models
   /// @todo m_list_per_trainer || m_list_per_model
-  double tm2 = get_time();
-  load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
+  load_list_of_samples(sample_list_file, true);
   if(is_master()) {
-      std::cout << "Finished loading sample list; time: " << get_time() - tm2 << std::endl;
     if (!check_data) {
       std::cout << "Skipping check data" << std::endl;
     }
@@ -923,14 +921,18 @@ void data_reader_jag_conduit::do_preload_data_store() {
   }
 }
 
-void data_reader_jag_conduit::load_list_of_samples(const std::string sample_list_file, size_t stride, size_t offset) {
+void data_reader_jag_conduit::load_list_of_samples(const std::string sample_list_file, bool load_interleave) {
   // load the sample list
   double tm1 = get_time();
-  m_sample_list.load(sample_list_file, stride, offset);
+  if (load_interleave) {
+    m_sample_list.load(sample_list_file, *(this->m_comm));
+  } else {
+    m_sample_list.load(sample_list_file);
+  }
   double tm2 = get_time();
 
   if (is_master()) {
-    std::cout << "Time to load sample list: " << tm2 - tm1 << std::endl;
+    std::cout << "Finished loading sample list; time: " << tm2 - tm1 << std::endl;
   }
 }
 

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -793,11 +793,6 @@ void data_reader_jag_conduit::load() {
   /// how sample lists are used between trainers and models
   /// @todo m_list_per_trainer || m_list_per_model
   load_list_of_samples(sample_list_file, true);
-  if(is_master()) {
-    if (!check_data) {
-      std::cout << "Skipping check data" << std::endl;
-    }
-  }
 
   /// Check the data that each rank loaded
   if (!m_is_data_loaded && !m_sample_list.empty()) {
@@ -827,11 +822,15 @@ void data_reader_jag_conduit::load() {
     m_sample_list.close_if_done_samples_file_handle(0);
   }
   if(is_master()) {
-    std::cout << "Done with data checking" << std::endl;
+    if (!check_data) {
+      std::cout << "Skip data checking" << std::endl;
+    } else {
+      std::cout << "Done with data checking" << std::endl;
+    }
   }
 
   /// Merge all of the sample lists
-  tm2 = get_time();
+  double tm2 = get_time();
   m_sample_list.all_gather_packed_lists(*m_comm);
   if (opts->has_string("write_sample_list") && m_comm->am_trainer_master()) {
     {
@@ -936,7 +935,8 @@ void data_reader_jag_conduit::load_list_of_samples(const std::string sample_list
   double tm2 = get_time();
 
   if (is_master()) {
-    std::cout << "Finished loading sample list; time: " << tm2 - tm1 << std::endl;
+    std::cout << "Finished loading sample list; time: "
+              << tm2 - tm1 << " (sec)" << std::endl;
   }
 }
 

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -936,7 +936,6 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
   if (image_reader == nullptr) {
     LBANN_ERROR("data_reader_image *image_reader = dynamic_cast<data_reader_image*>(m_reader) failed");
   }
-  const std::vector<image_data_reader::sample_t> &image_list = image_reader->get_image_list();
   std::vector<size_t> my_image_sizes;
 
   // this block fires if we're exchanging cache data at the end
@@ -950,13 +949,16 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
   }
   
   else {
+    const auto& sample_list = image_reader->get_sample_list();
     // get sizes of files for which I'm responsible
     for (size_t h=m_rank_in_trainer; h<m_shuffled_indices->size(); h += m_np_in_trainer) {
       ++m_my_num_indices;
-      const std::string fn = m_reader->get_file_dir() + '/' + image_list[(*m_shuffled_indices)[h]].first;
+      const auto file_id = sample_list[(*m_shuffled_indices)[h]].first;
+      const std::string fn = m_reader->get_file_dir() + '/'
+                           + sample_list.get_samples_filename(file_id);
       std::ifstream in(fn.c_str());
       if (!in) {
-        LBANN_ERROR("failed to open ", fn, " for reading; file_dir: ", m_reader->get_file_dir(), "  fn: ", image_list[h].first, "; role: ", m_reader->get_role());
+        LBANN_ERROR("failed to open ", fn, " for reading ", fn, "; role: " + m_reader->get_role());
       }
       in.seekg(0, std::ios::end);
       my_image_sizes.push_back((*m_shuffled_indices)[h]);
@@ -981,7 +983,7 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
     disp[h+1] = disp[h] + counts[h];
   }
 
-  std::vector<size_t> work(image_list.size()*2);
+  std::vector<size_t> work(sample_list.size()*2);
   m_comm->trainer_all_gather<size_t>(my_image_sizes, work, counts, disp);
   indices.resize(m_np_in_trainer);
   for (int h=0; h<m_np_in_trainer; h++) {
@@ -1156,7 +1158,7 @@ void data_store_conduit::read_files(std::vector<char> &work, map_is_t &sizes, st
 
   //get the list of images from the data reader
   image_data_reader *image_reader = dynamic_cast<image_data_reader*>(m_reader);
-  const std::vector<image_data_reader::sample_t> &image_list = image_reader->get_image_list();
+  const auto& sample_list = image_reader->get_sample_list();
 
   //read the images
   size_t offset = 0;
@@ -1164,7 +1166,9 @@ void data_store_conduit::read_files(std::vector<char> &work, map_is_t &sizes, st
   for (size_t j=0; j<indices.size(); ++j) {
     int idx = indices[j];
     size_t s = sizes[idx];
-    const std::string fn = m_reader->get_file_dir() + '/' + image_list[idx].first;
+    const auto file_id = sample_list[idx].first;
+    const std::string fn = m_reader->get_file_dir() + '/'
+                         + sample_list.get_samples_filename(file_id);
     std::ifstream in(fn, std::ios::in | std::ios::binary);
     in.read(work.data()+offset, s);
     in.close();
@@ -1174,10 +1178,10 @@ void data_store_conduit::read_files(std::vector<char> &work, map_is_t &sizes, st
 
 void data_store_conduit::build_conduit_nodes(map_is_t &sizes) {
   image_data_reader *image_reader = dynamic_cast<image_data_reader*>(m_reader);
-  const std::vector<image_data_reader::sample_t> &image_list = image_reader->get_image_list();
   for (auto t : sizes) {
     int data_id = t.first;
-    int label = image_list[data_id].second; 
+    const auto sample = image_reader->get_sample(static_cast<size_t>(data_id));
+    const auto label = sample.second;
     if (m_image_offsets.find(data_id) == m_image_offsets.end()) {
       LBANN_ERROR("m_image_offsets.find(data_id) == m_image_offsets.end() for data_id: ", data_id);
     }

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -936,6 +936,7 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
   if (image_reader == nullptr) {
     LBANN_ERROR("data_reader_image *image_reader = dynamic_cast<data_reader_image*>(m_reader) failed");
   }
+  const auto& sample_list = image_reader->get_sample_list();
   std::vector<size_t> my_image_sizes;
 
   // this block fires if we're exchanging cache data at the end
@@ -949,7 +950,6 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
   }
   
   else {
-    const auto& sample_list = image_reader->get_sample_list();
     // get sizes of files for which I'm responsible
     for (size_t h=m_rank_in_trainer; h<m_shuffled_indices->size(); h += m_np_in_trainer) {
       ++m_my_num_indices;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -717,12 +717,18 @@ void customize_data_readers_index_list(const lbann_comm& comm, lbann_data::Lbann
     std::ostringstream s;
     std::string basename = get_basename_without_ext(r->index_list());
     std::string ext = get_ext_name(r->index_list());
+    std::string dir = lbann::file::extract_parent_directory(r->index_list());
+    if (dir.empty()) {
+      dir = ".";
+    }
+
     if(r->index_list_per_model()) {
       s << pb_model.name() << "_";
     }
     if(r->index_list_per_trainer()) {
       s << "t" << comm.get_trainer_rank() << "_";
     }
+    s << dir << '/';
     s << basename;
     s << "." << ext;
     r->set_index_list(s.str());

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -102,6 +102,7 @@ void init_data_readers(
     } else if ((name == "imagenet") ||
                (name == "multihead_siamese")) {
       init_image_data_reader(readme, pb_metadata, master, reader);
+      reader->set_data_index_list(readme.index_list());
       set_transform_pipeline = false;
     } else if (name == "jag") {
       auto* reader_jag = new data_reader_jag(shuffle);

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -102,7 +102,7 @@ void init_data_readers(
     } else if ((name == "imagenet") ||
                (name == "multihead_siamese")) {
       init_image_data_reader(readme, pb_metadata, master, reader);
-      reader->set_data_index_list(readme.index_list());
+      reader->set_data_sample_list(readme.sample_list());
       set_transform_pipeline = false;
     } else if (name == "jag") {
       auto* reader_jag = new data_reader_jag(shuffle);
@@ -145,9 +145,9 @@ void init_data_readers(
       auto reader_jag_conduit = dynamic_cast<data_reader_jag_conduit*>(reader);
       const lbann_data::Model& pb_model = p.model();
       reader->set_mini_batch_size(static_cast<int>(pb_model.mini_batch_size()));
-      reader->set_data_index_list(readme.index_list());
-      reader_jag_conduit->set_list_per_trainer(readme.index_list_per_trainer());
-      reader_jag_conduit->set_list_per_model(readme.index_list_per_model());
+      reader->set_data_sample_list(readme.sample_list());
+      reader_jag_conduit->set_list_per_trainer(readme.sample_list_per_trainer());
+      reader_jag_conduit->set_list_per_model(readme.sample_list_per_model());
 
       /// Allow the prototext to control if the data readers is
       /// shareable for each phase training, validation, or testing
@@ -673,18 +673,18 @@ void set_data_readers_filenames(
   }
 }
 
-void set_data_readers_index_list(
+void set_data_readers_sample_list(
   const std::string& which, lbann_data::LbannPB& p)
 {
   options *opts = options::get();
   lbann_data::DataReader *readers = p.mutable_data_reader();
   int size = readers->reader_size();
-  const std::string key_role = "index_list_" + which;
+  const std::string key_role = "sample_list_" + which;
 
   for (int j=0; j<size; j++) {
     lbann_data::Reader *r = readers->mutable_reader(j);
     if (r->role() == which) {
-      r->set_index_list(opts->get_string(key_role));
+      r->set_sample_list(opts->get_string(key_role));
     }
   }
 }
@@ -707,7 +707,7 @@ void set_data_readers_percent(lbann_data::LbannPB& p)
   }
 }
 
-void customize_data_readers_index_list(const lbann_comm& comm, lbann_data::LbannPB& p)
+void customize_data_readers_sample_list(const lbann_comm& comm, lbann_data::LbannPB& p)
 {
   lbann_data::DataReader *readers = p.mutable_data_reader();
   const lbann_data::Model& pb_model = p.model();
@@ -715,23 +715,23 @@ void customize_data_readers_index_list(const lbann_comm& comm, lbann_data::Lbann
   for (int j=0; j<size; j++) {
     lbann_data::Reader *r = readers->mutable_reader(j);
     std::ostringstream s;
-    std::string basename = get_basename_without_ext(r->index_list());
-    std::string ext = get_ext_name(r->index_list());
-    std::string dir = lbann::file::extract_parent_directory(r->index_list());
+    std::string basename = get_basename_without_ext(r->sample_list());
+    std::string ext = get_ext_name(r->sample_list());
+    std::string dir = lbann::file::extract_parent_directory(r->sample_list());
     if (dir.empty()) {
       dir = ".";
     }
 
-    if(r->index_list_per_model()) {
+    if(r->sample_list_per_model()) {
       s << pb_model.name() << "_";
     }
-    if(r->index_list_per_trainer()) {
+    if(r->sample_list_per_trainer()) {
       s << "t" << comm.get_trainer_rank() << "_";
     }
     s << dir << '/';
     s << basename;
     s << "." << ext;
-    r->set_index_list(s.str());
+    r->set_sample_list(s.str());
   }
 }
 
@@ -766,11 +766,11 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
       or opts->has_string("label_filename_test")) {
     set_data_readers_filenames("test", p);
   }
-  if (opts->has_string("index_list_train")) {
-    set_data_readers_index_list("train", p);
+  if (opts->has_string("sample_list_train")) {
+    set_data_readers_sample_list("train", p);
   }
-  if (opts->has_string("index_list_test")) {
-    set_data_readers_index_list("test", p);
+  if (opts->has_string("sample_list_test")) {
+    set_data_readers_sample_list("test", p);
   }
   if (opts->has_string("data_reader_percent")) {
     set_data_readers_percent(p);
@@ -920,7 +920,7 @@ void print_help(std::ostream& os)
        "      sets the file directory for train and test data\n"
        "  --data_filedir_train=<string>   --data_filedir_test=<string>\n"
        "  --data_filename_train=<string>  --data_filename_test=<string>\n"
-       "  --index_list_train=<string>     --index_list_test=<string>\n"
+       "  --sample_list_train=<string>    --sample_list_test=<string>\n"
        "  --label_filename_train=<string> --label_filename_test=<string>\n"
        "  --data_reader_percent=<float>\n"
        "  --share_testing_data_readers=<bool:[0|1]>\n"

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -103,6 +103,7 @@ void init_data_readers(
                (name == "multihead_siamese")) {
       init_image_data_reader(readme, pb_metadata, master, reader);
       reader->set_data_sample_list(readme.sample_list());
+      reader->keep_sample_order(readme.sample_list_keep_order());
       set_transform_pipeline = false;
     } else if (name == "jag") {
       auto* reader_jag = new data_reader_jag(shuffle);
@@ -148,6 +149,7 @@ void init_data_readers(
       reader->set_data_sample_list(readme.sample_list());
       reader_jag_conduit->set_list_per_trainer(readme.sample_list_per_trainer());
       reader_jag_conduit->set_list_per_model(readme.sample_list_per_model());
+      reader_jag_conduit->keep_sample_order(readme.sample_list_keep_order());
 
       /// Allow the prototext to control if the data readers is
       /// shareable for each phase training, validation, or testing

--- a/src/proto/reader.proto
+++ b/src/proto/reader.proto
@@ -87,6 +87,8 @@ message Reader {
   //------------- start of only for sample lists ------------------
   bool sample_list_per_trainer = 400;
   bool sample_list_per_model   = 401;
+  // For testing and validation, keep the loaded sample order same as that in the file
+  bool sample_list_keep_order  = 402;
   //------------- end of only for sample lists ------------------
 
   PythonDataReader python = 501;

--- a/src/proto/reader.proto
+++ b/src/proto/reader.proto
@@ -44,7 +44,7 @@ message Reader {
   string data_local_filedir = 50; //to support data_store
   string data_filename = 6;
   string label_filename = 7;
-  string index_list = 8;
+  string sample_list = 8;
   double validation_percent = 9;
   int64 absolute_sample_count = 11;
   int64 first_n = 200;
@@ -84,10 +84,10 @@ message Reader {
        // 2 - there's a set of overlap indices that are common to all models
   //------------- end of only for partitioned data sets ------------------
 
-  //------------- start of only for index lists ------------------
-  bool index_list_per_trainer = 400;
-  bool index_list_per_model   = 401;
-  //------------- end of only for index lists ------------------
+  //------------- start of only for sample lists ------------------
+  bool sample_list_per_trainer = 400;
+  bool sample_list_per_model   = 401;
+  //------------- end of only for sample lists ------------------
 
   PythonDataReader python = 501;
 

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -206,8 +206,8 @@ std::unique_ptr<model> build_model_from_prototext(
     display_omp_setup();
   }
 
-  // Update the index lists to accomodate multi-trainer / multi-model specification
-  customize_data_readers_index_list(*comm, pb);
+  // Update the sample lists to accomodate multi-trainer / multi-model specification
+  customize_data_readers_sample_list(*comm, pb);
 
   // Initialize data readers
   //@todo: code not in place for correctly handling image preprocessing


### PR DESCRIPTION
PR #1401 supersedes this PR
- Currently, sample list loading is interleaved among processes per trainer.
  This I believe is to distribute the load while processing a single text input file in case that the load is non trivial.
 - However, data store pre-loads the label as long as the image file name without interleaving. Thus, the sample order in the sample list does not match the label order in the data store.
- This can be solved by reordering sample list after all_gather to make sure the order is as it is in the file. While this capability is added, another solution is used. **`m_labels`, which maps a sample name (file name) to its label replaces the list that contains the pair of image file name and label, `m_image_list`.**
- Currently, to express the location of sample list file in the prototext input, `data_reader_jag_conduit` obtains the filename from `index_list`, and replaces the directory path with the one for the data files which is given by `data_filedir`. However, this approach forces users to put the sample list in the same directory as where data are and create mess. T**o allows users to put sample list anywhere they want, I modified to use the full path of index_list.**
- The sample lists for imagenet are created under `/p/lustre2/brainusr/datasets/ILSVRC2012/sample_list`.  `*_sample_list.txt` is in the sample list format. `*_image_list.txt` is in the original format with the directory paths corrected from `lscratchf` to `lustre2`.

- verified by two methods
  - writing out sample list file and comparing it against the input file
  - compare the image file name obtained from m_sample_list and m_image_list in fetch_datum() over multiple epochs.