### PR TITLE
Tinkering with MPI launch invocations

### DIFF
--- a/python/lbann/launcher/lsf.py
+++ b/python/lbann/launcher/lsf.py
@@ -120,8 +120,14 @@ class LSFBatchScript(BatchScript):
             procs_per_node = self.procs_per_node
         args = [launcher]
         args.extend(make_iterable(launcher_args))
-        args.append('-n {}'.format(nodes))
-        args.append('--tasks_per_rs {}'.format(procs_per_node))
+        args.extend([
+            '--nrs {}'.format(nodes),
+            '--rs_per_host 1',
+            '--tasks_per_rs {}'.format(procs_per_node),
+            '--launch_distribution packed',
+            '--cpu_per_rs ALL_CPUS',
+            '--gpu_per_rs ALL_GPUS',
+        ])
         args.extend(make_iterable(command))
         self.add_command(args)
 


### PR DESCRIPTION
Changes to the Python frontend's main launcher (`lbann.run`):

- Fixed the LSF launcher's `jsrun` invocation. You can now call `lbann.run` on Lassen and it will run fine.

Changes to the LC-specific launcher (`lbann.contrib.lc.launcher.run`):

- Set the environment variable `IBV_FORK_SAFE ` on Lassen and Sierra. This fixes a hang in the Python data reader (the Python data reader creates a pool of worker processes, but [InfiniBand and OpenMPI have been known to fail after forking](https://www.open-mpi.org/faq/?category=openfabrics#ofa-fork)).
- Generalized the Pascal-specific optimizations to work with 1 proc/node. Running AlexNet with 2 nodes and 1 proc/node, the mini-batch time drops from 0.59s to 0.11s.
- Generalized the Sierra/Lassen-specific optimizations and only use 16 cores/socket. Running AlexNet with 2 Lassen nodes and 4 procs/node, the mini-batch time drops from 0.050s to 0.044s. Running with 1 proc/node, the mini-batch time drops from 0.064s to 0.061s.