### PR TITLE
Clean up protobuf message for fully-connected layer

### DIFF
--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -42,6 +42,12 @@ namespace lbann {
  *  optionally applies an entry-wise bias. Following the
  *  column-vector convention:
  *    @f[ y = W * \text{vec}(x) + b @f]
+ *
+ *  Two weights are required if bias is applied: the linearity and the
+ *  bias. Only the linearity weights are required if bias is not
+ *  applied. If weights aren't provided, the linearity weights are
+ *  initialized with He normal initialization and the bias weights are
+ *  initialized to zero.
  */
 template <data_layout T_layout, El::Device Dev>
 class fully_connected_layer : public learning_layer {

--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -36,7 +36,13 @@
 
 namespace lbann {
 
-/** @brief Perform an affine transformation. */
+/** @brief Affine transformation
+ *
+ *  Flattens the input tensor, multiplies with a weights matrix, and
+ *  optionally applies an entry-wise bias. Following the
+ *  column-vector convention:
+ *    @f[ y = W * \text{vec}(x) + b @f]
+ */
 template <data_layout T_layout, El::Device Dev>
 class fully_connected_layer : public learning_layer {
 public:

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -195,7 +195,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }

--- a/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
+++ b/model_zoo/models/autoencoder_mnist/model_autoencoder_mnist.prototext
@@ -59,7 +59,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -82,7 +81,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -105,7 +103,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -129,7 +126,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 30
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -142,7 +138,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 250
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -165,7 +160,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 500
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -189,7 +183,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }
@@ -212,7 +205,6 @@ model {
     data_layout: "model_parallel"
     hint_layer: "image"
     fully_connected {
-      weight_initialization: "glorot_uniform"
       has_bias: true
     }
   }

--- a/model_zoo/models/candle/pilot1/combo.prototext
+++ b/model_zoo/models/candle/pilot1/combo.prototext
@@ -91,7 +91,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -122,7 +121,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -153,7 +151,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -406,7 +403,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -437,7 +433,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -468,7 +463,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1000
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }
@@ -499,7 +493,6 @@ model {
     data_layout: "model_parallel"
     fully_connected {
       num_neurons: 1
-      weight_initialization: "he_normal"
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/wae.prototext
+++ b/model_zoo/models/jag/wae.prototext
@@ -472,9 +472,8 @@ model {
     parents: "decode1_dropout"
     name: "decode0"
     data_layout: "data_parallel"
+    hint_layer: "image_data_dummy"
     fully_connected {
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/wae_cycle_gan/cycle_gan.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/cycle_gan.prototext
@@ -297,8 +297,6 @@ model {
   layer {
     fully_connected {
       #num_neurons: 2500
-      #get_slice_points_from_reader: "independent"
-      #get_num_neurons_of_slice_from_reader: [ 1 ]
       #replace image_dim with latent_dim
       num_neurons: 20
       has_bias: true
@@ -307,6 +305,7 @@ model {
     data_layout: "data_parallel"
     weights: "gen1fc4linearity gen1fc4bias"
     parents: "gen1leaky_relu3"
+    # hint_layer: "image_data_dummy"
   }
   #concat latenty sample (image_data_dummy) and param
   layer {
@@ -597,14 +596,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3"
+    hint_layer: "param_data_id"
   }
   layer {
     name: "concat_param_n_img"
@@ -1107,14 +1105,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4_cyclic"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3_cyclic"
+    hint_layer: "param_data_id"
   }
   layer {
     name: "L_cyc_x"

--- a/model_zoo/models/jag/wae_cycle_gan/cycle_gan_only.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/cycle_gan_only.prototext
@@ -189,8 +189,6 @@ model {
   layer {
     fully_connected {
       #num_neurons: 2500
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       #replace image_dim with latent_dim
       #num_neurons: 20
       has_bias: true
@@ -199,6 +197,7 @@ model {
     data_layout: "data_parallel"
     weights: "gen1fc4linearity gen1fc4bias"
     parents: "gen1leaky_relu3"
+    hint_layer: "image_data_dummy"
   }
   #concat latenty sample (image_data_dummy) and param
   layer {
@@ -479,14 +478,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3"
+    hint_layer: "param_data_id"
   }
   layer {
     name: "concat_param_n_img"
@@ -967,14 +965,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4_cyclic"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3_cyclic"
+    hint_layer: "param_data_id"
   }
   layer {
     name: "L_cyc_x"

--- a/model_zoo/models/jag/wae_cycle_gan/wae.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae.prototext
@@ -599,9 +599,8 @@ model {
     name: "decode0"
     weights: "decode0linearity decode0bias"
     data_layout: "data_parallel"
+    hint_layer: "image_data_dummy"
     fully_connected {
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }

--- a/model_zoo/models/jag/wae_cycle_gan/wae_fw_inv.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae_fw_inv.prototext
@@ -448,10 +448,9 @@ model {
     name: "decode0"
     data_layout: "data_parallel"
     weights: "decode0linearity decode0bias"
+    hint_layer: "image_data_id"
     fully_connected {
       #num_neurons: 16384
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }
@@ -620,10 +619,9 @@ model {
     name: "ae_decode0"
     data_layout: "data_parallel"
     weights: "decode0linearity decode0bias"
+    hint_layer: "image_data_id"
     fully_connected {
       #num_neurons: 16384
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }
@@ -804,14 +802,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3"
+    hint_layer: "param_data_id"
   }
 
 
@@ -900,14 +897,13 @@ model {
   layer {
     fully_connected {
       #num_neurons: 11
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 2 ]
       has_bias: true
     }
     name: "gen2fc4_cyclic"
     data_layout: "data_parallel"
     weights: "gen2fc4linearity gen2fc4bias"
     parents: "gen2leaky_relu3_cyclic"
+    hint_layer: "param_data_id"
   }
   layer {
     name: "L_cyc_x"

--- a/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
@@ -578,9 +578,8 @@ model {
     name: "decode0"
     weights: "decode0linearity decode0bias"
     data_layout: "data_parallel"
+    hint_layer: "image_data_dummy"
     fully_connected {
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }

--- a/model_zoo/models/siamese/finetune-cub/model_cub.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub.prototext
@@ -616,10 +616,10 @@ model {
     parents: "drop7_new"
     name: "fc8_new"
     data_layout: "model_parallel"
+    # The number of outputs specific to the dataset used.
+    # E.g., 200 for CUB, and 431 for CompCars.
+    hint_layer: "label_new"
     fully_connected {
-      # The number of outputs specific to the dataset used.
-      # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm.prototext
@@ -770,10 +770,10 @@ model {
     parents: "drop7_new"
     name: "fc8_new"
     data_layout: "data_parallel"
+    # The number of outputs specific to the dataset used.
+    # E.g., 200 for CUB, and 431 for CompCars.
+    hint_layer: "label_new"
     fully_connected {
-      # The number of outputs specific to the dataset used.
-      # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
+++ b/model_zoo/models/siamese/finetune-cub/model_cub_batchnorm_transferred_and_frozen.prototext
@@ -1032,10 +1032,10 @@ model {
     name: "fc8_new"
     children: "prob_new"
     data_layout: "data_parallel"
+    # The number of outputs specific to the dataset used.
+    # E.g., 200 for CUB, and 431 for CompCars.
+    hint_layer: "label_new"
     fully_connected {
-      # The number of outputs specific to the dataset used.
-      # E.g., 200 for CUB, and 431 for CompCars.
-      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc8_new_linearity fc8_new_bias"

--- a/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
+++ b/model_zoo/models/siamese/triplet/model_triplet_alexnet_batchnorm_dag_frozen_bn.prototext
@@ -1610,8 +1610,8 @@ model {
     name: "fc9"
     children: "prob"
     data_layout: "data_parallel"
+    hint_layer: "label"
     fully_connected {
-      num_neurons_is_num_labels: true
       has_bias: false
     }
     weights: "fc9_linearity fc9_bias"

--- a/model_zoo/tests/data_reader_tests/jag_single_layer_ae.prototext
+++ b/model_zoo/tests/data_reader_tests/jag_single_layer_ae.prototext
@@ -95,9 +95,8 @@ model {
     parents: "encodefc1"
     name: "decode0"
     data_layout: "data_parallel"
+    hint_layer: "image_data_dummy"
     fully_connected {
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }

--- a/model_zoo/tests/model_jag_single_layer_ae.prototext
+++ b/model_zoo/tests/model_jag_single_layer_ae.prototext
@@ -123,9 +123,8 @@ model {
     parents: "encodeelu"
     name: "decode"
     data_layout: "data_parallel"
+    hint_layer: "image_data_dummy"
     fully_connected {
-      get_slice_points_from_reader: "independent"
-      get_num_neurons_of_slice_from_reader: [ 1 ]
       has_bias: true
     }
   }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -146,41 +146,9 @@ std::unique_ptr<Layer> construct_layer(
   // Fully connected layer
   if (proto_layer.has_fully_connected()) {
     const auto& params = proto_layer.fully_connected();
-    int num_neurons = 0;
-    std::string num_neurons_method_name;
-
-    if (params.get_num_neurons_of_slice_from_reader_size() > 0) {
-      num_neurons_method_name = "get_num_neurons_of_slice_from_reader";
-      const auto dr_generic  = lbann::peek_map(data_readers, execution_mode::training);
-      const int num_slice_indices = params.get_num_neurons_of_slice_from_reader_size();
-      if (dynamic_cast<lbann::data_reader_jag_conduit*>(dr_generic) != nullptr) {
-        const std::string& var = params.get_slice_points_from_reader();
-        bool is_supported = false; /// @todo Remove unneeded function parameter
-        const auto slice_points = get_slice_points_from_reader(dr_generic, var, is_supported);
-        for (int i = 0; i < num_slice_indices; ++i) {
-          const size_t idx = static_cast<size_t>(params.get_num_neurons_of_slice_from_reader(i));
-          if ((idx == 0u) || (idx >= slice_points.size())) {
-            err << "invalid slice index from get_num_neurons_of_slice_from_reader";
-            LBANN_ERROR(err.str());
-          }
-          const int diff = static_cast<int>(slice_points[idx] - slice_points[idx-1]);
-          num_neurons += diff;
-        }
-      }
-    } else {
-      num_neurons_method_name = "num_neurons";
-      num_neurons = params.num_neurons();
-      if (proto_layer.num_neurons_from_data_reader()) {
-        const auto dr  = lbann::peek_map(data_readers, execution_mode::training);
-        if (!dr) {
-          LBANN_ERROR("training data reader does not exist!");
-        }
-        num_neurons = dr->get_linearized_data_size();
-      }
-    }
     return lbann::make_unique<fully_connected_layer<Layout, Device>>(
              comm,
-             num_neurons,
+             params.num_neurons(),
              params.transpose(),
              nullptr,
              params.has_bias());

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -442,7 +442,6 @@ message Layer {
   /////////////////////
   message FullyConnected {
     int64 num_neurons = 1;
-    string weight_initialization = 2;    //DEPRECATED
     bool has_bias = 3;                   //default: true
     double bias_initial_value = 4;       //default: 0
     double l2_regularization_factor = 5; //default: 0

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -440,14 +440,22 @@ message Layer {
   /////////////////////
   // Learning layers //
   /////////////////////
-  message FullyConnected {
-    int64 num_neurons = 1;
-    bool has_bias = 3;                   //default: true
-    double bias_initial_value = 4;       //default: 0
-    bool transpose = 7;
 
-    repeated uint32 get_num_neurons_of_slice_from_reader = 13;
-    string get_slice_points_from_reader = 14;
+  // Affine transformation
+  //
+  // Flattens the input tensor, multiplies with a weights matrix, and
+  // optionally applies an entry-wise bias. Following the
+  // column-vector convention:
+  //   y = W * vec(x) + b
+  message FullyConnected {
+    // Output tensor size
+    int64 num_neurons = 1;
+    // Whether to apply entry-wise bias
+    bool has_bias = 2;
+    // Initial value of bias tensor
+    double bias_initial_value = 3;
+    // Whether to apply transpose of weights matrix
+    bool transpose = 4;
   }
 
   message Convolution {

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -444,8 +444,6 @@ message Layer {
     int64 num_neurons = 1;
     bool has_bias = 3;                   //default: true
     double bias_initial_value = 4;       //default: 0
-    double l2_regularization_factor = 5; //default: 0
-    double group_lasso_regularization_factor = 6; //default: 0
     bool transpose = 7;
     bool num_neurons_is_num_labels = 8;
 

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -446,10 +446,6 @@ message Layer {
     double bias_initial_value = 4;       //default: 0
     bool transpose = 7;
 
-    bool get_input_dimension_from_reader = 9;
-    bool get_image_and_scalar_dimension_from_reader = 10;
-    bool get_image_dimension_from_reader = 11;
-    bool get_scalar_dimension_from_reader = 12;
     repeated uint32 get_num_neurons_of_slice_from_reader = 13;
     string get_slice_points_from_reader = 14;
   }

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -441,12 +441,19 @@ message Layer {
   // Learning layers //
   /////////////////////
 
-  // Affine transformation
-  //
-  // Flattens the input tensor, multiplies with a weights matrix, and
-  // optionally applies an entry-wise bias. Following the
-  // column-vector convention:
-  //   y = W * vec(x) + b
+  /** @brief Affine transformation
+   *
+   *  Flattens the input tensor, multiplies with a weights matrix, and
+   *  optionally applies an entry-wise bias. Following the
+   *  column-vector convention:
+   *    @f[ y = W * \text{vec}(x) + b @f]
+   *
+   *  Two weights are required if bias is applied: the linearity and the
+   *  bias. Only the linearity weights are required if bias is not
+   *  applied. If weights aren't provided, the linearity weights are
+   *  initialized with He normal initialization and the bias weights are
+   *  initialized to zero.
+   */
   message FullyConnected {
     // Output tensor size
     int64 num_neurons = 1;

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -452,10 +452,8 @@ message Layer {
     int64 num_neurons = 1;
     // Whether to apply entry-wise bias
     bool has_bias = 2;
-    // Initial value of bias tensor
-    double bias_initial_value = 3;
     // Whether to apply transpose of weights matrix
-    bool transpose = 4;
+    bool transpose = 3;
   }
 
   message Convolution {

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -445,7 +445,6 @@ message Layer {
     bool has_bias = 3;                   //default: true
     double bias_initial_value = 4;       //default: 0
     bool transpose = 7;
-    bool num_neurons_is_num_labels = 8;
 
     bool get_input_dimension_from_reader = 9;
     bool get_image_and_scalar_dimension_from_reader = 10;


### PR DESCRIPTION
### Summary

I've gone through and removed a bunch of fields from the FC layer protobuf message. 

Making progress toward #297.

### Unused fields

Users could set these fields, but they didn't affect anything:

- `weight_initialization`
- `bias_initial_value`
- `l2_regularization_factor`
- `double group_lasso_regularization_factor`
- `get_input_dimension_from_reader`
- `get_image_and_scalar_dimension_from_reader`
- `get_image_dimension_from_reader`
- `get_scalar_dimension_from_reader`

### (Mostly) JAG-specific fields

The following fields were used to get dimensions from the data reader:

- `num_neurons_is_num_labels`
- `get_num_neurons_of_slice_from_reader`
- `get_slice_points_from_reader`

This required a lot of complicated interaction between the prototext parser and the data reader (mostly `data_reader_jag_conduit`). It's more general to use the `hint_layer` field, which sets the output dimensions to match another layer. Importantly, this functionality can be used for any layer with user-selected output dimensions, not just the FC layer.

From what I can tell, we implemented the "get slice point from reader" functionality to get around the fact that the data reader can only output one data tensor (plus one label tensor). The JAG models require three data tensors: image, scalars, inputs. The hack was to flatten the tensors, concatenate them in the data reader, and apply a slice layer to recover the original tensors. This works, but a better approach would be to refactor the data reader so it can emit an arbitrary number of output tensors. Once this is done, the `hint_layer` approach becomes easier since you can just set the output of the input layer as the hint.