### PR TITLE
Fix Develop errors

### DIFF
--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -40,8 +40,8 @@ if [ "${CLUSTER}" = 'lassen' ]; then
         timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 16 -W $ALLOCATION_TIME_LIMIT ./run.sh
     fi
 elif [ "${CLUSTER}" = 'catalyst' ] || [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTER}" = 'pascal' ]; then
+    ALLOCATION_TIME_LIMIT=960
     if [ ${WEEKLY} -ne 0 ]; then
-        ALLOCATION_TIME_LIMIT=720
         timeout -k 5 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh --weekly
         if [ "${CLUSTER}" = 'catalyst' ]; then
             cd integration_tests
@@ -51,11 +51,6 @@ elif [ "${CLUSTER}" = 'catalyst' ] || [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTE
             cd ..
         fi
     else
-        if [ "${CLUSTER}" = 'catalyst' ]; then
-            ALLOCATION_TIME_LIMIT=300
-        elif [ "${CLUSTER}" = 'corona' ] || [ "${CLUSTER}" = 'pascal' ]; then
-            ALLOCATION_TIME_LIMIT=660
-        fi
         timeout -k 5 24h salloc -N16 --partition=pbatch -t $ALLOCATION_TIME_LIMIT ./run.sh
     fi
 fi

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -561,7 +561,8 @@ def get_error_line(error_file_name):
                     ('Expired or invalid job' in line):
                 error_line = line
                 break
-            elif 'Stack trace:' in line:
+            elif ('Stack trace:' in line) or \
+                    ('Error is not recoverable: exiting now' in line):
                 error_line = previous_line
                 break
             else:

--- a/bamboo/integration_tests/expected_values/catalyst/clang6/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/clang6/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
 alexnet_nightly, 117.00,            2.80,          9.00,         1.20,         2.00,           0.00
-alexnet_weekly,  490.00,            1.00,          3.00,         0.60,         0.50,           100.00
+alexnet_weekly,  490.00,            1.00,          9.00,         0.60,         0.50,           2.50
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 lenet_mnist,     100.00,            0.12,          0.40,         0.10,         0.09,           98.40

--- a/bamboo/integration_tests/expected_values/catalyst/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/catalyst/gcc7/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
 alexnet_nightly, 65.00,             1.50,          8.30,        0.37,         1.70,           0.1
-alexnet_weekly,  360.00,            0.90,          4.00,        0.40,         0.70,           100.00
+alexnet_weekly,  360.00,            0.90,          4.00,        0.40,         0.70,           2.00
 cache_alexnet,   0.00,              0.00,          0.00,        0.00,         0.00,           100.00
 lenet_mnist,     137.00,            0.18,          0.40,        0.15,         0.04,           98.92

--- a/bamboo/integration_tests/expected_values/corona/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/corona/gcc7/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
 alexnet_nightly, 55.00,             1.03,          1.90,         0.80,         0.21,           0.00
-alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
+alexnet_weekly,  491.00,            1.00,          9.00,         1.11,         0.60,           2.00
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 lenet_mnist,     385.00,            0.50,          2.00,         0.51,         0.80,           98.40

--- a/bamboo/integration_tests/expected_values/lassen/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/lassen/gcc7/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
 alexnet_nightly, 23.00,             0.70,          10.30,        0.10,         1.20,           0.00
-alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
+alexnet_weekly,  56.00,             0.15,          10.00,        0.70,         0.70,           1.50
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 lenet_mnist,     10.10,             0.06,          5.30,         0.01,         0.60,           98.30

--- a/bamboo/integration_tests/expected_values/pascal/gcc7/expected_performance.csv
+++ b/bamboo/integration_tests/expected_values/pascal/gcc7/expected_performance.csv
@@ -1,5 +1,5 @@
 Model_name,      training_run_time, training_mean, training_max, training_min, training_stdev, test_accuracy
 alexnet_nightly, 51.00,             1.20,          4.00,         0.50,         0.40,           100.00
-alexnet_weekly,  0.00,              0.00,          0.00,         0.00,         0.00,           100.00
+alexnet_weekly,  300.00,            1.00,          7.00,         0.10,         1.30,           2.0
 cache_alexnet,   0.00,              0.00,          0.00,         0.00,         0.00,           100.00
 lenet_mnist,     12.00,             0.04,          6.00,         0.01,         0.40,           98.40

--- a/bamboo/integration_tests/full_alexnet.sh
+++ b/bamboo/integration_tests/full_alexnet.sh
@@ -2,28 +2,58 @@
 
 module load mpifileutils
 
+COMPILER=0
+while :; do
+    case ${1} in
+        --compiler)
+            # Choose compiler
+            if [ -n "${2}" ]; then
+                COMPILER=${2}
+                shift
+            else
+                echo "\"${1}\" option requires a non-empty option argument" >&2
+                exit 1
+            fi
+            ;;
+        -?*)
+            # Unknown option
+            echo "Unknown option (${1})" >&2
+            exit 1
+            ;;
+        *)
+            # Break loop if there are no more options
+            break
+    esac
+    shift
+done
+
+if [ ${COMPILER} -eq 0 ]; then
+    exit 1
+fi
+
+LBANN_DIR=$(git rev-parse --show-toplevel)
+CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
+FILE_PREFIX=${LBANN_DIR}/bamboo/unit_tests/output/full_alexnet_${CLUSTER}_${COMPILER}
+
 # Clear SSDs
-srun --wait=0 --clear-ssd hostname > /dev/null
+srun --wait=0 --clear-ssd hostname > ${FILE_PREFIX}_1_output.txt
 
 # Cache dataset
 echo "Caching dataset..."
 [ -e /l/ssd/lbannusr/datasets-resized/ILSVRC2012/train_resized.tar ] || \
-  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/train_resized.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/train_resized.tar > /dev/null
+  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/train_resized.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/train_resized.tar > ${FILE_PREFIX}_2_output.txt
 [ -d /l/ssd/lbannusr/datasets-resized/ILSVRC2012/train ] || \
   srun --nodes=128 --ntasks-per-node=1 tar xf /l/ssd/lbannusr/datasets-resized/ILSVRC2012/train_resized.tar -C /l/ssd/lbannusr/datasets-resized/ILSVRC2012
 [ -e /l/ssd/lbannusr/datasets-resized/ILSVRC2012/val_resized.tar ] || \
-  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/val_resized.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/val_resized.tar > /dev/null
+  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/val_resized.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/val_resized.tar > ${FILE_PREFIX}_3_output.txt
 [ -d /l/ssd/lbannusr/datasets-resized/ILSVRC2012/val ] || \
   srun --nodes=128 --ntasks-per-node=1 tar xf /l/ssd/lbannusr/datasets-resized/ILSVRC2012/val_resized.tar -C /l/ssd/lbannusr/datasets-resized/ILSVRC2012
 [ -e /l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels.tar ] || \
-  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/labels.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels.tar > /dev/null
+  srun --nodes=128 --ntasks-per-node=2 dbcast /p/lscratchh/brainusr/datasets/ILSVRC2012/original/labels.tar /l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels.tar > ${FILE_PREFIX}_4_output.txt
 [ -e /l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels/train.txt ] || \
   srun --nodes=128 --ntasks-per-node=1 tar xf /l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels.tar -C /l/ssd/lbannusr/datasets-resized/ILSVRC2012
 wait
 echo "Done caching dataset..."
-
-LBANN_DIR=$(git rev-parse --show-toplevel)
-CLUSTER=$(hostname | sed 's/\([a-zA-Z][a-zA-Z]*\)[0-9]*/\1/g')
 
 # Experiment
 srun --nodes=128 --ntasks-per-node=2 ${LBANN_DIR}/bamboo/compiler_tests/builds/catalyst_gcc-7.1.0_x86_64_mvapich2-2.2_openblas_rel/build/model_zoo/lbann --model=${LBANN_DIR}/model_zoo/models/alexnet/model_alexnet.prototext --optimizer=${LBANN_DIR}/model_zoo/optimizers/opt_sgd.prototext --reader=${LBANN_DIR}/model_zoo/data_readers/data_reader_imagenet.prototext --data_filedir_train=/l/ssd/lbannusr/datasets-resized/ILSVRC2012/train/ --data_filename_train=/l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels/train.txt --data_filedir_test=/l/ssd/lbannusr/datasets-resized/ILSVRC2012/val/ --data_filename_test=/l/ssd/lbannusr/datasets-resized/ILSVRC2012/labels/val.txt

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -24,9 +24,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_nockpt = os.system(command)
-    if return_code_nockpt != 0:
-        sys.stderr.write('LeNet (no checkpoint) execution failed, exiting with error')
-        sys.exit(1)
+    tools.assert_success(return_code_nockpt, error_file_name)
     os.system('mkdir ckpt_lenet_shared')
     no_ckpt_dir = 'ckpt_lenet_shared/no_ckpt_{c}'.format(c=compiler_name)
     os.system('mv ckpt {c}'.format(c=no_ckpt_dir))
@@ -42,9 +40,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         model_name='lenet_mnist_ckpt', num_epochs=1, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_ckpt_1 = os.system(command)
-    if return_code_ckpt_1 != 0:
-        sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
-        sys.exit(1)
+    tools.assert_success(return_code_ckpt_1, error_file_name)
 
     # Pick up from checkpoint, printing weights to files.
     output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_shared_restart_%s_output.txt' % (dir_name, compiler_name)
@@ -57,9 +53,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
     return_code_ckpt_2 = os.system(command)
-    if return_code_ckpt_2 != 0:
-        sys.stderr.write('LeNet execution (restart from checkpoint) failed, exiting with error')
-        sys.exit(1)
+    tools.assert_success(return_code_ckpt_2, error_file_name)
 
     diff_test = os.system('diff -rq ckpt {c}'.format(c=no_ckpt_dir))
     ckpt_dir = 'ckpt_lenet_shared/ckpt_{c}'.format(c=compiler_name)
@@ -89,9 +83,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
          model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_nockpt = os.system(command)
-     if return_code_nockpt != 0:
-         sys.stderr.write('LeNet (no checkpoint) execution failed, exiting with error')
-         sys.exit(1)
+     tools.assert_success(return_code_nockpt, error_file_name)
      os.system('mkdir ckpt_lenet_distributed')
      no_ckpt_dir = 'ckpt_lenet_distributed/no_ckpt_{c}'.format(c=compiler_name)
      os.system('mv ckpt {c}'.format(c=no_ckpt_dir))
@@ -107,9 +99,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
          model_name='lenet_mnist_dist_ckpt', num_epochs=1, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_1 = os.system(command)
-     if return_code_ckpt_1 != 0:
-         sys.stderr.write('LeNet (checkpoint) execution failed, exiting with error')
-         sys.exit(1)
+     tools.assert_success(return_code_ckpt_1, error_file_name)
 
      # Pick up from checkpoint, printing weights to files.
      output_file_name = '%s/bamboo/unit_tests/output/checkpoint_lenet_distributed_restart_%s_output.txt' % (dir_name, compiler_name)
@@ -122,9 +112,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
          model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name, error_file_name=error_file_name)
      return_code_ckpt_2 = os.system(command)
-     if return_code_ckpt_2 != 0:
-         sys.stderr.write('LeNet execution (restart from checkpoint) failed, exiting with error')
-         sys.exit(1)
+     tools.assert_success(return_code_ckpt_2, error_file_name)
 
      diff_test = os.system('diff -rq ckpt {c}'.format(c=no_ckpt_dir))
      ckpt_dir = 'ckpt_lenet_distributed/ckpt_{c}'.format(c=compiler_name)

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -28,10 +28,8 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
         error_file_name=error_file_name)
 
     os.mkdir('lbann2_ckpt')
-    return_code = os.system(command)
-    if return_code != 0:
-        sys.stderr.write('LBANN2 LeNet execution failed, exiting with error')
-        sys.exit(1)
+    return_code_no_ckpt = os.system(command)
+    tools.assert_success(return_code_no_ckpt, error_file_name)
 
     os.system('mkdir ckpt_lbann2_reload')
     no_ckpt_dir = 'ckpt_lbann2_reload/lbann2_no_ckpt_{c}'.format(c=compiler_name)
@@ -49,10 +47,7 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
         output_file_name=output_file_name,
         error_file_name=error_file_name)
     return_code_ckpt_1 = os.system(command)
-    if return_code_ckpt_1 != 0:
-        sys.stderr.write(
-            'LeNet (checkpoint) execution failed, exiting with error')
-        sys.exit(1)
+    tools.assert_success(return_code_ckpt_1, error_file_name)
 
     # Pick up from checkpoint, printing weights to files.
     output_file_name = '%s/bamboo/unit_tests/output/lbann2_restart_%s_output.txt' % (dir_name, compiler_name)
@@ -68,10 +63,7 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name):
         output_file_name=output_file_name,
         error_file_name=error_file_name)
     return_code_ckpt_2 = os.system(command)
-    if return_code_ckpt_2 != 0:
-        sys.stderr.write(
-            'LBANN2 LeNet weight reload failed, exiting with error')
-        sys.exit(1)
+    tools.assert_success(return_code_ckpt_2, error_file_name)
     os.system('rm lbann2_ckpt/model0-epoch*')
     os.system('rm lbann2_nockpt/model0-epoch*')
 


### PR DESCRIPTION
- Extended allocation time for Catalyst/Corona/Pascal tests.
- Added error reporting for the line before “Error is not recoverable” (which occurred on the full alexnet test).
- Updated expected values for weekly tests.
- Added compiler parameter to full_alexnet.sh.
- Sending full_alexnet output to output files.
- Replaced system exits in checkpoint and lbann2_reload tests with `tools.assert_success`



