### PR TITLE
Set a fixed version of hydrogen in the superbuild

### DIFF
--- a/superbuild/hydrogen/CMakeLists.txt
+++ b/superbuild/hydrogen/CMakeLists.txt
@@ -109,7 +109,7 @@ else ()
 endif ()
 
 # ... then the tag.
-set(HYDROGEN_TAG "hydrogen"
+set(HYDROGEN_TAG "v1.1.0-1"
   CACHE STRING "The git tag or hash to checkout for Hydrogen")
 
 if (HYDROGEN_CUSTOM_SOURCE_DIR)


### PR DESCRIPTION
This is to resolve the issue created by llnl/Elemental#84 in which the Aluminum/Hydrogen version stuff has gotten out of sync.