### PR TITLE
Store weights in unique_ptrs

### DIFF
--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -358,7 +358,7 @@ public:
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
       this->m_weights[0] = w.get();
-      this->m_model->add_weights(w.release());
+      this->m_model->add_weights(std::move(w));
     }
     auto& kernel_weights = *this->m_weights[0];
 
@@ -385,7 +385,7 @@ public:
         w->set_name(get_name() + "_bias");
         w->set_optimizer(std::move(opt));
         this->m_weights[1] = w.get();
-        this->m_model->add_weights(w.release());
+        this->m_model->add_weights(std::move(w));
       }
       auto& bias_weights = *this->m_weights[1];
       bias_weights.set_dims(output_dims[0]);

--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -93,25 +93,24 @@ public:
     const El::Int num_channels = get_output_dims()[0];
 
     // Construct default weights if needed
-    if (this->m_weights.size() < 1) {
-      this->m_weights.push_back(new weights(get_comm()));
+    // Note: Scale is initialized to 1 and bias to 0
+    if (this->m_weights.empty()) {
+      auto w = make_unique<weights>(get_comm());
       std::vector<DataType> vals(2*num_channels, DataType{0});
       std::fill(vals.begin(), vals.begin()+num_channels, DataType{1});
       auto init = make_unique<value_initializer>(vals);
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
-      this->m_weights[0]->set_name(get_name() + "_weights");
-      this->m_weights[0]->set_initializer(std::move(init));
-      this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      w->set_name(get_name() + "_weights");
+      w->set_initializer(std::move(init));
+      w->set_optimizer(std::move(opt));
+      this->m_weights.push_back(w.get());
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights.size() != 1) {
-      std::ostringstream err;
-      err << "attempted to setup "
-          << this->get_type() << " layer \"" << this->get_name() << "\" "
-          << "with an invalid number of weights "
-          << "(expected 1, "
-          << "found " << this->m_weights.size() << ")";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR("attempted to setup ",
+                  this->get_type()," layer \"",this->get_name(),"\" ",
+                  "with an invalid number of weights ",
+                  "(expected 1, found ",this->m_weights.size(),")");
     }
 
     // Setup weights

--- a/include/lbann/layers/learning/entrywise_scale_bias.hpp
+++ b/include/lbann/layers/learning/entrywise_scale_bias.hpp
@@ -92,25 +92,24 @@ public:
     const El::Int output_size = get_output_size();
 
     // Construct default weights if needed
-    if (this->m_weights.size() < 1) {
-      this->m_weights.push_back(new weights(get_comm()));
+    // Note: Scale is initialized to 1 and bias to 0
+    if (this->m_weights.empty()) {
+      auto w = make_unique<weights>(get_comm());
       std::vector<DataType> vals(2*output_size, DataType{0});
       std::fill(vals.begin(), vals.begin()+output_size, DataType{1});
       auto init = make_unique<value_initializer>(vals);
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
-      this->m_weights[0]->set_name(get_name() + "_weights");
-      this->m_weights[0]->set_initializer(std::move(init));
-      this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      w->set_name(get_name() + "_weights");
+      w->set_initializer(std::move(init));
+      w->set_optimizer(std::move(opt));
+      this->m_weights.push_back(w.get());
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights.size() != 1) {
-      std::ostringstream err;
-      err << "attempted to setup "
-          << this->get_type() << " layer \"" << this->get_name() << "\" "
-          << "with an invalid number of weights "
-          << "(expected 1, "
-          << "found " << this->m_weights.size() << ")";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR("attempted to setup ",
+                  this->get_type()," layer \"",this->get_name(),"\" ",
+                  "with an invalid number of weights ",
+                  "(expected 1, found ",this->m_weights.size(),")");
     }
 
     // Setup weights

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -134,7 +134,7 @@ protected:
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
       this->m_weights[0] = w.get();
-      this->m_model->add_weights(w.release());
+      this->m_model->add_weights(std::move(w));
     }
     auto& linearity_weights = *this->m_weights[0];
 
@@ -168,7 +168,7 @@ protected:
         w->set_name(get_name() + "_bias_weights");
         w->set_optimizer(std::move(opt));
         this->m_weights[1] = w.get();
-        this->m_model->add_weights(w.release());
+        this->m_model->add_weights(std::move(w));
       }
       auto& bias_weights = *this->m_weights[1];
       // Setup bias weights

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -250,36 +250,40 @@ protected:
     }
     this->m_weights.resize(4, nullptr);
     if (this->m_weights[0] == nullptr) {
-      this->m_weights[0] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType(1));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
-      this->m_weights[0]->set_name(get_name() + "_scale");
-      this->m_weights[0]->set_initializer(std::move(init));
-      this->m_weights[0]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[0]);
+      w->set_name(get_name() + "_scale");
+      w->set_initializer(std::move(init));
+      w->set_optimizer(std::move(opt));
+      this->m_weights[0] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[1] == nullptr) {
-      this->m_weights[1] = new weights(get_comm());
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType(0));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
-      this->m_weights[1]->set_name(get_name() + "_bias");
-      this->m_weights[1]->set_initializer(std::move(init));
-      this->m_weights[1]->set_optimizer(std::move(opt));
-      this->m_model->add_weights(this->m_weights[1]);
+      w->set_name(get_name() + "_bias");
+      w->set_initializer(std::move(init));
+      w->set_optimizer(std::move(opt));
+      this->m_weights[1] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[2] == nullptr) {
-      this->m_weights[2] = new weights(get_comm());
-      this->m_weights[2]->set_name(get_name() + "_running_mean");
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType(0));
-      this->m_weights[2]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[2]);
+      w->set_name(get_name() + "_running_mean");
+      w->set_initializer(std::move(init));
+      this->m_weights[2] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[3] == nullptr) {
-      this->m_weights[3] = new weights(get_comm());
-      this->m_weights[3]->set_name(get_name() + "_running_variance");
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType(1));
-      this->m_weights[3]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[3]);
+      w->set_name(get_name() + "_running_variance");
+      w->set_initializer(std::move(init));
+      this->m_weights[3] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
 
     // Setup weights

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -118,18 +118,20 @@ protected:
     }
     this->m_weights.resize(2, nullptr);
     if (this->m_weights[0] == nullptr) {
-      this->m_weights[0] = new weights(get_comm());
-      this->m_weights[0]->set_name(get_name() + "_running_mean");
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType{0});
-      this->m_weights[0]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[0]);
+      w->set_name(get_name() + "_running_mean");
+      w->set_initializer(std::move(init));
+      this->m_weights[0] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
     if (this->m_weights[1] == nullptr) {
-      this->m_weights[1] = new weights(get_comm());
-      this->m_weights[1]->set_name(get_name() + "_running_variance");
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType{1});
-      this->m_weights[1]->set_initializer(std::move(init));
-      this->m_model->add_weights(this->m_weights[1]);
+      w->set_name(get_name() + "_running_variance");
+      w->set_initializer(std::move(init));
+      this->m_weights[1] = w.get();
+      this->m_model->add_weights(std::move(w));
     }
 
     // Setup weights

--- a/include/lbann/layers/transform/weights.hpp
+++ b/include/lbann/layers/transform/weights.hpp
@@ -113,43 +113,38 @@ class weights_layer : public transform_layer {
     transform_layer::setup_data();
 
     // Initialize default weights if none are provided
-    if (this->m_weights.size() > 1) {
-      std::stringstream err;
-      err << "attempted to setup "
-          << get_type() << " layer \"" << get_name() << "\" "
-          << "with an invalid number of weights "
-          << "(expected at most 1, "
-          << "but found " << this->m_weights.size() << ")";
-      LBANN_ERROR(err.str());
-    }
-    this->m_weights.resize(1, nullptr);
-    auto& w = this->m_weights[0];
-    if (w == nullptr) {
-      w = new weights(get_comm());
+    if (this->m_weights.empty()) {
+      auto w = make_unique<weights>(get_comm());
       auto init = make_unique<constant_initializer>(DataType(0));
       std::unique_ptr<optimizer> opt(m_model->create_optimizer());
       w->set_name(get_name() + "_weights");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->m_model->add_weights(w);
+      this->m_weights.push_back(w.get());
+      this->m_model->add_weights(std::move(w));
+    }
+    if (this->m_weights.size() != 1) {
+      LBANN_ERROR("attempted to setup ",
+                  get_type()," layer \"",get_name(),"\" ",
+                  "with an invalid number of weights ",
+                  "(expected at most 1, ",
+                  "but found ",this->m_weights.size(),")");
     }
 
     // Setup weights and weights gradient
     m_gradient->AlignWith(get_activations());
     m_gradient->Resize(get_output_size(), 1);
-    w->set_dims(get_output_dims());
-    w->set_matrix_distribution(m_gradient->DistData());
+    m_weights[0]->set_dims(get_output_dims());
+    m_weights[0]->set_matrix_distribution(m_gradient->DistData());
 
     // Initialize freeze state
-    if (this->m_frozen) { w->freeze(); }
-    else                { w->unfreeze(); }
-    if (w->is_frozen() != this->m_frozen) {
-      std::stringstream err;
-      err << (m_frozen ? "" : "un") << "frozen "
-          << "layer \"" << get_name() << "\" has "
-          << (w->is_frozen() ? "" : "un") << "frozen "
-          << "weights \"" << w->get_name() << "\"";
-      LBANN_ERROR(err.str());
+    if (this->m_frozen) { m_weights[0]->freeze(); }
+    else                { m_weights[0]->unfreeze(); }
+    if (m_weights[0]->is_frozen() != this->m_frozen) {
+      LBANN_ERROR((m_frozen ? "" : "un"),"frozen ",
+                  "layer \"",get_name(),"\" has ",
+                  (m_weights[0]->is_frozen() ? "" : "un"),"frozen ",
+                  "weights \"",m_weights[0]->get_name(),"\"");
     }
 
   }

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -163,7 +163,7 @@ public:
   virtual void add_layer(std::unique_ptr<Layer> l);
 
   /** @brief Add weights to model. */
-  void add_weights(weights *w);
+  void add_weights(std::unique_ptr<weights> w);
 
   /** @brief Register a new callback for the model. */
   void add_callback(callback_base *cb);
@@ -407,7 +407,7 @@ private:
   std::vector<std::unique_ptr<Layer>> m_layers;
 
   /** @brief Trainable parameters. */
-  std::vector<weights*> m_weights;
+  std::vector<std::unique_ptr<weights>> m_weights;
 
   /** @details Maximum possible minibatch size supported by layers in
    *  this model.  Note that this is local to the particular model,

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -284,8 +284,8 @@ std::unique_ptr<model> construct_model(
 
   // Instantiate model
   auto m = instantiate_model(comm, std::move(obj), proto_opt, proto_model);
-  for (auto&& l   : layer_list   ) { m->add_layer(std::move(l)); }
-  for (auto&& w   : weights_list ) { m->add_weights(w.release());   }
+  for (auto&& l   : layer_list   ) { m->add_layer(std::move(l));    }
+  for (auto&& w   : weights_list ) { m->add_weights(std::move(w));  }
   for (auto&& met : metric_list  ) { m->add_metric(met.release());  }
   for (auto&& cb  : callback_list) { m->add_callback(cb.release()); }
   const auto& name = proto_model.name();


### PR DESCRIPTION
Previously, models kept their weights inside a vector of raw pointers. Storing weights inside a `vector<unique_ptr<weights>>` is safer and also allows for convenient serialization with Cereal.

I've run a few unit tests with gradient checking and metric checking, and nothing seems amiss. We'll see if Bamboo picks anything up.

This closes #1227 and makes progress toward #155 and #1228.