### PR TITLE
Callback to print model descriptions

### DIFF
--- a/include/lbann/callbacks/callback.hpp
+++ b/include/lbann/callbacks/callback.hpp
@@ -31,6 +31,7 @@
 
 #include "lbann/layers/layer.hpp"
 #include "lbann/models/model.hpp"
+#include "lbann/utils/description.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/summary.hpp"
 
@@ -89,6 +90,10 @@ public:
   /** @name Callback hooks */
   ///@{
 
+  /** @brief Called at the beginning of setup. */
+  virtual void on_setup_begin(model *m) {}
+  /** @brief Called at the end of setup. */
+  virtual void on_setup_end(model *m) {}
   /** @brief Called at the beginning of training. */
   virtual void on_train_begin(model *m) {}
   /** @brief Called at the end of training. */
@@ -172,6 +177,9 @@ public:
 
   /** @brief Return this callback's name. */
   virtual std::string name() const = 0;
+
+  /** @brief Human-readable description. */
+  virtual description get_description() const;
 
   ///@}
 

--- a/include/lbann/callbacks/print_model_description.hpp
+++ b/include/lbann/callbacks/print_model_description.hpp
@@ -32,6 +32,12 @@
 namespace lbann {
 namespace callback {
 
+/** @brief Print human-readable description of model to standard input.
+ *
+ *  Message is printed when the model has finished setup. The
+ *  description includes information on the model's layers, weights,
+ *  and callbacks.
+ */
 class print_model_description : public callback_base {
 public:
   print_model_description() : callback_base() {}

--- a/include/lbann/callbacks/print_model_description.hpp
+++ b/include/lbann/callbacks/print_model_description.hpp
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_PRINT_MODEL_DESCRIPTION_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_PRINT_MODEL_DESCRIPTION_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+
+namespace lbann {
+namespace callback {
+
+class print_model_description : public callback_base {
+public:
+  print_model_description() : callback_base() {}
+  print_model_description(const print_model_description&) = default;
+  print_model_description& operator=(const print_model_description&) = default;
+  print_model_description* copy() const override { return new print_model_description(*this); }
+  void on_setup_end(model *m) override;
+  std::string name() const override { return "print_model_description"; }
+
+};
+
+// Builder function
+std::unique_ptr<callback_base>
+build_print_model_description_callback_from_pbuf(
+  const google::protobuf::Message&, std::shared_ptr<lbann_summary> const&);
+
+} // namespace callback
+} // namespace lbann
+
+#endif  // LBANN_CALLBACKS_CALLBACK_PRINT_MODEL_DESCRIPTION_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -158,6 +158,7 @@
 #include "lbann/callbacks/monitor_io.hpp"
 #include "lbann/callbacks/perturb_adam.hpp"
 #include "lbann/callbacks/perturb_dropout.hpp"
+#include "lbann/callbacks/print_model_description.hpp"
 #include "lbann/callbacks/print_statistics.hpp"
 #include "lbann/callbacks/profiler.hpp"
 #include "lbann/callbacks/replace_weights.hpp"

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -387,6 +387,10 @@ protected:
   // Callbacks
   // ===========================================
 
+  /** @brief Execute callbacks at start of setup. */
+  virtual void do_setup_begin_cbs();
+  /** @brief Execute callbacks at end of setup. */
+  virtual void do_setup_end_cbs();
   /** @brief Execute callbacks at start of training. */
   virtual void do_train_begin_cbs();
   /** @brief Execute callbacks at end of training. */

--- a/model_zoo/vision/lenet.py
+++ b/model_zoo/vision/lenet.py
@@ -80,7 +80,9 @@ model = lbann.Model(mini_batch_size,
                     layers=lbann.traverse_layer_graph(input),
                     objective_function=loss,
                     metrics=[lbann.Metric(acc, name='accuracy', unit='%')],
-                    callbacks=[lbann.CallbackPrint(), lbann.CallbackTimer()])
+                    callbacks=[lbann.CallbackPrintModelDescription(),
+                               lbann.CallbackPrint(),
+                               lbann.CallbackTimer()])
 
 # Setup optimizer
 opt = lbann.SGD(learn_rate=0.01, momentum=0.9)

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  callback.cpp
   check_dataset.cpp
   check_gradients.cpp
   check_init.cpp

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -26,6 +26,7 @@ set_full_path(THIS_DIR_SOURCES
   monitor_io.cpp
   perturb_adam.cpp
   perturb_dropout.cpp
+  print_model_description.cpp
   print_statistics.cpp
   profiler.cpp
   replace_weights.cpp

--- a/src/callbacks/callback.cpp
+++ b/src/callbacks/callback.cpp
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/callback.hpp"
+
+namespace lbann {
+
+description callback_base::get_description() const {
+  return name();
+}
+
+} // namespace lbann

--- a/src/callbacks/print_model_description.cpp
+++ b/src/callbacks/print_model_description.cpp
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/print_model_description.hpp"
+#include "lbann/models/model.hpp"
+#include <callbacks.pb.h>
+
+namespace lbann {
+namespace callback {
+
+void print_model_description::on_setup_end(model *m) {
+  if (m->get_comm()->am_world_master()) {
+    std::cout << "\n"
+              << m->get_description()
+              << std::endl;
+  }
+}
+
+std::unique_ptr<callback_base>
+build_print_model_description_callback_from_pbuf(
+  const google::protobuf::Message& proto_msg, const std::shared_ptr<lbann_summary>&) {
+  return make_unique<print_model_description>();
+}
+
+} // namespace callback
+} // namespace lbann

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -632,7 +632,7 @@ void model::setup(std::shared_ptr<thread_pool> io_thread_pool) {
     cb->setup(this);
   }
 
-  do_setup_begin_cbs();
+  do_setup_end_cbs();
 }
 
 void model::setup_layer_topology() {

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -317,6 +317,11 @@ message Callback {
     string directory = 1;
   }
 
+  // Print human-readable description of model to standard output.
+  //
+  // Message is printed when the model has finished setup. The
+  // description includes information on the model's layers, weights,
+  // and callbacks.
   message CallbackPrintModelDescription {
   }
 

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -74,6 +74,7 @@ message Callback {
     CallbackCheckInit init = 42;
     CallbackEarlyStopping early_stopping = 43;
     CallbackTimeline timeline = 44;
+    CallbackPrintModelDescription print_model_description = 45;
   }
 
   message CallbackLTFB {
@@ -315,4 +316,8 @@ message Callback {
   message CallbackTimeline {
     string directory = 1;
   }
+
+  message CallbackPrintModelDescription {
+  }
+
 }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -51,6 +51,7 @@
 #include "lbann/callbacks/monitor_io.hpp"
 #include "lbann/callbacks/perturb_adam.hpp"
 #include "lbann/callbacks/perturb_dropout.hpp"
+#include "lbann/callbacks/print_model_description.hpp"
 #include "lbann/callbacks/print_statistics.hpp"
 #include "lbann/callbacks/profiler.hpp"
 #include "lbann/callbacks/replace_weights.hpp"
@@ -155,6 +156,8 @@ void register_default_builders(factory_type& factory)
                            build_perturb_dropout_callback_from_pbuf);
   factory.register_builder("CallbackPolyLearningRate",
                            build_poly_learning_rate_callback_from_pbuf);
+  factory.register_builder("CallbackPrintModelDescription",
+                           build_print_model_description_callback_from_pbuf);
   factory.register_builder("CallbackPrint",
                            build_print_statistics_callback_from_pbuf);
   factory.register_builder("CallbackProfiler",

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -209,11 +209,7 @@ std::unique_ptr<model> build_model_from_prototext(
 
   if (comm->am_world_master()) {
     std::cout << "\n"
-              << ret_model->get_description()
-              << "Callbacks:" << std::endl;
-    for (callback_base *cb : ret_model->get_callbacks()) {
-      std::cout << cb->name() << std::endl;
-    }
+              << ret_model->get_description();
   }
 
 #ifndef LBANN_DETERMINISTIC

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -207,11 +207,6 @@ std::unique_ptr<model> build_model_from_prototext(
   //@todo
   //model->restartShared();
 
-  if (comm->am_world_master()) {
-    std::cout << "\n"
-              << ret_model->get_description();
-  }
-
 #ifndef LBANN_DETERMINISTIC
   // Under normal conditions, reinitialize the random number generator so
   // that regularization techniques (e.g. dropout) generate unique patterns


### PR DESCRIPTION
Whenever we construct a model, we print out a human-readable message that describes the layers, weights, callbacks, etc. This is useful for understanding the model and debugging, but it gets a bit overwhelming when I run VRAM since it has >1000 layers.

This PR makes printing the model description optional. If the user wants all of this information, they can add the "print model description" callback. In the process of implementing this, I've added new callback hooks at the beginning and end of model setup.