### PR TITLE
Return LBANN exit code in Python-generated batch script

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -60,9 +60,11 @@ def run(trainer, model, data_reader, optimizer,
                                optimizer=optimizer)
     lbann_command.append('--prototext={}'.format(prototext_file))
     script.add_parallel_command(lbann_command)
+    script.add_command('status=$?')
 
-    # Batch script prints finish time
+    # Batch script prints finish time and returns status
     script.add_command('date | sed "s/^/Finished at /"')
+    script.add_command('exit ${status}')
 
     # Write, run, or submit batch script
     status = 0

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -104,9 +104,11 @@ def run(trainer, model, data_reader, optimizer,
                                optimizer=optimizer)
     lbann_command.append('--prototext={}'.format(prototext_file))
     script.add_parallel_command(lbann_command)
+    script.add_command('status=$?')
 
-    # Batch script prints finish time
+    # Batch script prints finish time and returns status
     script.add_command('date | sed "s/^/Finished at /"')
+    script.add_command('exit ${status}')
 
     # Write, run, or submit batch script
     status = 0


### PR DESCRIPTION
A batch script created by the Python `lbann.run` function looks something like:
```bash
date | sed "s/^/Started at /"
srun lbann
date | sed "s/^/Finished at /"
```
A bash script returns the exit code of its last command, so this script always returns 0. This is problematic for #1105, where we want to interrogate the exit status to determine if a unit test passed or not. The fix is simple:
```bash
date | sed "s/^/Started at /"
srun lbann
status=$?
date | sed "s/^/Finished at /"
exit ${status}
```