### PR TITLE
Refactor model factory

### DIFF
--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -28,10 +28,14 @@
 #define LBANN_PROTO_FACTORIES_HPP_INCLUDED
 
 #include "lbann/callbacks/callback.hpp"
-#include "lbann/proto/proto_common.hpp"
 #include "lbann/data_readers/data_reader.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/proto/proto_common.hpp"
 #include "lbann/transforms/transform.hpp"
 #include "lbann/transforms/transform_pipeline.hpp"
+
+#include <map>
+#include <memory>
 
 namespace lbann_data {
 class Model;
@@ -46,10 +50,11 @@ namespace lbann {
 namespace proto {
 
 /** Construct a model specified with a prototext. */
-model* construct_model(lbann_comm* comm,
-                       const std::map<execution_mode, generic_data_reader*>& data_readers,
-                       const lbann_data::Optimizer& proto_opt,
-                       const lbann_data::Model& proto_model);
+std::unique_ptr<model> construct_model(
+  lbann_comm* comm,
+  const std::map<execution_mode, generic_data_reader*>& data_readers,
+  const lbann_data::Optimizer& proto_opt,
+  const lbann_data::Model& proto_model);
 
 /** Construct a layer graph specified with a prototext. */
 std::vector<std::unique_ptr<Layer>> construct_layer_graph(
@@ -89,7 +94,8 @@ std::unique_ptr<optimizer> construct_optimizer(
   const lbann_data::Optimizer& proto_opt);
 
 /** Construct an objective function specified with prototext. */
-objective_function* construct_objective_function(const lbann_data::ObjectiveFunction& proto_obj);
+std::unique_ptr<objective_function>
+construct_objective_function(const lbann_data::ObjectiveFunction& proto_obj);
 
 /** Construct a transform given a prototext. */
 std::unique_ptr<transform::transform> construct_transform(

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -104,8 +104,7 @@ using lbann_exception = exception;
  *  @param[in] args The things to be stringified.
  */
 template <typename... Args>
-std::string build_string(Args&&... args)
-{
+std::string build_string(Args&&... args) {
   std::ostringstream oss;
   int dummy[] = { (oss << args, 0)... };
   (void) dummy; // silence compiler warnings

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -46,6 +46,9 @@
     throw lbann::exception(ss_LBANN_ERROR.str());               \
   } while (0)
 
+#define LBANN_ERROR_STR(...)                    \
+  LBANN_ERROR(build_string(__VA_ARGS__))
+
 // Macro to print a warning to standard error stream.
 #define LBANN_WARNING(message)                                          \
   do {                                                                  \
@@ -90,6 +93,24 @@ private:
 
 };
 using lbann_exception = exception;
+
+/** @brief Build a string from the arguments.
+ *
+ *  The arguments must be stream-outputable (have operator<<(ostream&,
+ *  T) defined). It will be a static error if this fails.
+ *
+ *  @tparam Args (Inferred) The types of the arguments.
+ *
+ *  @param[in] args The things to be stringified.
+ */
+template <typename... Args>
+std::string build_string(Args&&... args)
+{
+  std::ostringstream oss;
+  int dummy[] = { (oss << args, 0)... };
+  (void) dummy; // silence compiler warnings
+  return oss.str();
+}
 
 } // namespace lbann
 

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -68,9 +68,7 @@ instantiate_model(lbann_comm* comm,
   }
 
   // Throw error if model type is not supported
-  std::stringstream err;
-  err << "unknown model type (" << type << ")";
-  LBANN_ERROR(err.str());
+  LBANN_ERROR_STR("unknown model type (", type, ")");
   return nullptr;
 }
 
@@ -83,15 +81,12 @@ void assign_layers_to_objective_function(
   objective_function& obj,
   const lbann_data::ObjectiveFunction& proto_obj) {
 
-  std::stringstream err;
-
   // Construct map from layer names to layers
   std::unordered_map<std::string, Layer*> names_to_layers;
   for (auto&& l : layer_list) {
     const auto& name = l->get_name();
     if (names_to_layers.count(name) > 0) {
-      err << "layer name \"" << name << "\" is not unique";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR_STR("layer name \"", name, "\" is not unique");
     }
     names_to_layers[name] = l.get();
   }
@@ -106,10 +101,9 @@ void assign_layers_to_objective_function(
       const auto& params = proto_obj.layer_term(num_layer_terms-1);
       auto* l = names_to_layers[params.layer()];
       if (l == nullptr) {
-        err << "attempted to set objective function layer term "
-            << "to correspond to layer \"" << params.layer() << "\", "
-            << "but no such layer exists";
-        LBANN_ERROR(err.str());
+        LBANN_ERROR_STR("attempted to set objective function layer term ",
+                        "to correspond to layer \"", params.layer(), "\", ",
+                        "but no such layer exists");
       }
       term->set_layer(*l);
     }
@@ -117,11 +111,9 @@ void assign_layers_to_objective_function(
 
   // Check that layer terms in objective function match prototext
   if (num_layer_terms != proto_obj.layer_term_size()) {
-    err << "recieved " << num_layer_terms << " "
-        << "objective function layer terms, "
-        << "but there are " << proto_obj.layer_term_size() << " "
-        << "in the prototext";
-    LBANN_ERROR(err.str());
+    LBANN_ERROR_STR("recieved ", num_layer_terms,
+                    " objective function layer terms, but there are ",
+                    proto_obj.layer_term_size(), " in the prototext");
   }
 }
 
@@ -135,9 +127,7 @@ void assign_layers_to_metrics(
   for (auto&& l : layer_list) {
     const auto& name = l->get_name();
     if (names_to_layers.count(name) > 0) {
-      std::stringstream err;
-      err << "layer name \"" << name << "\" is not unique";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR_STR("layer name \"", name, "\" is not unique");
     }
     names_to_layers[name] = l.get();
   }
@@ -149,11 +139,10 @@ void assign_layers_to_metrics(
       const auto& params = proto_model.metric(i).layer_metric();
       auto* l = names_to_layers[params.layer()];
       if (l == nullptr) {
-        std::stringstream err;
-        err << "attempted to set layer metric \"" << m->name() << "\" "
-            << "to correspond to layer \"" << params.layer() << "\", "
-            << "but no such layer exists";
-        LBANN_ERROR(err.str());
+        LBANN_ERROR_STR("attempted to set layer metric "
+                        "\"", m->name(), "\" "
+                        "to correspond to layer \"", params.layer(), "\", "
+                        "but no such layer exists");
       }
       m->set_layer(*l);
     }
@@ -172,8 +161,7 @@ void assign_weights_to_layers(
   for (auto&& w : weights_list) {
     const auto& name = w->get_name();
     if (names_to_weights.count(name) > 0) {
-      err << "weights name \"" << name << "\" is not unique";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR_STR("weights name \"", name, "\" is not unique");
     }
     names_to_weights[name] = w.get();
   }
@@ -186,9 +174,10 @@ void assign_weights_to_layers(
     for (auto&& name : parse_list<std::string>(proto_layer.weights())) {
       auto&& w = names_to_weights[name];
       if (!w) {
-        err << "could not find weights named \"" << name << "\", "
-            << "which are expected by layer " << layer_list[i]->get_name();
-        LBANN_ERROR(err.str());
+        LBANN_ERROR_STR("could not find weights named "
+                        "\"", name, "\", "
+                        "which are expected by layer ",
+                        layer_list[i]->get_name());
       }
       if (is_frozen) {
         w->freeze();
@@ -210,15 +199,12 @@ void assign_weights_to_objective_function(
   objective_function& obj,
   const lbann_data::ObjectiveFunction& proto_obj) {
 
-  std::stringstream err;
-
   // Construct map from weights names to weights
   std::unordered_map<std::string, weights*> names_to_weights;
   for (auto&& w : weights_list) {
     const auto& name = w->get_name();
     if (names_to_weights.count(name) > 0) {
-      err << "weights name \"" << name << "\" is not unique";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR_STR("weights name \"", name, "\" is not unique");
     }
     names_to_weights[name] = w.get();
   }
@@ -234,11 +220,10 @@ void assign_weights_to_objective_function(
       std::vector<weights*> term_weights;
       for (auto&& weights_name : parse_list<std::string>(params.weights())) {
         auto&& w = names_to_weights[weights_name];
-        if (w == nullptr) {
-          err << "attempted to apply L2 weight regularization to "
-              << "weights \"" << weights_name << "\", "
-              << "but no such weights exists";
-          LBANN_ERROR(err.str());
+        if (!w) {
+          LBANN_ERROR_STR("attempted to apply L2 weight regularization to "
+                          "weights \"", weights_name, "\", "
+                          "but no such weights exists");
         }
         term_weights.push_back(w);
       }

--- a/src/proto/factories/objective_function_factory.cpp
+++ b/src/proto/factories/objective_function_factory.cpp
@@ -34,10 +34,11 @@
 namespace lbann {
 namespace proto {
 
-objective_function* construct_objective_function(const lbann_data::ObjectiveFunction& proto_obj) {
+std::unique_ptr<objective_function>
+construct_objective_function(const lbann_data::ObjectiveFunction& proto_obj) {
 
   // Instantiate objective function
-  objective_function* obj = new objective_function();
+  auto obj = make_unique<objective_function>();
 
   // Weight regularization terms
   for (int i=0; i<proto_obj.l2_weight_regularization_size(); ++i) {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -185,12 +185,8 @@ std::unique_ptr<model> build_model_from_prototext(
   print_parameters(*comm, pb);
 
   // Initalize model
-  std::unique_ptr<model> ret_model{
-    proto::construct_model(comm,
-                           data_readers,
-                           pb.optimizer(),
-                           pb.model())
-  };
+  auto ret_model =
+    proto::construct_model(comm, data_readers, pb.optimizer(), pb.model());
   ret_model->setup(std::move(io_thread_pool));
 
   if(opts->get_bool("disable_background_io_activity")) {


### PR DESCRIPTION
This just does some memory-management updates. There's not enough here to merit a proper refactory-ing -- there's only 1 concrete model class and I haven't heard about more in the pipeline. Likewise, objective functions are not polymorphic. However, new memory is returned by the `construct_*` functions, so `unique_ptr` is the correct return type for these functions.

Builds off of #1140.