### PR TITLE
Entry-wise batchnorm

### DIFF
--- a/include/lbann/layers/regularizers/CMakeLists.txt
+++ b/include/lbann/layers/regularizers/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_full_path(THIS_DIR_HEADERS
   batch_normalization.hpp
   dropout.hpp
+  entrywise_batch_normalization.hpp
   local_response_normalization.hpp
   regularizer.hpp
   selu_dropout.hpp

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -1,0 +1,210 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_REGULARIZERS_ENTRYWISE_BATCH_NORMALIZATION_HPP_INCLUDED
+#define LBANN_LAYERS_REGULARIZERS_ENTRYWISE_BATCH_NORMALIZATION_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/memory.hpp"
+
+namespace lbann {
+
+template <data_layout Layout, El::Device Device>
+class entrywise_batch_normalization_layer : public Layer {
+public:
+
+  entrywise_batch_normalization_layer(lbann_comm* comm,
+                                      DataType decay=0.9,
+                                      DataType epsilon=1e-5)
+    : Layer(comm), m_decay(decay), m_epsilon(epsilon) {}
+
+  entrywise_batch_normalization_layer(const entrywise_batch_normalization_layer& other)
+    : Layer(other),
+      m_decay(other.m_decay),
+      m_epsilon(other.m_epsilon),
+      m_batch_statistics(other.m_batch_statistics ?
+                         other.m_batch_statistics->Copy() :
+                         nullptr),
+      m_batch_statistics_gradient(other.m_batch_statistics_gradient ?
+                                  other.m_batch_statistics_gradient->Copy() :
+                                  nullptr) {}
+
+  entrywise_batch_normalization_layer& operator=(const entrywise_batch_normalization_layer& other) {
+    Layer::operator=(other);
+    m_decay = other.m_decay;
+    m_epsilon = other.m_epsilon;
+    m_batch_statistics.reset(other.m_batch_statistics ?
+                             other.m_batch_statistics->Copy() :
+                             nullptr);
+    m_batch_statistics_gradient.reset(other.m_batch_statistics_gradient ?
+                                      other.m_batch_statistics_gradient->Copy() :
+                                      nullptr);
+    return *this;
+  }
+
+  entrywise_batch_normalization_layer* copy() const override { return new entrywise_batch_normalization_layer(*this); }
+  std::string get_type() const override { return "entry-wise batch normalization"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
+
+  description get_description() const override {
+    auto desc = Layer::get_description();
+    desc.add("Decay", m_decay);
+    desc.add("Epsilon", m_epsilon);
+    return desc;
+  }
+
+protected:
+
+  void setup_matrices(const El::Grid& grid) override {
+    Layer::setup_matrices(grid);
+    auto dist = get_prev_activations().DistData();
+    dist.rowDist = El::STAR;
+    m_batch_statistics.reset(AbsDistMat::Instantiate(dist));
+    m_batch_statistics_gradient.reset(AbsDistMat::Instantiate(dist));
+  }
+
+  void setup_data() override {
+    Layer::setup_data();
+
+    // Initialize output dimensions
+    set_output_dims(get_input_dims());
+    const auto output_dims = get_output_dims();
+    const auto output_size = get_output_size();
+
+    // Initialize default weights if none are provided
+    if (this->m_weights.size() > 2) {
+      std::stringstream err;
+      err << "attempted to setup layer \"" << m_name << "\" "
+          << "with an invalid number of weights "
+          << "(found " << this->m_weights.size() << ", expected 2)";
+      LBANN_ERROR(err.str());
+    }
+    this->m_weights.resize(2, nullptr);
+    if (this->m_weights[0] == nullptr) {
+      this->m_weights[0] = new weights(get_comm());
+      this->m_weights[0]->set_name(get_name() + "_running_mean");
+      auto init = make_unique<constant_initializer>(DataType{0});
+      this->m_weights[0]->set_initializer(std::move(init));
+      this->m_model->add_weights(this->m_weights[0]);
+    }
+    if (this->m_weights[1] == nullptr) {
+      this->m_weights[1] = new weights(get_comm());
+      this->m_weights[1]->set_name(get_name() + "_running_variance");
+      auto init = make_unique<constant_initializer>(DataType{1});
+      this->m_weights[1]->set_initializer(std::move(init));
+      this->m_model->add_weights(this->m_weights[1]);
+    }
+
+    // Setup weights
+    auto dist = get_prev_activations().DistData();
+    dist.rowDist = El::STAR;
+    for (auto* w : this->m_weights) {
+      w->set_dims(output_dims);
+      w->set_matrix_distribution(dist);
+    }
+
+    // Initialize matrices
+    m_batch_statistics->AlignWith(dist);
+    m_batch_statistics->Resize(output_size, 2);
+    m_batch_statistics_gradient->AlignWith(dist);
+    m_batch_statistics_gradient->Resize(output_size, 2);
+
+  }
+
+  void fp_setup_outputs(El::Int mini_batch_size) override {
+    Layer::fp_setup_outputs(mini_batch_size);
+    const auto& input = get_prev_activations();
+    const auto input_size = get_input_size();
+
+    // Make sure batch statistics tensor is aligned with input tensor
+    m_batch_statistics->Empty(false);
+    m_batch_statistics->AlignWith(input);
+    m_batch_statistics->Resize(input_size, 2);
+
+#if 0 /// @todo See https://github.com/LLNL/lbann/issues/1123
+
+    // Check that weights tensors is aligned with input tensor
+    /// @todo Realign tensors if misaligned
+    bool aligned = true;
+    try {
+      const auto& running_mean = m_weights[0]->get_values();
+      const auto& running_var = m_weights[1]->get_values();
+      aligned = (input.ColAlign() == running_mean.ColAlign()
+                 && input.RowAlign() == running_mean.RowAlign()
+                 && input.ColAlign() == running_var.ColAlign()
+                 && input.RowAlign() == running_var.RowAlign());
+    }
+    catch (const exception& e) {
+      // An exception is thrown if you try accessing weights values
+      // before they are initialized. We don't care if this case is
+      // aligned, so it's safe to ignore.
+    }
+    if (!aligned) {
+      std::ostringstream err;
+      err << this->get_type() << " layer \"" << this->get_name() << "\" "
+          << "has misaligned input and weights matrices";
+      LBANN_ERROR(err.str());
+    }
+
+#endif // 0
+
+  }
+
+  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+    Layer::bp_setup_gradient_wrt_inputs(mini_batch_size);
+    m_batch_statistics_gradient->Empty(false);
+    m_batch_statistics_gradient->AlignWith(get_prev_activations());
+    m_batch_statistics_gradient->Resize(get_input_size(), 2);
+  }
+
+  void fp_compute() override;
+  void bp_compute() override;
+
+private:
+
+  /** Decay rate for the running statistics. */
+  DataType m_decay;
+  /** Small number to avoid division by zero. */
+  DataType m_epsilon;
+
+  /** @brief Current mini-batch statistics.
+   *
+   *  These are fused for performance when doing non-local batchnorm.
+   */
+  std::unique_ptr<AbsDistMat> m_batch_statistics;
+  /** @brief Gradients w.r.t. current mini-batch statistics.
+   *
+   * These are fused for performance when doing non-local batchnorm.
+   */
+  std::unique_ptr<AbsDistMat> m_batch_statistics_gradient;
+
+};
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_REGULARIZERS_ENTRYWISE_BATCH_NORMALIZATION_HPP_INCLUDED

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -33,6 +33,18 @@
 
 namespace lbann {
 
+/** @brief
+ *
+ *  Each input entry is normalized across the mini-batch to have zero
+ *  mean and unit standard deviation. This uses the standard approach
+ *  of maintaining the running mean and standard deviation (with
+ *  exponential decay) for use at test time. See:
+ *
+ *  Sergey Ioffe and Christian Szegedy. "Batch Normalization:
+ *  Accelerating Deep Network Training by Reducing Internal Covariate
+ *  Shift." In International Conference on Machine Learning,
+ *  pp. 448-456. 2015.
+ */
 template <data_layout Layout, El::Device Device>
 class entrywise_batch_normalization_layer : public Layer {
 public:

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -95,6 +95,7 @@
 #include "lbann/layers/regularizers/dropout.hpp"
 #include "lbann/layers/regularizers/selu_dropout.hpp"
 #include "lbann/layers/regularizers/batch_normalization.hpp"
+#include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 
 /// Input layer
 #include "lbann/layers/io/input/input_layer.hpp"

--- a/src/layers/regularizers/CMakeLists.txt
+++ b/src/layers/regularizers/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   batch_normalization.cpp
+  entrywise_batch_normalization.cpp
   )
 
 if (LBANN_HAS_CUDA)

--- a/src/layers/regularizers/CMakeLists.txt
+++ b/src/layers/regularizers/CMakeLists.txt
@@ -8,6 +8,7 @@ if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
     batch_normalization.cu
+    entrywise_batch_normalization.cu
     )
 endif ()
 

--- a/src/layers/regularizers/entrywise_batch_normalization.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization.cpp
@@ -229,7 +229,7 @@ void bp_training_impl(lbann_comm& comm,
     return;
   }
 
-  // Compute gradient contributions from local entries
+  // Compute local gradient w.r.t. batch statistics
   //   dL/dmean = - sum(dL/dy_i) / sqrt(var+epsilon)
   //   dL/dvar = - sum(dL/dy_i * (x_i-mean)) * (var+epsilon)^(-3/2) / 2
   El::Zero(gradient_wrt_statistics);
@@ -257,7 +257,7 @@ void bp_training_impl(lbann_comm& comm,
     }
   }
 
-  // Accumulate gradients across processes
+  // Accumulate gradient w.r.t. statistics across processes
   /// @todo Local statistics
   /// @todo Arbitrary group sizes
   comm.allreduce(gradient_wrt_statistics,

--- a/src/layers/regularizers/entrywise_batch_normalization.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization.cpp
@@ -1,0 +1,418 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
+
+namespace lbann {
+
+namespace {
+
+// Block size for loops
+// Note: x86 cache lines are 64B
+constexpr El::Int _bsize = 64 / sizeof(DataType);
+constexpr El::Int bsize = _bsize > 1 ? _bsize : 1;
+
+/**
+ *  mean = sum(x_i) / n
+ *
+ *  var = ( sum(x_i^2)/n - mean^2 ) * n/(n-1)
+ */
+void compute_batch_statistics(lbann_comm& comm,
+                              DataType decay,
+                              const CPUMat& local_input,
+                              AbsDistMat& batch_statistics,
+                              CPUMat& local_running_mean,
+                              CPUMat& local_running_var) {
+
+  // Local matrices
+  auto& local_batch_statistics = dynamic_cast<CPUMat&>(batch_statistics.Matrix());
+  auto local_batch_mean = El::View(local_batch_statistics, El::ALL, El::IR(0));
+  auto local_batch_var = El::View(local_batch_statistics, El::ALL, El::IR(1));
+
+  // Dimensions
+  const El::Int local_height = local_input.Height();
+  const El::Int local_width = local_input.Width();
+
+  // Compute local sums
+  El::Zero(batch_statistics);
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int row_start = 0; row_start < local_height; row_start += bsize) {
+    const El::Int row_end = std::min(row_start + bsize, local_height);
+    const El::Int col_start = 0;
+    const El::Int col_end = local_width;
+    for (El::Int col = col_start; col < col_end; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& x = local_input(row, col);
+        local_batch_mean(row, 0) += x;
+        local_batch_var(row, 0) += x * x;
+      }
+    }
+  }
+
+  // Accumulate sums between processes
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  comm.allreduce(batch_statistics,
+                 batch_statistics.RedundantComm(),
+                 El::mpi::SUM);
+  const size_t statistics_count = local_input.Width();
+
+  // Compute mini-batch statistics from sums
+  if (statistics_count <= 1) {
+    // local_mean already has correct values
+    El::Fill(local_batch_var, DataType{1});
+  } else {
+    LBANN_OMP_PARALLEL_FOR
+    for (El::Int row = 0; row < local_height; ++row) {
+      auto& mean = local_batch_mean(row, 0);
+      auto& var = local_batch_var(row, 0);
+      auto& _running_mean = local_running_mean(row, 0);
+      auto& _running_var = local_running_var(row, 0);
+      const auto sum = local_batch_mean(row, 0);
+      const auto sqsum = local_batch_var(row, 0);
+      mean = sum / statistics_count;
+      const auto sqmean = sqsum / statistics_count;
+      var = (sqmean - mean * mean) * statistics_count / (statistics_count - 1);
+      _running_mean = decay * _running_mean + (DataType{1} - decay) * mean;
+      _running_var = decay * _running_var + (DataType{1} - decay) * var;
+    }
+  }
+
+}
+
+/**
+ *  y_i = (x_i - mean) / sqrt(var + epsilon)
+ */
+void apply_batchnorm(DataType epsilon,
+                     const CPUMat& local_input,
+                     CPUMat& local_output,
+                     const CPUMat& local_mean,
+                     const CPUMat& local_var) {
+  const El::Int local_height = local_input.Height();
+  const El::Int local_width = local_input.Width();
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int row_start = 0; row_start < local_height; row_start += bsize) {
+    const El::Int row_end = std::min(row_start + bsize, local_height);
+    const El::Int col_start = 0;
+    const El::Int col_end = local_width;
+    DataType _inv_stdev[bsize];
+    for (El::Int row = row_start; row < row_end; ++row) {
+      const auto& var = local_var(row, 0);
+      _inv_stdev[row-row_start] = 1 / std::sqrt(var + epsilon);
+    }
+    for (El::Int col = col_start; col < col_end; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& mean = local_mean(row, 0);
+        const auto& inv_stdev = _inv_stdev[row - row_start];
+        const auto& x = local_input(row, col);
+        auto& y = local_output(row, col);
+        y = (x - mean) * inv_stdev;
+      }
+    }
+  }
+}
+
+void fp_impl(lbann_comm& comm,
+             DataType decay,
+             DataType epsilon,
+             bool is_training,
+             const AbsDistMat& input,
+             AbsDistMat& output,
+             AbsDistMat& batch_statistics,
+             AbsDistMat& running_mean,
+             AbsDistMat& running_var) {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const CPUMat&>(input.LockedMatrix());
+  auto& local_output = dynamic_cast<CPUMat&>(output.Matrix());
+  auto& local_running_mean = dynamic_cast<CPUMat&>(running_mean.Matrix());
+  auto& local_running_var = dynamic_cast<CPUMat&>(running_var.Matrix());
+
+  // Batchnorm has different behavior for training and inference
+  if (is_training) {
+
+    // For training, normalize with batch statistics
+    const auto& local_batch_statistics
+      = dynamic_cast<const CPUMat&>(batch_statistics.LockedMatrix());
+    const auto local_batch_mean = El::LockedView(local_batch_statistics,
+                                                 El::ALL, El::IR(0));
+    const auto local_batch_var = El::LockedView(local_batch_statistics,
+                                                El::ALL, El::IR(1));
+    compute_batch_statistics(comm,
+                             decay,
+                             local_input,
+                             batch_statistics,
+                             local_running_mean,
+                             local_running_var);
+    apply_batchnorm(epsilon,
+                    local_input,
+                    local_output,
+                    local_batch_mean,
+                    local_batch_var);
+
+  }
+  else {
+
+    // For inference, normalize with running statistics
+    apply_batchnorm(epsilon,
+                    local_input,
+                    local_output,
+                    local_running_mean,
+                    local_running_var);
+
+  }
+
+}
+
+/** @brief Backprop for training.
+ *
+ *  Assumes forward prop uses mini-batch statistics. In other words,
+ *  statistics are dependent on input.
+ */
+void bp_training_impl(lbann_comm& comm,
+                      DataType epsilon,
+                      const CPUMat& local_input,
+                      const CPUMat& local_gradient_wrt_output,
+                      CPUMat& local_gradient_wrt_input,
+                      const AbsDistMat& statistics,
+                      AbsDistMat& gradient_wrt_statistics) {
+
+  // Local matrices
+  const auto& local_statistics = dynamic_cast<const CPUMat&>(statistics.LockedMatrix());
+  const auto local_mean = El::LockedView(local_statistics, El::ALL, El::IR(0));
+  const auto local_var = El::LockedView(local_statistics, El::ALL, El::IR(1));
+  auto& local_gradient_wrt_statistics = dynamic_cast<CPUMat&>(gradient_wrt_statistics.Matrix());
+  auto local_gradient_wrt_mean = El::View(local_gradient_wrt_statistics, El::ALL, El::IR(0));
+  auto local_gradient_wrt_var = El::View(local_gradient_wrt_statistics, El::ALL, El::IR(1));
+
+  // Dimensions
+  const El::Int local_height = local_gradient_wrt_input.Height();
+  const El::Int local_width = local_gradient_wrt_input.Width();
+
+  // Count for statistics
+  // Note: Output is constant if statistics count is <=1, so error
+  // signal is zero.
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  const size_t statistics_count = local_input.Width();
+  if (statistics_count <= 1) {
+    El::Zero(local_gradient_wrt_input);
+    return;
+  }
+
+  // Compute gradient contributions from local entries
+  //   dL/dmean = - sum(dL/dy_i) / sqrt(var+epsilon)
+  //   dL/dvar = - sum(dL/dy_i * (x_i-mean)) * (var+epsilon)^(-3/2) / 2
+  El::Zero(gradient_wrt_statistics);
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int row_start = 0; row_start < local_height; row_start += bsize) {
+    const El::Int row_end = std::min(row_start + bsize, local_height);
+    const El::Int col_start = 0;
+    const El::Int col_end = local_width;
+    DataType _inv_stdev[bsize];
+    for (El::Int row = row_start; row < row_end; ++row) {
+      const auto& var = local_var(row, 0);
+      _inv_stdev[row-row_start] = 1 / std::sqrt(var + epsilon);
+    }
+    for (El::Int col = col_start; col < col_end; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& mean = local_mean(row, 0);
+        const auto& inv_stdev = _inv_stdev[row - row_start];
+        const auto& x = local_input(row, col);
+        const auto& dy = local_gradient_wrt_output(row, col);
+        auto& dmean = local_gradient_wrt_mean(row, 0);
+        auto& dvar = local_gradient_wrt_var(row, 0);
+        dmean += - dy * inv_stdev;
+        dvar += - dy * (x - mean) * inv_stdev * inv_stdev * inv_stdev / 2;
+      }
+    }
+  }
+
+  // Accumulate gradients across processes
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  comm.allreduce(gradient_wrt_statistics,
+                 gradient_wrt_statistics.RedundantComm(),
+                 El::mpi::SUM);
+
+  // Compute gradient w.r.t. input
+  //   dL/dx_i = ( dL/dy_i / sqrt(var+epsilon)
+  //             + dL/dmean / n
+  //             + dL/dvar * (x_i - mean) * 2/(n-1) )
+  const DataType inv_stats_count = DataType{1} / statistics_count;
+  const DataType inv_stats_countm1 = DataType{1} / (statistics_count - 1);
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int row_start = 0; row_start < local_height; row_start += bsize) {
+    const El::Int row_end = std::min(row_start + bsize, local_height);
+    const El::Int col_start = 0;
+    const El::Int col_end = local_width;
+    DataType _inv_stdev[bsize];
+    for (El::Int row = row_start; row < row_end; ++row) {
+      const auto& var = local_var(row, 0);
+      _inv_stdev[row-row_start] = 1 / std::sqrt(var + epsilon);
+    }
+    for (El::Int col = col_start; col < col_end; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& mean = local_mean(row, 0);
+        const auto& inv_stdev = _inv_stdev[row - row_start];
+        const auto& x = local_input(row, col);
+        const auto& dy = local_gradient_wrt_output(row, col);
+        auto& dx = local_gradient_wrt_input(row, col);
+        auto& dmean = local_gradient_wrt_mean(row, 0);
+        auto& dvar = local_gradient_wrt_var(row, 0);
+        dx = (dy * inv_stdev
+              + dmean * inv_stats_count
+              + dvar * (x - mean)) * 2 * inv_stats_countm1;
+      }
+    }
+  }
+
+}
+
+/** @brief Backprop for inference.
+ *
+ *  Assumes forward prop uses running statistics. In other words,
+ *  statistics are independent of input.
+ */
+void bp_inference_impl(DataType epsilon,
+                       const CPUMat& local_gradient_wrt_output,
+                       CPUMat& local_gradient_wrt_input,
+                       const CPUMat& local_var) {
+
+  // Compute gradient w.r.t. input
+  //   dL/dx_i = dL/dy_i / sqrt(var+epsilon)
+  const El::Int local_height = local_gradient_wrt_input.Height();
+  const El::Int local_width = local_gradient_wrt_input.Width();
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int row_start = 0; row_start < local_height; row_start += bsize) {
+    const El::Int row_end = std::min(row_start + bsize, local_height);
+    const El::Int col_start = 0;
+    const El::Int col_end = local_width;
+    DataType _inv_stdev[bsize];
+    for (El::Int row = row_start; row < row_end; ++row) {
+      const auto& var = local_var(row, 0);
+      _inv_stdev[row-row_start] = 1 / std::sqrt(var + epsilon);
+    }
+    for (El::Int col = col_start; col < col_end; ++col) {
+      for (El::Int row = row_start; row < row_end; ++row) {
+        const auto& inv_stdev = _inv_stdev[row - row_start];
+        const auto& dy = local_gradient_wrt_output(row, col);
+        auto& dx = local_gradient_wrt_input(row, col);
+        dx = dy * inv_stdev;
+      }
+    }
+  }
+
+}
+
+void bp_impl(lbann_comm& comm,
+             DataType epsilon,
+             bool is_training,
+             const AbsDistMat& input,
+             const AbsDistMat& gradient_wrt_output,
+             AbsDistMat& gradient_wrt_input,
+             const AbsDistMat& batch_statistics,
+             AbsDistMat& gradient_wrt_batch_statistics,
+             const AbsDistMat& running_var) {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const CPUMat&>(input.LockedMatrix());
+  const auto& local_gradient_wrt_output = dynamic_cast<const CPUMat&>(gradient_wrt_output.LockedMatrix());
+  auto& local_gradient_wrt_input = dynamic_cast<CPUMat&>(gradient_wrt_input.Matrix());
+  const auto& local_running_var = dynamic_cast<const CPUMat&>(running_var.LockedMatrix());
+
+  // Batchnorm has different behavior for training and inference
+  if (is_training) {
+    bp_training_impl(comm,
+                     epsilon,
+                     local_input,
+                     local_gradient_wrt_output,
+                     local_gradient_wrt_input,
+                     batch_statistics,
+                     gradient_wrt_batch_statistics);
+  }
+  else {
+    bp_inference_impl(epsilon,
+                      local_gradient_wrt_output,
+                      local_gradient_wrt_input,
+                      local_running_var);
+  }
+
+}
+
+} // namespace
+
+// Template instantiation
+template <>
+void entrywise_batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::fp_compute() {
+  fp_impl(*get_comm(),
+          m_decay,
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_activations(),
+          *m_batch_statistics,
+          m_weights[0]->get_values(),
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::fp_compute() {
+  fp_impl(*get_comm(),
+          m_decay,
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_activations(),
+          *m_batch_statistics,
+          m_weights[0]->get_values(),
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::CPU>::bp_compute() {
+  bp_impl(*get_comm(),
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_prev_error_signals(),
+          get_error_signals(),
+          *m_batch_statistics,
+          *m_batch_statistics_gradient,
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::MODEL_PARALLEL, El::Device::CPU>::bp_compute() {
+  bp_impl(*get_comm(),
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_prev_error_signals(),
+          get_error_signals(),
+          *m_batch_statistics,
+          *m_batch_statistics_gradient,
+          m_weights[1]->get_values());
+}
+
+} // namespace lbann

--- a/src/layers/regularizers/entrywise_batch_normalization.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization.cpp
@@ -300,8 +300,10 @@ void bp_training_impl(lbann_comm& comm,
 
 /** @brief Backprop for inference.
  *
- *  Assumes forward prop uses running statistics. In other words,
- *  statistics are independent of input.
+ *  Computes gradient w.r.t. input when the model is performing
+ *  inference, e.g. in validation or testing mode. In this case,
+ *  forward prop uses running statistics, which are independent of
+ *  input.
  */
 void bp_inference_impl(DataType epsilon,
                        const AbsDistMat& gradient_wrt_output,

--- a/src/layers/regularizers/entrywise_batch_normalization.cu
+++ b/src/layers/regularizers/entrywise_batch_normalization.cu
@@ -1,0 +1,604 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
+#include "lbann/utils/cuda.hpp"
+
+namespace lbann {
+
+namespace {
+
+/**
+ *  On input, sums and sqsums are assumed to be filled with zeros.
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (height / bsize) x 1 x 1
+ */
+__global__ void row_sums_kernel(size_t height,
+                                size_t width,
+                                const DataType* __restrict__ vals,
+                                size_t vals_ldim,
+                                DataType* __restrict__ sums,
+                                DataType* __restrict__ sqsums) {
+  const size_t gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t nthreads = blockDim.x * gridDim.x;
+  for (size_t row = gid; row < height; row += nthreads) {
+    auto& sum = sums[row];
+    auto& sqsum = sqsums[row];
+    for (size_t col = 0; col < width; ++col) {
+      const auto& x = vals[row + col * vals_ldim];
+      sum += x;
+      sqsum += x * x;
+    }
+  }
+}
+
+/**
+ *  On input, batch_mean and batch_var are assumed to contain sums and
+ *  squares of sums, respectively.
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (size / bsize) x 1 x 1
+ */
+__global__ void compute_statistics_kernel(size_t size,
+                                          size_t statistics_count,
+                                          DataType decay,
+                                          DataType* __restrict__ batch_mean,
+                                          DataType* __restrict__ batch_var,
+                                          DataType* __restrict__ running_mean,
+                                          DataType* __restrict__ running_var) {
+  const size_t gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t nthreads = blockDim.x * gridDim.x;
+  for (size_t i = gid; i < size; i += nthreads) {
+    auto& mean = batch_mean[i];
+    auto& var = batch_var[i];
+    auto& _running_mean = running_mean[i];
+    auto& _running_var = running_var[i];
+    const auto sum = batch_mean[i];
+    const auto sqsum = batch_var[i];
+    mean = sum / statistics_count;
+    const auto sqmean = sqsum / statistics_count;
+    var = (sqmean - mean * mean) * statistics_count / (statistics_count - 1);
+    _running_mean = decay * _running_mean + (DataType{1} - decay) * mean;
+    _running_var = decay * _running_var + (DataType{1} - decay) * var;
+  }
+}
+
+/**
+ *  mean = sum(x_i) / n
+ *
+ *  var = ( sum(x_i^2)/n - mean^2 ) * n/(n-1)
+ */
+void compute_batch_statistics(lbann_comm& comm,
+                              DataType decay,
+                              const AbsDistMat& input,
+                              AbsDistMat& batch_statistics,
+                              AbsDistMat& running_mean,
+                              AbsDistMat& running_var) {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const GPUMat&>(input.LockedMatrix());
+  auto& local_batch_statistics = dynamic_cast<GPUMat&>(batch_statistics.Matrix());
+  auto local_batch_mean = El::View(local_batch_statistics, El::ALL, El::IR(0));
+  auto local_batch_var = El::View(local_batch_statistics, El::ALL, El::IR(1));
+  auto& local_running_mean = dynamic_cast<GPUMat&>(running_mean.Matrix());
+  auto& local_running_var = dynamic_cast<GPUMat&>(running_var.Matrix());
+
+  // Dimensions
+  const size_t local_height = local_input.Height();
+  const size_t local_width = local_input.Width();
+
+  // Compute local sums
+  El::Zero(batch_statistics);
+  if (local_height > 0) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (local_height + block_size - 1) / block_size;
+    row_sums_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        local_height,
+        local_width,
+        local_input.LockedBuffer(),
+        local_input.LDim(),
+        local_batch_mean.Buffer(),
+        local_batch_var.Buffer());
+  }
+
+  // Accumulate sums between processes
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  comm.allreduce(batch_statistics,
+                 batch_statistics.RedundantComm(),
+                 El::mpi::SUM);
+  const size_t statistics_count = input.Width();
+
+  // Compute mini-batch statistics from sums
+  if (statistics_count <= 1) {
+    // local_mean already has correct values
+    El::Fill(local_batch_var, DataType{1});
+  } else {
+    if (local_height > 0) {
+      constexpr size_t block_size = 256;
+      dim3 block_dims, grid_dims;
+      block_dims.x = block_size;
+      grid_dims.x = (local_height + block_size - 1) / block_size;
+      compute_statistics_kernel
+        <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+          local_height,
+          statistics_count,
+          decay,
+          local_batch_mean.Buffer(),
+          local_batch_var.Buffer(),
+          local_running_mean.Buffer(),
+          local_running_var.Buffer());
+    }
+  }
+
+}
+
+/**
+ *  Block dimensions: bsizex x bsizey x 1
+ *
+ *  Grid dimensions: (height / bsizex) x (width / bsizey) x 1
+ */
+__global__ void batchnorm_kernel(size_t height,
+                                 size_t width,
+                                 const DataType* __restrict__ input,
+                                 size_t input_ldim,
+                                 DataType* __restrict__ output,
+                                 size_t output_ldim,
+                                 const DataType* __restrict__ mean,
+                                 const DataType* __restrict__ var) {
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  for (size_t row = gidx; row < height; row += nthreadsx) {
+    const auto& _mean = mean[row];
+    const auto& _var = var[row];
+    const auto inv_stdev = cuda::rsqrt(_var + epsilon);
+    for (size_t col = gidy; col < width; col += nthreadsy) {
+      const auto& x = input[row + col*input_ldim];
+      auto& y = output[row + col*output_ldim];
+      y = (x - _mean) * inv_stdev;
+    }
+  }
+}
+
+/**
+ *  y_i = (x_i - mean) / sqrt(var + epsilon)
+ */
+void apply_batchnorm(DataType epsilon,
+                     const GPUMat& local_input,
+                     GPUMat& local_output,
+                     const GPUMat& local_mean,
+                     const GPUMat& local_var) {
+  if (!local_input.IsEmpty()) {
+    const size_t local_height = local_input.Height();
+    const size_t local_width = local_input.Width();
+    constexpr size_t block_size_x = 256;
+    constexpr size_t block_size_y = 1;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size_x;
+    block_dims.y = block_size_y;
+    grid_dims.x = (local_height + block_size_x - 1) / block_size_x;
+    grid_dims.y = (local_width + block_size_y - 1) / block_size_y;
+    batchnorm_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        local_height,
+        local_width,
+        local_input.LockedBuffer(),
+        local_input.LDim(),
+        local_output.Buffer(),
+        local_output.LDim(),
+        local_mean.LockedBuffer(),
+        local_var.LockedBuffer());
+  }
+}
+
+void fp_impl(lbann_comm& comm,
+             DataType decay,
+             DataType epsilon,
+             bool is_training,
+             const AbsDistMat& input,
+             AbsDistMat& output,
+             AbsDistMat& batch_statistics,
+             AbsDistMat& running_mean,
+             AbsDistMat& running_var) {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const GPUMat&>(input.LockedMatrix());
+  auto& local_output = dynamic_cast<GPUMat&>(output.Matrix());
+
+  // Batchnorm has different behavior for training and inference
+  if (is_training) {
+
+    // For training, normalize with batch statistics
+    compute_batch_statistics(comm,
+                             decay,
+                             input,
+                             batch_statistics,
+                             running_mean,
+                             running_var);
+    const auto& local_batch_statistics
+      = dynamic_cast<const GPUMat&>(batch_statistics.LockedMatrix());
+    const auto local_batch_mean = El::LockedView(local_batch_statistics,
+                                                 El::ALL, El::IR(0));
+    const auto local_batch_var = El::LockedView(local_batch_statistics,
+                                                El::ALL, El::IR(1));
+    apply_batchnorm(epsilon,
+                    local_input,
+                    local_output,
+                    local_batch_mean,
+                    local_batch_var);
+
+  }
+  else {
+
+    // For inference, normalize with running statistics
+    const auto& local_running_mean = dynamic_cast<const GPUMat&>(running_mean.LockedMatrix());
+    const auto& local_running_var = dynamic_cast<const GPUMat&>(running_var.LockedMatrix());
+    apply_batchnorm(epsilon,
+                    local_input,
+                    local_output,
+                    local_running_mean,
+                    local_running_var);
+
+  }
+
+}
+
+/**
+ *  On input, gradient_wrt_mean and gradient_wrt_var are assumed to be
+ *  filled with zeros.
+ *
+ *  dL/dmean = - sum(dL/dy_i) / sqrt(var+epsilon)
+ *
+ *  dL/dvar = - sum(dL/dy_i * (x_i-mean)) * (var+epsilon)^(-3/2) / 2
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (height / bsize) x 1 x 1
+ */
+__global__ void bp_training_stats_gradient_kernel(size_t height,
+                                                  size_t width,
+                                                  DataType epsilon,
+                                                  const DataType* __restrict__ input,
+                                                  size_t input_ldim,
+                                                  const DataType* __restrict__ gradient_wrt_output,
+                                                  size_t gradient_wrt_output_ldim,
+                                                  const DataType* __restrict__ mean,
+                                                  const DataType* __restrict__ var,
+                                                  DataType* __restrict__ gradient_wrt_mean,
+                                                  DataType* __restrict__ gradient_wrt_var) {
+  const size_t gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t nthreads = blockDim.x * gridDim.x;
+  for (size_t row = gid; row < height; row += nthreads) {
+    const auto& _mean = mean[row];
+    const auto& _var = var[row];
+    const auto inv_stdev = cuda::rsqrt(_var + epsilon);
+    auto& dmean = gradient_wrt_mean[row];
+    auto& dvar = gradient_wrt_var[row];
+    for (size_t col = 0; col < width; ++col) {
+      const auto& x = input[row + col * input_ldim];
+      const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_ldim];
+      dmean += - dy * inv_stdev;
+      dvar += - dy * (x - _mean) * inv_stdev*inv_stdev*inv_stdev / 2;
+    }
+  }
+}
+
+/**
+ *  dL/dx_i = ( dL/dy_i / sqrt(var+epsilon)
+ *              + dL/dmean / n
+ *              + dL/dvar * (x_i - mean) * 2/(n-1) )
+ *
+ *  Block dimensions: bsizex x bsizey x 1
+ *
+ *  Grid dimensions: (height / bsizex) x (width / bsizey) x 1
+ */
+__global__ void bp_training_error_signal_kernel(size_t height,
+                                                size_t width,
+                                                DataType epsilon,
+                                                size_t statistics_count,
+                                                const DataType* __restrict__ gradient_wrt_output,
+                                                size_t gradient_wrt_output_ldim,
+                                                DataType* __restrict__ gradient_wrt_input,
+                                                size_t gradient_wrt_input_ldim,
+                                                const DataType* __restrict__ mean,
+                                                const DataType* __restrict__ var,
+                                                const DataType* __restrict__ gradient_wrt_mean,
+                                                const DataType* __restrict__ gradient_wrt_var) {
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  for (size_t row = gidx; row < height; row += nthreadsx) {
+    const auto& _mean = mean[row];
+    const auto& _var = var[row];
+    const auto& dmean = gradient_wrt_mean[row];
+    const auto& dvar = gradient_wrt_var[row];
+    const auto inv_stdev = cuda::rsqrt(_var + epsilon);
+    for (size_t col = gidy; col < width; col += nthreadsy) {
+      const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_ldim];
+      auto& dx = gradient_wrt_input[row + col * gradient_wrt_input_ldim];
+      dx = (dy * inv_stdev
+            + dmean / statistics_count
+            + dvar * (x - _mean)) * 2 / (statistics_count - 1);
+    }
+  }
+}
+
+/** @brief Backprop for training.
+ *
+ *  Assumes forward prop uses mini-batch statistics. In other words,
+ *  statistics are dependent on input.
+ */
+void bp_training_impl(lbann_comm& comm,
+                      DataType epsilon,
+                      const AbsDistMat& input,
+                      const AbsDistMat& gradient_wrt_output,
+                      AbsDistMat& gradient_wrt_input,
+                      const AbsDistMat& statistics,
+                      AbsDistMat& gradient_wrt_statistics) {
+
+  // Local matrices
+  const auto& local_input = dynamic_cast<const GPUMat&>(input.LockedMatrix());
+  const auto& local_gradient_wrt_output = dynamic_cast<const GPUMat&>(gradient_wrt_output.LockedMatrix());
+  auto& local_gradient_wrt_input = dynamic_cast<GPUMat&>(gradient_wrt_input.Matrix());
+  const auto& local_statistics = dynamic_cast<const GPUMat&>(statistics.LockedMatrix());
+  const auto local_mean = El::LockedView(local_statistics, El::ALL, El::IR(0));
+  const auto local_var = El::LockedView(local_statistics, El::ALL, El::IR(1));
+  auto& local_gradient_wrt_statistics = dynamic_cast<GPUMat&>(gradient_wrt_statistics.Matrix());
+  auto local_gradient_wrt_mean = El::View(local_gradient_wrt_statistics, El::ALL, El::IR(0));
+  auto local_gradient_wrt_var = El::View(local_gradient_wrt_statistics, El::ALL, El::IR(1));
+
+  // Dimensions
+  const size_t local_height = local_gradient_wrt_input.Height();
+  const size_t local_width = local_gradient_wrt_input.Width();
+
+  // Count for statistics
+  // Note: Output is constant if statistics count is <=1, so error
+  // signal is zero.
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  const size_t statistics_count = input.Width();
+  if (statistics_count <= 1) {
+    El::Zero(local_gradient_wrt_input);
+    return;
+  }
+
+  // Compute local gradient w.r.t. batch statistics
+  El::Zero(gradient_wrt_statistics);
+  if (local_height > 0) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (local_height + block_size - 1) / block_size;
+    bp_training_stats_gradient_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        local_height,
+        local_width,
+        epsilon,
+        local_input.LockedBuffer(),
+        local_input.LDim(),
+        local_gradient_wrt_output.LockedBuffer(),
+        local_gradient_wrt_output.LDim(),
+        local_mean.LockedBuffer(),
+        local_var.LockedBuffer(),
+        local_gradient_wrt_mean.Buffer(),
+        local_gradient_wrt_var.Buffer());
+  }
+
+  // Accumulate gradient w.r.t. statistics across processes
+  /// @todo Local statistics
+  /// @todo Arbitrary group sizes
+  comm.allreduce(gradient_wrt_statistics,
+                 gradient_wrt_statistics.RedundantComm(),
+                 El::mpi::SUM);
+
+  // Compute gradient w.r.t. input
+  if (!local_input.IsEmpty()) {
+    const size_t local_height = local_input.Height();
+    const size_t local_width = local_input.Width();
+    constexpr size_t block_size_x = 256;
+    constexpr size_t block_size_y = 1;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size_x;
+    block_dims.y = block_size_y;
+    grid_dims.x = (local_height + block_size_x - 1) / block_size_x;
+    grid_dims.y = (local_width + block_size_y - 1) / block_size_y;
+    bp_training_err_signal_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        local_height,
+        local_width,
+        epsilon,
+        statistics_count,
+        local_gradient_wrt_output.LockedBuffer(),
+        local_gradient_wrt_output.LDim(),
+        local_gradient_wrt_input.Buffer(),
+        local_gradient_wrt_input.LDim(),
+        local_mean.LockedBuffer(),
+        local_var.LockedBuffer(),
+        local_gradient_wrt_mean.LockedBuffer(),
+        local_gradient_wrt_var.LockedBuffer());
+  }
+
+}
+
+/**
+ *  dL/dx_i = dL/dy_i / sqrt(var+epsilon)
+ *
+ *  Block dimensions: bsizex x bsizey x 1
+ *
+ *  Grid dimensions: (height / bsizex) x (width / bsizey) x 1
+ */
+__global__ void bp_inference_kernel(size_t height,
+                                    size_t width,
+                                    const DataType* __restrict__ gradient_wrt_output,
+                                    size_t gradient_wrt_output_ldim,
+                                    DataType* __restrict__ gradient_wrt_input,
+                                    size_t gradient_wrt_input_ldim,
+                                    const DataType* __restrict__ running_var) {
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  for (size_t row = gidx; row < height; row += nthreadsx) {
+    const auto& var = running_var[row];
+    const auto inv_stdev = cuda::rsqrt(var + epsilon);
+    for (size_t col = gidy; col < width; col += nthreadsy) {
+      const auto& dy = gradient_wrt_output[row + col * gradient_wrt_output_ldim];
+      auto& dx = gradient_wrt_input[row + col * gradient_wrt_input_ldim];
+      dx = dy * inv_stdev;
+    }
+  }
+}
+
+/** @brief Backprop for inference.
+ *
+ *  Assumes forward prop uses running statistics. In other words,
+ *  statistics are independent of input.
+ */
+void bp_inference_impl(DataType epsilon,
+                       const AbsDistMat& gradient_wrt_output,
+                       AbsDistMat& gradient_wrt_input,
+                       const AbsDistMat& running_var) {
+
+  // Local matrices
+  const auto& local_gradient_wrt_output = dynamic_cast<const GPUMat&>(gradient_wrt_output.LockedMatrix());
+  auto& local_gradient_wrt_input = dynamic_cast<GPUMat&>(gradient_wrt_input.Matrix());
+  const auto& local_running_var = dynamic_cast<const GPUMat&>(running_var.LockedMatrix());
+
+  // Compute gradient w.r.t. input
+  if (!local_input.IsEmpty()) {
+    const size_t local_height = local_input.Height();
+    const size_t local_width = local_input.Width();
+    constexpr size_t block_size_x = 256;
+    constexpr size_t block_size_y = 1;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size_x;
+    block_dims.y = block_size_y;
+    grid_dims.x = (local_height + block_size_x - 1) / block_size_x;
+    grid_dims.y = (local_width + block_size_y - 1) / block_size_y;
+    bp_inference_kernel
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        local_height,
+        local_width,
+        local_gradient_wrt_output.LockedBuffer(),
+        local_gradient_wrt_output.LDim(),
+        local_gradient_wrt_input.Buffer(),
+        local_gradient_wrt_input.LDim(),
+        local_running_var.LockedBuffer());
+  }
+
+}
+
+void bp_impl(lbann_comm& comm,
+             DataType epsilon,
+             bool is_training,
+             const AbsDistMat& input,
+             const AbsDistMat& gradient_wrt_output,
+             AbsDistMat& gradient_wrt_input,
+             const AbsDistMat& batch_statistics,
+             AbsDistMat& gradient_wrt_batch_statistics,
+             const AbsDistMat& running_var) {
+
+  // Batchnorm has different behavior for training and inference
+  if (is_training) {
+    bp_training_impl(comm,
+                     epsilon,
+                     input,
+                     gradient_wrt_output,
+                     gradient_wrt_input,
+                     batch_statistics,
+                     gradient_wrt_batch_statistics);
+  }
+  else {
+    bp_inference_impl(epsilon,
+                      gradient_wrt_output,
+                      gradient_wrt_input,
+                      running_var);
+  }
+
+}
+
+} // namespace
+
+// Template instantiation
+template <>
+void entrywise_batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::fp_compute() {
+  fp_impl(*get_comm(),
+          m_decay,
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_activations(),
+          *m_batch_statistics,
+          m_weights[0]->get_values(),
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::fp_compute() {
+  fp_impl(*get_comm(),
+          m_decay,
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_activations(),
+          *m_batch_statistics,
+          m_weights[0]->get_values(),
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::bp_compute() {
+  bp_impl(*get_comm(),
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_prev_error_signals(),
+          get_error_signals(),
+          *m_batch_statistics,
+          *m_batch_statistics_gradient,
+          m_weights[1]->get_values());
+}
+template <>
+void entrywise_batch_normalization_layer<data_layout::MODEL_PARALLEL, El::Device::GPU>::bp_compute() {
+  bp_impl(*get_comm(),
+          m_epsilon,
+          m_model->get_execution_mode() == execution_mode::training,
+          get_prev_activations(),
+          get_prev_error_signals(),
+          get_error_signals(),
+          *m_batch_statistics,
+          *m_batch_statistics_gradient,
+          m_weights[1]->get_values());
+}
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -574,7 +574,6 @@ std::unique_ptr<Layer> construct_layer(
   }
   if (proto_layer.has_entrywise_batch_normalization()) {
     const auto& params = proto_layer.entrywise_batch_normalization();
-    /// @todo Support GPU implementation
     return lbann::make_unique<entrywise_batch_normalization_layer<Layout, Device>>(comm, params.decay(), params.epsilon());
   }
 

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -66,6 +66,7 @@
 #include "lbann/layers/regularizers/local_response_normalization.hpp"
 #include "lbann/layers/regularizers/regularizer.hpp"
 #include "lbann/layers/regularizers/selu_dropout.hpp"
+#include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 #include "lbann/layers/transform/bernoulli.hpp"
 #include "lbann/layers/transform/categorical_random.hpp"
 #include "lbann/layers/transform/concatenation.hpp"
@@ -570,6 +571,11 @@ std::unique_ptr<Layer> construct_layer(
     } else {
       return lbann::make_unique<selu_dropout<Layout, Device>>(comm, keep_prob);
     }
+  }
+  if (proto_layer.has_entrywise_batch_normalization()) {
+    const auto& params = proto_layer.entrywise_batch_normalization();
+    /// @todo Support GPU implementation
+    return lbann::make_unique<entrywise_batch_normalization_layer<Layout, El::Device::CPU>>(comm, params.decay(), params.epsilon());
   }
 
   // Math layers

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -575,7 +575,7 @@ std::unique_ptr<Layer> construct_layer(
   if (proto_layer.has_entrywise_batch_normalization()) {
     const auto& params = proto_layer.entrywise_batch_normalization();
     /// @todo Support GPU implementation
-    return lbann::make_unique<entrywise_batch_normalization_layer<Layout, El::Device::CPU>>(comm, params.decay(), params.epsilon());
+    return lbann::make_unique<entrywise_batch_normalization_layer<Layout, Device>>(comm, params.decay(), params.epsilon());
   }
 
   // Math layers

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -151,6 +151,7 @@ message Layer {
     LocalResponseNormalization local_response_normalization = 20;
     Dropout dropout = 21;
     SeluDropout selu_dropout = 229;
+    EntrywiseBatchNormalization entrywise_batch_normalization = 230;
 
     // Activation layers
     Elu elu = 200;
@@ -279,6 +280,11 @@ message Layer {
     string stats_aggregation = 5; // default: local; deprecated
     // default: 1 (local aggregation); set to a negative value for global stats.
     int64 statistics_group_size = 6;
+  }
+
+  message EntrywiseBatchNormalization {
+    double decay = 1;
+    double epsilon = 2;
   }
 
   message SeluDropout {


### PR DESCRIPTION
Our current batchnorm does not work well with large fully-connected networks (like the last few layers in AlexNet) since it only supports data-parallel data. Supporting data in (`MC`, `MR`) format is not feasible. This PR implements an entry-wise batchnorm layer, which is equivalent to our current usage with flattened data, but can also support the model-parallel case. Gradient checking passes on for both data-parallel and model-parallel cases on both CPU and GPU.

Note that we currently only support global statistics. I don't think it would be hard to support local statistics, but it might not be advisable since statistics counts are already so small. Defining reasonable "statistics groups" would also be trickier for (`MC`, `MR`) data: row communicators would probably consist of non-adjacent processes, so I don't expect much latency benefits from reducing over a subset of the row communicator.