### PR TITLE
Check gradient callback can be applied at any execution mode

### DIFF
--- a/include/lbann/callbacks/check_gradients.hpp
+++ b/include/lbann/callbacks/check_gradients.hpp
@@ -36,9 +36,9 @@ namespace callback {
 
 /** @brief Gradient checking callback.
  *
- *  Gradient checking is performed at the end of the test phase. Using
- *  a fourth-order finite difference scheme, a numerical partial
- *  derivative is computed for every weight parameter. If the
+ *  Gradient checking is performed at the end of each execution mode
+ *  phase. Using a fourth-order finite difference scheme, a numerical
+ *  partial derivative is computed for every weight parameter. If the
  *  numerical derivative differs signifcantly from the analytical
  *  derivative computed during backprop, the gradient check has
  *  failed.
@@ -47,6 +47,7 @@ class check_gradients : public callback_base {
 public:
 
   /**
+   *  @param modes              Execution modes with gradient checks.
    *  @param step_size          Step size for numerical
    *                            differentiation (with a step size of
    *                            zero, the step size is estimated to
@@ -56,23 +57,31 @@ public:
    *  @param error_on_failure   Whether to throw an exception for
    *                            large gradient errors.
    */
-  check_gradients(DataType step_size = DataType(0),
-                                 bool verbose = false,
-                                 bool error_on_failure = false);
+  check_gradients(std::set<execution_mode> modes = {},
+                  DataType step_size = DataType(0),
+                  bool verbose = false,
+                  bool error_on_failure = false);
   check_gradients* copy() const override {
     return new check_gradients(*this);
   }
-  void on_test_end(model *m) override;
   std::string name() const override { return "check gradients"; }
+  void on_train_end(model *m) override      { do_check_gradients(*m); }
+  void on_validation_end(model *m) override { do_check_gradients(*m); }
+  void on_test_end(model *m) override       { do_check_gradients(*m); }
 
 private:
 
+  /** Execution modes with gradient checks. */
+  std::set<execution_mode> m_modes;
   /** Step size for numerical differentiation. */
   DataType m_step_size;
   /** Whether to print results for each parameter. */
   bool m_verbose;
   /** Whether to throw an exception for large gradient errors. */
   bool m_error_on_failure;
+
+  /** Does nothing if current execution mode is not in m_modes. */
+  void do_check_gradients(model& m) const;
 
 };
 

--- a/include/lbann/callbacks/check_gradients.hpp
+++ b/include/lbann/callbacks/check_gradients.hpp
@@ -47,7 +47,9 @@ class check_gradients : public callback_base {
 public:
 
   /**
-   *  @param modes              Execution modes with gradient checks.
+   *  @param modes              Execution modes with gradient checks. If
+   *                            none are provided, gradient checking is
+   *                            performed for every execution mode.
    *  @param step_size          Step size for numerical
    *                            differentiation (with a step size of
    *                            zero, the step size is estimated to

--- a/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
+++ b/model_zoo/tests/layer_tests/model_channelwise_mean.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_clamp.prototext
+++ b/model_zoo/tests/layer_tests/model_clamp.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_covariance.prototext
+++ b/model_zoo/tests/layer_tests/model_covariance.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_elu.prototext
+++ b/model_zoo/tests/layer_tests/model_elu.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_identity.prototext
+++ b/model_zoo/tests/layer_tests/model_identity.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_l1_norm.prototext
+++ b/model_zoo/tests/layer_tests/model_l1_norm.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_l2_norm2.prototext
+++ b/model_zoo/tests/layer_tests/model_l2_norm2.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_leaky_relu.prototext
+++ b/model_zoo/tests/layer_tests/model_leaky_relu.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_log_sigmoid.prototext
+++ b/model_zoo/tests/layer_tests/model_log_sigmoid.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_log_softmax.prototext
+++ b/model_zoo/tests/layer_tests/model_log_softmax.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_mean_absolute_error.prototext
+++ b/model_zoo/tests/layer_tests/model_mean_absolute_error.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_relu.prototext
+++ b/model_zoo/tests/layer_tests/model_relu.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_selu.prototext
+++ b/model_zoo/tests/layer_tests/model_selu.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_sigmoid.prototext
+++ b/model_zoo/tests/layer_tests/model_sigmoid.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_softmax.prototext
+++ b/model_zoo/tests/layer_tests/model_softmax.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_softplus.prototext
+++ b/model_zoo/tests/layer_tests/model_softplus.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_softsign.prototext
+++ b/model_zoo/tests/layer_tests/model_softsign.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_squared_difference.prototext
+++ b/model_zoo/tests/layer_tests/model_squared_difference.prototext
@@ -34,6 +34,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_tessellate.prototext
+++ b/model_zoo/tests/layer_tests/model_tessellate.prototext
@@ -34,6 +34,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/layer_tests/model_variance.prototext
+++ b/model_zoo/tests/layer_tests/model_variance.prototext
@@ -37,6 +37,7 @@ model {
   }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/model_mnist_conv_graph.prototext
+++ b/model_zoo/tests/model_mnist_conv_graph.prototext
@@ -20,6 +20,7 @@ model {
   callback { timer {} }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/model_mnist_ridge_regression.prototext
+++ b/model_zoo/tests/model_mnist_ridge_regression.prototext
@@ -30,6 +30,7 @@ model {
   callback { timer {} }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/model_zoo/tests/model_mnist_softmax_classifier.prototext
+++ b/model_zoo/tests/model_mnist_softmax_classifier.prototext
@@ -28,6 +28,7 @@ model {
   callback { timer {} }
   callback {
     check_gradients {
+      execution_modes: "test"
       verbose: false
       error_on_failure: true
     }

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -81,7 +81,7 @@ void check_gradients::do_check_gradients(model& m) const {
   const auto mode = m.get_execution_mode();
   const auto& layers = m.get_layers();
 
-  // Return immediately if execution mode is invalid
+  // Return immediately if gradient check isn't currently needed
   if (!m_modes.empty() && m_modes.count(mode) == 0) { return; }
 
   // Reset statistics and gradients

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -27,6 +27,7 @@
 #include "lbann/callbacks/check_gradients.hpp"
 #include "lbann/data_readers/data_reader.hpp"
 #include "lbann/layers/io/input/generic_input_layer.hpp"
+#include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/memory.hpp"
 
 #include <callbacks.pb.h>
@@ -64,40 +65,44 @@ DataType compute_objective_function(model& m) {
 
 } // namespace
 
-check_gradients
-  ::check_gradients(DataType step_size,
-                                   bool verbose,
-                                   bool error_on_failure)
-  : m_step_size(step_size),
+check_gradients::check_gradients(std::set<execution_mode> modes,
+                                 DataType step_size,
+                                 bool verbose,
+                                 bool error_on_failure)
+  : m_modes(std::move(modes)),
+    m_step_size(step_size),
     m_verbose(verbose),
     m_error_on_failure(error_on_failure) {}
 
-void check_gradients::on_test_end(model *m) {
+void check_gradients::do_check_gradients(model& m) const {
 
   // Get objects from model
-  lbann_comm *comm = m->get_comm();
-  auto mode = m->get_execution_mode();
-  const auto& layers = m->get_layers();
+  auto& comm = *m.get_comm();
+  const auto mode = m.get_execution_mode();
+  const auto& layers = m.get_layers();
+
+  // Return immediately if execution mode is invalid
+  if (!m_modes.empty() && m_modes.count(mode) == 0) { return; }
 
   // Reset statistics and gradients
-  m->get_objective_function()->reset_statistics(mode);
-  for (auto&& met : m->get_metrics()) {
+  m.get_objective_function()->reset_statistics(mode);
+  for (auto&& met : m.get_metrics()) {
     met->reset_statistics(mode);
   }
-  for (auto&& w : m->get_weights()) {
+  for (auto&& w : m.get_weights()) {
     auto&& opt = w->get_optimizer();
     if (opt != nullptr) { opt->clear_gradient(); }
   }
 
   // Load data in input layers
-  for (auto&& l : m->get_layers()) {
+  for (auto&& l : m.get_layers()) {
     if (dynamic_cast<generic_input_layer*>(l) != nullptr) {
       l->forward_prop();
     }
   }
 
   // Compute objective function
-  const DataType objective = compute_objective_function(*m);
+  const DataType objective = compute_objective_function(m);
 
   // Choose finite difference step
   // Note: Consider a central difference scheme:
@@ -110,23 +115,22 @@ void check_gradients::on_test_end(model *m) {
   // If step size is not specified, then we choose h so that
   //   E_fl <= sqrt(epsilon)
   const DataType epsilon = std::pow(std::numeric_limits<DataType>::epsilon(), 0.9);
-  DataType step_size = m_step_size;
-  if (m_step_size <= DataType(0)) {
-    step_size = std::fabs(objective) * std::sqrt(epsilon);
-  }
+  const DataType step_size = (m_step_size > DataType{0} ?
+                              m_step_size :
+                              std::fabs(objective) * std::sqrt(epsilon));
   DataType expected_error = (epsilon * objective / step_size
                              + std::pow(step_size, 4) / 18);
   expected_error = std::pow(expected_error, 0.9);
 
   // Compute gradients
-  m->get_objective_function()->differentiate();
-  m->get_objective_function()->compute_weight_regularization();
-  for (int l = layers.size() - 1; l > 0; --l) {
-    layers[l]->back_prop();
+  m.get_objective_function()->differentiate();
+  m.get_objective_function()->compute_weight_regularization();
+  for (El::Int i = layers.size()-1; i >= 0; --i) {
+    layers[i]->back_prop();
   }
 
   // Print objective function value
-  if (comm->am_world_master()) {
+  if (comm.am_world_master()) {
     std::cout << "----------------------------------------------------------------\n"
               << "Gradient checking...\n"
               << "  Objective function value = " << objective << "\n"
@@ -134,11 +138,11 @@ void check_gradients::on_test_end(model *m) {
               << "  Expected gradient error  = " << expected_error << "\n";
   }
 
-  for (weights *w : m->get_weights()) {
+  for (weights *w : m.get_weights()) {
     if (w->get_optimizer() == nullptr) {
       continue;
     }
-    if (comm->am_world_master()) {
+    if (comm.am_world_master()) {
       std::cout << "Checking " << w->get_name() << std::endl;
     }
 
@@ -165,13 +169,13 @@ void check_gradients::on_test_end(model *m) {
         // Note: matrix entry is reset after computing objective
         // function values
         w->set_value(initial_weight + 2 * step_size, row, col);
-        const DataType f_2h = compute_objective_function(*m);
+        const DataType f_2h = compute_objective_function(m);
         w->set_value(initial_weight + step_size, row, col);
-        const DataType f_h = compute_objective_function(*m);
+        const DataType f_h = compute_objective_function(m);
         w->set_value(initial_weight - step_size, row, col);
-        const DataType f_nh = compute_objective_function(*m);
+        const DataType f_nh = compute_objective_function(m);
         w->set_value(initial_weight - 2 * step_size, row, col);
-        const DataType f_n2h = compute_objective_function(*m);
+        const DataType f_n2h = compute_objective_function(m);
         w->set_value(initial_weight, row, col);
 
         // Compute relative error in gradient.
@@ -198,7 +202,8 @@ void check_gradients::on_test_end(model *m) {
                       << "    Error               = " << error << std::endl
                       << "    Relative error      = " << relative_error << std::endl;
             if (m_error_on_failure) {
-              throw lbann_exception("callback_check_gradients: found large error in gradient");
+              LBANN_ERROR("gradient checking found large difference between "
+                          "analytical and numerical gradients");
             }
           } else if (m_verbose) {
             std::cout << "  " << w->get_name() << ", "
@@ -215,21 +220,21 @@ void check_gradients::on_test_end(model *m) {
     }
 
   }
-  if (comm->am_world_master()) {
+  if (comm.am_world_master()) {
     std::cout << "----------------------------------------------------------------\n";
   }
 
   // Clean up
   /// @todo tym: I'm not sure if data readers are properly reset
-  for (auto&& l : m->get_layers()) {
+  for (auto&& l : m.get_layers()) {
     auto&& input = dynamic_cast<generic_input_layer*>(l);
     if (input != nullptr) {
       auto&& reader = input->get_data_reader(mode);
       reader->set_initial_position();
     }
   }
-  m->get_objective_function()->reset_statistics(mode);
-  for (auto&& met : m->get_metrics()) {
+  m.get_objective_function()->reset_statistics(mode);
+  for (auto&& met : m.get_metrics()) {
     met->reset_statistics(mode);
   }
 
@@ -241,9 +246,12 @@ build_check_gradients_callback_from_pbuf(
   const google::protobuf::Message& proto_msg, const std::shared_ptr<lbann_summary>&) {
   const auto& params =
     dynamic_cast<const lbann_data::Callback::CallbackCheckGradients&>(proto_msg);
-  return make_unique<check_gradients>(params.step_size(),
-                                                     params.verbose(),
-                                                     params.error_on_failure());
+  const auto& modes =
+    parse_set<execution_mode>(params.execution_modes());
+  return make_unique<check_gradients>(modes,
+                                      params.step_size(),
+                                      params.verbose(),
+                                      params.error_on_failure());
 }
 
 } // namespace callback

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -230,6 +230,7 @@ message Callback {
     double step_size = 1;
     bool verbose = 2;
     bool error_on_failure = 3; // Throw error if gradient check fails
+    string execution_modes = 4; // Default: all modes
   }
 
   message CallbackCheckMetric {


### PR DESCRIPTION
Previously, gradient checking was only performed at the end of the test phase. This is inconvenient for verifying batchnorm, which has different behavior during training and inference. This PR adds functionality so that the user can choose when gradient checking happens: after each training epoch or after each validation or training set phase.