### PR TITLE
Fix some documentation problems

### DIFF
--- a/docs/SourceTreeDoxyfile
+++ b/docs/SourceTreeDoxyfile
@@ -1616,7 +1616,7 @@ PAPER_TYPE             = a4wide
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = amsmath
+EXTRA_PACKAGES         = amsmath, amssymb, amsfonts, latexsym
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -65,13 +65,13 @@ public:
   }
 
   /** @brief Current step in the training algorithm
-    *  @detailed Step counts the number of iterations in the training
+    *  @details Step counts the number of iterations in the training
     *  algorithm's internal state
     */
   size_t get_step() const noexcept { return m_step; }
 
   /** @brief Increment the current step in the training algorithm
-    *  @detailed Increment the step count in the training
+    *  @details Increment the step count in the training
     *  algorithm's internal state
     */
   void inc_step() noexcept { ++m_step; }
@@ -139,13 +139,13 @@ private:
   execution_mode m_execution_mode = execution_mode::training;
 
   /** @brief Current step in the training algorithm
-    *  @detailed Step counts the number of iterations in the training
+    *  @details Step counts the number of iterations in the training
     *  algorithm's internal state
     */
   size_t m_step = 0;
 
   /** @brief Whether to terminate training.
-   *  @detailed If true, training will terminate immediately before
+   *  @details If true, training will terminate immediately before
    *  the next epoch.
    */
   bool m_terminate_training = false;

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -39,7 +39,7 @@ public:
 
 /** @brief SGD Uses the step to track the Current mini-batch step for
   *  execution mode.
-  *  @detailed Step counts are not reset after each epoch.
+  *  @details Step counts are not reset after each epoch.
   */
 class sgd_execution_context final : public execution_context {
 public:
@@ -71,7 +71,7 @@ public:
   inline size_t get_epoch() const noexcept { return m_epoch; }
 
   /** @brief Increment the current epoch in the execution context
-    *  @detailed Increment the counter tracking the number of times
+    *  @details Increment the counter tracking the number of times
     *  that the data set has been traversed.
     */
   void inc_epoch() noexcept { ++m_epoch; }

--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -48,7 +48,7 @@ namespace lbann {
  *  The scale and bias vectors are fused into a single weights tensor
  *  to reduce the number of gradient allreduces during backprop. In
  *  particular, the weights tensor is a
- *  @f$ \text{num_channels} \times 2 @f$ matrix, where the first
+ *  @f$ \text{num\_channels} \times 2 @f$ matrix, where the first
  *  column correspond to scale terms and the second column to bias
  *  terms.
  */


### PR DESCRIPTION
There were some issues generating LaTeX output (for those wanting a PDF of the docs). Also, the doxygen command is `@details`, not `@detailed`. There are many more warnings, but the LaTeX issue actually stopped the build and the `@details` issue was the most obvious and easily `sed`-ed.