### PR TITLE
Add some doc text for new directories

### DIFF
--- a/docs/RSTDocsFlavorText.py
+++ b/docs/RSTDocsFlavorText.py
@@ -57,10 +57,10 @@ The data store provides in-memory caching of the data set and
 inter-epoch data shuffling.''',
 
     'execution_contexts' : '''
-When a model is attached to a trainer the execution context of the
-training algorithm is stored in an execution_context class (or
-sub-class) per execution mode.  Thus there is one execution context
-per model and mode that contains all of the state with respect to the
+When a model is attached to a trainer, the execution context of the
+training algorithm is stored in an `execution_context` (or sub-class)
+object per execution mode.  Thus there is one execution context per
+model and mode that contains all of the state with respect to the
 training algorithm being applied to the model.
 
 For example it tracks the current:
@@ -68,7 +68,7 @@ For example it tracks the current:
 * step
 * execution mode
 * epoch
-* and a pointer back to the trainer
+* and a pointer back to the trainer.
 ''',
 
     'layers' : '''
@@ -123,21 +123,22 @@ python front end of LBANN will emit a network description in the
 protobuf format that is ingested at runtime.''',
 
     'trainers' : '''
-A trainer is a collection of compute resources and defines a explicit
-communication domain.  It provides the execution for both the training
-and inference of a trained model.  Once constructed a trainer owns an
-LBANN comm object that defines both intra- and inter-trainer
+A trainer is a collection of compute resources and defines an explicit
+communication domain.  It manages the execution for both the training
+and inference of a trained model.  Once constructed, a trainer owns an
+`lbann_comm` object that defines both intra- and inter-trainer
 communication domains.  Additionally, a trainer will contain an I/O
-thread pool that is used to fetch and pre-process data that will be
+thread pool that is used to fetch and preprocess data that will be
 provided to the trainer's models.
 
 A trainer owns:
 
-* comm object
-* I/O thread pool
-* One or more models
-* Execution context for each model
-* In the future, it will also contain the data readers.
+* `lbann_comm` object,
+* I/O thread pool,
+* One or more models, and
+* Execution context for each model.
+
+In the future, it will also contain the data readers.
 ''',
 
     'training_algorithms' : '''

--- a/docs/RSTDocsFlavorText.py
+++ b/docs/RSTDocsFlavorText.py
@@ -56,6 +56,21 @@ code.''',
 The data store provides in-memory caching of the data set and
 inter-epoch data shuffling.''',
 
+    'execution_contexts' : '''
+When a model is attached to a trainer the execution context of the
+training algorithm is stored in an execution_context class (or
+sub-class) per execution mode.  Thus there is one execution context
+per model and mode that contains all of the state with respect to the
+training algorithm being applied to the model.
+
+For example it tracks the current:
+
+* step
+* execution mode
+* epoch
+* and a pointer back to the trainer
+''',
+
     'layers' : '''
 LBANN models are defined in model prototext files. The bulk of these
 defintions will be the series of layers which make up the model
@@ -106,6 +121,30 @@ architecture of neural networks, data readers, and optimizers. It
 serves as the "assembly language" interface to the toolkit. The
 python front end of LBANN will emit a network description in the
 protobuf format that is ingested at runtime.''',
+
+    'trainers' : '''
+A trainer is a collection of compute resources and defines a explicit
+communication domain.  It provides the execution for both the training
+and inference of a trained model.  Once constructed a trainer owns an
+LBANN comm object that defines both intra- and inter-trainer
+communication domains.  Additionally, a trainer will contain an I/O
+thread pool that is used to fetch and pre-process data that will be
+provided to the trainer's models.
+
+A trainer owns:
+
+* comm object
+* I/O thread pool
+* One or more models
+* Execution context for each model
+* In the future, it will also contain the data readers.
+''',
+
+    'training_algorithms' : '''
+The training algorithm defines the optimization that is to be
+applied to the model(s) being trained.  Additionally, it can
+specify how to evaluate the model.
+''',
 
     'utils' : 'Utility classes and functions.',
 

--- a/docs/RSTDocsFlavorText.py
+++ b/docs/RSTDocsFlavorText.py
@@ -9,6 +9,7 @@ lbann_rst_headers = {
     'callbacks' : 'Callback Interface',
     'data_readers' : 'Data Readers Interface',
     'data_store' : 'Data Store Interface',
+    'execution_contexts' : 'Execution Context Interface',
     'layers' : 'Layer Interface',
     'layers/activations' : 'Activation Layers',
     'layers/image' : 'Image Layers',
@@ -26,6 +27,9 @@ lbann_rst_headers = {
     'objective_functions/weight_regularization' : 'Objective Functions for Weight Regularization',
     'optimizers' : 'Optimizer Interface',
     'proto' : 'Protobuf and Front-End Utilities',
+    'trainers' : 'Trainer Interface',
+    'training_algorithms' : 'Training Algorithm Interface',
+    'transforms' : 'Transform Interface',
     'utils' : 'General Utilities',
     'utils/threads' : 'Multithreading Utilities',
     'weights' : 'Weights Interface'


### PR DESCRIPTION
I noticed that the docs had not be updated to take into account #916. This just takes the `lbann.rst` text about these classes and adds it to the auto-generated class documentation pages.