### PR TITLE
Setup data readers after model has been constructed

### DIFF
--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -220,11 +220,6 @@ std::unique_ptr<model> build_model_from_prototext(
     is_shared_testing_data_reader = opts->get_bool("share_testing_data_readers");
   }
   init_data_readers(comm, pb, data_readers, is_shared_training_data_reader, is_shared_testing_data_reader);
-  /// Setup the data readers with the I/O thread pool
-  for(auto&& dr: data_readers) {
-    dr.second->setup(io_threads_per_process, &io_thread_pool);
-    dr.second->set_rank(comm->get_rank_in_trainer());
-  }
 
   // hack to prevent all data readers from loading identical data; instead,
   // share a single copy. See data_reader_jag_conduit_hdf5 for example
@@ -274,6 +269,13 @@ std::unique_ptr<model> build_model_from_prototext(
     }
   }
 
+  // Setup data readers
+  for(auto&& dr: data_readers) {
+    dr.second->setup(io_threads_per_process, &io_thread_pool);
+    dr.second->set_rank(comm->get_rank_in_trainer());
+  }
+
+  // Setup models
   ret_model->setup();
 
   if (opts->get_bool("use_data_store") || opts->get_bool("preload_data_store") || opts->get_bool("data_store_cache")) {


### PR DESCRIPTION
### Problem

PR #916 introduced a runtime error in the Python data reader:

<details> <summary> Error message on Pascal </summary>

```
****************************************************************
Caught signal 11 (SIGSEGV - invalid memory reference) on rank 0
Stack trace:
   0: lbann::stack_trace::get[abi:cxx11]()
   1: lbann::exception::exception(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool)
   2: /usr/WS1/moon13/src/lbann/build/gnu.Release.pascal.llnl.gov/install/lib64/liblbann.so(+0x11ef5dd) [0x2aaaac0c25dd] (could not find stack frame symbol)
   3: /lib64/libpthread.so.0(+0xf5d0) [0x2aaacdca45d0] (could not find stack frame symbol)
   4: lbann::python_reader::setup(int, lbann::thread_pool*)
   5: lbann::build_model_from_prototext(int, char**, lbann_data::Trainer const*, lbann_data::LbannPB&, lbann::lbann_comm*, lbann::options*, lbann::thread_pool&, bool)
   6: /usr/WS1/moon13/src/lbann/build/gnu.Release.pascal.llnl.gov/install/bin/lbann() [0x412df0] (could not find stack frame symbol)
   7: __libc_start_main (demangling failed)
   8: /usr/WS1/moon13/src/lbann/build/gnu.Release.pascal.llnl.gov/install/bin/lbann() [0x413448] (could not find stack frame symbol)
****************************************************************
```

</details>

The problem is that the Python data reader needs to know the maximum mini-batch size during setup so that it can allocate a block of shared memory. This information resides in the model. However, the model is constructed _after_ the data readers are setup, so we get a segfault.

### Solution

This PR just changes the order so that the data readers are setup after the model has been constructed. This is approximately similar to the status quo before PR #916, where the data readers were setup when the input layer was setup, so I don't expect there to be major problems.

### Discussion

The data reader and model should both know the maximum mini-batch size during setup, since they may need to allocate workspace buffers. I think the logical place for this information to live is in the execution context, since mini-batch size is more of an algorithmic decision than an inherent part of data ingestion or evaluating the model.