### PR TITLE
Use CMake mechanism for correctly finding Python libraries

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -64,13 +64,19 @@ execute_process(
   COMMAND "${Python_EXECUTABLE}" "-c"
   "import sys; from distutils.sysconfig import get_config_var; sys.stdout.write(get_config_var('LIBDIR'))"
   OUTPUT_VARIABLE _LIB_DIR)
-if (BUILD_SHARED_LIBS)
-  set(_GLOB_EXPR "${_LIB_DIR}/libpython*${CMAKE_SHARED_LIBRARY_SUFFIX}")
-ELSE (BUILD_SHARED_LIBS)
-  set(_GLOB_EXPR "${_LIB_DIR}/libpython*${CMAKE_STATIC_LIBRARY_SUFFIX}")
-endif (BUILD_SHARED_LIBS)
-FILE(GLOB _GLOB_RESULT "${_GLOB_EXPR}")
-get_filename_component(Python_LIBRARIES "${_GLOB_RESULT}" ABSOLUTE)
+
+set(_PY_MAJ_MIN_VERSION "${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}")
+find_library(Python_LIBRARY
+  NAMES python python${_PY_MAJ_MIN_VERSION}m python${_PY_MAJ_MIN_VERSION}
+  python${Python_VERSION_MAJOR}m python${Python_VERSION_MAJOR}
+  HINTS ${_LIB_DIR}
+  DOC "The python${Python_VERSION_MAJOR} library."
+  NO_DEFAULT_PATH)
+if (NOT Python_LIBRARY)
+  message(FATAL_ERROR "Could not find Python library for version "
+    "${_PY_MAJ_MIN_VERSION} in directory: ${_LIB_DIR}")
+endif ()
+set(Python_LIBRARIES "${Python_LIBRARY}")
 
 # Handle the find_package arguments
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
The logic in the module is flawed. There's no relationship between LBANN's decision to build a shared or static library and whether or not Python should be linked dynamically or statically. Additionally, this may not even link to the proper libraries in the proper order -- if you're using, e.g., v3.7 but you had v3.5 installed to the same prefix previously, the file glob would find, e.g., both `libpython3.5m.a` and `libpython3.7m.a` and add them to the link line *in that order*. Realistically this is only likely to result in you getting something different than you were expecting, but it could affect behavior if some relevant behavior changes across versions.

I'm not sure how Python2 is affected; I'm also not concerned since we only have to live with that for [a short time](https://pythonclock.org). Oh, would that the seconds tick faster!