### PR TITLE
Destroy embedded Python session during LBANN finalization

### DIFF
--- a/include/lbann/utils/python.hpp
+++ b/include/lbann/utils/python.hpp
@@ -29,59 +29,44 @@
 
 #include "lbann/base.hpp"
 #ifdef LBANN_HAS_PYTHON
-#include <string>
+
 #include <Python.h>
+
+#include <mutex>
+#include <string>
 
 namespace lbann {
 namespace python {
 
-/** @brief Singleton class to manage embedded Python session.
+/** @brief Start embedded Python session.
  *
- *  This mostly manages the initialization and finalization of the
- *  Python session. It is rarely necessary to interact with the
- *  singleton instance directly.
+ *  Does nothing if Python has already been started. This function is
+ *  thread-safe.
  *
- *  All static member functions are thread-safe.
+ *  Be warned that restarting Python after it has been ended is a bad
+ *  idea since any Python objects left over from the first session
+ *  will be invalid in the second. Expect segfaults.
  */
-class session {
-public:
+void initialize();
 
-  /** @brief Start embedded Python session if not already running.
-   *  @details Does nothing if Python has already been started.
-   */
-  static void start_once();
+/** @brief End embedded Python session.
+ *
+ *  Does nothing if Python is not running. This function is
+ *  thread-safe.
+ */
+void finalize();
 
-  /** @brief Check if embedded Python session is running. */
-  static bool is_active() noexcept;
+/** @brief Check if embedded Python session is running. */
+bool is_active();
 
-  /** @brief Check if a Python error has occurred.
-   *
-   *  Throws an exception if a Python error is detected.
-   *
-   *  @param force_error Whether to force an exception to be thrown.
-   */
-  static void check_error(bool force_error = false);
-
-  /** @brief Get singleton instance.
-   *
-   *  Initializes an embedded Python session the first time it is
-   *  called.
-   */
-  static session& get();
-
-  ~session();
-
-private:
-
-  /** @brief State on main Python thread. */
-  PyThreadState* m_thread_state = nullptr;
-
-  // Lifetime functions
-  session();
-  session(const session&) = delete;
-  session& operator=(const session&) = delete;
-
-};
+/** @brief Check if a Python error has occurred.
+ *
+ *  Throws an exception if a Python error is detected. The GIL is
+ *  acquired internally.
+ *
+ *  @param force_error Whether to force an exception to be thrown.
+ */
+void check_error(bool force_error = false);
 
 /** @brief RAII wrapper for Python GIL.
  *
@@ -90,6 +75,8 @@ private:
  *  time. Make sure to acquire the GIL before calling Python C API
  *  functions. The GIL can be acquired recursively, i.e. you can
  *  acquire the GIL even if you already control it.
+ *
+ *  If an Python session is not running, one is started.
  */
 class global_interpreter_lock {
 public:

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -45,6 +45,9 @@
 #ifdef LBANN_HAS_CUDNN
 #include "lbann/utils/cudnn.hpp"
 #endif
+#ifdef LBANN_HAS_PYTHON
+#include "lbann/utils/python.hpp"
+#endif
 
 #include <iostream>
 #include <string>
@@ -94,6 +97,9 @@ world_comm_ptr initialize(int& argc, char**& argv, int seed) {
 void finalize(lbann_comm* comm) {
 #ifdef LBANN_HAS_CUDNN
   cudnn::destroy();
+#endif
+#ifdef LBANN_HAS_PYTHON
+  python::finalize();
 #endif
   if (comm != nullptr) {
     delete comm;


### PR DESCRIPTION
As discussed in Issue #1111, it seems that PyTorch is sloppy when destroying objects at program termination. It can rely on Python's garbage collection, so I suspect many other packages are similar. However, problems show up since we manage an embedded Python session with a singleton `lbann::python::session` class. If PyTorch is destroyed before `lbann::python::session`, then it will destroy its internal objects without telling Python. This will cause segfaults when `lbann::python::session` is destroyed and Python attempts garbage collection.

This PR gets around this by explicitly destroying the embedded Python session inside LBANN's finalization function. `lbann::python::session` has been removed and its static member functions have been added as global functions in the `lbann::python` namespace.

This closes #1111.