### PR TITLE
Test clean up

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -391,11 +391,11 @@ def get_command(cluster,
         option_processes_per_model = ' --procs_per_model=%d' % processes_per_model
     if ckpt_dir is not None:
         option_ckpt_dir = ' --ckpt_dir=%s' % ckpt_dir
+    extra_options = ''
     if extra_lbann_flags is not None:
         # If extra_lbann_flags is not a dict, then we have already appended
         # this error to lbann_errors.
         if isinstance(extra_lbann_flags, dict):
-            extra_options = ''
             # See `lbann --help` or src/proto/proto_common.cpp
             allowed_flags = [
                 # 'model',

--- a/bamboo/integration_tests/test_integration_autoencoders.py
+++ b/bamboo/integration_tests/test_integration_autoencoders.py
@@ -88,7 +88,7 @@ def test_integration_autoencoder_imagenet_intel19(cluster, dirname, exes,
     skeleton_autoencoder_imagenet(cluster, dirname, exes, 'intel19', weekly)
 
 
-# Run with python -m pytest -s test_integration_autoencoder.py -k 'test_integration_autoencoder_imagenet_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_autoencoder.py -k 'test_integration_autoencoder_imagenet_exe' --exe=<executable>
 def test_integration_autoencoder_imagenet_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_integration_autoencoder_imagenet_exe: Non-local testing'

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -84,7 +84,7 @@ def test_integration_cifar_intel19_debug(cluster, dirname, exes, weekly, debug_b
     skeleton_cifar_debug(cluster, dirname, exes, 'intel19_debug', weekly, debug_build)
 
 
-# Run with python -m pytest -s test_integration_debug.py -k 'test_integration_mnist_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_debug.py -k 'test_integration_mnist_exe' --exe=<executable>
 def test_integration_mnist_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_integration_mnist_exe: Non-local testing'
@@ -94,7 +94,7 @@ def test_integration_mnist_exe(cluster, dirname, exe):
     skeleton_mnist_debug(cluster, dirname, exes, 'exe', True, True)
 
 
-# Run with python -m pytest -s test_integration_debug.py -k 'test_integration_cifar_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_debug.py -k 'test_integration_cifar_exe' --exe=<executable>
 def test_integration_cifar_exe(cluster, dirname, exe):
     if exe == None:
         e = 'test_integration_cifar_exe: Non-local testing'

--- a/bamboo/integration_tests/test_integration_performance.py
+++ b/bamboo/integration_tests/test_integration_performance.py
@@ -216,7 +216,7 @@ def test_integration_performance_full_alexnet_intel19(cluster, dirname, exes,
                                     run)
 
 
-# Run with python -m pytest -s test_integration_performance.py -k 'test_integration_performance_lenet_mnist_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_lenet_mnist_exe' --exe=<executable>
 def test_integration_performance_lenet_mnist_exe(cluster, dirname, exe):
     if exe is None:
       e = 'test_integration_performance_lenet_mnist_exe: Non-local testing'
@@ -226,7 +226,7 @@ def test_integration_performance_lenet_mnist_exe(cluster, dirname, exe):
     skeleton_performance_lenet_mnist(cluster, dirname, exes, 'exe')
 
 
-# Run with python -m pytest -s test_integration_performance.py -k 'test_integration_performance_alexnet_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_alexnet_exe' --exe=<executable>
 def test_integration_performance_alexnet_exe(cluster, dirname, exe):
     if exe is None:
       e = 'stest_integration_performance_alexnet_exe: Non-local testing'
@@ -236,7 +236,7 @@ def test_integration_performance_alexnet_exe(cluster, dirname, exe):
     skeleton_performance_alexnet(cluster, dirname, exes, 'exe', True)
 
 
-# Run with python -m pytest -s test_integration_performance.py -k 'test_integration_performance_full_alexnet_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_full_alexnet_exe' --exe=<executable>
 def test_integration_performance_full_alexnet_exe(cluster, dirname, exe):
     if exe is None:
       e = 'test_integration_performance_full_alexnet_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -130,7 +130,7 @@ def test_unit_models_intel19(cluster, dirname, exes):
     skeleton_models(cluster, dirname, exes, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_check_proto_models.py -k 'test_unit_models_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_check_proto_models.py -k 'test_unit_models_exe' --exe=<executable>
 def test_unit_models_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_models_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -140,7 +140,7 @@ def test_unit_checkpoint_lenet_intel19(cluster, exes, dirname):
     skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_exe' --exe=<executable>
 def test_unit_checkpoint_lenet_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_checkpoint_lenet_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_clamp.py
+++ b/bamboo/unit_tests/test_unit_layer_clamp.py
@@ -36,7 +36,7 @@ def test_unit_layer_clamp_intel19(cluster, exes, dirname):
     skeleton_layer_clamp(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_clamp.py -k 'test_unit_layer_clamp_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_clamp.py -k 'test_unit_layer_clamp_exe' --exe=<executable>
 def test_unit_layer_clamp_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_clamp_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_covariance.py
+++ b/bamboo/unit_tests/test_unit_layer_covariance.py
@@ -36,7 +36,7 @@ def test_unit_layer_covariance_intel19(cluster, exes, dirname):
     skeleton_layer_covariance(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_covariance_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_covariance_exe' --exe=<executable>
 def test_unit_layer_covariance_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_covariance_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_elu.py
+++ b/bamboo/unit_tests/test_unit_layer_elu.py
@@ -36,7 +36,7 @@ def test_unit_layer_elu_intel19(cluster, exes, dirname):
     skeleton_layer_elu(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_elu.py -k 'test_unit_layer_elu_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_elu.py -k 'test_unit_layer_elu_exe' --exe=<executable>
 def test_unit_layer_elu_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_elu_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_identity.py
+++ b/bamboo/unit_tests/test_unit_layer_identity.py
@@ -36,7 +36,7 @@ def test_unit_layer_identity_intel19(cluster, exes, dirname):
     skeleton_layer_identity(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_identity.py -k 'test_unit_layer_identity_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_identity.py -k 'test_unit_layer_identity_exe' --exe=<executable>
 def test_unit_layer_identity_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_identity_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_l1_norm.py
+++ b/bamboo/unit_tests/test_unit_layer_l1_norm.py
@@ -36,7 +36,7 @@ def test_unit_layer_l1_norm_intel19(cluster, exes, dirname):
     skeleton_layer_l1_norm(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l1_norm_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l1_norm_exe' --exe=<executable>
 def test_unit_layer_l1_norm_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_l1_norm_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_l2_norm2.py
+++ b/bamboo/unit_tests/test_unit_layer_l2_norm2.py
@@ -35,7 +35,7 @@ def test_unit_layer_l2_norm2_intel19(cluster, exes, dirname):
     skeleton_layer_l2_norm2(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l2_norm2_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l2_norm2_exe' --exe=<executable>
 def test_unit_layer_l2_norm2_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_l2_norm2_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu.py
@@ -36,7 +36,7 @@ def test_unit_layer_leaky_relu_intel19(cluster, exes, dirname):
     skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_leaky_relu_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_leaky_relu_exe' --exe=<executable>
 def test_unit_layer_leaky_relu_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_leaky_relu_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
@@ -36,7 +36,7 @@ def test_unit_layer_log_sigmoid_intel19(cluster, exes, dirname):
     skeleton_layer_log_sigmoid(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_log_sigmoid.py -k 'test_unit_layer_log_sigmoid_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_log_sigmoid.py -k 'test_unit_layer_log_sigmoid_exe' --exe=<executable>
 def test_unit_layer_log_sigmoid_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_log_sigmoid_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_log_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_log_softmax.py
@@ -37,7 +37,7 @@ def test_unit_layer_log_softmax_intel19(cluster, exes, dirname):
     skeleton_layer_log_softmax(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_log_softmax_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_log_softmax_exe' --exe=<executable>
 def test_unit_layer_log_softmax_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_log_softmax_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
+++ b/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
@@ -36,7 +36,7 @@ def test_unit_layer_mean_absolute_error_intel19(cluster, exes, dirname):
     skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_mean_absolute_error_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_mean_absolute_error_exe' --exe=<executable>
 def test_unit_layer_mean_absolute_error_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_mean_absolute_error_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_relu.py
@@ -37,7 +37,7 @@ def test_unit_layer_relu_intel19(cluster, exes, dirname):
     skeleton_layer_relu(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_relu.py -k 'test_unit_layer_relu_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_relu.py -k 'test_unit_layer_relu_exe' --exe=<executable>
 def test_unit_layer_relu_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_relu_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_selu.py
+++ b/bamboo/unit_tests/test_unit_layer_selu.py
@@ -37,7 +37,7 @@ def test_unit_layer_selu_intel19(cluster, exes, dirname):
     skeleton_layer_selu(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_selu.py -k 'test_unit_layer_selu_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_selu.py -k 'test_unit_layer_selu_exe' --exe=<executable>
 def test_unit_layer_selu_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_selu_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_sigmoid.py
@@ -37,7 +37,7 @@ def test_unit_layer_sigmoid_intel19(cluster, exes, dirname):
     skeleton_layer_sigmoid(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_sigmoid.py -k 'test_unit_layer_sigmoid_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_sigmoid.py -k 'test_unit_layer_sigmoid_exe' --exe=<executable>
 def test_unit_layer_sigmoid_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_sigmoid_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_softmax.py
@@ -37,7 +37,7 @@ def test_unit_layer_softmax_intel19(cluster, exes, dirname):
     skeleton_layer_softmax(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_softmax_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_softmax_exe' --exe=<executable>
 def test_unit_layer_softmax_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_softmax_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_softplus.py
+++ b/bamboo/unit_tests/test_unit_layer_softplus.py
@@ -36,7 +36,7 @@ def test_unit_layer_softplus_intel19(cluster, exes, dirname):
     skeleton_layer_softplus(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_softplus.py -k 'test_unit_layer_softplus_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_softplus.py -k 'test_unit_layer_softplus_exe' --exe=<executable>
 def test_unit_layer_softplus_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_softplus_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_softsign.py
+++ b/bamboo/unit_tests/test_unit_layer_softsign.py
@@ -40,7 +40,7 @@ def test_unit_layer_softsign_intel19(cluster, exes, dirname):
     skeleton_layer_softsign(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_softsign.py -k 'test_unit_layer_softsign_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_softsign.py -k 'test_unit_layer_softsign_exe' --exe=<executable>
 def test_unit_layer_softsign_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_softsign_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_squared_difference.py
+++ b/bamboo/unit_tests/test_unit_layer_squared_difference.py
@@ -36,7 +36,7 @@ def test_unit_layer_squared_difference_intel19(cluster, exes, dirname):
     skeleton_layer_squared_difference(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_squared_difference.py -k 'test_unit_layer_squared_difference_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_squared_difference.py -k 'test_unit_layer_squared_difference_exe' --exe=<executable>
 def test_unit_layer_squared_difference_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_squared_difference_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_tessellate.py
+++ b/bamboo/unit_tests/test_unit_layer_tessellate.py
@@ -36,7 +36,7 @@ def test_unit_layer_tessellate_intel19(cluster, exes, dirname):
     skeleton_layer_tessellate(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_layer_tessellate.py -k 'test_unit_layer_tessellate_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_layer_tessellate.py -k 'test_unit_layer_tessellate_exe' --exe=<executable>
 def test_unit_layer_tessellate_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_tessellate_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_layer_variance.py
+++ b/bamboo/unit_tests/test_unit_layer_variance.py
@@ -37,7 +37,7 @@ def test_unit_layer_variance_intel19(cluster, exes, dirname):
     skeleton_layer_variance(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_variance_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_variance_exe' --exe=<executable>
 def test_unit_layer_variance_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_layer_variance_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -134,7 +134,7 @@ def test_unit_lbann2_reload_intel19(cluster, exes, dirname):
     skeleton_lbann2_reload(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>
 def test_unit_lbann2_reload_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_lbann2_reload_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_lbann_invocation.py
+++ b/bamboo/unit_tests/test_unit_lbann_invocation.py
@@ -3,8 +3,13 @@ sys.path.insert(0, '../common_python')
 import tools
 import os, sys
 
+
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_no_params_bad' --exes=<executable>
 def test_unit_no_params_bad(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with no params; lbann should throw exception\n')
     command = tools.get_command(
         cluster=cluster, executable=exe, exit_after_setup=True)
@@ -12,8 +17,12 @@ def test_unit_no_params_bad(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_one_model_bad' --exes=<executable>
 def test_unit_one_model_bad(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with no optimizer or reader; lbann should throw exception\n')
     model_path = 'prototext/model_mnist_simple_1.prototext'
     command = tools.get_command(
@@ -23,8 +32,12 @@ def test_unit_one_model_bad(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_two_models_bad' --exes=<executable>
 def test_unit_two_models_bad(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with two models but no optimizer or reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -34,8 +47,12 @@ def test_unit_two_models_bad(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_two_models_bad2' --exes=<executable>
 def test_unit_two_models_bad2(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with two models with missing {; lbann should throw exception\n')
     model_path='prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     command = tools.get_command(
@@ -45,8 +62,12 @@ def test_unit_two_models_bad2(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_missing_optimizer' --exes=<executable>
 def test_unit_missing_optimizer(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with two models, reader, but no optimizer; lbann should throw exception\n')
     model_path='{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path='prototext/data_reader_mnist.prototext'
@@ -58,8 +79,12 @@ def test_unit_missing_optimizer(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_missing_reader' --exes=<executable>
 def test_unit_missing_reader(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with two models, reader, but no reader; lbann should throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     optimizer_path = 'prototext/opt_sgd.prototext'
@@ -70,8 +95,12 @@ def test_unit_missing_reader(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_bad_params' --exes=<executable>
 def test_unit_bad_params(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with ill-formed param (missing -) lbann should throw exception\n')
     (command_allocate, command_run, _, _) = tools.get_command(cluster=cluster, executable=exe, return_tuple=True)
     command_string = '%s%s %s -exit_after_setup --reader=prototext/data_reader_mnist.prototext --model={prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext} --optimizer=prototext/opt_sgd.prototext' % (command_allocate, command_run, exe)
@@ -79,8 +108,12 @@ def test_unit_bad_params(cluster, exes):
     assert return_code != 0
 
 
+# Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_should_work' --exes=<executable>
 def test_unit_should_work(cluster, exes):
-    exe = exes['gcc7']
+    if isinstance(exes, dict):
+        exe = exes['gcc7']
+    else:
+        exe = exes
     sys.stderr.write('TESTING: run lbann with two models, reader, and optimizer; lbann should NOT throw exception\n')
     model_path = '{prototext/model_mnist_simple_1.prototext,prototext/model_mnist_simple_1.prototext}'
     data_reader_path = 'prototext/data_reader_mnist.prototext'

--- a/bamboo/unit_tests/test_unit_mnist_conv_graph.py
+++ b/bamboo/unit_tests/test_unit_mnist_conv_graph.py
@@ -42,7 +42,7 @@ def test_unit_mnist_conv_graph_intel19(cluster, exes, dirname):
     skeleton_mnist_conv_graph(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_conv_graph.py -k 'test_unit_mnist_conv_graph_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_conv_graph.py -k 'test_unit_mnist_conv_graph_exe' --exe=<executable>
 def test_unit_mnist_conv_graph_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_mnist_conv_graph_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
+++ b/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
@@ -36,7 +36,7 @@ def test_unit_mnist_ridge_regression_intel19(cluster, exes, dirname):
     skeleton_mnist_ridge_regression(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_mnist_ridge_regression_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_mnist_ridge_regression_exe' --exe=<executable>
 def test_unit_mnist_ridge_regression_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_mnist_ridge_regression_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
+++ b/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
@@ -36,7 +36,7 @@ def test_unit_mnist_softmax_classifier_intel19(cluster, exes, dirname):
     skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_softmax_classifier.py -k 'test_unit_mnist_softmax_classifier_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_softmax_classifier.py -k 'test_unit_mnist_softmax_classifier_exe' --exe=<executable>
 def test_unit_mnist_softmax_classifier_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_mnist_softmax_classifier_exe: Non-local testing'

--- a/bamboo/unit_tests/test_unit_reconstruction_loss.py
+++ b/bamboo/unit_tests/test_unit_reconstruction_loss.py
@@ -42,7 +42,7 @@ def test_unit_jag_reconstruction_loss_intel19(cluster, exes, dirname):
     skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'intel19')
 
 
-# Run with python -m pytest -s test_unit_ridge_regression.py -k 'test_unit_jag_reconstruction_loss_exe' --exe=<executable>
+# Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_jag_reconstruction_loss_exe' --exe=<executable>
 def test_unit_jag_reconstruction_loss_exe(cluster, dirname, exe):
     if exe is None:
         e = 'test_unit_jag_reconstruction_loss_exe: Non-local testing'


### PR DESCRIPTION
- Fix scope of `extra_options`
- Add ability to choose your own executable when running tests in `test_unit_lbann_invocation.py`.
- Update `python` to `python3` in comments about how to run tests.