### PR TITLE
Refactoring LBANN_ERROR to make it more flexible.

### DIFF
--- a/include/lbann/utils/cublas.hpp
+++ b/include/lbann/utils/cublas.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/base.hpp"
 #include "lbann/utils/cuda.hpp"
+#include "lbann/utils/exception.hpp"
 
 #ifdef LBANN_HAS_CUDA
 #include <cuda_runtime.h>
@@ -44,8 +45,9 @@
       const cublasStatus_t status_FORCE_CHECK_CUBLAS = (cublas_call);   \
       if (status_FORCE_CHECK_CUBLAS != CUBLAS_STATUS_SUCCESS) {         \
         cudaDeviceReset();                                              \
-        LBANN_ERROR(std::string("cuBLAS error: ")                       \
-                    + lbann::cublas::get_error_string(status_FORCE_CHECK_CUBLAS)); \
+        LBANN_ERROR("cuBLAS error: ",                                   \
+                    lbann::cublas::get_error_string(                    \
+                      status_FORCE_CHECK_CUBLAS));                      \
       }                                                                 \
     }                                                                   \
     {                                                                   \
@@ -55,8 +57,8 @@
         status_FORCE_CHECK_CUBLAS = cudaGetLastError();                 \
       if (status_FORCE_CHECK_CUBLAS != cudaSuccess) {                   \
         cudaDeviceReset();                                              \
-        LBANN_ERROR(std::string("CUDA error: ")                         \
-                    + cudaGetErrorString(status_FORCE_CHECK_CUBLAS));   \
+        LBANN_ERROR("CUDA error: ",                                     \
+                    cudaGetErrorString(status_FORCE_CHECK_CUBLAS));     \
       }                                                                 \
     }                                                                   \
   } while (0)
@@ -67,20 +69,19 @@
       const cublasStatus_t status_FORCE_CHECK_CUBLAS = (cublas_call);   \
       if (status_FORCE_CHECK_CUBLAS != CUBLAS_STATUS_SUCCESS) {         \
         cudaDeviceReset();                                              \
-        LBANN_ERROR(std::string("cuBLAS error: ")                       \
-                    + lbann::cublas::get_error_string(status_FORCE_CHECK_CUBLAS)); \
+        LBANN_ERROR("cuBLAS error: ",                                   \
+                    lbann::cublas::get_error_string(                    \
+                      status_FORCE_CHECK_CUBLAS));                      \
       }                                                                 \
     }                                                                   \
   } while (0)
-#define FORCE_CHECK_CUBLAS_SYNC(cuda_call)                                    \
-  do {                                                                        \
-    const cudaError_t cuda_status = cuda_call;                                \
-    if (cuda_status != cudaSuccess) {                                         \
-      std::cerr << "CUDA error: " << cudaGetErrorString(cuda_status) << "\n"; \
-      std::cerr << "Error at " << __FILE__ << ":" << __LINE__ << "\n";        \
-      cudaDeviceReset();                                                      \
-      throw lbann::lbann_exception("CUDA error");                             \
-    }                                                                         \
+#define FORCE_CHECK_CUBLAS_SYNC(cuda_call)                              \
+  do {                                                                  \
+    const cudaError_t cuda_status = cuda_call;                          \
+    if (cuda_status != cudaSuccess) {                                   \
+      cudaDeviceReset();                                                \
+      LBANN_ERROR("CUDA error: ", cudaGetErrorString(cuda_status));     \
+    }                                                                   \
   } while (0)
 #ifdef LBANN_DEBUG
 #define CHECK_CUBLAS(cublas_call)                       \

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -28,39 +28,35 @@
 #define LBANN_UTILS_EXCEPTION_HPP_INCLUDED
 
 #include "lbann/comm.hpp"
+
+#include <exception>
 #include <iostream>
 #include <sstream>
-#include <exception>
 
 // Macro to throw an LBANN exception
-#define LBANN_ERROR(message)                                    \
+#define LBANN_ERROR(...)                                        \
   do {                                                          \
-    std::stringstream ss_LBANN_ERROR;                           \
-    ss_LBANN_ERROR << "LBANN error ";                           \
     const int rank_LBANN_ERROR = lbann::get_rank_in_world();    \
-    if (rank_LBANN_ERROR >= 0) {                                \
-      ss_LBANN_ERROR << "on rank " << rank_LBANN_ERROR << " ";  \
-    }                                                           \
-    ss_LBANN_ERROR << "(" << __FILE__ << ":" << __LINE__ << ")" \
-                     << ": " << (message);                      \
-    throw lbann::exception(ss_LBANN_ERROR.str());               \
+    throw lbann::exception(                                     \
+      lbann::build_string(                                      \
+        "LBANN error",                                          \
+        (rank_LBANN_ERROR >= 0                                  \
+         ? " on rank " + std::to_string(rank_LBANN_ERROR)       \
+         : std::string()),                                      \
+        " (", __FILE__, ":", __LINE__, "): ", __VA_ARGS__));    \
   } while (0)
 
-#define LBANN_ERROR_STR(...)                    \
-  LBANN_ERROR(build_string(__VA_ARGS__))
-
 // Macro to print a warning to standard error stream.
-#define LBANN_WARNING(message)                                          \
-  do {                                                                  \
-    std::stringstream ss_LBANN_WARNING;                                 \
-    ss_LBANN_WARNING << "LBANN warning ";                               \
-    const int rank_LBANN_WARNING = lbann::get_rank_in_world();          \
-    if (rank_LBANN_WARNING >= 0) {                                      \
-      ss_LBANN_WARNING << "on rank " << rank_LBANN_WARNING << " ";      \
-    }                                                                   \
-    ss_LBANN_WARNING << "(" << __FILE__ << ":" << __LINE__ << ")"       \
-                     << ": " << (message) << std::endl;                 \
-    std::cerr << ss_LBANN_WARNING.str();                                \
+#define LBANN_WARNING(...)                                      \
+  do {                                                          \
+    const int rank_LBANN_WARNING = lbann::get_rank_in_world();  \
+    std::cerr << lbann::build_string(                           \
+      "LBANN warning",                                          \
+      (rank_LBANN_WARNING >= 0                                  \
+       ? " on rank " + std::to_string(rank_LBANN_WARNING)       \
+       : std::string()),                                        \
+      " (", __FILE__, ":", __LINE__, "): ", __VA_ARGS__)        \
+              << std::endl;                                     \
   } while (0)
 
 namespace lbann {

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -68,7 +68,7 @@ instantiate_model(lbann_comm* comm,
   }
 
   // Throw error if model type is not supported
-  LBANN_ERROR_STR("unknown model type (", type, ")");
+  LBANN_ERROR("unknown model type (", type, ")");
   return nullptr;
 }
 
@@ -86,7 +86,7 @@ void assign_layers_to_objective_function(
   for (auto&& l : layer_list) {
     const auto& name = l->get_name();
     if (names_to_layers.count(name) > 0) {
-      LBANN_ERROR_STR("layer name \"", name, "\" is not unique");
+      LBANN_ERROR("layer name \"", name, "\" is not unique");
     }
     names_to_layers[name] = l.get();
   }
@@ -101,9 +101,9 @@ void assign_layers_to_objective_function(
       const auto& params = proto_obj.layer_term(num_layer_terms-1);
       auto* l = names_to_layers[params.layer()];
       if (l == nullptr) {
-        LBANN_ERROR_STR("attempted to set objective function layer term ",
-                        "to correspond to layer \"", params.layer(), "\", ",
-                        "but no such layer exists");
+        LBANN_ERROR("attempted to set objective function layer term ",
+                    "to correspond to layer \"", params.layer(), "\", ",
+                    "but no such layer exists");
       }
       term->set_layer(*l);
     }
@@ -111,9 +111,9 @@ void assign_layers_to_objective_function(
 
   // Check that layer terms in objective function match prototext
   if (num_layer_terms != proto_obj.layer_term_size()) {
-    LBANN_ERROR_STR("recieved ", num_layer_terms,
-                    " objective function layer terms, but there are ",
-                    proto_obj.layer_term_size(), " in the prototext");
+    LBANN_ERROR("recieved ", num_layer_terms,
+                " objective function layer terms, but there are ",
+                proto_obj.layer_term_size(), " in the prototext");
   }
 }
 
@@ -127,7 +127,7 @@ void assign_layers_to_metrics(
   for (auto&& l : layer_list) {
     const auto& name = l->get_name();
     if (names_to_layers.count(name) > 0) {
-      LBANN_ERROR_STR("layer name \"", name, "\" is not unique");
+      LBANN_ERROR("layer name \"", name, "\" is not unique");
     }
     names_to_layers[name] = l.get();
   }
@@ -139,10 +139,10 @@ void assign_layers_to_metrics(
       const auto& params = proto_model.metric(i).layer_metric();
       auto* l = names_to_layers[params.layer()];
       if (l == nullptr) {
-        LBANN_ERROR_STR("attempted to set layer metric "
-                        "\"", m->name(), "\" "
-                        "to correspond to layer \"", params.layer(), "\", "
-                        "but no such layer exists");
+        LBANN_ERROR("attempted to set layer metric "
+                    "\"", m->name(), "\" "
+                    "to correspond to layer \"", params.layer(), "\", "
+                    "but no such layer exists");
       }
       m->set_layer(*l);
     }
@@ -161,7 +161,7 @@ void assign_weights_to_layers(
   for (auto&& w : weights_list) {
     const auto& name = w->get_name();
     if (names_to_weights.count(name) > 0) {
-      LBANN_ERROR_STR("weights name \"", name, "\" is not unique");
+      LBANN_ERROR("weights name \"", name, "\" is not unique");
     }
     names_to_weights[name] = w.get();
   }
@@ -174,10 +174,10 @@ void assign_weights_to_layers(
     for (auto&& name : parse_list<std::string>(proto_layer.weights())) {
       auto&& w = names_to_weights[name];
       if (!w) {
-        LBANN_ERROR_STR("could not find weights named "
-                        "\"", name, "\", "
-                        "which are expected by layer ",
-                        layer_list[i]->get_name());
+        LBANN_ERROR("could not find weights named "
+                    "\"", name, "\", "
+                    "which are expected by layer ",
+                    layer_list[i]->get_name());
       }
       if (is_frozen) {
         w->freeze();
@@ -204,7 +204,7 @@ void assign_weights_to_objective_function(
   for (auto&& w : weights_list) {
     const auto& name = w->get_name();
     if (names_to_weights.count(name) > 0) {
-      LBANN_ERROR_STR("weights name \"", name, "\" is not unique");
+      LBANN_ERROR("weights name \"", name, "\" is not unique");
     }
     names_to_weights[name] = w.get();
   }
@@ -221,9 +221,9 @@ void assign_weights_to_objective_function(
       for (auto&& weights_name : parse_list<std::string>(params.weights())) {
         auto&& w = names_to_weights[weights_name];
         if (!w) {
-          LBANN_ERROR_STR("attempted to apply L2 weight regularization to "
-                          "weights \"", weights_name, "\", "
-                          "but no such weights exists");
+          LBANN_ERROR("attempted to apply L2 weight regularization to "
+                      "weights \"", weights_name, "\", "
+                      "but no such weights exists");
         }
         term_weights.push_back(w);
       }


### PR DESCRIPTION
It's not a particular pretty anti-pattern to build up some string stream in the middle of the code. This hides that detail by just making LBANN_ERROR (and LBANN_WARNING) accept variadic arguments.

This doesn't clean up any code in the guts of LBANN except what needed to be cleaned up to make this work. It would be a massive PR to do that all now. Rather, IMO, it should be done piecemeal as others are touching other parts of the code.