### PR TITLE
Embedding layer with padding index

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_embedding.py
+++ b/bamboo/unit_tests/test_unit_layer_embedding.py
@@ -18,15 +18,15 @@ import tools
 # the functions below to ingest data.
 
 # Data
-dictionary_size = 7
-embedding_size = 5
+num_embeddings = 7
+embedding_dim = 5
 np.random.seed(4321)
-embedding_array = np.random.normal(size=(dictionary_size,embedding_size))
+embedding_array = np.random.normal(size=(num_embeddings,embedding_dim))
 
 # Sample access functions
 def get_sample(index):
     np.random.seed(1234+index)
-    return [np.random.randint(dictionary_size)]
+    return [np.random.randint(num_embeddings)]
 def num_samples():
     return 41
 def sample_dims():
@@ -66,8 +66,8 @@ def construct_model(lbann):
     input = lbann.Input()
     embedding = lbann.Embedding(input,
                                 weights=w,
-                                dictionary_size=dictionary_size,
-                                embedding_size=embedding_size,
+                                num_embeddings=num_embeddings,
+                                embedding_dim=embedding_dim,
                                 device='cpu')
     l2_norm2 = lbann.L2Norm2(embedding)
     layers = list(lbann.traverse_layer_graph(input))

--- a/bamboo/unit_tests/test_unit_layer_embedding.py
+++ b/bamboo/unit_tests/test_unit_layer_embedding.py
@@ -20,12 +20,12 @@ import tools
 # Data
 num_embeddings = 7
 embedding_dim = 5
-np.random.seed(4321)
+np.random.seed(20191015)
 embedding_array = np.random.normal(size=(num_embeddings,embedding_dim))
 
 # Sample access functions
 def get_sample(index):
-    np.random.seed(1234+index)
+    np.random.seed(2019101500+index)
     return [np.random.randint(num_embeddings)]
 def num_samples():
     return 41

--- a/bamboo/unit_tests/test_unit_layer_embedding.py
+++ b/bamboo/unit_tests/test_unit_layer_embedding.py
@@ -18,15 +18,16 @@ import tools
 # the functions below to ingest data.
 
 # Data
-num_embeddings = 7
-embedding_dim = 5
-np.random.seed(20191015)
-embedding_array = np.random.normal(size=(num_embeddings,embedding_dim))
+_num_samples = 41
+_num_embeddings = 7
 
 # Sample access functions
 def get_sample(index):
     np.random.seed(2019101500+index)
-    return [np.random.randint(num_embeddings)]
+    i = np.random.randint(_num_embeddings)
+    if index in (1,2,4,7,17,31):
+        i = 0
+    return [i]
 def num_samples():
     return 41
 def sample_dims():
@@ -57,49 +58,129 @@ def construct_model(lbann):
 
     """
 
-    # Construct weights for embeddings
-    embedding_values = ' '.join([str(i) for i in np.nditer(embedding_array)])
-    init = lbann.ValueInitializer(values=embedding_values)
-    w = lbann.Weights(optimizer=lbann.SGD(), initializer=init)
+    # Convenience function to convert list to a space-separated string
+    def str_list(it):
+        return ' '.join([str(i) for i in it])
 
-    # Layer graph
-    input = lbann.Input()
-    embedding = lbann.Embedding(input,
-                                weights=w,
-                                num_embeddings=num_embeddings,
-                                embedding_dim=embedding_dim,
-                                device='cpu')
-    l2_norm2 = lbann.L2Norm2(embedding)
-    layers = list(lbann.traverse_layer_graph(input))
-    metric = lbann.Metric(l2_norm2, name='L2 norm squared')
-    obj = lbann.ObjectiveFunction(l2_norm2)
+    # Convenience function to compute L2 norm squared with NumPy
+    def l2_norm2(x):
+        x = x.reshape(-1)
+        return np.inner(x, x)
 
-    # Compute expected value
-    metric_vals = []
+    # Input data
+    x = lbann.Identity(lbann.Input())
+    x_lbann = x
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # No padding index
+    # ------------------------------------------
+
+    # Embeddings
+    np.random.seed(20191015)
+    embedding_dim = 5
+    embeddings = np.random.normal(size=(_num_embeddings,embedding_dim))
+
+    # LBANN implementation
+    embedding_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(values=str_list(np.nditer(embeddings)))
+    )
+    x = x_lbann
+    y = lbann.Embedding(x,
+                        weights=embedding_weights,
+                        num_embeddings=_num_embeddings,
+                        embedding_dim=embedding_dim,
+                        device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='no padding index'))
+
+    # NumPy implementation
+    vals = []
     for i in range(num_samples()):
-        input = get_sample(i)
-        embedding = embedding_array[int(input[0]), :]
-        l2_norm2 = np.inner(embedding, embedding)
-        metric_vals.append(l2_norm2)
-    expected_metric_value = np.mean(metric_vals)
-    tol = 8 * expected_metric_value * np.finfo(np.float32).eps
+        x = get_sample(i)[0]
+        y = embeddings[x]
+        z = l2_norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
 
-    # Initialize check metric callback
-    callbacks = [lbann.CallbackCheckMetric(metric='L2 norm squared',
-                                           lower_bound=expected_metric_value-tol,
-                                           upper_bound=expected_metric_value+tol,
-                                           error_on_failure=True,
-                                           execution_modes='test'),
-                 lbann.CallbackCheckGradients(error_on_failure=True)]
+    # ------------------------------------------
+    # Padding index 0
+    # ------------------------------------------
+
+    # Embeddings
+    np.random.seed(201910152)
+    embedding_dim = 3
+    padding_idx = 0
+    embeddings = np.random.normal(size=(_num_embeddings,embedding_dim))
+
+    # LBANN implementation
+    # Note: Embedding layer gradients are not exact if a padding index
+    # is set. Avoid gradient checking by not using an optimizer.
+    embedding_weights = lbann.Weights(
+        optimizer=None,
+        initializer=lbann.ValueInitializer(values=str_list(np.nditer(embeddings)))
+    )
+    x = x_lbann
+    y = lbann.Embedding(x,
+                        weights=embedding_weights,
+                        num_embeddings=_num_embeddings,
+                        embedding_dim=embedding_dim,
+                        padding_idx=padding_idx,
+                        device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='padding index = 0'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i)[0]
+        if x == padding_idx:
+            y = np.zeros(shape=embedding_dim, dtype=np.float32)
+        else:
+            y = embeddings[x]
+        z = l2_norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
 
     # Construct model
     mini_batch_size = 17
     num_epochs = 0
     return lbann.Model(mini_batch_size,
                        num_epochs,
-                       layers=layers,
+                       layers=lbann.traverse_layer_graph(x_lbann),
                        objective_function=obj,
-                       metrics=[metric],
+                       metrics=metrics,
                        callbacks=callbacks)
 
 def construct_data_reader(lbann):

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -31,6 +31,12 @@
 
 namespace lbann {
 
+/** @brief Lookup table to vectors of fixed size.
+ *
+ *  Takes a scalar input, interprets it as an index, and outputs the
+ *  corresponding vector. If the index is out-of-range, then the
+ *  output is a vector of zeros.
+ */
 template <data_layout Layout, El::Device Device>
 class embedding_layer : public Layer {
   static_assert(Layout == data_layout::DATA_PARALLEL,
@@ -39,12 +45,17 @@ class embedding_layer : public Layer {
                 "embedding layer only supports CPU");
 public:
 
+  /**
+   *  @param comm           LBANN communicator.
+   *  @param num_embeddings Size of dictionary of embeddings.
+   *  @param embedding_dim  Size of embedding vectors.
+   */
   embedding_layer(lbann_comm* comm,
-                  El::Int dictionary_size,
-                  El::Int embedding_size)
+                  size_t num_embeddings,
+                  size_t embedding_dim)
     : Layer(comm),
-      m_dictionary_size{dictionary_size},
-      m_embedding_size{embedding_size} {
+      m_num_embeddings{num_embeddings},
+      m_embedding_dim{embedding_dim} {
   }
 
   embedding_layer(const embedding_layer& other) = default;
@@ -61,8 +72,8 @@ public:
 
   description get_description() const override {
     auto desc = Layer::get_description();
-    desc.add("Dictionary size", m_dictionary_size);
-    desc.add("Embedding size", m_embedding_size);
+    desc.add("Num embeddings", m_num_embeddings);
+    desc.add("Embedding dim", m_embedding_dim);
     return desc;
   }
 
@@ -77,8 +88,11 @@ protected:
 
 private:
 
-  El::Int m_dictionary_size;
-  El::Int m_embedding_size;
+  /** Size of dictionary of embeddings. */
+  size_t m_num_embeddings;
+  /** Size of embedding vectors. */
+  size_t m_embedding_dim;
+  /** Gradient w.r.t. embedding weights. */
   StarMat<El::Device::CPU> m_dictionary_gradient;
 
 };

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -28,6 +28,8 @@
 #define LBANN_LAYERS_LEARNING_EMBEDDING_HPP_INCLUDED
 
 #include "lbann/layers/layer.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/memory.hpp"
 
 namespace lbann {
 
@@ -55,14 +57,19 @@ public:
    *  @param comm           LBANN communicator.
    *  @param num_embeddings Size of dictionary of embeddings.
    *  @param embedding_dim  Size of embedding vectors.
+   *  @param padding_idx    If set, then the corresponding embedding
+   *                        vector is initialized with zeros. The
+   *                        objective function gradient w.r.t. this
+   *                        embedding vector is always zero.
    */
   embedding_layer(lbann_comm* comm,
                   size_t num_embeddings,
-                  size_t embedding_dim)
+                  size_t embedding_dim,
+                  El::Int padding_idx=-1)
     : Layer(comm),
       m_num_embeddings{num_embeddings},
-      m_embedding_dim{embedding_dim} {
-  }
+      m_embedding_dim{embedding_dim},
+      m_padding_idx{padding_idx} {}
 
   embedding_layer(const embedding_layer& other) = default;
   embedding_layer& operator=(const embedding_layer& other) = default;
@@ -76,12 +83,7 @@ public:
   data_layout get_data_layout() const override { return Layout; }
   El::Device get_device_allocation() const override { return Device; }
 
-  description get_description() const override {
-    auto desc = Layer::get_description();
-    desc.add("Num embeddings", m_num_embeddings);
-    desc.add("Embedding dim", m_embedding_dim);
-    return desc;
-  }
+  description get_description() const override;
 
 protected:
 
@@ -98,10 +100,87 @@ private:
   size_t m_num_embeddings;
   /** Size of embedding vectors. */
   size_t m_embedding_dim;
+  /** If the padding index is set, then the corresponding embedding
+   *  vector is initialized with zeros. The objective function
+   *  gradient w.r.t. this embedding vector is always zero.
+   */
+  El::Int m_padding_idx;
+
   /** Gradient w.r.t. embedding weights. */
   StarMat<El::Device::CPU> m_dictionary_gradient;
 
 };
+
+// =========================================================
+// Implementation
+// =========================================================
+
+template <data_layout Layout, El::Device Device>
+description embedding_layer<Layout,Device>::get_description() const {
+  auto desc = Layer::get_description();
+  desc.add("Num embeddings", m_num_embeddings);
+  desc.add("Embedding dim", m_embedding_dim);
+  return desc;
+}
+
+template <data_layout Layout, El::Device Device>
+void embedding_layer<Layout,Device>::setup_dims() {
+  Layer::setup_dims();
+
+  // Make sure input dimensions are valid
+  if (this->get_input_size() != 1) {
+    const auto& dims = this->get_input_dims();
+    std::ostringstream dims_ss;
+    for (size_t i = 0; i < dims.size(); ++i) {
+      dims_ss << (i > 0 ? "x" : "") << dims[i];
+    }
+    LBANN_ERROR(this->get_type()," layer \"",this->get_name(),"\" ",
+                "recieved an input tensor with invalid dimensions "
+                "(expected 1, got ",dims_ss.str(),")");
+  }
+
+  // Output is size of embedding vector
+  this->set_output_dims({static_cast<int>(m_embedding_dim)});
+
+}
+
+template <data_layout Layout, El::Device Device>
+void embedding_layer<Layout,Device>::setup_data() {
+  Layer::setup_data();
+
+  // Construct default weights if needed
+  // Note: Randomly drawn from normal distribution with mean 0 and
+  // standard deviation 1.
+  if (this->m_weights.empty()) {
+    auto w = make_unique<weights>(get_comm());
+    auto init = make_unique<normal_initializer>(0,1);
+    auto opt = std::unique_ptr<optimizer>(m_model->create_optimizer());
+    w->set_name(this->get_name() + "_weights");
+    w->set_initializer(std::move(init));
+    w->set_optimizer(std::move(opt));
+    this->m_weights.push_back(w.get());
+    this->m_model->add_weights(std::move(w));
+  }
+  if (this->m_weights.size() != 1) {
+    LBANN_ERROR("attempted to setup ",
+                this->get_type()," layer \"",this->get_name(),"\" ",
+                "with an invalid number of weights ",
+                "(expected 1, found ",this->m_weights.size(),")");
+  }
+
+  // Initialize dictionary
+  auto& dict = *m_weights[0];
+  auto matrix_dist = get_prev_activations().DistData();
+  matrix_dist.colDist = El::STAR;
+  matrix_dist.rowDist = El::STAR;
+  dict.set_dims({static_cast<int>(m_embedding_dim)},
+                {static_cast<int>(m_num_embeddings)});
+  dict.set_matrix_distribution(matrix_dist);
+
+  // Initialize gradient w.r.t. dictionary
+  m_dictionary_gradient.Resize(m_embedding_dim, m_num_embeddings);
+
+}
 
 #ifndef LBANN_EMBEDDING_LAYER_INSTANTIATE
 extern template class embedding_layer<

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -34,8 +34,14 @@ namespace lbann {
 /** @brief Lookup table to vectors of fixed size.
  *
  *  Takes a scalar input, interprets it as an index, and outputs the
- *  corresponding vector. If the index is out-of-range, then the
+ *  corresponding vector. The number of embedding vectors and the size
+ *  of vectors are fixed. If the index is out-of-range, then the
  *  output is a vector of zeros.
+ *
+ *  The embedding vectors are stored in an
+ *  @f$ \text{embedding_dim} \times \text{num_embeddings} @f$
+ *  weights matrix. Note that this is the transpose of the weights in
+ *  the PyTorch embedding layer.
  */
 template <data_layout Layout, El::Device Device>
 class embedding_layer : public Layer {

--- a/src/layers/learning/embedding.cpp
+++ b/src/layers/learning/embedding.cpp
@@ -56,7 +56,7 @@ void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::setup_dims() {
   }
 
   // Output is size of embedding vector
-  this->set_output_dims({static_cast<int>(m_embedding_size)});
+  this->set_output_dims({static_cast<int>(m_embedding_dim)});
 
 }
 
@@ -80,12 +80,12 @@ void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::setup_data() {
   auto matrix_dist = get_prev_activations().DistData();
   matrix_dist.colDist = El::STAR;
   matrix_dist.rowDist = El::STAR;
-  dict.set_dims({static_cast<int>(m_embedding_size)},
-                {static_cast<int>(m_dictionary_size)});
+  dict.set_dims({static_cast<int>(m_embedding_dim)},
+                {static_cast<int>(m_num_embeddings)});
   dict.set_matrix_distribution(matrix_dist);
 
   // Initialize gradient w.r.t. dictionary
-  m_dictionary_gradient.Resize(m_embedding_size, m_dictionary_size);
+  m_dictionary_gradient.Resize(m_embedding_dim, m_num_embeddings);
 
 }
 

--- a/src/layers/learning/embedding.cpp
+++ b/src/layers/learning/embedding.cpp
@@ -38,58 +38,6 @@ void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::setup_matrices
 }
 
 template <>
-void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::setup_dims() {
-  Layer::setup_dims();
-
-  // Make sure input dimensions are valid
-  if (this->get_input_size() != 1) {
-    const auto& input_dims = this->get_input_dims();
-    std::ostringstream err;
-    err << get_type() << " layer \"" << get_name() << "\" "
-        << "recieved an input tensor with invalid dimensions "
-        << "(expected 1, got ";
-    for (size_t i = 0; i < input_dims.size(); ++i) {
-      err << (i > 0 ? "x" : "") << input_dims[i];
-    }
-    err << ")";
-    LBANN_ERROR(err.str());
-  }
-
-  // Output is size of embedding vector
-  this->set_output_dims({static_cast<int>(m_embedding_dim)});
-
-}
-
-template <>
-void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::setup_data() {
-  Layer::setup_data();
-
-  // Make sure layer has weights for dictionary
-  if (this->m_weights.size() != 1) {
-    std::ostringstream err;
-    err << "attempted to setup "
-        << this->get_type() << " layer \"" << this->get_name() << "\" "
-        << "with an invalid number of weights "
-        << "(expected 1, "
-        << "found " << this->m_weights.size() << ")";
-    LBANN_ERROR(err.str());
-  }
-
-  // Initialize dictionary
-  auto& dict = *m_weights[0];
-  auto matrix_dist = get_prev_activations().DistData();
-  matrix_dist.colDist = El::STAR;
-  matrix_dist.rowDist = El::STAR;
-  dict.set_dims({static_cast<int>(m_embedding_dim)},
-                {static_cast<int>(m_num_embeddings)});
-  dict.set_matrix_distribution(matrix_dist);
-
-  // Initialize gradient w.r.t. dictionary
-  m_dictionary_gradient.Resize(m_embedding_dim, m_num_embeddings);
-
-}
-
-template <>
 void embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::fp_compute() {
 
   // Local data

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -243,10 +243,14 @@ std::unique_ptr<Layer> construct_layer(
   // Learning layers
   if (proto_layer.has_embedding()) {
     const auto& params = proto_layer.embedding();
+    const size_t num_embeddings = params.num_embeddings();
+    const size_t embedding_dim = params.embedding_dim();
+    const El::Int padding_idx = (params.has_padding_idx() ?
+                                 params.padding_idx().value() : -1);
     if (Layout == data_layout::DATA_PARALLEL
         && Device == El::Device::CPU) {
       return lbann::make_unique<embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(
-               comm, params.num_embeddings(), params.embedding_dim());
+        comm, num_embeddings, embedding_dim, padding_idx);
     } else {
       LBANN_ERROR("embedding layer is only supported with "
                   "data-parallel data layout and on CPU");

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -246,7 +246,7 @@ std::unique_ptr<Layer> construct_layer(
     if (Layout == data_layout::DATA_PARALLEL
         && Device == El::Device::CPU) {
       return lbann::make_unique<embedding_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(
-               comm, params.dictionary_size(), params.embedding_size());
+               comm, params.num_embeddings(), params.embedding_dim());
     } else {
       LBANN_ERROR("embedding layer is only supported with "
                   "data-parallel data layout and on CPU");

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -517,9 +517,17 @@ message Layer {
     double l2_regularization_factor = 12; //default: 0
   }
 
+  /** @brief Lookup table to vectors of fixed size.
+   *
+   *  Takes a scalar input, interprets it as an index, and outputs the
+   *  corresponding vector. If the index is out-of-range, then the
+   *  output is a vector of zeros.
+   */
   message Embedding {
-    int64 dictionary_size = 1;
-    int64 embedding_size = 2;
+    // Size of dictionary of embeddings
+    int64 num_embeddings = 1;
+    // Size of embedding vectors
+    int64 embedding_dim = 2;
   }
 
   message ChannelwiseScaleBias {}

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -539,7 +539,6 @@ message Layer {
     /** If the padding index is set, then the corresponding embedding
      *  vector is initialized with zeros. The objective function
      *  gradient w.r.t. this embedding vector is always zero.
-     *  @todo Implement
      */
     google.protobuf.Int64Value padding_idx = 3;
   }

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -28,6 +28,8 @@ syntax = "proto3";
 
 package lbann_data;
 
+import "google/protobuf/wrappers.proto";
+
 message Layer {
   string name = 50;
   string parents = 151;
@@ -517,17 +519,29 @@ message Layer {
     double l2_regularization_factor = 12; //default: 0
   }
 
-  /** @brief Lookup table to vectors of fixed size.
+  /** @brief Lookup table to embedding vectors.
    *
    *  Takes a scalar input, interprets it as an index, and outputs the
-   *  corresponding vector. If the index is out-of-range, then the
-   *  output is a vector of zeros.
+   *  corresponding vector. The number of embedding vectors and the
+   *  size of vectors are fixed. If the index is out-of-range, then
+   *  the output is a vector of zeros.
+   *
+   *  The embedding vectors are stored in an
+   *  @f$ \text{embedding_dim} \times \text{num_embeddings} @f$
+   *  weights matrix. Note that this is the transpose of the weights
+   *  in the PyTorch embedding layer.
    */
   message Embedding {
-    // Size of dictionary of embeddings
+    /// Size of dictionary of embeddings
     int64 num_embeddings = 1;
-    // Size of embedding vectors
+    /// Size of embedding vectors
     int64 embedding_dim = 2;
+    /** If the padding index is set, then the corresponding embedding
+     *  vector is initialized with zeros. The objective function
+     *  gradient w.r.t. this embedding vector is always zero.
+     *  @todo Implement
+     */
+    google.protobuf.Int64Value padding_idx = 3;
   }
 
   message ChannelwiseScaleBias {}

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -274,6 +274,9 @@ void weights::setup_default_matrix_distribution() {
 
 void weights::setup() {
 
+  // Return immediately if weights have already been setup
+  if (m_values != nullptr) { return; }
+
   // Check that tensor dimensions are valid
   const auto& is_nonpositive = [] (int d) { return d <= 0; };
   if (std::any_of(m_matrix_height_dims.begin(),


### PR DESCRIPTION
This PR makes several changes to the embedding layer to match [PyTorch's API](https://pytorch.org/docs/stable/nn.html#embedding):

- Added support for an optional padding index. The embedding corresponding to the padding index is initialized to zero and the embedding layer will not contribute to its gradient.
- The non-optional parameters have been renamed to `num_embeddings` and `embedding_dim`.
- Expanded documentation.

This depends on PR #1292. If that is merged, the Bamboo unit test passes on Catalyst.