### PR TITLE
Protobuf message for no optimizer

### DIFF
--- a/model_zoo/models/gan/mnist/adversarial_model.prototext
+++ b/model_zoo/models/gan/mnist/adversarial_model.prototext
@@ -145,7 +145,7 @@ model {
 
   weights {
      name: "gen_fc_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -303,7 +303,7 @@ model {
 
   weights {
      name: "dis_flatten_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        he_normal_initializer {}
      }
@@ -322,7 +322,7 @@ model {
 
   weights {
      name: "dis_fc1_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -348,7 +348,7 @@ model {
 
   weights {
      name: "dis_fc2_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -375,7 +375,7 @@ model {
  # FULLY_CONNECTED fc1
   weights {
      name: "dis_fc3_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }

--- a/model_zoo/models/gan/mnist/discriminator_model.prototext
+++ b/model_zoo/models/gan/mnist/discriminator_model.prototext
@@ -137,7 +137,7 @@ model {
   }
   weights {
      name: "gen_fc1_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -180,7 +180,7 @@ model {
 
   weights {
      name: "gen_fc2_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -220,7 +220,7 @@ model {
 
   weights {
      name: "gen_fc3_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }
@@ -260,7 +260,7 @@ model {
 
   weights {
      name: "gen_fc4_weights"
-     optimizer { }
+     optimizer { no_optimizer {} }
      initializer {
        glorot_normal_initializer {}
      }

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
@@ -388,7 +388,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -399,7 +399,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -410,7 +410,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -421,7 +421,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -432,7 +432,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -443,7 +443,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -454,7 +454,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -465,7 +465,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -476,7 +476,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -487,7 +487,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -498,7 +498,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -509,7 +509,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -520,7 +520,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -531,7 +531,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -542,7 +542,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -553,7 +553,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -564,7 +564,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -575,7 +575,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -586,7 +586,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -597,7 +597,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -374,7 +374,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -385,7 +385,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -396,7 +396,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -407,7 +407,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -418,7 +418,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -429,7 +429,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -440,7 +440,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -451,7 +451,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -462,7 +462,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -473,7 +473,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -484,7 +484,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -495,7 +495,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -506,7 +506,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -517,7 +517,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -528,7 +528,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -539,7 +539,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -550,7 +550,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -561,7 +561,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -572,7 +572,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -583,7 +583,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -594,7 +594,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -605,7 +605,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -616,7 +616,7 @@ model {
         value: 0.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
 
@@ -627,7 +627,7 @@ model {
         value: 1.0
       }
     }
-    optimizer {}
+    optimizer { no_optimizer {} }
   }
 
   ###################################################

--- a/model_zoo/tests/layer_tests/model_tessellate.prototext
+++ b/model_zoo/tests/layer_tests/model_tessellate.prototext
@@ -103,7 +103,7 @@ model {
         values: "1.2 1.3 1.4 1.5 1.6 1.7 1.8 1.9 2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 2.8 2.9 3.0 3.1 3.2 3.3 3.4 3.5"
       }
     }
-    optimizer {} # No optimizer
+    optimizer { no_optimizer {} }
   }
   layer {
     parents: "sum scales"

--- a/python/lbann/__init__.py
+++ b/python/lbann/__init__.py
@@ -19,7 +19,7 @@ if os.path.isfile(_config_file):
         _lbann_exe = _config['Paths']['lbann_exe']
     except:
         pass
-import lbann_pb2, callbacks_pb2, layers_pb2, metrics_pb2, model_pb2, objective_functions_pb2, optimizers_pb2, weights_pb2
+import lbann_pb2, callbacks_pb2, layers_pb2, metrics_pb2, model_pb2, objective_functions_pb2, optimizers_pb2, reader_pb2, weights_pb2
 def lbann_exe():
     """LBANN executable."""
     return _lbann_exe if _lbann_exe else 'lbann'

--- a/python/lbann/proto.py
+++ b/python/lbann/proto.py
@@ -2,7 +2,7 @@
 
 import google.protobuf.text_format
 import google.protobuf.message
-from lbann import lbann_pb2
+from lbann import lbann_pb2, NoOptimizer
 
 def save_prototext(filename, **kwargs):
     """Save a prototext file.
@@ -36,7 +36,7 @@ def save_prototext(filename, **kwargs):
     # provided.
     if not message.HasField('optimizer'):
         from lbann import Optimizer
-        message.optimizer.CopyFrom(Optimizer().export_proto())
+        message.optimizer.CopyFrom(NoOptimizer().export_proto())
         message.optimizer.SetInParent()
 
     # Write to file

--- a/src/proto/factories/optimizer_factory.cpp
+++ b/src/proto/factories/optimizer_factory.cpp
@@ -46,7 +46,7 @@ namespace {
 std::unique_ptr<optimizer>
 build_no_optimizer_from_pbuf(
   google::protobuf::Message const& msg, lbann_comm* comm) {
-  return std::unique_ptr<optimizer>();
+  return nullptr;
 }
 
 using factory_type = lbann::generic_factory<

--- a/src/proto/factories/optimizer_factory.cpp
+++ b/src/proto/factories/optimizer_factory.cpp
@@ -43,6 +43,12 @@ namespace lbann {
 namespace proto {
 namespace {
 
+std::unique_ptr<optimizer>
+build_no_optimizer_from_pbuf(
+  google::protobuf::Message const& msg, lbann_comm* comm) {
+  return std::unique_ptr<optimizer>();
+}
+
 using factory_type = lbann::generic_factory<
   lbann::optimizer,
   std::string,
@@ -52,6 +58,7 @@ using factory_type = lbann::generic_factory<
   default_key_error_policy>;
 
 void register_default_builders(factory_type& factory) {
+  factory.register_builder("NoOptimizer", build_no_optimizer_from_pbuf);
   factory.register_builder("AdaGrad", build_adagrad_optimizer_from_pbuf);
   factory.register_builder("Adam", build_adam_optimizer_from_pbuf);
   factory.register_builder("HypergradientAdam",

--- a/src/proto/optimizers.proto
+++ b/src/proto/optimizers.proto
@@ -30,12 +30,15 @@ package lbann_data;
 
 message Optimizer {
   oneof optimizer_type {
-    AdaGrad adagrad = 1;
-    Adam adam = 2;
-    HypergradientAdam hypergradient_adam = 3;
-    RMSprop rmsprop = 4;
-    SGD sgd = 5;
+    NoOptimizer no_optimizer = 1;
+    AdaGrad adagrad = 2;
+    Adam adam = 3;
+    HypergradientAdam hypergradient_adam = 4;
+    RMSprop rmsprop = 5;
+    SGD sgd = 6;
   }
+
+  message NoOptimizer {}
 
   message AdaGrad {
     double learn_rate = 1;


### PR DESCRIPTION
When constructing models, we sometimes need to specify weights without any optimizers. We currently do this with empty `Optimizer` messages (we have different behavior if the `Weights`'s `optimizer` field is not set at all, in which case we construct the model's default optimizer). This is a bit of a hack and doesn't work with the recent optimizer factory refactor (see PRs #1138 and #1158). To get around this, we can now specify no optimizer with the `NoOptimizer` message or the corresponding class in the Python frontend.