### PR TITLE
Test length modes

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -12,10 +12,13 @@ def check_list(substrings, strings):
 
 def get_command(cluster,
                 executable,
+                # Allocation/Run Parameters
                 num_nodes=None,
+                num_processes=None,
                 partition=None,
                 time_limit=None,
-                num_processes=None,
+                # LBANN Parameters
+                ckpt_dir=None,
                 dir_name=None,
                 data_filedir_default=None,
                 data_filedir_train_default=None,
@@ -36,24 +39,32 @@ def get_command(cluster,
                 optimizer_path=None,
                 processes_per_model=None,
                 extra_lbann_flags=None,
-                ckpt_dir=None,
-                output_file_name=None,
+                # Error/Output Redirect
                 error_file_name=None,
-                return_tuple=False,
+                output_file_name=None,
+                # Misc. Parameters
                 check_executable_existence=True,
-                skip_no_exe=True):
+                return_tuple=False,
+                skip_no_exe=True,
+                weekly=False):
     # Check parameters for black-listed characters like semi-colons that
     # would terminate the command and allow for an extra command
     blacklist = [';', '--']
     strings = [
-        cluster, executable, num_nodes, partition, time_limit, num_processes,
-        dir_name, data_filedir_default, data_filedir_train_default,
+        cluster, executable,
+        # Allocation/Run Parameters
+        num_nodes, num_processes, partition, time_limit,
+        # LBANN Parameters
+        ckpt_dir, dir_name, data_filedir_default, data_filedir_train_default,
         data_filename_train_default, data_filedir_test_default,
         data_filename_test_default, data_reader_name, data_reader_path,
         data_reader_percent, exit_after_setup, metadata, mini_batch_size,
         model_folder, model_name, model_path, num_epochs, optimizer_name,
-        optimizer_path, processes_per_model, ckpt_dir, output_file_name,
-        error_file_name, return_tuple, check_executable_existence, skip_no_exe
+        optimizer_path, processes_per_model,
+        # Error/Output Redirect
+        error_file_name, output_file_name,
+        # Misc. Parameters
+        check_executable_existence, return_tuple,  skip_no_exe, weekly
     ]
     lbann_errors = []
     if extra_lbann_flags is not None:
@@ -70,8 +81,14 @@ def get_command(cluster,
         raise Exception('Invalid character(s): %s' % ' , '.join(
             invalid_character_errors))
 
+    DEFAULT_TIME = 35
     MAX_TIME = 360  # 6 hours.
-    if (time_limit is None) or (time_limit > MAX_TIME):
+    if time_limit is None:
+        if weekly:
+            time_limit = MAX_TIME
+        else:
+            time_limit = DEFAULT_TIME
+    if time_limit > MAX_TIME:
         time_limit = MAX_TIME
 
     # Check executable existence
@@ -378,7 +395,22 @@ def get_command(cluster,
                  ' data_reader_path are.'))
         # else: no conflicts
     if data_reader_percent is not None:
-        option_data_reader_percent = ' --data_reader_percent=%f' % data_reader_percent
+        # If data_reader_percent is not None, then it will override `weekly`.
+        # If it is None however, we choose its value based on `weekly`.
+        try:
+            data_reader_percent = float(data_reader_percent)
+
+        except ValueError:
+            lbann_errors.append(
+                'data_reader_percent={d} is not a float.'.format(
+                    d=data_reader_percent))
+    elif weekly:
+        data_reader_percent = 1.00
+    else:
+        # Nightly
+        data_reader_percent = 0.10
+    option_data_reader_percent = ' --data_reader_percent={d}'.format(
+        d=data_reader_percent)
     if exit_after_setup:
         option_exit_after_setup = ' --exit_after_setup'
     if metadata is not None:

--- a/bamboo/compiler_tests/conftest.py
+++ b/bamboo/compiler_tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_addoption(parser):
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
     parser.addoption('--dirname', action='store', default=default_dirname,
-                     help='--dirname specifies the top-level directory')
+                     help='--dirname=<path_to_dir> specifies the top-level directory')
 
 
 @pytest.fixture

--- a/bamboo/integration_tests/common_code.py
+++ b/bamboo/integration_tests/common_code.py
@@ -6,40 +6,55 @@ import collections, csv, os, pprint, re, time
 
 # Set up the command ##########################################################
 def get_command(cluster, dir_name, model_folder, model_name, executable,
-                output_file_name, error_file_name, compiler_name, weekly=False):
+                output_file_name, error_file_name, compiler_name, weekly=False,
+                data_reader_percent=None):
     if model_name in ['alexnet', 'conv_autoencoder_imagenet']:
         if weekly:
-            data_reader_percent = 0.10
-            time_limit = 600
+            time_limit = 360
         else:
-            data_reader_percent = 0.01
             time_limit = 60
         if cluster == 'lassen':
             command = tools.get_command(
-                cluster=cluster, executable=executable, num_nodes=16,
-                partition='pbatch', time_limit=time_limit, num_processes=32,
+                cluster=cluster, executable=executable,
+                # Allocation/Run Parameters
+                num_nodes=16, num_processes=32, partition='pbatch',
+                time_limit=time_limit,
+                # LBANN Parameters
                 dir_name=dir_name,
                 data_filedir_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/train/',
                 data_filename_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/train.txt',
                 data_filedir_test_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/val/',
                 data_filename_test_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/val.txt',
-                data_reader_name='imagenet_lassen', data_reader_percent=data_reader_percent,
+                data_reader_name='imagenet_lassen',
+                data_reader_percent=data_reader_percent,
                 model_folder=model_folder, model_name=model_name, num_epochs=20,
-                optimizer_name='adagrad', output_file_name=output_file_name,
-                error_file_name=error_file_name)
+                optimizer_name='adagrad',
+                # Error/Output Redirect
+                error_file_name=error_file_name,
+                output_file_name=output_file_name,
+                # Misc. Parameters
+                weekly=weekly)
         else:
             command = tools.get_command(
-                cluster=cluster, executable=executable, num_nodes=16,
-                partition='pbatch', time_limit=time_limit, num_processes=32,
+                cluster=cluster, executable=executable,
+                # Allocation/Run Parameters
+                num_nodes=16, num_processes=32, partition='pbatch',
+                time_limit=time_limit,
+                # LBANN Parameters
                 dir_name=dir_name,
                 data_filedir_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/train/',
                 data_filename_train_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/train.txt',
                 data_filedir_test_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/original/val/',
                 data_filename_test_default='/p/lscratchh/brainusr/datasets/ILSVRC2012/labels/val.txt',
-                data_reader_name='imagenet', data_reader_percent=data_reader_percent,
+                data_reader_name='imagenet',
+                data_reader_percent=data_reader_percent,
                 model_folder=model_folder, model_name=model_name, num_epochs=20,
-                optimizer_name='adagrad', output_file_name=output_file_name,
-                error_file_name=error_file_name)
+                optimizer_name='adagrad',
+                # Error/Output Redirect
+                error_file_name=error_file_name,
+                output_file_name=output_file_name,
+                # Misc. Parameters
+                weekly=weekly)
     elif model_name in ['conv_autoencoder_mnist', 'lenet_mnist']:
         if (model_name == 'lenet_mnist') and \
                 (compiler_name in ['clang6', 'intel19']):
@@ -53,13 +68,21 @@ def get_command(cluster, dir_name, model_folder, model_name, executable,
         else:
             num_processes = 2
         command = tools.get_command(
-            cluster=cluster, executable=executable, num_nodes=1,
-            partition=partition, time_limit=time_limit,
-            num_processes=num_processes, dir_name=dir_name,
+            cluster=cluster, executable=executable,
+            # Allocation/Run Parameters
+            num_nodes=1, num_processes=num_processes, partition=partition,
+            time_limit=time_limit,
+            # LBANN Parameters
+            dir_name=dir_name,
             data_filedir_default='/p/lscratchh/brainusr/datasets/MNIST',
-            data_reader_name='mnist', model_folder=model_folder,
-            model_name=model_name, num_epochs=5, optimizer_name='adagrad',
-            output_file_name=output_file_name, error_file_name=error_file_name)
+            data_reader_name='mnist', data_reader_percent=data_reader_percent,
+            model_folder=model_folder, model_name=model_name, num_epochs=5,
+            optimizer_name='adagrad',
+            # Error/Output Redirect
+            error_file_name=error_file_name,
+            output_file_name=output_file_name,
+            # Misc. Parameters
+            weekly=weekly)
     else:
         raise Exception('Invalid model: %s' % model_name)
     return command
@@ -214,7 +237,8 @@ def extract_data(output_file_name, data_fields, should_log):
 
 
 def skeleton(cluster, dir_name, executable, model_folder, model_name,
-             data_fields, should_log, compiler_name=None, weekly=False):
+             data_fields, should_log, compiler_name=None, weekly=False,
+             data_reader_percent=None):
     if compiler_name is None:
         output_file_name = '%s/bamboo/integration_tests/output/%s_output.txt' % (dir_name, model_name)
         error_file_name = '%s/bamboo/integration_tests/error/%s_error.txt' % (dir_name, model_name)
@@ -223,7 +247,8 @@ def skeleton(cluster, dir_name, executable, model_folder, model_name,
         error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' % (dir_name, model_name, compiler_name)
     command = get_command(
         cluster, dir_name, model_folder, model_name, executable,
-        output_file_name, error_file_name, compiler_name, weekly=weekly)
+        output_file_name, error_file_name, compiler_name, weekly=weekly,
+        data_reader_percent=data_reader_percent)
     run_lbann(command, model_name, output_file_name,
               error_file_name, should_log)
     return extract_data(output_file_name, data_fields, should_log)

--- a/bamboo/integration_tests/conftest.py
+++ b/bamboo/integration_tests/conftest.py
@@ -24,6 +24,8 @@ def pytest_addoption(parser):
     parser.addoption('--weekly', action='store_true', default=False,
                      help='--weekly specifies that the test should ONLY be run weekly, not nightly. Default False')
     # For local testing only
+    parser.addoption('--data-reader-percent', action='store', default=None,
+                     help='--data-reader-percent=<percent of dataset to be used>. Default None. Note that 1.0 is 100%.')
     parser.addoption('--exe', action='store', help='--exe=<hand-picked executable>')
 
 
@@ -55,6 +57,11 @@ def run(request):
 @pytest.fixture
 def weekly(request):
     return request.config.getoption('--weekly')
+
+
+@pytest.fixture
+def data_reader_percent(request):
+    return request.config.getoption('--data-reader-percent')
 
 
 @pytest.fixture

--- a/bamboo/integration_tests/test_integration_autoencoders.py
+++ b/bamboo/integration_tests/test_integration_autoencoders.py
@@ -49,7 +49,7 @@ DATA_FIELDS = [
 
 
 def skeleton_autoencoder_imagenet(cluster, dir_name, executables, compiler_name,
-                                  weekly):
+                                  weekly, data_reader_percent):
   if cluster in ['lassen', 'pascal']:
       e = 'skeleton_autoencoder_imagenet: does not run on GPU'
       print('Skip - ' + e)
@@ -63,7 +63,8 @@ def skeleton_autoencoder_imagenet(cluster, dir_name, executables, compiler_name,
   should_log = False
   actual_objective_functions = common_code.skeleton(
       cluster, dir_name, executables[compiler_name], model_folder, model_name,
-      DATA_FIELDS, should_log, compiler_name=compiler_name, weekly=weekly)
+      DATA_FIELDS, should_log, compiler_name=compiler_name, weekly=weekly,
+      data_reader_percent=data_reader_percent)
   frequency_str = '_nightly'
   if weekly:
     frequency_str = '_weekly'
@@ -72,24 +73,30 @@ def skeleton_autoencoder_imagenet(cluster, dir_name, executables, compiler_name,
 
 
 def test_integration_autoencoder_imagenet_clang6(cluster, dirname, exes,
-                                                 weekly):
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'clang6', weekly)
+                                                 weekly, data_reader_percent):
+    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'clang6', weekly,
+                                  data_reader_percent)
 
 
-def test_integration_autoencoder_imagenet_gcc7(cluster, dirname, exes, weekly):
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'gcc7', weekly)
+def test_integration_autoencoder_imagenet_gcc7(cluster, dirname, exes, weekly,
+                                               data_reader_percent):
+    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'gcc7', weekly,
+                                  data_reader_percent)
 
 
 def test_integration_autoencoder_imagenet_intel19(cluster, dirname, exes,
-                                                  weekly):
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'intel19', weekly)
+                                                  weekly, data_reader_percent):
+    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'intel19', weekly,
+                                  data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_autoencoder.py -k 'test_integration_autoencoder_imagenet_exe' --exe=<executable>
-def test_integration_autoencoder_imagenet_exe(cluster, dirname, exe):
+def test_integration_autoencoder_imagenet_exe(cluster, dirname, exe, weekly,
+                                              data_reader_percent):
     if exe is None:
         e = 'test_integration_autoencoder_imagenet_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip()
     exes = {'exe': exe}
-    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'exe', True)
+    skeleton_autoencoder_imagenet(cluster, dirname, exes, 'exe', weekly,
+                                  data_reader_percent)

--- a/bamboo/integration_tests/test_integration_debug.py
+++ b/bamboo/integration_tests/test_integration_debug.py
@@ -6,7 +6,8 @@ import common_code
 
 
 def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
-                         debug_build, should_log=False):
+                         debug_build, should_log=False,
+                         data_reader_percent=None):
     # If weekly or debug_build are true, then run the test.
     if not (weekly or debug_build):
         e = 'skeleton_mnist_debug: Not doing weekly or debug_build testing'
@@ -20,18 +21,28 @@ def skeleton_mnist_debug(cluster, dir_name, executables, compiler_name, weekly,
     output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
     error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name)
     command = tools.get_command(
-        cluster=cluster, executable=executables[compiler_name], num_nodes=1,
-        partition='pbatch', time_limit=100, dir_name=dir_name,
+        cluster=cluster, executable=executables[compiler_name],
+        # Allocation/Run Parameters
+        num_nodes=1, partition='pbatch', time_limit=100,
+        # LBANN Parameters
+        dir_name=dir_name,
         data_filedir_default='/p/lscratchh/brainusr/datasets/MNIST',
-        data_reader_name='mnist', model_folder='models/' + model_name,
+        data_reader_name='mnist',
+        data_reader_percent=data_reader_percent,
+        model_folder='models/' + model_name,
         model_name=model_name, num_epochs=5, optimizer_name='adagrad',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        # Error/Output Redirect
+        error_file_name=error_file_name,
+        output_file_name=output_file_name,
+        # Misc. Parameters
+        weekly=weekly)
     common_code.run_lbann(command, model_name, output_file_name,
                           error_file_name, should_log)
 
 
 def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
-                         debug_build, should_log=False):
+                         debug_build, should_log=False,
+                         data_reader_percent=None):
     # If weekly or debug_build are true, then run the test.
     if not (weekly or debug_build):
         e = 'skeleton_cifar_debug: Not doing weekly or debug_build testing'
@@ -49,56 +60,82 @@ def skeleton_cifar_debug(cluster, dir_name, executables, compiler_name, weekly,
     output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
     error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name)
     command = tools.get_command(
-        cluster=cluster, executable=executables[compiler_name],	num_nodes=1,
-        partition='pbatch', time_limit=100, dir_name=dir_name,
+        cluster=cluster, executable=executables[compiler_name],
+        # Allocation/Run Parameters
+        num_nodes=1, partition='pbatch', time_limit=100,
+        # LBANN Parameters
+        dir_name=dir_name,
         data_filename_train_default='/p/lscratchh/brainusr/datasets/cifar10-bin/data_all.bin',
         data_filename_test_default='/p/lscratchh/brainusr/datasets/cifar10-bin/test_batch.bin',
-        data_reader_name='cifar10', data_reader_percent=0.01, model_folder='models/' + model_name,
+        data_reader_name='cifar10', data_reader_percent=data_reader_percent,
+        model_folder='models/' + model_name,
         model_name='conv_' + model_name, num_epochs=5, optimizer_name='adagrad',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        # Error/Output Redirect
+        error_file_name=error_file_name,
+        output_file_name=output_file_name,
+        # Misc. Parameters
+        weekly=weekly)
     common_code.run_lbann(command, model_name, output_file_name,
                           error_file_name, should_log)
 
 
-def test_integration_mnist_clang6_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_mnist_debug(cluster, dirname, exes, 'clang6_debug', weekly, debug_build)
+def test_integration_mnist_clang6_debug(cluster, dirname, exes, weekly,
+                                        debug_build, data_reader_percent):
+    skeleton_mnist_debug(cluster, dirname, exes, 'clang6_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
-def test_integration_cifar_clang6_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_cifar_debug(cluster, dirname, exes, 'clang6_debug', weekly, debug_build)
+def test_integration_cifar_clang6_debug(cluster, dirname, exes, weekly,
+                                        debug_build, data_reader_percent):
+    skeleton_cifar_debug(cluster, dirname, exes, 'clang6_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
-def test_integration_mnist_gcc7_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_mnist_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug_build)
+def test_integration_mnist_gcc7_debug(cluster, dirname, exes, weekly,
+                                      debug_build, data_reader_percent):
+    skeleton_mnist_debug(cluster, dirname, exes, 'gcc7_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
-def test_integration_cifar_gcc7_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_cifar_debug(cluster, dirname, exes, 'gcc7_debug', weekly, debug_build)
+def test_integration_cifar_gcc7_debug(cluster, dirname, exes, weekly,
+                                      debug_build, data_reader_percent):
+    skeleton_cifar_debug(cluster, dirname, exes, 'gcc7_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
-def test_integration_mnist_intel19_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_mnist_debug(cluster, dirname, exes, 'intel19_debug', weekly, debug_build)
+def test_integration_mnist_intel19_debug(cluster, dirname, exes, weekly,
+                                         debug_build, data_reader_percent):
+    skeleton_mnist_debug(cluster, dirname, exes, 'intel19_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
-def test_integration_cifar_intel19_debug(cluster, dirname, exes, weekly, debug_build):
-    skeleton_cifar_debug(cluster, dirname, exes, 'intel19_debug', weekly, debug_build)
+def test_integration_cifar_intel19_debug(cluster, dirname, exes, weekly,
+                                         debug_build, data_reader_percent):
+    skeleton_cifar_debug(cluster, dirname, exes, 'intel19_debug', weekly,
+                         debug_build, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_debug.py -k 'test_integration_mnist_exe' --exe=<executable>
-def test_integration_mnist_exe(cluster, dirname, exe):
+def test_integration_mnist_exe(cluster, dirname, exe, weekly,
+                               data_reader_percent):
     if exe is None:
         e = 'test_integration_mnist_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_mnist_debug(cluster, dirname, exes, 'exe', True, True)
+    debug_build = True
+    skeleton_mnist_debug(cluster, dirname, exes, 'exe', weekly, debug_build,
+                         data_reader_percent=data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_debug.py -k 'test_integration_cifar_exe' --exe=<executable>
-def test_integration_cifar_exe(cluster, dirname, exe):
+def test_integration_cifar_exe(cluster, dirname, exe, weekly,
+                               data_reader_percent):
     if exe == None:
         e = 'test_integration_cifar_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_cifar_debug(cluster, dirname, exes, 'exe', True, True)
+    debug_build=True
+    skeleton_cifar_debug(cluster, dirname, exes, 'exe', weekly, debug_build,
+                         data_reader_percent=data_reader_percent)

--- a/bamboo/integration_tests/test_integration_performance.py
+++ b/bamboo/integration_tests/test_integration_performance.py
@@ -98,7 +98,8 @@ DATA_FIELDS = [
 
 
 def skeleton_performance_lenet_mnist(cluster, dir_name, executables,
-                                     compiler_name):
+                                     compiler_name, weekly,
+                                     data_reader_percent):
   if compiler_name not in executables:
     e = 'skeleton_performance_lenet_mnist: default_exes[%s] does not exist' % compiler_name
     print('Skip - ' + e)
@@ -115,7 +116,7 @@ def skeleton_performance_lenet_mnist(cluster, dir_name, executables,
 
 
 def skeleton_performance_alexnet(cluster, dir_name, executables, compiler_name,
-                                 weekly):
+                                 weekly, data_reader_percent):
   if compiler_name not in executables:
     e = 'skeleton_performance_alexnet: default_exes[%s] does not exist' % compiler_name
     print('Skip - ' + e)
@@ -135,7 +136,10 @@ def skeleton_performance_alexnet(cluster, dir_name, executables, compiler_name,
 
 
 def skeleton_performance_full_alexnet(cluster, dir_name, executables,
-                                      compiler_name, weekly, run):
+                                      compiler_name, weekly, run,
+                                      data_reader_percent):
+  # `run` is False for calls to run.sh.
+  # `run` is True, in allocate_and_run.sh, if this is a Weekly test on Catalyst.
   if not run:
     e = 'skeleton_performance_full_alexnet: Ignored'
     print('Skip - ' + e)
@@ -155,9 +159,10 @@ def skeleton_performance_full_alexnet(cluster, dir_name, executables,
   should_log = True
   output_file_name = '%s/bamboo/integration_tests/output/%s_%s_output.txt' %(dir_name, model_name, compiler_name)
   error_file_name = '%s/bamboo/integration_tests/error/%s_%s_error.txt' %(dir_name, model_name, compiler_name) 
+  # No use for data_reader_percent here.
   if cluster in ['catalyst']:
     command = 'salloc --nodes 128 %s/bamboo/integration_tests/%s.sh > %s 2> %s' % (dir_name, model_name, output_file_name, error_file_name)
-  elif cluster in ['pascal', 'ray']:
+  elif cluster in ['lassen', 'pascal', 'ray']:
     e = 'skeleton_performance_full_alexnet: Pascal, Ray are unsupported for skeleton_performance_full_alexnet'
     print('Skip - ' + e)
     pytest.skip(e)
@@ -171,75 +176,96 @@ def skeleton_performance_full_alexnet(cluster, dir_name, executables,
             cluster)
 
 
-def test_integration_performance_lenet_mnist_clang6(cluster, dirname, exes):
-  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'clang6')
+def test_integration_performance_lenet_mnist_clang6(cluster, dirname, exes,
+                                                    weekly, data_reader_percent):
+  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'clang6', weekly,
+                                   data_reader_percent)
 
 
-def test_integration_performance_alexnet_clang6(cluster, dirname, exes, weekly):
-  skeleton_performance_alexnet(cluster, dirname, exes, 'clang6', weekly)
+def test_integration_performance_alexnet_clang6(cluster, dirname, exes, weekly,
+                                                data_reader_percent):
+  skeleton_performance_alexnet(cluster, dirname, exes, 'clang6', weekly,
+                               data_reader_percent)
 
 
 def test_integration_performance_full_alexnet_clang6(cluster, dirname, exes,
-                                                     weekly, run):
+                                                     weekly, run,
+                                                     data_reader_percent):
   skeleton_performance_full_alexnet(cluster, dirname, exes, 'clang6', weekly,
-                                    run)
+                                    run, data_reader_percent)
 
 
-def test_integration_performance_lenet_mnist_gcc7(cluster, dirname, exes):
-  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'gcc7')
+def test_integration_performance_lenet_mnist_gcc7(cluster, dirname, exes,
+                                                  weekly, data_reader_percent):
+  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'gcc7', weekly,
+                                   data_reader_percent)
 
 
-def test_integration_performance_alexnet_gcc7(cluster, dirname, exes, weekly):
-  skeleton_performance_alexnet(cluster, dirname, exes, 'gcc7', weekly)
+def test_integration_performance_alexnet_gcc7(cluster, dirname, exes, weekly,
+                                              data_reader_percent):
+  skeleton_performance_alexnet(cluster, dirname, exes, 'gcc7', weekly,
+                               data_reader_percent)
 
 
 def test_integration_performance_full_alexnet_gcc7(cluster, dirname, exes,
-                                                   weekly, run):
-  skeleton_performance_full_alexnet(cluster, dirname, exes, 'gcc7', weekly, run)
+                                                   weekly, run,
+                                                   data_reader_percent):
+  skeleton_performance_full_alexnet(cluster, dirname, exes, 'gcc7', weekly, run,
+                                    data_reader_percent)
 
 
-def test_integration_performance_lenet_mnist_intel19(cluster, dirname, exes):
-  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'intel19')
+def test_integration_performance_lenet_mnist_intel19(cluster, dirname, exes,
+                                                     weekly,
+                                                     data_reader_percent):
+  skeleton_performance_lenet_mnist(cluster, dirname, exes, 'intel19', weekly,
+                                   data_reader_percent)
 
 
 def test_integration_performance_alexnet_intel19(cluster, dirname, exes,
-                                                 weekly):
-  skeleton_performance_alexnet(cluster, dirname, exes, 'intel19', weekly)
+                                                 weekly, data_reader_percent):
+  skeleton_performance_alexnet(cluster, dirname, exes, 'intel19', weekly,
+                               data_reader_percent)
 
 
 def test_integration_performance_full_alexnet_intel19(cluster, dirname, exes,
-                                                      weekly, run):
+                                                      weekly, run,
+                                                      data_reader_percent):
   skeleton_performance_full_alexnet(cluster, dirname, exes, 'intel19', weekly,
-                                    run)
+                                    run, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_lenet_mnist_exe' --exe=<executable>
-def test_integration_performance_lenet_mnist_exe(cluster, dirname, exe):
+def test_integration_performance_lenet_mnist_exe(cluster, dirname, exe, weekly,
+                                                 data_reader_percent):
     if exe is None:
       e = 'test_integration_performance_lenet_mnist_exe: Non-local testing'
       print('Skip - ' + e)
       pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_performance_lenet_mnist(cluster, dirname, exes, 'exe')
+    skeleton_performance_lenet_mnist(cluster, dirname, exes, 'exe', weekly,
+                                     data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_alexnet_exe' --exe=<executable>
-def test_integration_performance_alexnet_exe(cluster, dirname, exe):
+def test_integration_performance_alexnet_exe(cluster, dirname, exe, weekly,
+                                             data_reader_percent):
     if exe is None:
       e = 'stest_integration_performance_alexnet_exe: Non-local testing'
       print('Skip - ' + e)
       pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_performance_alexnet(cluster, dirname, exes, 'exe', True)
+    skeleton_performance_alexnet(cluster, dirname, exes, 'exe', weekly,
+                                 data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_integration_performance.py -k 'test_integration_performance_full_alexnet_exe' --weekly --run --exe=<executable>
 def test_integration_performance_full_alexnet_exe(cluster, dirname, weekly,
-                                                  run, exe):
+                                                  run, exe,
+                                                  data_reader_percent):
     if exe is None:
       e = 'test_integration_performance_full_alexnet_exe: Non-local testing'
       print('Skip - ' + e)
       pytest.skip(e)
     exes = {'exe': exe}
     skeleton_performance_full_alexnet(cluster, dirname, exes, 'exe', weekly,
-                                      run)
+                                      run, data_reader_percent)

--- a/bamboo/local_test.cmd
+++ b/bamboo/local_test.cmd
@@ -1,10 +1,11 @@
 #!/bin/bash
 #SBATCH --nodes 16
 #SBATCH --partition pbatch
-#SBATCH --time 960
+#SBATCH --time 1440
 
 # Update "--time" above to increase/decrease allocation time.
 # Update "executable" with your executable.
+# Use "data-reader-percent" to specify data reader percent. Note that `data-reader-percent=1.0` means 100%, not 1%.
 # Use "--integration-tests" to only run integration tests.
 # Use "--unit-tests" to only run unit tests.
-./local_test.sh --executable "../build/gnu.Release.pascal.llnl.gov/install/bin/lbann"
+./local_test.sh --executable "../build/gnu.Release.pascal.llnl.gov/install/bin/lbann" --data-reader-percent 0.001 --unit-tests

--- a/bamboo/local_test.sh
+++ b/bamboo/local_test.sh
@@ -14,10 +14,11 @@ function help_message {
 Run integration and unit tests locally, outside Bamboo.
 Usage: ./${SCRIPT} [options]
 Options:
-  ${C}--help${N}                  Display this help message and exit.
-  ${C}--executable${N} <val>      Specify executable to be used. Required field.
-  ${C}--integration-tests${N}     Specify that only integration tests should be run.
-  ${C}--unit-tests${N}            Specify that only unit tests should be run.
+  ${C}--help${N}                      Display this help message and exit.
+  ${C}--data-reader-percent${N} <val> Specify data reader percent. Note that `data-reader-percent=1.0` means 100%, not 1%.
+  ${C}--executable${N} <val>          Specify executable to be used. Required field.
+  ${C}--integration-tests${N}         Specify that only integration tests should be run.
+  ${C}--unit-tests${N}                Specify that only unit tests should be run.
 EOF
 }
 
@@ -25,6 +26,7 @@ EOF
 # Parse command-line arguments
 ################################################################
 
+DATA_READER_PERCENT=0.001
 EXECUTABLE=
 INTEGRATION_TESTS=1
 UNIT_TESTS=1
@@ -35,8 +37,20 @@ while :; do
             help_message
             exit 0
             ;;
+        -d|--data-reader-percent)
+            # Set data reader percent.
+            # -n: check if string has non-zero length.
+            if [ -n "${2}" ]; then
+                DATA_READER_PERCENT=${2}
+                shift
+            else
+                echo "\"${1}\" option requires a non-empty option argument" >&2
+                help_message
+                exit 1
+            fi
+            ;;
         -e|--executable)
-            # Set executable
+            # Set executable.
             # -n: check if string has non-zero length.
             if [ -n "${2}" ]; then
                 EXECUTABLE=${2}
@@ -99,7 +113,7 @@ cd ..
 echo "Task: Unit Tests"
 cd unit_tests
 if [ ${UNIT_TESTS} -ne 0 ]; then
-    $PYTHON -m pytest -s -vv --durations=0 --exe=${EXECUTABLE}
+    $PYTHON -m pytest -s -vv --durations=0 --exe=${EXECUTABLE} --data-reader-percent=${DATA_READER_PERCENT}
 fi
 cd ..
 

--- a/bamboo/unit_tests/conftest.py
+++ b/bamboo/unit_tests/conftest.py
@@ -14,13 +14,14 @@ def pytest_addoption(parser):
     parser.addoption('--cluster', action='store', default=cluster,
                      help='--cluster=<cluster> to specify the cluster being run on, for the purpose of determing which commands to use. Default the current cluster')
     parser.addoption('--dirname', action='store', default=default_dirname,
-                     help='--dirname specifies the top-level directory')
+                     help='--dirname=<path_to_dir> specifies the top-level directory')
     parser.addoption('--exes', action='store', default=default_exes,
                      help='--exes={compiler_name: path}')
+    parser.addoption('--weekly', action='store_true', default=False,
+                     help='--weekly specifies that the test should ONLY be run weekly, not nightly. Default False')
     # For local testing only
-    parser.addoption('--data-reader-percent', action='store', default=1.0,
-                     help='--data-reader-percent=<percent of dataset to be used'
-                     )
+    parser.addoption('--data-reader-percent', action='store', default=None,
+                     help='--data-reader-percent=<percent of dataset to be used>. Default None. Note that 1.0 is 100%.')
     parser.addoption('--exe', action='store',
                      help='--exe=<hand-picked executable>')
 
@@ -38,6 +39,11 @@ def dirname(request):
 @pytest.fixture
 def exes(request):
     return request.config.getoption('--exes')
+
+
+@pytest.fixture
+def weekly(request):
+    return request.config.getoption('--weekly')
 
 
 @pytest.fixture

--- a/bamboo/unit_tests/test_unit_check_proto_models.py
+++ b/bamboo/unit_tests/test_unit_check_proto_models.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_models(cluster, dir_name, executables, compiler_name):
+def skeleton_models(cluster, dir_name, executables, compiler_name,
+                    weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_models: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -98,10 +99,11 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                         data_filename_test_default=data_filename_test_default,
                         data_reader_name=data_reader_name,
                         data_reader_path=data_reader_path,
+                        data_reader_percent=data_reader_percent,
                         exit_after_setup=True, model_path=model_path,
                         optimizer_name=opt,
                         output_file_name=output_file_name,
-                        error_file_name=error_file_name)
+                        error_file_name=error_file_name, weekly=weekly)
                     if os.system(cmd) != 0:
                         print("Error detected in " + model_path)
                         #defective_models.append(file_name)
@@ -121,23 +123,23 @@ def skeleton_models(cluster, dir_name, executables, compiler_name):
                 nd=num_defective, dms=defective_models))
 
 
-def test_unit_models_clang6(cluster, dirname, exes):
-    skeleton_models(cluster, dirname, exes, 'clang6')
+def test_unit_models_clang6(cluster, dirname, exes, weekly, data_reader_percent):
+    skeleton_models(cluster, dirname, exes, 'clang6', weekly, data_reader_percent)
 
 
-def test_unit_models_gcc7(cluster, dirname, exes):
-    skeleton_models(cluster, exes, dirname, 'gcc7')
+def test_unit_models_gcc7(cluster, dirname, exes, weekly, data_reader_percent):
+    skeleton_models(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_models_intel19(cluster, dirname, exes):
-    skeleton_models(cluster, dirname, exes, 'intel19')
+def test_unit_models_intel19(cluster, dirname, exes, weekly, data_reader_percent):
+    skeleton_models(cluster, dirname, exes, 'intel19', weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_check_proto_models.py -k 'test_unit_models_exe' --exe=<executable>
-def test_unit_models_exe(cluster, dirname, exe):
+def test_unit_models_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_models_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe' : exe}
-    skeleton_models(cluster, dirname, exes, 'exe')
+    skeleton_models(cluster, dirname, exes, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_checkpoint.py
+++ b/bamboo/unit_tests/test_unit_checkpoint.py
@@ -6,7 +6,7 @@ import os
 
 
 def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
-                                     compiler_name, data_reader_percent=1.0):
+                                     compiler_name, weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_checkpoint_lenet_shared: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -25,7 +25,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=no_ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_nockpt = os.system(command)
     tools.assert_success(return_code_nockpt, error_file_name)
 
@@ -40,7 +40,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_ckpt', num_epochs=1, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_1 = os.system(command)
     tools.assert_success(return_code_ckpt_1, error_file_name)
 
@@ -54,7 +54,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_2 = os.system(command)
     tools.assert_success(return_code_ckpt_2, error_file_name)
 
@@ -68,7 +68,7 @@ def skeleton_checkpoint_lenet_shared(cluster, executables, dir_name,
 
 def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
                                           compiler_name,
-                                          data_reader_percent=1.0):
+                                          weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_checkpoint_lenet_distributed: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -87,7 +87,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=no_ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_nockpt = os.system(command)
     tools.assert_success(return_code_nockpt, error_file_name)
 
@@ -102,7 +102,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_dist_ckpt', num_epochs=1, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_1 = os.system(command)
     tools.assert_success(return_code_ckpt_1, error_file_name)
 
@@ -116,7 +116,7 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
         data_reader_name='mnist', data_reader_percent=data_reader_percent,
         ckpt_dir=ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_dist_ckpt', num_epochs=2, optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_2 = os.system(command)
     tools.assert_success(return_code_ckpt_2, error_file_name)
 
@@ -129,45 +129,59 @@ def skeleton_checkpoint_lenet_distributed(cluster, executables, dir_name,
                 dt=diff_test, ncd=no_ckpt_dir, cd=ckpt_dir, p=path_prefix))
 
 
-def test_unit_checkpoint_lenet_shared_clang6(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'clang6')
+def test_unit_checkpoint_lenet_shared_clang6(cluster, exes, dirname,
+                                             weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'clang6',
+                                     weekly, data_reader_percent)
 
 
-def test_unit_checkpoint_lenet_distributed_clang6(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang6')
+def test_unit_checkpoint_lenet_distributed_clang6(cluster, exes, dirname,
+                                                  weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'clang6',
+                                          weekly, data_reader_percent)
 
 
-def test_unit_checkpoint_lenet_shared_gcc7(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc7')
+def test_unit_checkpoint_lenet_shared_gcc7(cluster, exes, dirname,
+                                           weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'gcc7',
+                                     weekly, data_reader_percent)
 
 
-def test_unit_checkpoint_lenet_distributed_gcc7(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc7')
+def test_unit_checkpoint_lenet_distributed_gcc7(cluster, exes, dirname,
+                                                weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'gcc7',
+                                          weekly, data_reader_percent)
 
 
-def test_unit_checkpoint_lenet_shared_intel19(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'intel19')
+def test_unit_checkpoint_lenet_shared_intel19(cluster, exes, dirname,
+                                              weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'intel19',
+                                     weekly, data_reader_percent)
 
 
-def test_unit_checkpoint_lenet_distributed_intel19(cluster, exes, dirname):
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel19')
+def test_unit_checkpoint_lenet_distributed_intel19(cluster, exes, dirname,
+                                                   weekly, data_reader_percent):
+    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'intel19',
+                                          weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_shared_exe' --exe=<executable>
-def test_unit_checkpoint_lenet_shared_exe(cluster, dirname, exe, data_reader_percent):
+def test_unit_checkpoint_lenet_shared_exe(cluster, dirname, exe,
+                                          weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_checkpoint_lenet_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'exe', data_reader_percent)
+    skeleton_checkpoint_lenet_shared(cluster, exes, dirname, 'exe',
+                                     weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_checkpoint.py -k 'test_unit_checkpoint_lenet_distributed_exe' --exe=<executable>
-def test_unit_checkpoint_lenet_distributed_exe(cluster, dirname, exe, data_reader_percent):
+def test_unit_checkpoint_lenet_distributed_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_checkpoint_lenet_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'exe', data_reader_percent)
+    skeleton_checkpoint_lenet_distributed(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_clamp.py
+++ b/bamboo/unit_tests/test_unit_layer_clamp.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_clamp(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_clamp(cluster, executables, dir_name, compiler_name,
+                         weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_layer_clamp: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -17,30 +18,31 @@ def skeleton_layer_clamp(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='clamp',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_clamp_clang6(cluster, exes, dirname):
-    skeleton_layer_clamp(cluster, exes, dirname, 'clang6')
+def test_unit_layer_clamp_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_clamp(cluster, exes, dirname, 'clang6', weekly, data_reader_percent)
 
 
-def test_unit_layer_clamp_gcc7(cluster, exes, dirname):
-    skeleton_layer_clamp(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_clamp_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_clamp(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_clamp_intel19(cluster, exes, dirname):
-    skeleton_layer_clamp(cluster, exes, dirname, 'intel19')
+def test_unit_layer_clamp_intel19(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_clamp(cluster, exes, dirname, 'intel19', weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_clamp.py -k 'test_unit_layer_clamp_exe' --exe=<executable>
-def test_unit_layer_clamp_exe(cluster, dirname, exe):
+def test_unit_layer_clamp_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_clamp_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_clamp(cluster, exes, dirname, 'exe')
+    skeleton_layer_clamp(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_covariance.py
+++ b/bamboo/unit_tests/test_unit_layer_covariance.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_covariance(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_covariance(cluster, executables, dir_name, compiler_name,
+                              weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_layer_covariance: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -17,30 +18,38 @@ def skeleton_layer_covariance(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='covariance',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_covariance_clang6(cluster, exes, dirname):
-    skeleton_layer_covariance(cluster, exes, dirname, 'clang6')
+def test_unit_layer_covariance_clang6(cluster, exes, dirname,
+                                      weekly, data_reader_percent):
+    skeleton_layer_covariance(cluster, exes, dirname, 'clang6',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_covariance_gcc7(cluster, exes, dirname):
-    skeleton_layer_covariance(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_covariance_gcc7(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_covariance(cluster, exes, dirname, 'gcc7',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_covariance_intel19(cluster, exes, dirname):
-    skeleton_layer_covariance(cluster, exes, dirname, 'intel19')
+def test_unit_layer_covariance_intel19(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_layer_covariance(cluster, exes, dirname, 'intel19',
+                              weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_covariance_exe' --exe=<executable>
-def test_unit_layer_covariance_exe(cluster, dirname, exe):
+def test_unit_layer_covariance_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_covariance_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_covariance(cluster, exes, dirname, 'exe')
+    skeleton_layer_covariance(cluster, exes, dirname, 'exe',
+                              weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_elu.py
+++ b/bamboo/unit_tests/test_unit_layer_elu.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_elu(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_elu(cluster, executables, dir_name, compiler_name,
+                       weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_layer_elu: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -17,30 +18,31 @@ def skeleton_layer_elu(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='elu',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_elu_clang6(cluster, exes, dirname):
-    skeleton_layer_elu(cluster, exes, dirname, 'clang6')
+def test_unit_layer_elu_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_elu(cluster, exes, dirname, 'clang6', weekly, data_reader_percent)
 
 
-def test_unit_layer_elu_gcc7(cluster, exes, dirname):
-    skeleton_layer_elu(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_elu_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_elu(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_elu_intel19(cluster, exes, dirname):
-    skeleton_layer_elu(cluster, exes, dirname, 'intel19')
+def test_unit_layer_elu_intel19(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_elu(cluster, exes, dirname, 'intel19', weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_elu.py -k 'test_unit_layer_elu_exe' --exe=<executable>
-def test_unit_layer_elu_exe(cluster, dirname, exe):
+def test_unit_layer_elu_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_elu_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_elu(cluster, exes, dirname, 'exe')
+    skeleton_layer_elu(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_identity.py
+++ b/bamboo/unit_tests/test_unit_layer_identity.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_identity(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_identity(cluster, executables, dir_name, compiler_name,
+                            weekly, data_reader_percent):
     if compiler_name not in executables:
         e = 'skeleton_layer_identity: default_exes[%s] does not exist' % compiler_name
         print('Skip - ' + e)
@@ -17,30 +18,35 @@ def skeleton_layer_identity(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='identity',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_identity_clang6(cluster, exes, dirname):
-    skeleton_layer_identity(cluster, exes, dirname, 'clang6')
+def test_unit_layer_identity_clang6(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_identity(cluster, exes, dirname, 'clang6',
+                            weekly, data_reader_percent)
 
 
-def test_unit_layer_identity_gcc7(cluster, exes, dirname):
-    skeleton_layer_identity(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_identity_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_identity(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_identity_intel19(cluster, exes, dirname):
-    skeleton_layer_identity(cluster, exes, dirname, 'intel19')
+def test_unit_layer_identity_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_identity(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_identity.py -k 'test_unit_layer_identity_exe' --exe=<executable>
-def test_unit_layer_identity_exe(cluster, dirname, exe):
+def test_unit_layer_identity_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_identity_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_identity(cluster, exes, dirname, 'exe')
+    skeleton_layer_identity(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_l1_norm.py
+++ b/bamboo/unit_tests/test_unit_layer_l1_norm.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_l1_norm(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_l1_norm(cluster, executables, dir_name, compiler_name,
+                           weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_l1_norm: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,34 @@ def skeleton_layer_l1_norm(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='l1_norm',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_l1_norm_clang6(cluster, exes, dirname):
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'clang6')
+def test_unit_layer_l1_norm_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_l1_norm(cluster, exes, dirname, 'clang6',
+                           weekly, data_reader_percent)
 
 
-def test_unit_layer_l1_norm_gcc7(cluster, exes, dirname):
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_l1_norm_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_l1_norm(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_l1_norm_intel19(cluster, exes, dirname):
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'intel19')
+def test_unit_layer_l1_norm_intel19(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_l1_norm(cluster, exes, dirname, 'intel19',
+                           weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l1_norm_exe' --exe=<executable>
-def test_unit_layer_l1_norm_exe(cluster, dirname, exe):
+def test_unit_layer_l1_norm_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_l1_norm_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_l1_norm(cluster, exes, dirname, 'exe')
+    skeleton_layer_l1_norm(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_l2_norm2.py
+++ b/bamboo/unit_tests/test_unit_layer_l2_norm2.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_l2_norm2(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_l2_norm2(cluster, executables, dir_name, compiler_name,
+                            weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_l2_norm2: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,29 +18,34 @@ def skeleton_layer_l2_norm2(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='l2_norm2',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_l2_norm2_clang6(cluster, exes, dirname):
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'clang6')
+def test_unit_layer_l2_norm2_clang6(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_l2_norm2(cluster, exes, dirname, 'clang6',
+                            weekly, data_reader_percent)
 
-def test_unit_layer_l2_norm2_gcc7(cluster, exes, dirname):
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_l2_norm2_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_l2_norm2(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_l2_norm2_intel19(cluster, exes, dirname):
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'intel19')
+def test_unit_layer_l2_norm2_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_l2_norm2(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_l2_norm2_exe' --exe=<executable>
-def test_unit_layer_l2_norm2_exe(cluster, dirname, exe):
+def test_unit_layer_l2_norm2_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_l2_norm2_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_l2_norm2(cluster, exes, dirname, 'exe')
+    skeleton_layer_l2_norm2(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_leaky_relu(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_leaky_relu(cluster, executables, dir_name, compiler_name,
+                              weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_leaky_relu: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,37 @@ def skeleton_layer_leaky_relu(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='leaky_relu',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_leaky_relu_clang6(cluster, exes, dirname):
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'clang6')
+def test_unit_layer_leaky_relu_clang6(cluster, exes, dirname,
+                                      weekly, data_reader_percent):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'clang6',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_leaky_relu_gcc7(cluster, exes, dirname):
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_leaky_relu_gcc7(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'gcc7',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_leaky_relu_intel19(cluster, exes, dirname):
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel19')
+def test_unit_layer_leaky_relu_intel19(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'intel19',
+                              weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_leaky_relu_exe' --exe=<executable>
-def test_unit_layer_leaky_relu_exe(cluster, dirname, exe):
+def test_unit_layer_leaky_relu_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_leaky_relu_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_leaky_relu(cluster, exes, dirname, 'exe')
+    skeleton_layer_leaky_relu(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_log_sigmoid(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_log_sigmoid(cluster, executables, dir_name, compiler_name,
+                               weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_log_sigmoid: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,38 @@ def skeleton_layer_log_sigmoid(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='log_sigmoid',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_log_sigmoid_clang6(cluster, exes, dirname):
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'clang6')
+def test_unit_layer_log_sigmoid_clang6(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'clang6',
+                               weekly, data_reader_percent)
 
 
-def test_unit_layer_log_sigmoid_gcc7(cluster, exes, dirname):
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_log_sigmoid_gcc7(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'gcc7',
+                               weekly, data_reader_percent)
 
 
-def test_unit_layer_log_sigmoid_intel19(cluster, exes, dirname):
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'intel19')
+def test_unit_layer_log_sigmoid_intel19(cluster, exes, dirname,
+                                        weekly, data_reader_percent):
+    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'intel19',
+                               weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_log_sigmoid.py -k 'test_unit_layer_log_sigmoid_exe' --exe=<executable>
-def test_unit_layer_log_sigmoid_exe(cluster, dirname, exe):
+def test_unit_layer_log_sigmoid_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_log_sigmoid_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'exe')
+    skeleton_layer_log_sigmoid(cluster, exes, dirname, 'exe',
+                               weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_log_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_log_softmax.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_log_softmax(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_log_softmax(cluster, executables, dir_name, compiler_name,
+                               weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_log_softmax: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,38 @@ def skeleton_layer_log_softmax(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='log_softmax',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_log_softmax_clang6(cluster, exes, dirname):
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'clang6')
+def test_unit_layer_log_softmax_clang6(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_layer_log_softmax(cluster, exes, dirname, 'clang6',
+                               weekly, data_reader_percent)
 
 
-def test_unit_layer_log_softmax_gcc7(cluster, exes, dirname):
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_log_softmax_gcc7(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_log_softmax(cluster, exes, dirname, 'gcc7',
+                               weekly, data_reader_percent)
 
 
-def test_unit_layer_log_softmax_intel19(cluster, exes, dirname):
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'intel19')
+def test_unit_layer_log_softmax_intel19(cluster, exes, dirname,
+                                        weekly, data_reader_percent):
+    skeleton_layer_log_softmax(cluster, exes, dirname, 'intel19',
+                               weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_log_softmax_exe' --exe=<executable>
-def test_unit_layer_log_softmax_exe(cluster, dirname, exe):
+def test_unit_layer_log_softmax_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_log_softmax_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_log_softmax(cluster, exes, dirname, 'exe')
+    skeleton_layer_log_softmax(cluster, exes, dirname, 'exe',
+                               weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
+++ b/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_mean_absolute_error(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_mean_absolute_error(cluster, executables, dir_name,
+                                       compiler_name, weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_mean_absolute_error: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,39 @@ def skeleton_layer_mean_absolute_error(cluster, executables, dir_name, compiler_
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='mean_absolute_error',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_mean_absolute_error_clang6(cluster, exes, dirname):
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'clang6')
+def test_unit_layer_mean_absolute_error_clang6(cluster, exes, dirname,
+                                               weekly, data_reader_percent):
+    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'clang6',
+                                       weekly, data_reader_percent)
 
 
-def test_unit_layer_mean_absolute_error_gcc7(cluster, exes, dirname):
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_mean_absolute_error_gcc7(cluster, exes, dirname,
+                                             weekly, data_reader_percent):
+    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'gcc7',
+                                       weekly, data_reader_percent)
 
 
-def test_unit_layer_mean_absolute_error_intel19(cluster, exes, dirname):
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'intel19')
+def test_unit_layer_mean_absolute_error_intel19(cluster, exes, dirname,
+                                                weekly, data_reader_percent):
+    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'intel19',
+                                       weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_mean_absolute_error_exe' --exe=<executable>
-def test_unit_layer_mean_absolute_error_exe(cluster, dirname, exe):
+def test_unit_layer_mean_absolute_error_exe(cluster, dirname, exe,
+                                            weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_mean_absolute_error_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'exe')
+    skeleton_layer_mean_absolute_error(cluster, exes, dirname, 'exe',
+                                       weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_relu.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_relu(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_relu(cluster, executables, dir_name, compiler_name,
+                        weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_relu: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,31 @@ def skeleton_layer_relu(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='relu',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_relu_clang6(cluster, exes, dirname):
-    skeleton_layer_relu(cluster, exes, dirname, 'clang6')
+def test_unit_layer_relu_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_relu(cluster, exes, dirname, 'clang6', weekly, data_reader_percent)
 
 
-def test_unit_layer_relu_gcc7(cluster, exes, dirname):
-    skeleton_layer_relu(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_relu_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_relu(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_relu_intel19(cluster, exes, dirname):
-    skeleton_layer_relu(cluster, exes, dirname, 'intel19')
+def test_unit_layer_relu_intel19(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_relu(cluster, exes, dirname, 'intel19', weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_relu.py -k 'test_unit_layer_relu_exe' --exe=<executable>
-def test_unit_layer_relu_exe(cluster, dirname, exe):
+def test_unit_layer_relu_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_relu_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_relu(cluster, exes, dirname, 'exe')
+    skeleton_layer_relu(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_selu.py
+++ b/bamboo/unit_tests/test_unit_layer_selu.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_selu(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_selu(cluster, executables, dir_name, compiler_name,
+                        weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_selu: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,31 @@ def skeleton_layer_selu(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='selu',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_selu_clang6(cluster, exes, dirname):
-    skeleton_layer_selu(cluster, exes, dirname, 'clang6')
+def test_unit_layer_selu_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_selu(cluster, exes, dirname, 'clang6', weekly, data_reader_percent)
 
 
-def test_unit_layer_selu_gcc7(cluster, exes, dirname):
-    skeleton_layer_selu(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_selu_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_selu(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_selu_intel19(cluster, exes, dirname):
-    skeleton_layer_selu(cluster, exes, dirname, 'intel19')
+def test_unit_layer_selu_intel19(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_selu(cluster, exes, dirname, 'intel19', weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_selu.py -k 'test_unit_layer_selu_exe' --exe=<executable>
-def test_unit_layer_selu_exe(cluster, dirname, exe):
+def test_unit_layer_selu_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_selu_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_selu(cluster, exes, dirname, 'exe')
+    skeleton_layer_selu(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_sigmoid.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_sigmoid(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_sigmoid(cluster, executables, dir_name, compiler_name,
+                           weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_sigmoid: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,34 @@ def skeleton_layer_sigmoid(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='sigmoid',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_sigmoid_clang6(cluster, exes, dirname):
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'clang6')
+def test_unit_layer_sigmoid_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_sigmoid(cluster, exes, dirname, 'clang6',
+                           weekly, data_reader_percent)
 
 
-def test_unit_layer_sigmoid_gcc7(cluster, exes, dirname):
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_sigmoid_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_sigmoid(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_sigmoid_intel19(cluster, exes, dirname):
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'intel19')
+def test_unit_layer_sigmoid_intel19(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_sigmoid(cluster, exes, dirname, 'intel19',
+                           weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_sigmoid.py -k 'test_unit_layer_sigmoid_exe' --exe=<executable>
-def test_unit_layer_sigmoid_exe(cluster, dirname, exe):
+def test_unit_layer_sigmoid_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_sigmoid_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_sigmoid(cluster, exes, dirname, 'exe')
+    skeleton_layer_sigmoid(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_softmax.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_softmax(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_softmax(cluster, executables, dir_name, compiler_name,
+                           weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_softmax: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,34 @@ def skeleton_layer_softmax(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='softmax',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_softmax_clang6(cluster, exes, dirname):
-    skeleton_layer_softmax(cluster, exes, dirname, 'clang6')
+def test_unit_layer_softmax_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_softmax(cluster, exes, dirname, 'clang6',
+                           weekly, data_reader_percent)
 
 
-def test_unit_layer_softmax_gcc7(cluster, exes, dirname):
-    skeleton_layer_softmax(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_softmax_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_softmax(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_softmax_intel19(cluster, exes, dirname):
-    skeleton_layer_softmax(cluster, exes, dirname, 'intel19')
+def test_unit_layer_softmax_intel19(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_softmax(cluster, exes, dirname, 'intel19',
+                           weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_softmax_exe' --exe=<executable>
-def test_unit_layer_softmax_exe(cluster, dirname, exe):
+def test_unit_layer_softmax_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_softmax_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_softmax(cluster, exes, dirname, 'exe')
+    skeleton_layer_softmax(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_softplus.py
+++ b/bamboo/unit_tests/test_unit_layer_softplus.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_softplus(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_softplus(cluster, executables, dir_name, compiler_name,
+                            weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_softplus: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,35 @@ def skeleton_layer_softplus(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='softplus',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_softplus_clang6(cluster, exes, dirname):
-    skeleton_layer_softplus(cluster, exes, dirname, 'clang6')
+def test_unit_layer_softplus_clang6(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_softplus(cluster, exes, dirname, 'clang6',
+                            weekly, data_reader_percent)
 
 
-def test_unit_layer_softplus_gcc7(cluster, exes, dirname):
-    skeleton_layer_softplus(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_softplus_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_softplus(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_softplus_intel19(cluster, exes, dirname):
-    skeleton_layer_softplus(cluster, exes, dirname, 'intel19')
+def test_unit_layer_softplus_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_softplus(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_softplus.py -k 'test_unit_layer_softplus_exe' --exe=<executable>
-def test_unit_layer_softplus_exe(cluster, dirname, exe):
+def test_unit_layer_softplus_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_softplus_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_softplus(cluster, exes, dirname, 'exe')
+    skeleton_layer_softplus(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_softsign.py
+++ b/bamboo/unit_tests/test_unit_layer_softsign.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_softsign(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_softsign(cluster, executables, dir_name, compiler_name,
+                            weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_softsign: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,34 +18,40 @@ def skeleton_layer_softsign(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='softsign',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_softsign_clang6(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'clang6')
+def test_unit_layer_softsign_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_softsign(cluster, exes, dirname, 'clang6',
+                            weekly, data_reader_percent)
 
 
-def test_unit_layer_softsign_gcc7(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_softsign_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_softsign(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_softsign_intel19(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'intel19')
+def test_unit_layer_softsign_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_softsign(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
-def test_unit_layer_softsign_intel19(cluster, exes, dirname):
-    skeleton_layer_softsign(cluster, exes, dirname, 'intel19')
+def test_unit_layer_softsign_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_softsign(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_softsign.py -k 'test_unit_layer_softsign_exe' --exe=<executable>
-def test_unit_layer_softsign_exe(cluster, dirname, exe):
+def test_unit_layer_softsign_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_softsign_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_softsign(cluster, exes, dirname, 'exe')
+    skeleton_layer_softsign(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_squared_difference.py
+++ b/bamboo/unit_tests/test_unit_layer_squared_difference.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_squared_difference(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_squared_difference(cluster, executables, dir_name,
+                                      compiler_name, weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_squared_difference: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,39 @@ def skeleton_layer_squared_difference(cluster, executables, dir_name, compiler_n
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='squared_difference',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_squared_difference_clang6(cluster, exes, dirname):
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'clang6')
+def test_unit_layer_squared_difference_clang6(cluster, exes, dirname,
+                                              weekly, data_reader_percent):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'clang6',
+                                      weekly, data_reader_percent)
 
 
-def test_unit_layer_squared_difference_gcc7(cluster, exes, dirname):
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_squared_difference_gcc7(cluster, exes, dirname,
+                                            weekly, data_reader_percent):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'gcc7',
+                                      weekly, data_reader_percent)
 
 
-def test_unit_layer_squared_difference_intel19(cluster, exes, dirname):
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'intel19')
+def test_unit_layer_squared_difference_intel19(cluster, exes, dirname,
+                                               weekly, data_reader_percent):
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'intel19',
+                                      weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_squared_difference.py -k 'test_unit_layer_squared_difference_exe' --exe=<executable>
-def test_unit_layer_squared_difference_exe(cluster, dirname, exe):
+def test_unit_layer_squared_difference_exe(cluster, dirname, exe,
+                                           weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_squared_difference_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_squared_difference(cluster, exes, dirname, 'exe')
+    skeleton_layer_squared_difference(cluster, exes, dirname, 'exe',
+                                      weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_tessellate.py
+++ b/bamboo/unit_tests/test_unit_layer_tessellate.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_tessellate(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_tessellate(cluster, executables, dir_name, compiler_name,
+                              weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_tessellate: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,37 @@ def skeleton_layer_tessellate(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='tessellate',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_tessellate_clang6(cluster, exes, dirname):
-    skeleton_layer_tessellate(cluster, exes, dirname, 'clang6')
+def test_unit_layer_tessellate_clang6(cluster, exes, dirname,
+                                      weekly, data_reader_percent):
+    skeleton_layer_tessellate(cluster, exes, dirname, 'clang6',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_tessellate_gcc7(cluster, exes, dirname):
-    skeleton_layer_tessellate(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_tessellate_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_tessellate(cluster, exes, dirname, 'gcc7',
+                              weekly, data_reader_percent)
 
 
-def test_unit_layer_tessellate_intel19(cluster, exes, dirname):
-    skeleton_layer_tessellate(cluster, exes, dirname, 'intel19')
+def test_unit_layer_tessellate_intel19(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_layer_tessellate(cluster, exes, dirname, 'intel19',
+                              weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_layer_tessellate.py -k 'test_unit_layer_tessellate_exe' --exe=<executable>
-def test_unit_layer_tessellate_exe(cluster, dirname, exe):
+def test_unit_layer_tessellate_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_tessellate_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_tessellate(cluster, exes, dirname, 'exe')
+    skeleton_layer_tessellate(cluster, exes, dirname, 'exe',
+                              weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_layer_variance.py
+++ b/bamboo/unit_tests/test_unit_layer_variance.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_layer_variance(cluster, executables, dir_name, compiler_name):
+def skeleton_layer_variance(cluster, executables, dir_name, compiler_name,
+                            weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_layer_variance: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -18,30 +19,35 @@ def skeleton_layer_variance(cluster, executables, dir_name, compiler_name):
         time_limit=10,
         num_processes=2, dir_name=dir_name,
         data_reader_name='synthetic',
+        data_reader_percent=data_reader_percent,
         model_folder='tests/layer_tests', model_name='variance',
         optimizer_name='sgd',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_layer_variance_clang6(cluster, exes, dirname):
-    skeleton_layer_variance(cluster, exes, dirname, 'clang6')
+def test_unit_layer_variance_clang6(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_layer_variance(cluster, exes, dirname, 'clang6',
+                            weekly, data_reader_percent)
 
 
-def test_unit_layer_variance_gcc7(cluster, exes, dirname):
-    skeleton_layer_variance(cluster, exes, dirname, 'gcc7')
+def test_unit_layer_variance_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_layer_variance(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_layer_variance_intel19(cluster, exes, dirname):
-    skeleton_layer_variance(cluster, exes, dirname, 'intel19')
+def test_unit_layer_variance_intel19(cluster, exes, dirname,
+                                     weekly, data_reader_percent):
+    skeleton_layer_variance(cluster, exes, dirname, 'intel19',
+                            weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_layer_variance_exe' --exe=<executable>
-def test_unit_layer_variance_exe(cluster, dirname, exe):
+def test_unit_layer_variance_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_layer_variance_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_layer_variance(cluster, exes, dirname, 'exe')
+    skeleton_layer_variance(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_lbann2_reload.py
+++ b/bamboo/unit_tests/test_unit_lbann2_reload.py
@@ -2,10 +2,11 @@ import sys
 sys.path.insert(0, '../common_python')
 import tools
 import pytest
-import os, sys
+import os
 
 
-def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name, data_reader_percent=1.0):
+def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name,
+                           weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_lbann2_reload: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -28,7 +29,7 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name, data_r
         optimizer_name='sgd',
         num_epochs=2,
         output_file_name=output_file_name,
-        error_file_name=error_file_name)
+        error_file_name=error_file_name, weekly=weekly)
 
     return_code_no_ckpt = os.system(command)
     tools.assert_success(return_code_no_ckpt, error_file_name)
@@ -45,7 +46,7 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name, data_r
         ckpt_dir=ckpt_dir, model_folder='tests',
         model_name='lenet_mnist_ckpt', num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name,
-        error_file_name=error_file_name)
+        error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_1 = os.system(command)
     tools.assert_success(return_code_ckpt_1, error_file_name)
 
@@ -62,13 +63,14 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name, data_r
         model_path='../../model_zoo/tests/model_lenet_mnist_lbann2ckpt.prototext',
         num_epochs=2, optimizer_name='sgd',
         output_file_name=output_file_name,
-        error_file_name=error_file_name)
+        error_file_name=error_file_name, weekly=weekly)
     return_code_ckpt_2 = os.system(command)
     tools.assert_success(return_code_ckpt_2, error_file_name)
 #    os.system('rm lbann2_ckpt/model0-epoch*')
 #    os.system('rm lbann2_nockpt/model0-epoch*')
 
-    diff_result = os.system('diff -rq {ckpt} {no_ckpt}'.format(ckpt=ckpt_dir, no_ckpt=no_ckpt_dir))
+    diff_result = os.system('diff -rq {ckpt} {no_ckpt}'.format(
+        ckpt=ckpt_dir, no_ckpt=no_ckpt_dir))
     allow_epsilon_diff = False
     if allow_epsilon_diff and (diff_result != 0):
         equal_within_epsilon = True
@@ -110,23 +112,26 @@ def skeleton_lbann2_reload(cluster, executables, dir_name, compiler_name, data_r
     assert diff_result == 0
 
 
-def test_unit_lbann2_reload_clang6(cluster, exes, dirname):
-    skeleton_lbann2_reload(cluster, exes, dirname, 'clang6')
+def test_unit_lbann2_reload_clang6(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_lbann2_reload(cluster, exes, dirname, 'clang6',
+                           weekly, data_reader_percent)
 
 
-def test_unit_lbann2_reload_gcc7(cluster, exes, dirname):
-    skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7')
+def test_unit_lbann2_reload_gcc7(cluster, exes, dirname, weekly, data_reader_percent):
+    skeleton_lbann2_reload(cluster, exes, dirname, 'gcc7', weekly, data_reader_percent)
 
 
-def test_unit_lbann2_reload_intel19(cluster, exes, dirname):
-    skeleton_lbann2_reload(cluster, exes, dirname, 'intel19')
+def test_unit_lbann2_reload_intel19(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_lbann2_reload(cluster, exes, dirname, 'intel19',
+                           weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_lbann2_reload.py -k 'test_unit_lbann2_reload_exe' --exe=<executable>
-def test_unit_lbann2_reload_exe(cluster, dirname, exe, data_reader_percent):
+def test_unit_lbann2_reload_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_lbann2_reload_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_lbann2_reload(cluster, exes, dirname, 'exe', data_reader_percent)
+    skeleton_lbann2_reload(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_mnist_conv_graph.py
+++ b/bamboo/unit_tests/test_unit_mnist_conv_graph.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_mnist_conv_graph(cluster, executables, dir_name, compiler_name):
+def skeleton_mnist_conv_graph(cluster, executables, dir_name, compiler_name,
+                              weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_mnist_conv_graph: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -21,32 +22,40 @@ def skeleton_mnist_conv_graph(cluster, executables, dir_name, compiler_name):
         num_nodes=1, time_limit=tl, num_processes=1,
         dir_name=dir_name,
         data_filedir_default='/p/lscratchh/brainusr/datasets/MNIST',
-        data_reader_name='mnist', model_folder='tests',
+        data_reader_name='mnist',
+        data_reader_percent=data_reader_percent,
+        model_folder='tests',
         model_name='mnist_conv_graph',
         optimizer_name='adam',
         output_file_name=output_file_name,
-        error_file_name=error_file_name)
+        error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_mnist_conv_graph_clang6(cluster, exes, dirname):
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'clang6')
+def test_unit_mnist_conv_graph_clang6(cluster, exes, dirname,
+                                      weekly, data_reader_percent):
+    skeleton_mnist_conv_graph(cluster, exes, dirname, 'clang6',
+                              weekly, data_reader_percent)
 
 
-def test_unit_mnist_conv_graph_gcc7(cluster, exes, dirname):
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'gcc7')
+def test_unit_mnist_conv_graph_gcc7(cluster, exes, dirname,
+                                    weekly, data_reader_percent):
+    skeleton_mnist_conv_graph(cluster, exes, dirname, 'gcc7',
+                              weekly, data_reader_percent)
 
 
-def test_unit_mnist_conv_graph_intel19(cluster, exes, dirname):
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'intel19')
+def test_unit_mnist_conv_graph_intel19(cluster, exes, dirname,
+                                       weekly, data_reader_percent):
+    skeleton_mnist_conv_graph(cluster, exes, dirname, 'intel19',
+                              weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_conv_graph.py -k 'test_unit_mnist_conv_graph_exe' --exe=<executable>
-def test_unit_mnist_conv_graph_exe(cluster, dirname, exe):
+def test_unit_mnist_conv_graph_exe(cluster, dirname, exe, weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_mnist_conv_graph_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_mnist_conv_graph(cluster, exes, dirname, 'exe')
+    skeleton_mnist_conv_graph(cluster, exes, dirname, 'exe', weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
+++ b/bamboo/unit_tests/test_unit_mnist_ridge_regression.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def skeleton_mnist_ridge_regression(cluster, executables, dir_name,
-                                    compiler_name):
+                                    compiler_name, weekly, data_reader_percent):
     tools.process_executable(
        'skeleton_mnist_ridge_regression', compiler_name, executables)
 
@@ -91,8 +91,16 @@ def skeleton_mnist_ridge_regression(cluster, executables, dir_name,
         'procs_per_node': 1
     }
 
+    if data_reader_percent is None:
+        if weekly:
+            data_reader_percent = 1.00
+        else:
+            # Nightly
+            data_reader_percent = 0.10
+    lbann_args = '--data_reader_percent={drp}'.format(drp=data_reader_percent)
     if cluster == 'lassen':
-        kwargs['lbann_args'] = '--data_filedir_train=/p/gpfs1/brainusr/datasets/MNIST --data_filedir_test=/p/gpfs1/brainusr/datasets/MNIST'
+        lbann_args += ' --data_filedir_train=/p/gpfs1/brainusr/datasets/MNIST --data_filedir_test=/p/gpfs1/brainusr/datasets/MNIST'
+    kwargs['lbann_args'] = lbann_args
 
     # Run
     experiment_dir = '{d}/bamboo/unit_tests/experiments/mnist_ridge_regression_{c}'.format(
@@ -114,23 +122,31 @@ def skeleton_mnist_ridge_regression(cluster, executables, dir_name,
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_mnist_ridge_regression_clang6(cluster, exes, dirname):
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'clang6')
+def test_unit_mnist_ridge_regression_clang6(cluster, exes, dirname,
+                                            weekly, data_reader_percent):
+    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'clang6',
+                                    weekly, data_reader_percent)
 
 
-def test_unit_mnist_ridge_regression_gcc7(cluster, exes, dirname):
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'gcc7')
+def test_unit_mnist_ridge_regression_gcc7(cluster, exes, dirname,
+                                          weekly, data_reader_percent):
+    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'gcc7',
+                                    weekly, data_reader_percent)
 
 
-def test_unit_mnist_ridge_regression_intel19(cluster, exes, dirname):
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'intel19')
+def test_unit_mnist_ridge_regression_intel19(cluster, exes, dirname,
+                                             weekly, data_reader_percent):
+    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'intel19',
+                                    weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_mnist_ridge_regression_exe' --exe=<executable>
-def test_unit_mnist_ridge_regression_exe(cluster, dirname, exe):
+def test_unit_mnist_ridge_regression_exe(cluster, dirname, exe,
+                                         weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_mnist_ridge_regression_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'exe')
+    skeleton_mnist_ridge_regression(cluster, exes, dirname, 'exe',
+                                    weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
+++ b/bamboo/unit_tests/test_unit_mnist_softmax_classifier.py
@@ -5,7 +5,8 @@ import pytest
 import os
 
 
-def skeleton_mnist_softmax_classifier(cluster, executables, dir_name, compiler_name):
+def skeleton_mnist_softmax_classifier(cluster, executables, dir_name, compiler_name,
+                                      weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_mnist_softmax_classifier: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -17,30 +18,39 @@ def skeleton_mnist_softmax_classifier(cluster, executables, dir_name, compiler_n
         num_processes=1, dir_name=dir_name,
         data_filedir_default='/p/lscratchh/brainusr/datasets/MNIST',
         data_reader_name='mnist',
+        data_reader_percent=data_reader_percent,
         model_folder='tests', model_name='mnist_softmax_classifier',
         optimizer_name='adam',
-        output_file_name=output_file_name, error_file_name=error_file_name)
+        output_file_name=output_file_name, error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_mnist_softmax_classifier_clang6(cluster, exes, dirname):
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'clang6')
+def test_unit_mnist_softmax_classifier_clang6(cluster, exes, dirname,
+                                              weekly, data_reader_percent):
+    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'clang6',
+                                      weekly, data_reader_percent)
 
 
-def test_unit_mnist_softmax_classifier_gcc7(cluster, exes, dirname):
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'gcc7')
+def test_unit_mnist_softmax_classifier_gcc7(cluster, exes, dirname,
+                                            weekly, data_reader_percent):
+    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'gcc7',
+                                      weekly, data_reader_percent)
 
 
-def test_unit_mnist_softmax_classifier_intel19(cluster, exes, dirname):
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'intel19')
+def test_unit_mnist_softmax_classifier_intel19(cluster, exes, dirname,
+                                               weekly, data_reader_percent):
+    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'intel19',
+                                      weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_softmax_classifier.py -k 'test_unit_mnist_softmax_classifier_exe' --exe=<executable>
-def test_unit_mnist_softmax_classifier_exe(cluster, dirname, exe):
+def test_unit_mnist_softmax_classifier_exe(cluster, dirname, exe,
+                                           weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_mnist_softmax_classifier_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'exe')
+    skeleton_mnist_softmax_classifier(cluster, exes, dirname, 'exe',
+                                      weekly, data_reader_percent)

--- a/bamboo/unit_tests/test_unit_reconstruction_loss.py
+++ b/bamboo/unit_tests/test_unit_reconstruction_loss.py
@@ -5,7 +5,8 @@ import pytest
 import tools
 
 
-def skeleton_jag_reconstruction_loss(cluster, executables, dir_name, compiler_name):
+def skeleton_jag_reconstruction_loss(cluster, executables, dir_name, compiler_name,
+                                     weekly, data_reader_percent):
     if compiler_name not in executables:
       e = 'skeleton_jag_reconstruction_loss: default_exes[%s] does not exist' % compiler_name
       print('Skip - ' + e)
@@ -20,33 +21,42 @@ def skeleton_jag_reconstruction_loss(cluster, executables, dir_name, compiler_na
         dir_name=dir_name,
         data_filedir_default='/p/lscratchh/brainusr/datasets/10MJAG/1M_A/100K4trainers',
         data_reader_name='jag',
+        data_reader_percent=data_reader_percent,
         metadata='model_zoo/models/jag/wae_cycle_gan/jag_100M_metadata.prototext',
         model_folder='tests',
         model_name='jag_single_layer_ae',
         optimizer_name='adam',
         output_file_name=output_file_name,
-        error_file_name=error_file_name)
+        error_file_name=error_file_name, weekly=weekly)
     return_code = os.system(command)
     tools.assert_success(return_code, error_file_name)
 
 
-def test_unit_jag_reconstruction_loss_clang6(cluster, exes, dirname):
-    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'clang6')
+def test_unit_jag_reconstruction_loss_clang6(cluster, exes, dirname,
+                                             weekly, data_reader_percent):
+    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'clang6',
+                                     weekly, data_reader_percent)
 
 
-def test_unit_jag_reconstruction_loss_gcc7(cluster, exes, dirname):
-    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'gcc7')
+def test_unit_jag_reconstruction_loss_gcc7(cluster, exes, dirname,
+                                           weekly, data_reader_percent):
+    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'gcc7',
+                                     weekly, data_reader_percent)
 
 
-def test_unit_jag_reconstruction_loss_intel19(cluster, exes, dirname):
-    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'intel19')
+def test_unit_jag_reconstruction_loss_intel19(cluster, exes, dirname,
+                                              weekly, data_reader_percent):
+    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'intel19',
+                                     weekly, data_reader_percent)
 
 
 # Run with python3 -m pytest -s test_unit_ridge_regression.py -k 'test_unit_jag_reconstruction_loss_exe' --exe=<executable>
-def test_unit_jag_reconstruction_loss_exe(cluster, dirname, exe):
+def test_unit_jag_reconstruction_loss_exe(cluster, dirname, exe,
+                                          weekly, data_reader_percent):
     if exe is None:
         e = 'test_unit_jag_reconstruction_loss_exe: Non-local testing'
         print('Skip - ' + e)
         pytest.skip(e)
     exes = {'exe': exe}
-    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'exe')
+    skeleton_jag_reconstruction_loss(cluster, exes, dirname, 'exe',
+                                     weekly, data_reader_percent)

--- a/docs/continuous_integration.rst
+++ b/docs/continuous_integration.rst
@@ -59,7 +59,7 @@ They consist of an identical list of tasks:
 
 
 The tests in Task 2 run
-:bash:`$PYTHON -m pytest -s [--weekly] --junitxml=results.xml`,
+:bash:`$PYTHON -m pytest -s -vv --durations=0 [--weekly] --junitxml=results.xml`,
 which will run all the pytests in the job's associated directory.
 Note that :bash:`$PYTHON` refers to the Python build to use.
 Also note that only Weekly Develop adds the :bash:`--weekly` option.
@@ -80,7 +80,8 @@ Writing Your Own Tests
 A side effect of our Bamboo setup is that tests must be written using pytest.
 Test files must begin with :bash:`test_` to be recognized by pytest.
 Individual test methods must also begin with :python:`test_`.
-Test methods should use the :python:`assert` keyword.
+Test methods should use the :python:`assert` keyword or raise an
+:python:`AssertionError`.
 A test will only fail if the assertion turns out to be false.
 Not putting an assertion will automatically cause the test to pass.
 
@@ -133,21 +134,6 @@ Alternatively, you can determine the agent from one of the first lines in the
 build logs:
 "Build working directory is /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>".
 
-Some build logs can be very large (e.g. over 100,000 lines).
-Beyond about 5,000 lines it is a good idea to download a log instead of
-viewing it in the browser.
-Beyond about 10,000 lines, some text editors may experience slowness.
-At this point it is good to split up the files with
-:bash:`split -l 10000 <log-file>`, which creates files of the form `x*` and of
-length 10,000.
-You can then run a command such as :bash:`grep -in "Errors for:" x*` to find
-which files have reported errors.
-After you are done, you can remove the files with :bash:`rm x*`.
-Note that the original log file is not modified by any of these steps.
-
-As an alternative to splitting the file,
-errors can be searched for with
-:bash:`grep -in -A <expected-number-of-errors> "Errors for:" <log-file>`.
 
 Bamboo Agent Properties
 ----------------------------------------
@@ -197,8 +183,9 @@ There should be a line above the test that gives the command to run the test
 locally, likely in the following form:
 :bash:`python -m pytest -s <test_file>.py -k '<test_name>' --exe=<executable>`.
 
-At this time, there is no way to run all the :python:`_exe` tests in a subdirectory
-and only those.
+If you have an executable, you can run the :python:`_exe` tests with
+:bash:`local_test.sh`. Use :bash:`local_test.cmd` as a template for writing
+a batch script. You can run only integration tests, only unit tests, or both.
 
 Helpful Files
 ----------------------------------------
@@ -206,7 +193,11 @@ Helpful Files
 First, run :bash:`sudo lbannusr`.
 
 To look at output and error from previous builds:
-:bash:`cd /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>/bamboo/<compiler_tests, integration_tests, or unit_tests>/<error or output>`
+:bash:`cd /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>/bamboo/<compiler_tests, integration_tests, or unit_tests>/<error or output>`.
+If the test uses the Python Front-End, use:
+:bash:`cd /usr/workspace/wsb/lbannusr/bamboo/<bamboo-agent-name>/xml-data/build-dir/<build-plan-and-job>/bamboo/<compiler_tests, integration_tests, or unit_tests>/experiments/<test-folder>`.
+(Note that these files can also be read by clicking on the "Artifacts" tab on
+the Bamboo build).
 
 To look at archived results from previous builds:
 :bash:`cd /usr/workspace/wsb/lbannusr/archives/<build-plan>`


### PR DESCRIPTION
- Add ability to shorten or extend test length/duration by using a certain `data_reader_percent`.
- Add `weekly` option to unit tests.
- By default, Weekly will use a `data_reader_percent` of 1.0 (100%) and Nightly will use 0.10 (10%).
- Add a default time limit of 35 minutes for all non-Weekly (e.g. Nightly Develop and local) tests.
