### PR TITLE
Expand error reporting

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -557,7 +557,9 @@ def assert_success(return_code, error_file_name):
             error_line = ''
             previous_line = ''
             for line in error_file:
-                if 'ERROR' in line:
+                if ('ERROR' in line) or ('LBANN error' in line) or \
+                        ('Error:' in line) or \
+                        ('Expired or invalid job' in line):
                     error_line = line
                     break
                 elif 'Stack trace:' in line:

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -1,6 +1,6 @@
-# import sys
-# sys.path.insert(0, '../common_python')
-# import tools
+import sys
+sys.path.insert(0, '../common_python')
+import tools
 import pytest
 import os, re, subprocess
 
@@ -22,7 +22,7 @@ def test_compiler_build_script(cluster, dirname):
         error_file = open(error_file_name, 'r')
         for line in error_file:
             print('%s: %s' % (error_file_name, line))
-    assert return_code == 0
+    tools.assert_success(return_code, error_file_name)
 
 
 def test_compiler_clang6_release(cluster, dirname):
@@ -137,7 +137,7 @@ def spack_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
         error_file = open(error_file_name, 'r')
         for line in error_file:
             print('%s: %s' % (error_file_name, line))
-    assert return_code == 0
+    tools.assert_success(return_code, error_file_name)
 
 
 def build_skeleton(dir_name, compiler, debug, should_log):
@@ -172,7 +172,7 @@ def build_skeleton(dir_name, compiler, debug, should_log):
         error_file = open(error_file_name, 'r')
         for line in error_file:
             print('%s: %s' % (error_file_name, line))
-    assert return_code == 0
+    tools.assert_success(return_code, error_file_name)
 
 
 def build_script(cluster, dirname, compiler, debug):
@@ -196,4 +196,4 @@ def build_script(cluster, dirname, compiler, debug):
         error_file = open(error_file_name, 'r')
         for line in error_file:
             print('%s: %s' % (error_file_name, line))
-    assert return_code == 0
+    tools.assert_success(return_code, error_file_name)

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -72,12 +72,12 @@ def run_lbann(command, model_name, output_file_name, error_file_name,
     print('About to run: %s' % command)
     print('%s began waiting in the queue at ' % model_name +
           time.strftime('%H:%M:%S', time.localtime()))
-    output_value = os.system(command)
+    return_code = os.system(command)
     print('%s finished at ' % model_name +
           time.strftime('%H:%M:%S', time.localtime()))
     lbann_exceptions = []
     timed_out = False
-    if should_log or (output_value != 0):
+    if should_log or (return_code != 0):
         output_file = open(output_file_name, 'r')
         for line in output_file:
             print('%s: %s' % (output_file_name, line))
@@ -94,13 +94,13 @@ def run_lbann(command, model_name, output_file_name, error_file_name,
             is_match = re.search('LBANN error on (.*)', line)
             if is_match:
                 lbann_exceptions.append(is_match.group(1))
-    if output_value != 0:
-        error_string = ('Model %s crashed with output_value=%d, timed_out=%s,'
+    if return_code != 0:
+        error_string = ('Model %s crashed with return_code=%d, timed_out=%s,'
                         ' and lbann exceptions=%s. Command was: %s') % (
-            model_name, output_value, str(timed_out),
+            model_name, return_code, str(timed_out),
             str(collections.Counter(lbann_exceptions)), command)
-        raise Exception(error_string)
-    return output_value
+        print(error_string)
+    tools.assert_success(return_code, error_file_name)
 
 # Extract data from output ####################################################
 

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -26,8 +26,7 @@ def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='mnist', model_folder='models/' + model_name,
         model_name=model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
-    assert output_value == 0
+    common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
 
 
 def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
@@ -56,8 +55,7 @@ def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='cifar10', data_reader_percent=0.01, model_folder='models/' + model_name,
         model_name='conv_' + model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    output_value = common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
-    assert output_value == 0
+    common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
 
 
 def test_integration_mnist_clang6_debug(cluster, dirname, exes, weekly, debug_build):


### PR DESCRIPTION
Expand on #1178 by improving error reporting for compiler and integration tests.

Since `assert os.path.exists(path)` in `compiler_tests` and `assert errors == []` in `integration_tests` already give detail beyond a non-zero return code,  I'm not replacing them with calls to something like `tools.assert_success`.