### PR TITLE
Synchronize IO thread pool in input layer destructor

### DIFF
--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -93,6 +93,16 @@ class generic_input_layer : public io_layer {
   }
 
   ~generic_input_layer() override {
+
+    // Synchronize the I/O thread pool
+    // Note: The thread pool may still be running asynchronously if the
+    // trainer is destroyed in the middle of an epoch. The thread pool
+    // needs to interact with data readers, etc., so it needs to be
+    // synchronized before any of them are destroyed.
+    if (this->m_model != nullptr) {
+      this->m_model->get_execution_context().get_io_thread_pool().reap_threads();
+    }
+
     for (auto& io_buffer : m_io_buffers) {
       delete io_buffer;
     }

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -86,6 +86,16 @@ trainer& trainer::operator=(const trainer& other) {
 }
 
 trainer::~trainer() {
+
+  // Synchronize the I/O thread pool
+  // Note: The thread pool may still be running asynchronously if the
+  // trainer is destroyed in the middle of an epoch. The thread pool
+  // needs to interact with data readers, etc., so it needs to be
+  // synchronized before any of them are destroyed.
+  if (m_io_thread_pool != nullptr) {
+    m_io_thread_pool->reap_threads();
+  }
+
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -86,16 +86,6 @@ trainer& trainer::operator=(const trainer& other) {
 }
 
 trainer::~trainer() {
-
-  // Synchronize the I/O thread pool
-  // Note: The thread pool may still be running asynchronously if the
-  // trainer is destroyed in the middle of an epoch. The thread pool
-  // needs to interact with data readers, etc., so it needs to be
-  // synchronized before any of them are destroyed.
-  if (m_io_thread_pool != nullptr) {
-    m_io_thread_pool->reap_threads();
-  }
-
 }
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
As discussed in #1236, the IO thread pool is sometimes active when the program ends, which causes segfaults when it interacts with data readers that have already been destroyed. The quick fix is to synchronize the thread pool in the trainer's destructor, after which the data reader can be safely destroyed. I don't see any more errors when I run my minimum reproducer on Catalyst.

Closes #1236.