### PR TITLE
bug fixes for data_store_conduit for the mode: --preload_data_store. …

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -550,9 +550,17 @@ class generic_data_reader {
   }
 
   /**
-   * Select the appropriate subset of data based on settings.
+   * Optionally resizes the shuffled indices based on the data reader
+   * prototext settings: absolute_sample_count, percent_of_data_to_use.
+   * (dah - this was formerly part of select_subset_of_data)
    */
-  virtual void select_subset_of_data();
+  void resize_shuffled_indices();
+
+  /**
+   * Select the appropriate subset of data for the validation set based on
+   * the data reader prototext setting: validation_percent
+   */
+  void select_subset_of_data();
 
   /// called by select_subset_of_data() if data set is partitioned
   void select_subset_of_data_partitioned();
@@ -741,6 +749,12 @@ class generic_data_reader {
   double get_use_percent() const;
 
   /**
+   * Returns the percent of the shuffled indices that are to be 
+   * used. Code in this method was formerly in select_subset_of_data()
+   */
+  double get_percent_to_use() const;
+
+  /**
    * Return the percent of the dataset to be used for validation.
    */
   double get_validation_percent() const;
@@ -783,6 +797,11 @@ class generic_data_reader {
     NOT_IMPLEMENTED("fetch_response");
     return false;
   }
+
+  /// returns the percent of shuffled indices that are used;
+  /// the returned value  depends on the values returned by 
+  /// get_absolute_sample_count() and get_use_percent().
+  double get_percent_to_use();
 
   /**
    * Called before fetch_datum/label/response to allow initialization.
@@ -906,6 +925,10 @@ class generic_data_reader {
   /// but we're not retrieving a conduit::Node from the store. This typically occurs
   /// during the test phase
   bool m_issue_warning;
+
+  /// throws exception if get_absolute_sample_count() and
+  /// get_use_percent() are incorrect
+  void error_check_counts() const;
 };
 
 template<typename T>

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -350,35 +350,30 @@ int generic_data_reader::get_next_position() const {
   }
 }
 
-void generic_data_reader::select_subset_of_data_partitioned() {
-
-  //sanity checks
-  if (get_absolute_sample_count()) {
-    throw lbann_exception(
-      std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: generic_data_reader - absolute_sample_count is not supported "
-      + "for partitioned data_set");
-  }
+void generic_data_reader::error_check_counts() const {
+  size_t count = get_absolute_sample_count();
   double use_percent = get_use_percent();
-  if (use_percent <= 0.0 || use_percent > 1.0) {
-    throw lbann_exception(
-      std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: generic_data_reader - percent_of_data_to_use must be > 0 "
-      + "and <= 1");
+  if (count == 0 and use_percent == 0.0) {
+      LBANN_ERROR("get_use_percent() and get_absolute_sample_count() are both zero; exactly one must be zero");
   }
-  if (! (m_partition_mode == 1 || m_partition_mode == 2)) {
-    throw lbann_exception(
-      std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-      " :: generic_data_reader - overlap mode must be 1 or 2\n"
+  if (!(count == 0 or use_percent == 0.0)) {
+      LBANN_ERROR("get_use_percent() and get_absolute_sample_count() are both non-zero; exactly one must be zero");
+  }
+  if (m_is_partitioned && !(m_partition_mode == 1 || m_partition_mode == 2)) {
+    LBANN_ERROR("overlap mode must be 1 or 2\n"
       " 1 - share overlap data with one neighboring models;\n"
       " 2 - a set of overlap indices is common to (is shared by) all models");
   }
+  if (count != 0) {
+    if(count > static_cast<size_t>(get_num_data())) {
+      LBANN_ERROR("absolute_sample_count=" +
+        std::to_string(count) + " is > get_num_data=" +
+        std::to_string(get_num_data()));
+    }
+  }
+}
 
-  shuffle_indices();
-
-  //optionally only use a portion of the data (useful during development
-  //and testing)
-  m_shuffled_indices.resize( get_use_percent() * m_shuffled_indices.size());
+void generic_data_reader::select_subset_of_data_partitioned() {
 
   std::vector<int> common_pool;
   //case where there's an overlap set that is common to all models
@@ -494,54 +489,43 @@ void generic_data_reader::select_subset_of_data_partitioned() {
   }
 }
 
-void generic_data_reader::select_subset_of_data() {
+double generic_data_reader::get_percent_to_use() {
+  error_check_counts();
+  size_t count = get_absolute_sample_count();
+  double use_percent = get_use_percent();
+  double r = 0.;
+  
+  if (count != 0) {
+    r = count / get_num_data();
+  }
+
+  if (use_percent) {
+    r = (use_percent*get_num_data()) / get_num_data();
+  }
+
+  return r;
+}
+
+void generic_data_reader::resize_shuffled_indices() {
   // ensure that all readers have the same number of indices
   if (m_jag_partitioned) {
     size_t n = m_comm->trainer_allreduce<size_t>(m_shuffled_indices.size(), El::mpi::MIN);
     m_shuffled_indices.resize(n);
   }
 
+  double use_percent = get_percent_to_use();
+  shuffle_indices();
+  m_shuffled_indices.resize(use_percent * get_num_data());
+}
+
+void generic_data_reader::select_subset_of_data() {
   // optionally partition data set amongst the models
   if (m_is_partitioned) {
     select_subset_of_data_partitioned();
     return ;
   }
 
-  shuffle_indices();
-
-  size_t count = get_absolute_sample_count();
-  double use_percent = get_use_percent();
-  if (count == 0 and use_percent == 0.0) {
-      throw lbann_exception(
-        std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-        " :: generic_data_reader::select_subset_of_data() get_use_percent() "
-        + "and get_absolute_sample_count() are both zero; exactly one "
-        + "must be zero");
-  }
-  if (!(count == 0 or use_percent == 0.0)) {
-      throw lbann_exception(
-        std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-        " :: generic_data_reader::select_subset_of_data() get_use_percent() "
-        "and get_absolute_sample_count() are both non-zero; exactly one "
-        "must be zero");
-  }
-
-  if (count != 0) {
-    if(count > static_cast<size_t>(get_num_data())) {
-      throw lbann_exception(
-        std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-        " :: generic_data_reader::select_subset_of_data() - absolute_sample_count=" +
-        std::to_string(count) + " is > get_num_data=" +
-        std::to_string(get_num_data()));
-    }
-    m_shuffled_indices.resize(get_absolute_sample_count());
-  }
-
-  if (use_percent) {
-    m_shuffled_indices.resize(get_use_percent()*get_num_data());
-  }
-
-  long unused = get_validation_percent()*get_num_data(); //get_num_data() = m_shuffled_indices.size()
+  long unused = get_validation_percent()*get_num_data(); 
   long use_me = get_num_data() - unused;
   if (unused > 0) {
       m_unused_indices=std::vector<int>(m_shuffled_indices.begin() + use_me, m_shuffled_indices.end());
@@ -742,11 +726,16 @@ void generic_data_reader::instantiate_data_store(const std::vector<int>& local_l
       std::cout << "generic_data_reader::instantiate_data_store - Starting the preload" << std::endl;
     }
     if (local_list_sizes.size() != 0) {
+      if (is_master()) std::cout << "XX local_list_sizes.size() != 0\n";
       m_data_store->build_preloaded_owner_map(local_list_sizes);
     }
+else {
+      if (is_master()) std::cout << "XX local_list_sizes.size() == 0\n";
+}
     preload_data_store();
     if(is_master()) {
      std::cout << "preload complete" << std::endl;
+     std::cout << "num loaded samples in P_0: " << m_data_store->get_data_size() << std::endl;
     }
   }
 

--- a/src/data_readers/data_reader_ascii.cpp
+++ b/src/data_readers/data_reader_ascii.cpp
@@ -109,6 +109,7 @@ void ascii_reader::load() {
     std::cerr << "calling select_subset_of_data; m_shuffled_indices.size: " <<
       m_shuffled_indices.size() << std::endl;
   }
+  resize_shuffled_indices();
   select_subset_of_data();
 
 }

--- a/src/data_readers/data_reader_cifar10.cpp
+++ b/src/data_readers/data_reader_cifar10.cpp
@@ -120,6 +120,7 @@ void cifar10_reader::load() {
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_images.size());
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_csv.cpp
+++ b/src/data_readers/data_reader_csv.cpp
@@ -265,6 +265,7 @@ void csv_reader::load() {
   // Reset indices.
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_jag.cpp
+++ b/src/data_readers/data_reader_jag.cpp
@@ -339,7 +339,7 @@ void data_reader_jag::load() {
 
   m_shuffled_indices.resize(num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
-
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_merge_features.cpp
+++ b/src/data_readers/data_reader_merge_features.cpp
@@ -87,6 +87,7 @@ void data_reader_merge_features::load() {
   // Reset indices.
   m_shuffled_indices.resize(num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_merge_samples.cpp
+++ b/src/data_readers/data_reader_merge_samples.cpp
@@ -92,6 +92,7 @@ void data_reader_merge_samples::setup_indices(int num_samples) {
   // That's not strictly necessary, but does not impact anything.
   m_shuffled_indices.resize(num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_mesh.cpp
+++ b/src/data_readers/data_reader_mesh.cpp
@@ -63,6 +63,7 @@ void mesh_reader::load() {
   // Reset indices.
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_mnist.cpp
+++ b/src/data_readers/data_reader_mnist.cpp
@@ -176,6 +176,7 @@ void mnist_reader::load() {
     std::cerr << "calling select_subset_of_data; m_shuffled_indices.size: " <<
       m_shuffled_indices.size() << std::endl;
   }
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_moving_mnist.cpp
+++ b/src/data_readers/data_reader_moving_mnist.cpp
@@ -278,6 +278,7 @@ void moving_mnist_reader::load() {
   // Reset indices
   m_shuffled_indices.resize(num_images);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 
 }

--- a/src/data_readers/data_reader_multi_images.cpp
+++ b/src/data_readers/data_reader_multi_images.cpp
@@ -176,7 +176,7 @@ void data_reader_multi_images::load() {
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_image_list.size());
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
-
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_multihead_siamese.cpp
+++ b/src/data_readers/data_reader_multihead_siamese.cpp
@@ -152,7 +152,7 @@ void data_reader_multihead_siamese::load() {
 
   m_shuffled_indices.resize(num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
-
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_numpy.cpp
+++ b/src/data_readers/data_reader_numpy.cpp
@@ -127,6 +127,7 @@ void numpy_reader::load() {
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_numpy_npz.cpp
+++ b/src/data_readers/data_reader_numpy_npz.cpp
@@ -157,6 +157,7 @@ namespace lbann {
     m_shuffled_indices.clear();
     m_shuffled_indices.resize(m_num_samples);
     std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+    resize_shuffled_indices();
     select_subset_of_data();
   }
 

--- a/src/data_readers/data_reader_numpy_npz_conduit.cpp
+++ b/src/data_readers/data_reader_numpy_npz_conduit.cpp
@@ -94,9 +94,16 @@ void numpy_npz_conduit_reader::load() {
   std::string infile = get_data_filename();
   read_filelist(m_comm, infile, m_filenames);
 
-  // fills in: m_num_samples, m_num_features, m_num_response_features,
+  // fills in: m_num_features, m_num_response_features,
   // m_data_dims, m_data_word_size, m_response_word_size
   fill_in_metadata();
+
+  // Reset indices.
+  m_shuffled_indices.clear();
+  m_shuffled_indices.resize(m_num_samples);
+  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
+  m_num_samples = m_shuffled_indices.size();
 
   if (m_num_labels == 0 && !opts->get_bool("preload_data_store") && opts->get_bool("use_data_store")) {
     LBANN_WARNING("when not preloading you must specify the number of labels in the prototext file if you are doing classification");
@@ -119,16 +126,8 @@ void numpy_npz_conduit_reader::load() {
     }
   }
 
-  // Reset indices.
-  m_shuffled_indices.clear();
-  m_shuffled_indices.resize(m_num_samples);
-  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
-
   instantiate_data_store(local_list_sizes);
 
-  // TODO: this may need fixing up for efficiency. If using an absolute
-  //       num samples, or percentage of samples, and we've preloaded,
-  //       this is wasteful and not what we want
   select_subset_of_data();
 }
 
@@ -325,11 +324,6 @@ void numpy_npz_conduit_reader::fill_in_metadata() {
     LBANN_ERROR("failed to open " + m_filenames[my_file] + " for reading");
   }
   in.close();
-
-  m_num_samples = m_filenames.size();
-  if (is_master()) {
-    std::cout << "num samples: " << m_num_samples << "\n";
-  }
 
   int data_id = 0; //meaningless
   conduit::Node node;

--- a/src/data_readers/data_reader_pilot2_molecular.cpp
+++ b/src/data_readers/data_reader_pilot2_molecular.cpp
@@ -115,6 +115,7 @@ void pilot2_molecular_reader::load() {
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_python.cpp
+++ b/src/data_readers/data_reader_python.cpp
@@ -319,6 +319,7 @@ def @init_func@():
 void python_reader::load() {
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_synthetic.cpp
+++ b/src/data_readers/data_reader_synthetic.cpp
@@ -91,6 +91,7 @@ void data_reader_synthetic::load() {
   m_shuffled_indices.clear();
   m_shuffled_indices.resize(m_num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 

--- a/src/data_readers/data_reader_triplet.cpp
+++ b/src/data_readers/data_reader_triplet.cpp
@@ -146,7 +146,7 @@ void data_reader_triplet::load() {
 
   m_shuffled_indices.resize(num_samples);
   std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
-
+  resize_shuffled_indices();
   select_subset_of_data();
 }
 


### PR DESCRIPTION
…There were two problems.

  1) the entire data set was being loaded, even if the data reader specified that only an absolute number, or precentage should be used
  2) the validation set's schema was corrupted (see: data_store_conduit::copy_members); I don't know why, as this used to work; changes to the conduit repo, perhaps?

To get data store preloading to work I had to refactor data_store::select_subset_of_data(). Formerly this method performed two functions:

  1) resizing the shuffled_indices list
  2) selecting a portion of the list for the validation set.

To fix preloading (first problem) we need to perform (1), then call preload for
the data store, then call (2). Hence, select_subset_of_data() was refactored int
o two methods: resize_shuffled_indices() and select_subset_of_data()

This refactor required touching every data reader: calls to select_subset_of_data() needed to be replaced by two calls:
  resize_shuffled_indices()
  select_subset_of_data()