### PR TITLE
Made data_reader_jag_conduit::preload_data_store() more efficient

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -346,6 +346,7 @@ class data_reader_jag_conduit : public generic_data_reader {
 
   bool has_path(const file_handle_t& h, const std::string& path) const;
   void read_node(const file_handle_t& h, const std::string& path, conduit::Node& n) const;
+  void read_partial_node(const file_handle_t& h, const std::string& path, conduit::Node& n) const;
 
   /// Allow const access to the conduit data structure
   static const conduit::Node& get_conduit_node(const conduit::Node& n_base, const std::string key);

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -717,7 +717,7 @@ void generic_data_reader::instantiate_data_store(const std::vector<int>& local_l
   // optionally preload the data store
   if (opts->get_bool("preload_data_store") && !opts->get_bool("data_store_cache")) {
     if(is_master()) {
-      std::cout << "generic_data_reader::instantiate_data_store - Starting the preload" << std::endl;
+      std::cerr << "generic_data_reader::instantiate_data_store - Starting the preload" << std::endl;
     }
     double tm2 = get_time();
     if (local_list_sizes.size() != 0) {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -355,10 +355,54 @@ bool data_reader_jag_conduit::load_conduit_node(const size_t i, const std::strin
     }
   }
 
-  read_node(h, path, node);
+  if (options::get()->get_bool("old_method") || ! options::get()->get_bool("preload_data_store")) {
+    read_node(h, path, node);
+  } else {
+    read_partial_node(h, path, node);
+  }
 
   return true;
 }
+
+#ifdef _USE_IO_HANDLE_
+void data_reader_jag_conduit::read_partial_node(const data_reader_jag_conduit::file_handle_t& h, const std::string& path, conduit::Node& n) const {
+  LBANN_ERROR("Not implemented; please contact Dave Hysom");
+}
+#else
+
+void data_reader_jag_conduit::read_partial_node(const data_reader_jag_conduit::file_handle_t& h, const std::string& path, conduit::Node& n) const {
+  conduit::Node work;
+  if (!has_path(h, path)) {
+    LBANN_ERROR("has_path failed for: ", path, ": num nodes successfully loaded by this rank: ", m_data_store->get_data_size());
+  }
+  const std::string key = path + "/inputs";
+  const std::string key2 = path + "/outputs/scalars";
+
+  if (! has_path(h, key)) {
+    LBANN_ERROR("has_path failed for: ", key, ": num nodes successfully loaded by this rank: ", m_data_store->get_data_size());
+  }
+  conduit::relay::io::hdf5_read(h, key, work);
+  n["inputs"] = work;
+  //n[key2] = work;
+
+  if (! has_path(h, key2)) {
+    LBANN_ERROR("has_path failed for: ", key2, ": num nodes successfully loaded by this rank: ", m_data_store->get_data_size());
+  }
+  conduit::relay::io::hdf5_read(h, key2, work);
+  n["/outputs/scalars"] = work;
+  //n[key] = work;
+
+  for (auto &&t : m_emi_image_keys) {
+    const std::string key3 = "/" + path + "/outputs/images/" + t;
+    if (! has_path(h, key3)) {
+      LBANN_ERROR("has_path failed for: ", key3, ": num nodes successfully loaded by this rank: ", m_data_store->get_data_size());
+    }
+    conduit::relay::io::hdf5_read(h, key3, work);
+    //n[key3] = work;
+    n["/outputs/images/" + t] = work;
+  }
+}
+#endif
 
 bool data_reader_jag_conduit::has_conduit_path(const size_t i, const std::string& key) const {
   const sample_t& s = m_sample_list[i];
@@ -778,19 +822,24 @@ void data_reader_jag_conduit::load() {
   m_shuffled_indices.clear();
 
   if(is_master()) {
-    std::cout << "starting load" << std::endl;
+    std::cout << "data_reader_jag_conduit - starting load" << std::endl;
   }
   const std::string data_dir = add_delimiter(get_file_dir());
   const std::string sample_list_file = data_dir + get_data_index_list();
 
   options *opts = options::get();
+  bool check_data = ! opts->get_bool("no_check_data");
 
   /// The use of these flags need to be updated to properly separate
   /// how index lists are used between trainers and models
   /// @todo m_list_per_trainer || m_list_per_model
   load_list_of_samples(sample_list_file, m_comm->get_procs_per_trainer(), m_comm->get_rank_in_trainer());
   if(is_master()) {
-    std::cout << "Finished sample list, check data" << std::endl;
+    if (check_data) {
+      std::cout << "Finished sample list, check data" << std::endl;
+    } else {
+      std::cout << "Finished sample list, skipping check data" << std::endl;
+    }
   }
 
   /// Check the data that each rank loaded
@@ -803,14 +852,20 @@ void data_reader_jag_conduit::load() {
     if (m_scalar_keys.size() == 0u) {
       set_all_scalar_choices(); // use all by default if none is specified
     }
-    check_scalar_keys();
+    if (check_data) {
+      check_scalar_keys();
+    }  
 
     if (m_input_keys.size() == 0u) {
       set_all_input_choices(); // use all by default if none is specified
     }
-    check_input_keys();
+    if (check_data) {
+      check_input_keys();
+    }  
 
-    check_image_data();
+    if (check_data) {
+      check_image_data();
+    }  
 
     m_sample_list.close_if_done_samples_file_handle(0);
   }
@@ -856,7 +911,6 @@ void data_reader_jag_conduit::load() {
       }
     }
   }
-
   instantiate_data_store(local_list_sizes);
 
   select_subset_of_data();
@@ -875,9 +929,7 @@ void data_reader_jag_conduit::preload_data_store() {
   double tm1 = get_time();
   if (get_comm()->am_world_master() ||
       (opts->get_bool("ltfb_verbose") && get_comm()->am_trainer_master())) {
-    std::stringstream msg;
-    msg << " for role: " << get_role() << " starting preload";
-    LBANN_WARNING(msg.str());
+    LBANN_WARNING("starting preload for role: ", get_role(), "; --old_method=", opts->get_bool("old_method"));
   }
 
   for (size_t idx=0; idx < m_shuffled_indices.size(); idx++) {
@@ -892,7 +944,6 @@ void data_reader_jag_conduit::preload_data_store() {
       conduit::Node & node = m_data_store->get_empty_node(index);
       const std::string padded_idx = '/' + LBANN_DATA_ID_STR(index);
       node[padded_idx] = work;
-
       m_data_store->set_preloaded_conduit_node(index, node);
     } catch (conduit::Error const& e) {
       LBANN_ERROR(" :: trying to load the node " + std::to_string(index) + " with key " + key + " and got " + e.what());
@@ -906,6 +957,8 @@ void data_reader_jag_conduit::preload_data_store() {
     }
     m_sample_list.close_if_done_samples_file_handle(index);
   }
+
+
   if (get_comm()->am_world_master() ||
       (opts->get_bool("ltfb_verbose") && get_comm()->am_trainer_master())) {
     std::stringstream msg;
@@ -1209,11 +1262,13 @@ data_reader_jag_conduit::get_image_data(const size_t sample_id, conduit::Node& s
 
   for (const auto& emi_tag : m_emi_image_keys) {
     const std::string conduit_field = m_output_image_prefix + emi_tag;
-    const std::string conduit_obj = '/' + LBANN_DATA_ID_STR(sample_id) + '/' + conduit_field;
+    const std::string conduit_obj = LBANN_DATA_ID_STR(sample_id) + conduit_field;
     if(sample[conduit_obj].schema().dtype().is_empty()) {
       if (data_store_active()) {
-        LBANN_ERROR("Unable to find field " + conduit_obj
-                    + " in conduit node: " + std::to_string(sample_id));
+        LBANN_ERROR("Unable to find field ", conduit_obj,
+                    " in conduit node: ", std::to_string(sample_id),
+                    ": num nodes successfully loaded by this rank: ", 
+                    m_data_store->get_data_size(), " num successful calls to get_image_data on this rank: ");
       }
       conduit::Node n_image;
       bool from_file = load_conduit_node(sample_id, conduit_field, n_image);
@@ -1232,6 +1287,7 @@ data_reader_jag_conduit::get_image_data(const size_t sample_id, conduit::Node& s
 
   return image_ptrs;
 }
+
 
 std::vector<data_reader_jag_conduit::scalar_t> data_reader_jag_conduit::get_scalars(const size_t sample_id, conduit::Node& sample) const {
   std::vector<scalar_t> scalars;


### PR DESCRIPTION
 Previously, data_reader_jag_conduit::preload_data_store() loaded entire JAG conduit nodes into the data_store, even though we currently only use ~25% of the data. This PR modifies the preload so that only that portion of the JAG data that we use is loaded. This results in over a 4x reduction in memory usage. Accordingly, MPI volume for exchanging the data is reduced by slightly over a factor of 4x (this will of course change, if/when we use more/less of the data fields).

The previous behavior has been retained for testing purposes. To employ it, include the cmd line flag: --old_method

Additionally you can skip the (time-consuming) data checking phase by including the cmd line flag: --no_data_check