### PR TITLE
use realpaths instead of abspaths in setup.py

### DIFF
--- a/cmake/configure_files/setup.py.in
+++ b/cmake/configure_files/setup.py.in
@@ -9,9 +9,9 @@ config_file = '@_PYTHON_CONFIG_INI@'
 
 # Get relative paths
 # Note: setuptools does not accept absolute paths
-current_dir = os.path.dirname(os.path.abspath(__file__))
-src_dir = os.path.relpath(os.path.abspath(src_dir), current_dir)
-config_file = os.path.relpath(os.path.abspath(config_file), current_dir)
+current_dir = os.path.dirname(os.path.realpath(__file__))
+src_dir = os.path.relpath(os.path.realpath(src_dir), current_dir)
+config_file = os.path.relpath(os.path.realpath(config_file), current_dir)
 
 # Setup package
 setuptools.setup(


### PR DESCRIPTION
There was an issue with a user building in a directory that had a symlink in it. The structure was roughly:
```
source: /a/b/lbann/python
build: /a/b/symlink/superbuild_dir/lbann/build
```
The relative path from build to source is computed as `../../../../lbann/python`. Of course, this doesn't work. Thus, we need to use the relative path from `realpath(build)` to `realpath(source)`.