### PR TITLE
Add Catch2 tests for embedded Python session

### DIFF
--- a/include/lbann/utils/python.hpp
+++ b/include/lbann/utils/python.hpp
@@ -148,6 +148,13 @@ public:
    */
   PyObject* release() noexcept;
 
+  /** Convert Python @c str to C++ @c std::string. */
+  operator std::string();
+  /** Convert Python @c int to C++ @c long. */
+  operator long();
+  /** Convert Python @c float to C++ @c double. */
+  operator double();
+
 private:
 
   /** Python object pointer. */

--- a/include/lbann/utils/python.hpp
+++ b/include/lbann/utils/python.hpp
@@ -61,8 +61,9 @@ bool is_active();
 
 /** @brief Check if a Python error has occurred.
  *
- *  Throws an exception if a Python error is detected. The GIL is
- *  acquired internally.
+ *  If a Python error is detected, then the Python error indicator is
+ *  cleared and a C++ exception is thrown. The GIL is acquired
+ *  internally.
  *
  *  @param force_error Whether to force an exception to be thrown.
  */

--- a/src/utils/python.cpp
+++ b/src/utils/python.cpp
@@ -136,6 +136,7 @@ void check_error(bool force_error) {
 
     // Clean up and throw exception
     PyErr_Restore(type.release(), value.release(), traceback.release());
+    PyErr_Clear();
     LBANN_ERROR(err.str());
 
   }

--- a/src/utils/python.cpp
+++ b/src/utils/python.cpp
@@ -221,6 +221,41 @@ PyObject* object::release() noexcept {
   return old_ptr;
 }
 
+object::operator std::string() {
+  global_interpreter_lock gil;
+  if (m_ptr == nullptr) {
+    LBANN_ERROR("Attempted to convert Python object to std::string, "
+                "but it has not been set");
+  }
+  object python_str = PyObject_Str(m_ptr);
+  std::ostringstream ss;
+  ss << PyUnicode_AsUTF8(python_str);
+  check_error();
+  return ss.str();
+}
+
+object::operator long() {
+  global_interpreter_lock gil;
+  if (m_ptr == nullptr) {
+    LBANN_ERROR("Attempted to convert Python object to long, "
+                "but it has not been set");
+  }
+  auto val = PyLong_AsLong(m_ptr);
+  check_error();
+  return val;
+}
+
+object::operator double() {
+  global_interpreter_lock gil;
+  if (m_ptr == nullptr) {
+    LBANN_ERROR("Attempted to convert Python object to double, "
+                "but it has not been set");
+  }
+  auto val = PyFloat_AsDouble(m_ptr);
+  check_error();
+  return val;
+}
+
 } // namespace python
 } // namespace lbann
 

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(_DIR_LBANN_CATCH2_TEST_FILES
   beta_distribution_test.cpp
   factory_test.cpp
   image_test.cpp
+  python_test.cpp
   random_test.cpp
   type_erased_matrix_test.cpp
   )

--- a/src/utils/unit_test/python_test.cpp
+++ b/src/utils/unit_test/python_test.cpp
@@ -100,6 +100,13 @@ def make_syntax_error():
       REQUIRE_NOTHROW(lbann::python::check_error());
     }
 
+    SECTION("PyObject* constructor with null pointer") {
+      std::unique_ptr<lbann::python::object> obj;
+      REQUIRE_NOTHROW(obj.reset(new lbann::python::object(nullptr)));
+      REQUIRE_NOTHROW(obj.reset());
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
     SECTION("PyObject* access functions") {
       PyObject* ptr = Py_BuildValue("(i,d,s)", 12, 3.4, "56");
       REQUIRE(ptr != nullptr);

--- a/src/utils/unit_test/python_test.cpp
+++ b/src/utils/unit_test/python_test.cpp
@@ -1,0 +1,224 @@
+// MUST include this
+#include <catch2/catch.hpp>
+
+// File being tested
+#include <lbann/utils/python.hpp>
+
+#ifdef LBANN_HAS_PYTHON
+TEST_CASE ("Testing the embedded Python session", "[python][utilities]") {
+
+  /// @todo Test finalization and reinitialization
+  SECTION("Before initialization") {
+    // Check twice to make sure interacting doesn't initialize Python
+    CHECK_FALSE(lbann::python::is_active());
+    CHECK_FALSE(lbann::python::is_active());
+  }
+
+  SECTION("Initialization") {
+    REQUIRE_NOTHROW(lbann::python::initialize());
+    REQUIRE(lbann::python::is_active());
+  }
+
+  SECTION("Global interpreter lock") {
+    SECTION("Acquire GIL once") {
+      std::unique_ptr<lbann::python::global_interpreter_lock> gil;
+      REQUIRE_NOTHROW(gil.reset(new lbann::python::global_interpreter_lock()));
+      REQUIRE_NOTHROW(gil.reset());
+    }
+    SECTION("Acquire GIL recursively") {
+      std::unique_ptr<lbann::python::global_interpreter_lock> gil1, gil2, gil3;
+      REQUIRE_NOTHROW(gil1.reset(new lbann::python::global_interpreter_lock()));
+      REQUIRE_NOTHROW(gil2.reset(new lbann::python::global_interpreter_lock()));
+      REQUIRE_NOTHROW(gil3.reset(new lbann::python::global_interpreter_lock()));
+      REQUIRE_NOTHROW(gil3.reset());
+      REQUIRE_NOTHROW(gil2.reset());
+      REQUIRE_NOTHROW(gil1.reset());
+    }
+  }
+
+  SECTION("Python error checking") {
+    lbann::python::global_interpreter_lock gil;
+    REQUIRE_NOTHROW(lbann::python::check_error());
+    REQUIRE_THROWS(lbann::python::check_error(true));
+
+    // Syntax error
+    /// @todo Handle exception gracefully
+    // auto main = PyImport_ImportModule("__main__");
+    // auto x = PyObject_GetAttrString(main, "_bogus_variable_name({)}))");
+    // REQUIRE(x == nullptr);
+    //REQUIRE_THROWS(lbann::python::check_error());
+    // Py_DECREF(main);
+    REQUIRE_NOTHROW(lbann::python::check_error());
+
+  }
+
+  SECTION("Python object") {
+    lbann::python::global_interpreter_lock gil;
+
+    SECTION("Default constructor") {
+      std::unique_ptr<lbann::python::object> obj;
+      REQUIRE_NOTHROW(obj.reset(new lbann::python::object()));
+      REQUIRE(*obj == nullptr);
+      REQUIRE_NOTHROW(obj.reset());
+    }
+
+    SECTION("PyObject* constructor") {
+      PyObject* ptr = Py_BuildValue("(i,d,s)", 987, 6.54, "321");
+      REQUIRE(ptr != nullptr);
+      Py_INCREF(ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      std::unique_ptr<lbann::python::object> obj;
+      REQUIRE_NOTHROW(obj.reset(new lbann::python::object(ptr)));
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE_NOTHROW(obj.reset());
+      REQUIRE(Py_REFCNT(ptr) == 1);
+      Py_DECREF(ptr);
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("PyObject* access functions") {
+      PyObject* ptr = Py_BuildValue("(i,d,s)", 12, 3.4, "56");
+      REQUIRE(ptr != nullptr);
+      Py_INCREF(ptr);
+      std::unique_ptr<lbann::python::object> obj;
+      REQUIRE_NOTHROW(obj.reset(new lbann::python::object(ptr)));
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE(obj->get() == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE(const_cast<const lbann::python::object&>(*obj).get() == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE(*obj == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE(const_cast<const lbann::python::object&>(*obj) == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE(obj->release() == ptr);
+      REQUIRE(obj->get() == nullptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      REQUIRE_NOTHROW(obj.reset());
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      Py_DECREF(ptr);
+      Py_DECREF(ptr);
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("Copy constructor") {
+      PyObject* ptr = Py_BuildValue("(i,d,s)", 98, 7.6, "54");
+      std::unique_ptr<lbann::python::object> obj1(new lbann::python::object(ptr));
+      std::unique_ptr<lbann::python::object> obj2;
+      REQUIRE_NOTHROW(obj2.reset(new lbann::python::object(*obj1)));
+      REQUIRE(*obj1 == ptr);
+      REQUIRE(*obj2 == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 2);
+      obj1.reset();
+      REQUIRE(Py_REFCNT(ptr) == 1);
+      obj2.reset();
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("Copy assignment operator") {
+      PyObject* ptr1 = Py_BuildValue("(i,d,s)", 1, 2., "3");
+      PyObject* ptr2 = Py_BuildValue("(i,d,s)", 4, 5., "6");
+      Py_INCREF(ptr1);
+      Py_INCREF(ptr2);
+      REQUIRE((Py_REFCNT(ptr1) == 2 && Py_REFCNT(ptr2) == 2));
+      std::unique_ptr<lbann::python::object> obj1(new lbann::python::object(ptr1));
+      std::unique_ptr<lbann::python::object> obj2(new lbann::python::object(ptr2));
+      REQUIRE_NOTHROW(*obj2 = *obj1);
+      REQUIRE(*obj1 == ptr1);
+      REQUIRE(*obj2 == ptr1);
+      REQUIRE((Py_REFCNT(ptr1) == 3 && Py_REFCNT(ptr2) == 1));
+      obj1.reset();
+      REQUIRE((Py_REFCNT(ptr1) == 2 && Py_REFCNT(ptr2) == 1));
+      obj2.reset();
+      Py_DECREF(ptr1);
+      Py_DECREF(ptr2);
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("Move constructor") {
+      PyObject* ptr = Py_BuildValue("(i,d,s)", 987, 65.4, "three two one");
+      std::unique_ptr<lbann::python::object> obj1(new lbann::python::object(ptr));
+      std::unique_ptr<lbann::python::object> obj2;
+      REQUIRE_NOTHROW(obj2.reset(new lbann::python::object(std::move(*obj1))));
+      REQUIRE(*obj1 == nullptr);
+      REQUIRE(*obj2 == ptr);
+      REQUIRE(Py_REFCNT(ptr) == 1);
+      obj1.reset();
+      REQUIRE(Py_REFCNT(ptr) == 1);
+      obj2.reset();
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("Move assignment operator") {
+      PyObject* ptr1 = Py_BuildValue("(i,d,s)", 9, 8., "7");
+      PyObject* ptr2 = Py_BuildValue("(i,d,s)", 6, 5., "4");
+      Py_INCREF(ptr1);
+      Py_INCREF(ptr2);
+      REQUIRE((Py_REFCNT(ptr1) == 2 && Py_REFCNT(ptr2) == 2));
+      std::unique_ptr<lbann::python::object> obj1(new lbann::python::object(ptr1));
+      std::unique_ptr<lbann::python::object> obj2(new lbann::python::object(ptr2));
+      REQUIRE_NOTHROW(*obj2 = std::move(*obj1));
+      REQUIRE(*obj1 == nullptr);
+      REQUIRE(*obj2 == ptr1);
+      REQUIRE((Py_REFCNT(ptr1) == 2 && Py_REFCNT(ptr2) == 1));
+      obj1.reset();
+      REQUIRE((Py_REFCNT(ptr1) == 2 && Py_REFCNT(ptr2) == 1));
+      obj2.reset();
+      Py_DECREF(ptr1);
+      Py_DECREF(ptr2);
+      REQUIRE_NOTHROW(lbann::python::check_error());
+    }
+
+    SECTION("str") {
+      SECTION("Empty string"){
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object("")));
+        REQUIRE(static_cast<std::string>(*obj).empty());
+      }
+      SECTION("Non-empty string"){
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object("one two three")));
+        REQUIRE(static_cast<std::string>(*obj) == "one two three");
+      }
+    }
+
+    SECTION("int") {
+      SECTION("Zero") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(0l)));
+        REQUIRE(static_cast<long>(*obj) == 0l);
+      }
+      SECTION("Positive") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(123l)));
+        REQUIRE(static_cast<long>(*obj) == 123l);
+      }
+      SECTION("Negative") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(-321l)));
+        REQUIRE(static_cast<long>(*obj) == -321l);
+      }
+    }
+
+    SECTION("float") {
+      SECTION("Zero") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(0.0)));
+        REQUIRE(static_cast<double>(*obj) == 0.0);
+      }
+      SECTION("Positive") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(3.21)));
+        REQUIRE(static_cast<double>(*obj) == 3.21);
+      }
+      SECTION("Negative") {
+        std::unique_ptr<lbann::python::object> obj;
+        REQUIRE_NOTHROW(obj.reset(new lbann::python::object(-12.3)));
+        REQUIRE(static_cast<double>(*obj) == -12.3);
+      }
+    }
+
+  }
+
+}
+#endif // LBANN_HAS_PYTHON

--- a/src/utils/unit_test/python_test.cpp
+++ b/src/utils/unit_test/python_test.cpp
@@ -7,14 +7,15 @@
 #ifdef LBANN_HAS_PYTHON
 TEST_CASE ("Testing the embedded Python session", "[python][utilities]") {
 
-  /// @todo Test finalization and reinitialization
-  SECTION("Before initialization") {
-    // Check twice to make sure interacting doesn't initialize Python
-    CHECK_FALSE(lbann::python::is_active());
-    CHECK_FALSE(lbann::python::is_active());
-  }
-
   SECTION("Initialization") {
+    REQUIRE_NOTHROW(lbann::python::initialize());
+    REQUIRE(lbann::python::is_active());
+    REQUIRE_NOTHROW(lbann::python::initialize());
+    REQUIRE(lbann::python::is_active());
+    REQUIRE_NOTHROW(lbann::python::finalize());
+    REQUIRE_FALSE(lbann::python::is_active());
+    REQUIRE_NOTHROW(lbann::python::finalize());
+    REQUIRE_FALSE(lbann::python::is_active());
     REQUIRE_NOTHROW(lbann::python::initialize());
     REQUIRE(lbann::python::is_active());
   }


### PR DESCRIPTION
I believe these tests cover all the functionality in the Python utility header. The sequential unit tests pass on Pascal. This is my first time using Catch2, so I welcome suggestions on style.