### PR TITLE
Fix unit test error related to empty optimizer messages

### DIFF
--- a/include/lbann/proto/helpers.hpp
+++ b/include/lbann/proto/helpers.hpp
@@ -51,6 +51,10 @@ using generate_builder_type =
 namespace helpers
 {
 
+/** @brief Test whether the message has the oneof field. */
+bool has_oneof(
+  google::protobuf::Message const& msg, std::string const& oneof_name);
+
 /** @brief Get a "derived type" message from the given message. */
 google::protobuf::Message const&
 get_oneof_message(

--- a/src/proto/factories/weights_factory.cpp
+++ b/src/proto/factories/weights_factory.cpp
@@ -111,12 +111,15 @@ std::unique_ptr<weights> construct_weights(
 
   // Set weights initializer and optimizer
   auto init = construct_initializer(proto_weights);
-  std::unique_ptr<optimizer> opt;
-  if (proto_weights.has_optimizer()) {
-    opt = construct_optimizer(comm, proto_weights.optimizer());
-  } else {
-    opt = construct_optimizer(comm, proto_opt);
-  }
+  const lbann_data::Optimizer& opt_msg =
+    (proto_weights.has_optimizer()
+     ? proto_weights.optimizer()
+     : proto_opt);
+
+  std::unique_ptr<optimizer> opt =
+    (helpers::has_oneof(opt_msg, "optimizer_type")
+     ? construct_optimizer(comm, opt_msg)
+     : nullptr);
   w->set_initializer(std::move(init));
   w->set_optimizer(std::move(opt));
 


### PR DESCRIPTION
Fixes an issue in which an empty `optimizer` message is both valid and different from not having such a message at all.