### PR TITLE
Updating the model class to hold a a vector of unique pointers to weight classes.

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -358,7 +358,7 @@ public:
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
       this->m_weights[0] = w.get();
-      this->m_model->add_weights(w.release());
+      this->m_model->add_weights(std::move(w));
     }
     auto& kernel_weights = *this->m_weights[0];
 
@@ -385,7 +385,7 @@ public:
         w->set_name(get_name() + "_bias");
         w->set_optimizer(std::move(opt));
         this->m_weights[1] = w.get();
-        this->m_model->add_weights(w.release());
+        this->m_model->add_weights(std::move(w));
       }
       auto& bias_weights = *this->m_weights[1];
       bias_weights.set_dims(output_dims[0]);

--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -94,7 +94,8 @@ public:
 
     // Construct default weights if needed
     if (this->m_weights.size() < 1) {
-      this->m_weights.push_back(new weights(get_comm()));
+      std::unique_ptr<weights> w = make_unique<weights>(get_comm());
+      this->m_weights.push_back(w.get());
       std::vector<DataType> vals(2*num_channels, DataType{0});
       std::fill(vals.begin(), vals.begin()+num_channels, DataType{1});
       auto init = make_unique<value_initializer>(vals);
@@ -102,7 +103,7 @@ public:
       this->m_weights[0]->set_name(get_name() + "_weights");
       this->m_weights[0]->set_initializer(std::move(init));
       this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights.size() != 1) {
       std::ostringstream err;

--- a/include/lbann/layers/learning/entrywise_scale_bias.hpp
+++ b/include/lbann/layers/learning/entrywise_scale_bias.hpp
@@ -93,7 +93,8 @@ public:
 
     // Construct default weights if needed
     if (this->m_weights.size() < 1) {
-      this->m_weights.push_back(new weights(get_comm()));
+      auto w = make_unique<weights>(get_comm());
+      this->m_weights.push_back(w.get());
       std::vector<DataType> vals(2*output_size, DataType{0});
       std::fill(vals.begin(), vals.begin()+output_size, DataType{1});
       auto init = make_unique<value_initializer>(vals);
@@ -101,7 +102,7 @@ public:
       this->m_weights[0]->set_name(get_name() + "_weights");
       this->m_weights[0]->set_initializer(std::move(init));
       this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights.size() != 1) {
       std::ostringstream err;

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -134,7 +134,7 @@ protected:
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
       this->m_weights[0] = w.get();
-      this->m_model->add_weights(w.release());
+      this->m_model->add_weights(std::move(w));
     }
     auto& linearity_weights = *this->m_weights[0];
 
@@ -168,7 +168,7 @@ protected:
         w->set_name(get_name() + "_bias_weights");
         w->set_optimizer(std::move(opt));
         this->m_weights[1] = w.get();
-        this->m_model->add_weights(w.release());
+        this->m_model->add_weights(std::move(w));
       }
       auto& bias_weights = *this->m_weights[1];
       // Setup bias weights

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -250,36 +250,40 @@ protected:
     }
     this->m_weights.resize(4, nullptr);
     if (this->m_weights[0] == nullptr) {
-      this->m_weights[0] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
+      this->m_weights[0] = w.get();
       auto init = make_unique<constant_initializer>(DataType(1));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
       this->m_weights[0]->set_name(get_name() + "_scale");
       this->m_weights[0]->set_initializer(std::move(init));
       this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[1] == nullptr) {
-      this->m_weights[1] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
+      this->m_weights[1] = w.get();
       auto init = make_unique<constant_initializer>(DataType(0));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
       this->m_weights[1]->set_name(get_name() + "_bias");
       this->m_weights[1]->set_initializer(std::move(init));
       this->m_weights[1]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[1]);
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[2] == nullptr) {
-      this->m_weights[2] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
+      this->m_weights[2] = w.get();
       this->m_weights[2]->set_name(get_name() + "_running_mean");
       auto init = make_unique<constant_initializer>(DataType(0));
       this->m_weights[2]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[2]);
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[3] == nullptr) {
-      this->m_weights[3] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
+      this->m_weights[3] = w.get();
       this->m_weights[3]->set_name(get_name() + "_running_variance");
       auto init = make_unique<constant_initializer>(DataType(1));
       this->m_weights[3]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[3]);
+      this->m_model->add_weights(std::move(w));
     }
 
     // Setup weights

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -118,18 +118,20 @@ protected:
     }
     this->m_weights.resize(2, nullptr);
     if (this->m_weights[0] == nullptr) {
-      this->m_weights[0] = new weights(get_comm());
+      auto new_weights = make_unique<weights>(get_comm());
+      this->m_weights[0] = new_weights.get();
       this->m_weights[0]->set_name(get_name() + "_running_mean");
       auto init = make_unique<constant_initializer>(DataType{0});
       this->m_weights[0]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[0]);
+      this->m_model->add_weights(std::move(new_weights));
     }
     if (this->m_weights[1] == nullptr) {
-      this->m_weights[1] = new weights(get_comm());
+      auto new_weights = make_unique<weights>(get_comm());
+      this->m_weights[1] = new_weights.get();
       this->m_weights[1]->set_name(get_name() + "_running_variance");
       auto init = make_unique<constant_initializer>(DataType{1});
       this->m_weights[1]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[1]);
+      this->m_model->add_weights(std::move(new_weights));
     }
 
     // Setup weights

--- a/include/lbann/layers/transform/weights.hpp
+++ b/include/lbann/layers/transform/weights.hpp
@@ -125,13 +125,14 @@ class weights_layer : public transform_layer {
     this->m_weights.resize(1, nullptr);
     auto& w = this->m_weights[0];
     if (w == nullptr) {
-      w = new weights(get_comm());
+      auto new_weight = make_unique<weights>(get_comm());
+      w = new_weight.get();
       auto init = make_unique<constant_initializer>(DataType(0));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
       w->set_name(get_name() + "_weights");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->m_model->add_weights(w);
+      this->m_model->add_weights(std::move(new_weight));
     }
 
     // Setup weights and weights gradient

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -163,7 +163,7 @@ public:
   virtual void add_layer(std::unique_ptr<Layer> l);
 
   /** @brief Add weights to model. */
-  void add_weights(weights *w);
+  void add_weights(std::unique_ptr<weights> w);
 
   /** @brief Register a new callback for the model. */
   void add_callback(callback_base *cb);
@@ -407,7 +407,7 @@ private:
   std::vector<std::unique_ptr<Layer>> m_layers;
 
   /** @brief Trainable parameters. */
-  std::vector<weights*> m_weights;
+  std::vector<std::unique_ptr<weights>> m_weights;
 
   /** @details Maximum possible minibatch size supported by layers in
    *  this model.  Note that this is local to the particular model,

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -285,7 +285,7 @@ std::unique_ptr<model> construct_model(
   // Instantiate model
   auto m = instantiate_model(comm, std::move(obj), proto_opt, proto_model);
   for (auto&& l   : layer_list   ) { m->add_layer(std::move(l)); }
-  for (auto&& w   : weights_list ) { m->add_weights(w.release());   }
+  for (auto&& w   : weights_list ) { m->add_weights(std::move(w));   }
   for (auto&& met : metric_list  ) { m->add_metric(met.release());  }
   for (auto&& cb  : callback_list) { m->add_callback(cb.release()); }
   const auto& name = proto_model.name();


### PR DESCRIPTION
Currently, weights are constructed with unique  pointers, but then passed into the model as raw pointers.

Please note that in the model class the two functions replace_weights and setup_weights are incomplete.