### PR TITLE
Fix for case where global archive size is > INT_MAX

### DIFF
--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -105,6 +105,8 @@ class sample_list {
   const std::string& get_samples_dirname() const;
 
   void all_gather_archive(const std::string &archive, std::vector<std::string>& gathered_archive, lbann_comm& comm);
+  void all_gather_archive_new(const std::string &archive, std::vector<std::string>& gathered_archive, lbann_comm& comm);
+
   template<typename T> size_t all_gather_field(T data, std::vector<T>& gathered_data, lbann_comm& comm);
   virtual void all_gather_packed_lists(lbann_comm& comm);
 

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <memory>
 #include <type_traits>
+#include <limits>
 
 #include <cereal/archives/binary.hpp>
 #include <unistd.h>
@@ -392,12 +393,14 @@ inline void sample_list<sample_name_t>
   // there's commented out code below to deal with the case where
   // archive.size() > INT_MAX; but for now let's assume we won't
   // encounter that (which is true for the 100M JAG set)
+  int constexpr max_int = std::numeric_limits<int>::max();
   size_t n = archive.size();
-  if (n > INT_MAX) {
-    LBANN_ERROR("(n > INT_MAX");
+  if (n > max_int
+    LBANN_ERROR("(n > max_int");
   }
 
-  // change int to size_t for case where n > INT_MAX
+  // change int to size_t for case where n > max_int (see commented out
+  // code block below)
   int size_of_my_archive= archive.size();
   std::vector<int> packed_sizes(comm.get_procs_per_trainer());
   comm.trainer_all_gather(size_of_my_archive, packed_sizes);

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -337,6 +337,11 @@ inline void sample_list<sample_name_t>
 ::all_gather_archive(const std::string &archive,
                      std::vector<std::string>& gathered_archive,
                      lbann_comm& comm) {
+  if (options::get()->get_bool("all_gather_new")) {
+    all_gather_archive_new(archive, gathered_archive, comm);
+    return;
+  }
+
   int size_of_list_archive = archive.size();
   std::vector<int> packed_sizes(comm.get_procs_per_trainer());
 
@@ -375,6 +380,92 @@ inline void sample_list<sample_name_t>
     buf.resize(sz);
     buf.assign(first, last);
   }
+  return;
+}
+
+template <typename sample_name_t>
+inline void sample_list<sample_name_t>
+::all_gather_archive_new(const std::string &archive,
+                     std::vector<std::string>& gathered_archive,
+                     lbann_comm& comm) {
+
+  // there's commented out code below to deal with the case where
+  // archive.size() > INT_MAX; but for now let's assume we won't
+  // encounter that (which is true for the 100M JAG set)
+  size_t n = archive.size();
+  if (n > INT_MAX) {
+    LBANN_ERROR("(n > INT_MAX");
+  }
+
+  // change int to size_t for case where n > INT_MAX
+  int size_of_my_archive= archive.size();
+  std::vector<int> packed_sizes(comm.get_procs_per_trainer());
+  comm.trainer_all_gather(size_of_my_archive, packed_sizes);
+
+  int me = comm.get_rank_in_trainer();
+  int np = comm.get_procs_per_trainer();
+
+  size_t g = 0;
+  for (auto t : packed_sizes) {
+    g += t;
+  }
+  if (!me) {
+    std::cout << "global archive size: " << g << std::endl;
+  }
+
+
+  for (int p=0; p<np; p++) {
+    gathered_archive[p].resize(packed_sizes[p]);
+    if (me == p) {
+      gathered_archive[p] = archive;
+    } 
+    int sz = packed_sizes[p];
+    char *data = const_cast<char*>(gathered_archive[p].data());
+    comm.trainer_broadcast<char>(p, data, sz);
+  }
+
+#if 0
+  std::vector<int> rounds;
+  for (int p=0; p<np; p++) {
+    std::string& buf = gathered_archive[p];
+    buf.resize(packed_sizes[p]);
+
+    rounds.clear();
+    int n = packed_sizes[p]/INT_MAX;
+    if (n < 0) {
+      LBANN_ERROR("(n < 0; that shouldn't be possible; there's a bug; n: ", n, " packed_sizes[p]: ", packed_sizes[p], " packed_sizes[p]/INT_MAX: ", n);
+    }
+    for (int k=0; k<n; k++) {
+      rounds.push_back(INT_MAX);
+    }
+    int remainder = packed_sizes[p] - (n*INT_MAX);
+    rounds.push_back(remainder);
+
+    if (p != me) {
+      gathered_archive[p].resize(packed_sizes[p]);
+    }
+else {
+std::cout << "XX me: " << me << " rounds: ";
+for (auto t : rounds) std::cout << t << " ";
+std::cout << std::endl;
+}
+    size_t offset = 0;
+    for (size_t k=0; k<rounds.size(); k++) {
+      if (me == p) {
+        char *data = const_cast<char*>(archive.data() + offset);
+        comm.trainer_broadcast<char>(p, data, rounds[k]);
+      } else {
+        char *data = const_cast<char*>(gathered_archive[p].data() + offset);
+        comm.trainer_broadcast<char>(p, data, rounds[k]);
+      }
+      offset += rounds[k];
+if (me == p) {
+std::cout << "XX finished round" << std::endl;
+}
+    }
+  }
+#endif
+
   return;
 }
 

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -395,7 +395,7 @@ inline void sample_list<sample_name_t>
   // encounter that (which is true for the 100M JAG set)
   int constexpr max_int = std::numeric_limits<int>::max();
   size_t n = archive.size();
-  if (n > max_int
+  if (n > max_int) {
     LBANN_ERROR("(n > max_int");
   }
 

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -338,7 +338,7 @@ inline void sample_list<sample_name_t>
 ::all_gather_archive(const std::string &archive,
                      std::vector<std::string>& gathered_archive,
                      lbann_comm& comm) {
-  if (options::get()->get_bool("all_gather_new")) {
+  if (!options::get()->get_bool("all_gather_old")) {
     all_gather_archive_new(archive, gathered_archive, comm);
     return;
   }
@@ -386,7 +386,7 @@ inline void sample_list<sample_name_t>
 
 template <typename sample_name_t>
 inline void sample_list<sample_name_t>
-::all_gather_archive_new(const std::string &archive,
+::all_gather_archive(const std::string &archive,
                      std::vector<std::string>& gathered_archive,
                      lbann_comm& comm) {
 

--- a/include/lbann/data_readers/sample_list_open_files_impl.hpp
+++ b/include/lbann/data_readers/sample_list_open_files_impl.hpp
@@ -556,7 +556,7 @@ inline void sample_list_open_files<sample_name_t, file_handle_t>
           LBANN_ERROR("mp.find(filename) == mp.end()");
         }
         index = search_result->second;
-      }
+      }  
       m_sample_list.emplace_back(std::make_pair(index, s.second));
     }
   }


### PR DESCRIPTION
Modified sample_list<sample_name_t>::all_gather_archive() to deal wit…h the case where the size of the global archive is > INT_MAX.

To use the modification, include the cmd line flag: --all_gather_new