### PR TITLE
Fix bug in CIFAR autoencoder integration test

### DIFF
--- a/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
+++ b/model_zoo/models/autoencoder_cifar10/model_conv_autoencoder_cifar10.prototext
@@ -7,7 +7,6 @@ model {
   data_layout: "data_parallel"
   mini_batch_size: 128
   num_epochs: 10
-  procs_per_trainer: 0
   disable_cuda: true
 
   ###################################################


### PR DESCRIPTION
PR #916 moved the `procs_per_trainer` protobuf field from `Model` to `Trainer`. We forgot to make this change in a CIFAR-10 autoencoder model, which caused a problem in the corresponding Bamboo integration test.