### PR TITLE
Utility functions for hashing

### DIFF
--- a/include/lbann/utils/hash.hpp
+++ b/include/lbann/utils/hash.hpp
@@ -59,7 +59,7 @@ struct enum_hash {
   = typename std::conditional<std::is_enum<T>::value,
                               typename std::underlying_type<T>::type,
                               T>::type;
-  std::size_t operator()(T val) {
+  std::size_t operator()(T val) const {
     return std::hash<underlying_t>()(static_cast<underlying_t>(val));
   }
 };
@@ -70,7 +70,7 @@ template <class T1,
           class Hash1=std::hash<T1>,
           class Hash2=std::hash<T2>>
 struct pair_hash {
-  std::size_t operator()(const std::pair<T1,T2>& val) {
+  std::size_t operator()(const std::pair<T1,T2>& val) const {
     auto seed = Hash1()(val.first);
     return hash_combine<T2,Hash2>(seed, val.second);
   }

--- a/include/lbann/utils/hash.hpp
+++ b/include/lbann/utils/hash.hpp
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_HASH_HPP_INCLUDED
+#define LBANN_UTILS_HASH_HPP_INCLUDED
+
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+namespace lbann {
+
+/** @brief Combine two hash values
+ *
+ *  A hash function is applied to an object and the resulting hash
+ *  value is "mixed" with another hash value. See
+ *  https://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine.
+ *
+ *  @param seed     Hash value.
+ *  @param val      Input to hash function.
+ *  @tparam Hash    Hash function for type @c T.
+ */
+template <class T, class Hash=std::hash<T>>
+std::size_t hash_combine(std::size_t seed, const T& val) {
+  return seed ^ (Hash()(val) + 0x9e3779b9 + (seed << 6) + (seed >> 2));
+}
+
+/** @brief Hash function for enumeration type
+ *
+ *  Equivalent to @c std::hash if the input is not an enumeration
+ *  type.
+ */
+template <class T>
+struct enum_hash {
+  using underlying_t
+  = typename std::conditional<std::is_enum<T>::value,
+                              typename std::underlying_type<T>::type,
+                              T>::type;
+  std::size_t operator()(T val) {
+    return std::hash<underlying_t>()(static_cast<underlying_t>(val));
+  }
+};
+
+/** @brief Hash function for @c std::pair */
+template <class T1,
+          class T2,
+          class Hash1=std::hash<T1>,
+          class Hash2=std::hash<T2>>
+struct pair_hash {
+  std::size_t operator()(const std::pair<T1,T2>& val) {
+    auto seed = Hash1()(val.first);
+    return hash_combine<T2,Hash2>(seed, val.second);
+  }
+};
+
+} // namespace lbann
+
+#endif // LBANN_UTILS_HASH_HPP_INCLUDED

--- a/include/lbann/utils/hash.hpp
+++ b/include/lbann/utils/hash.hpp
@@ -36,7 +36,7 @@ namespace lbann {
 /** @brief Combine two hash values
  *
  *  A hash function is applied to an object and the resulting hash
- *  value is "mixed" with another hash value. See
+ *  value is mixed with another hash value. See
  *  https://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine.
  *
  *  @param seed     Hash value.

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -2,6 +2,7 @@ set_full_path(_DIR_LBANN_CATCH2_TEST_FILES
   any_test.cpp
   beta_distribution_test.cpp
   factory_test.cpp
+  hash_test.cpp
   image_test.cpp
   python_test.cpp
   random_test.cpp

--- a/src/utils/unit_test/hash_test.cpp
+++ b/src/utils/unit_test/hash_test.cpp
@@ -1,0 +1,49 @@
+// MUST include this
+#include <catch2/catch.hpp>
+
+// File being tested
+#include <lbann/utils/hash.hpp>
+
+#include <unordered_set>
+
+TEST_CASE ("Testing convenience functions for hashing", "[hash][utilities]") {
+
+  SECTION ("hash_combine") {
+    std::unordered_set<size_t> hashes;
+    for (size_t seed=0; seed<10; ++seed) {
+      hashes.insert(seed);
+    }
+    for (size_t seed=0; seed<=16; seed+=2) {
+      for (int val=-49; val<=49; val+=7) {
+        const auto hash = lbann::hash_combine(seed, val);
+        CHECK_FALSE(hashes.count(hash));
+        hashes.insert(hash);
+      }
+    }
+  }
+
+  SECTION ("enum_hash") {
+    enum class Humor { PHLEGMATIC, CHOLERIC, SANGUINE, MELANCHOLIC };
+    std::vector<Humor> enum_list = { Humor::MELANCHOLIC, Humor::SANGUINE,
+                                     Humor::CHOLERIC, Humor::PHLEGMATIC };
+    std::unordered_set<size_t> hashes;
+    for (size_t i=0; i<enum_list.size(); ++i) {
+      const auto hash = lbann::enum_hash<Humor>()(enum_list[i]);
+      CHECK_FALSE(hashes.count(hash));
+      hashes.insert(hash);
+    }
+  }
+
+  SECTION ("pair_hash") {
+    std::unordered_set<size_t> hashes;
+    for (char i=-12; i<=12; i+=3) {
+      for (unsigned long j=0; j<=11209; j+=1019) {
+        std::pair<char,unsigned long> val(i,j);
+        const auto hash = lbann::pair_hash<char,unsigned long>()(val);
+        CHECK_FALSE(hashes.count(hash));
+        hashes.insert(hash);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is a minor PR intended to close #1222. It adds a utility header `utils/hash.hpp` with the following functions/functors:

- `hash_combine`: Mix two hash values using a [magic one-liner from Boost](https://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine).
- `enum_hash`: Hash function for enums.
- `pair_hash`: Hash function for `std::pair`s.

These all have Catch2 unit tests that check for hash collisions. This functionality is largely moved from `trainers/trainer.hpp`. I've also gone ahead and used the `hash_combine` function to replace how we mix RNG seeds.