### PR TITLE
Remove error printing

### DIFF
--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -15,13 +15,6 @@ def test_compiler_build_script(cluster, dirname):
     command = '%s/bamboo/compiler_tests/build_script.sh > %s 2> %s' % (
         dirname, output_file_name, error_file_name)
     return_code = os.system(command)
-    if return_code != 0:
-        output_file = open(output_file_name, 'r')
-        for line in output_file:
-            print('%s: %s' % (output_file_name, line))
-        error_file = open(error_file_name, 'r')
-        for line in error_file:
-            print('%s: %s' % (error_file_name, line))
     tools.assert_success(return_code, error_file_name)
 
 
@@ -73,48 +66,46 @@ def test_compiler_intel19_debug(cluster, dirname):
         assert os.path.exists(path)
 
 
-def skeleton_clang6(cluster, dir_name, debug, should_log=False):
+def skeleton_clang6(cluster, dir_name, debug):
     if cluster not in ['catalyst']:
         e = 'skeleton_clang6: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)
         pytest.skip(e)
     try:
-        spack_skeleton(dir_name, 'clang@6.0.0', 'mvapich2@2.2', debug,
-                       should_log)
-        build_skeleton(dir_name, 'clang@6.0.0', debug, should_log)
+        spack_skeleton(dir_name, 'clang@6.0.0', 'mvapich2@2.2', debug)
+        build_skeleton(dir_name, 'clang@6.0.0', debug)
     except AssertionError as e:
         print(e)
         build_script(cluster, dir_name, 'clang6', debug)
 
 
-def skeleton_gcc7(cluster, dir_name, debug, should_log=False):
+def skeleton_gcc7(cluster, dir_name, debug):
     if cluster not in ['catalyst', 'pascal']:
         e = 'skeleton_gcc7: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)
         pytest.skip(e)
     try:
-        spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug, should_log)
-        build_skeleton(dir_name, 'gcc@7.1.0', debug, should_log)
+        spack_skeleton(dir_name, 'gcc@7.1.0', 'mvapich2@2.2', debug)
+        build_skeleton(dir_name, 'gcc@7.1.0', debug)
     except AssertionError as e:
         print(e)
         build_script(cluster, dir_name, 'gcc7', debug)
 
 
-def skeleton_intel19(cluster, dir_name, debug, should_log=False):
+def skeleton_intel19(cluster, dir_name, debug):
     if cluster not in []:  # Taking out 'catalyst'
         e = 'skeleton_intel19: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)
         pytest.skip(e)
     try:
-        spack_skeleton(dir_name, 'intel@19.0.0', 'mvapich2@2.2', debug,
-                       should_log)
-        build_skeleton(dir_name, 'intel@19.0.0', debug, should_log)
+        spack_skeleton(dir_name, 'intel@19.0.0', 'mvapich2@2.2', debug)
+        build_skeleton(dir_name, 'intel@19.0.0', debug)
     except AssertionError as e:
         print(e)
         build_script(cluster, dir_name, 'intel19', debug)
 
 
-def spack_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
+def spack_skeleton(dir_name, compiler, mpi_lib, debug):
     compiler_underscored = re.sub('[@\.]', '_', compiler)
     if debug:
         build_type = 'debug'
@@ -130,17 +121,10 @@ def spack_skeleton(dir_name, compiler, mpi_lib, debug, should_log):
         dir_name, compiler, mpi_lib, debug_flag, output_file_name, error_file_name)
     return_code = os.system(command)
     os.chdir('..')
-    if should_log or (return_code != 0):
-        output_file = open(output_file_name, 'r')
-        for line in output_file:
-            print('%s: %s' % (output_file_name, line))
-        error_file = open(error_file_name, 'r')
-        for line in error_file:
-            print('%s: %s' % (error_file_name, line))
     tools.assert_success(return_code, error_file_name)
 
 
-def build_skeleton(dir_name, compiler, debug, should_log):
+def build_skeleton(dir_name, compiler, debug):
     compiler_underscored = re.sub('[@\.]', '_', compiler)
     if debug:
         build_type = 'debug'
@@ -165,13 +149,6 @@ def build_skeleton(dir_name, compiler, debug, should_log):
     command = 'make -j all > %s 2> %s' % (output_file_name, error_file_name)
     return_code = os.system(command)
     os.chdir('../..')
-    if should_log or (return_code != 0):
-        output_file = open(output_file_name, 'r')
-        for line in output_file:
-            print('%s: %s' % (output_file_name, line))
-        error_file = open(error_file_name, 'r')
-        for line in error_file:
-            print('%s: %s' % (error_file_name, line))
     tools.assert_success(return_code, error_file_name)
 
 
@@ -189,11 +166,4 @@ def build_script(cluster, dirname, compiler, debug):
     error_file_name = '%s/bamboo/compiler_tests/error/%s_%s_%s_build_script_error.txt' % (dirname, cluster, compiler, build)
     command = '%s/bamboo/compiler_tests/build_script_specific.sh --compiler %s %s> %s 2> %s' % (dirname, compiler, debug_flag, output_file_name, error_file_name)
     return_code = os.system(command)
-    if return_code != 0:
-        output_file = open(output_file_name, 'r')
-        for line in output_file:
-            print('%s: %s' % (output_file_name, line))
-        error_file = open(error_file_name, 'r')
-        for line in error_file:
-            print('%s: %s' % (error_file_name, line))
     tools.assert_success(return_code, error_file_name)

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -80,7 +80,6 @@ def run_lbann(command, model_name, output_file_name, error_file_name,
     if should_log or (return_code != 0):
         output_file = open(output_file_name, 'r')
         for line in output_file:
-            print('%s: %s' % (output_file_name, line))
             is_match = re.search(
                 'This lbann_exception is about to be thrown:(.*)', line)
             if is_match:
@@ -90,7 +89,6 @@ def run_lbann(command, model_name, output_file_name, error_file_name,
                 timed_out = True
         error_file = open(error_file_name, 'r')
         for line in error_file:
-            print('%s: %s' % (error_file_name, line))
             is_match = re.search('LBANN error on (.*)', line)
             if is_match:
                 lbann_exceptions.append(is_match.group(1))
@@ -227,7 +225,7 @@ def skeleton(cluster, dir_name, executable, model_folder, model_name,
         cluster, dir_name, model_folder, model_name, executable,
         output_file_name, error_file_name, compiler_name, weekly=weekly)
     run_lbann(command, model_name, output_file_name,
-              error_file_name, should_log)  # Don't need return value
+              error_file_name, should_log)
     return extract_data(output_file_name, data_fields, should_log)
 
 # Misc. functions  ############################################################

--- a/bamboo/integration_tests/test_integration_autoencoders.py
+++ b/bamboo/integration_tests/test_integration_autoencoders.py
@@ -36,9 +36,6 @@ def run_tests(actual_objective_functions, model_name, dir_name, cluster,
              actual_objective_functions, expected_objective_functions,
              model_name, errors, all_values, frequency_str)
 
-    print('Errors for: %s %s (%d)' % (model_name, compiler_name, len(errors)))
-    for error in errors:
-        print(error)
     if should_log:
         print('All values for: %s %s (%d)' % (model_name, compiler_name,
                                               len(all_values)))

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -26,7 +26,8 @@ def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='mnist', model_folder='models/' + model_name,
         model_name=model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
+    common_code.run_lbann(command, model_name, output_file_name,
+                          error_file_name, should_log)
 
 
 def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
@@ -55,7 +56,8 @@ def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
         data_reader_name='cifar10', data_reader_percent=0.01, model_folder='models/' + model_name,
         model_name='conv_' + model_name, num_epochs=5, optimizer_name='adagrad',
         output_file_name=output_file_name, error_file_name=error_file_name)
-    common_code.run_lbann(command, model_name, output_file_name, error_file_name, should_log)
+    common_code.run_lbann(command, model_name, output_file_name,
+                          error_file_name, should_log)
 
 
 def test_integration_mnist_clang6_debug(cluster, dirname, exes, weekly, debug_build):

--- a/bamboo/integration_tests/test_integration_performance.py
+++ b/bamboo/integration_tests/test_integration_performance.py
@@ -80,9 +80,6 @@ def run_tests(actual_performance, model_name, dir_name, should_log,
   else:
     print('os.environ["LOGNAME"]=%s' % os.environ['LOGNAME'])
 
-  print('Errors for: %s %s (%d)' % (model_name, compiler_name, len(errors)))
-  for error in errors:
-    print(error)
   if should_log:
     print('All values for: %s %s (%d)' % (
       model_name, compiler_name, len(all_values)))


### PR DESCRIPTION
Now that error and output file artifacts on Bamboo are set up, we can remove code to print error/output files to the log.

After this PR, we shouldn't have a series of `*_error.txt: <line from error file>` or `*_output.txt: <line from output file>` in the logs anymore.