### PR TITLE
Fix a mismatched forward-declaration

### DIFF
--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -38,7 +38,8 @@ namespace lbann {
 // Forward-declare this.
 class trainer;
 
-struct termination_criteria {
+class termination_criteria {
+public:
   size_t num_steps;
 };
 

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -31,7 +31,8 @@
 #include <cereal/types/base_class.hpp>
 namespace lbann {
 
-struct sgd_termination_criteria : public termination_criteria {
+class sgd_termination_criteria : public termination_criteria {
+public:
   size_t num_epochs;
 };
 


### PR DESCRIPTION
I opted to make the definition use `class` rather than changing the forward-declaration. The reason for this is that logically this type represents a more complicated idea than a true POD struct. This has not been fleshed out yet (see #1199), but it will be soon.