### PR TITLE
Improve time reporting in Python-generated batch script

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -47,7 +47,7 @@ def run(trainer, model, data_reader, optimizer,
         has_allocation = 'LSB_JOBID' in os.environ
 
     # Batch script prints start time
-    script.add_command('date | sed "s/^/Started at /"')
+    script.add_command('echo "Started at $(date)"')
 
     # Batch script invokes LBANN
     lbann_command = [lbann.lbann_exe()]
@@ -63,7 +63,7 @@ def run(trainer, model, data_reader, optimizer,
     script.add_command('status=$?')
 
     # Batch script prints finish time and returns status
-    script.add_command('date | sed "s/^/Finished at /"')
+    script.add_command('echo "Finished at $(date)"')
     script.add_command('exit ${status}')
 
     # Write, run, or submit batch script

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -91,7 +91,7 @@ def run(trainer, model, data_reader, optimizer,
         has_allocation = 'LSB_JOBID' in os.environ
 
     # Batch script prints start time
-    script.add_command('date | sed "s/^/Started at /"')
+    script.add_command('echo "Started at $(date)"')
 
     # Batch script invokes LBANN
     lbann_command = [lbann.lbann_exe()]
@@ -107,7 +107,7 @@ def run(trainer, model, data_reader, optimizer,
     script.add_command('status=$?')
 
     # Batch script prints finish time and returns status
-    script.add_command('date | sed "s/^/Finished at /"')
+    script.add_command('echo "Finished at $(date)"')
     script.add_command('exit ${status}')
 
     # Write, run, or submit batch script


### PR DESCRIPTION
@benson31 has pointed out that the time reporting in the Python-generated batch scripts is needlessly complicated:
```bash
date | sed "s/^/Started at /"
```
When you use the sed hammer, everything looks like a string substitution nail. This is more straightforward and slightly more portable:
```bash
echo "Started at $(date)"
```