### PR TITLE
Revert "Make jag-utils optional in the build/install"

### DIFF
--- a/docs/build_with_cmake.rst
+++ b/docs/build_with_cmake.rst
@@ -225,28 +225,6 @@ require additional CMake/environment flags to be set before properly
 resolving.
 
 ------------------------------
-Building JAG utilities
-------------------------------
-The JAG utility executables are not part of the `all` target. In order
-to use or install them, they must be built using the `jag-utils`
-target. In order to install them, this must be done before installing.
-
-.. code-block:: bash
-
-    # Configure LBANN
-    cmake <see below... or above> /path/to/lbann
-
-    # Build main LBANN library and front-ends
-    cmake --build .
-
-    # If JAG utilities are required, build them
-    cmake --build . --target jag-utils
-
-    # Install all (built) targets
-    cmake --build . --target install
-    
-
-------------------------------
 Example CMake invocation
 ------------------------------
 

--- a/model_zoo/jag_utils/CMakeLists.txt
+++ b/model_zoo/jag_utils/CMakeLists.txt
@@ -1,104 +1,77 @@
-# Add a target to control building all the utilities
-add_custom_target(jag-utils)
+  add_executable( build_index-bin build_index.cpp )
+  target_link_libraries(build_index-bin lbann )
+  set_target_properties(build_index-bin PROPERTIES OUTPUT_NAME build_index)
 
-add_executable(build_index
-  EXCLUDE_FROM_ALL build_index.cpp)
-target_link_libraries(build_index lbann)
-add_dependencies(jag-utils build_index)
+  add_executable( extract_random_samples-bin extract_random_samples.cpp )
+  target_link_libraries(extract_random_samples-bin lbann )
+  set_target_properties(extract_random_samples-bin PROPERTIES OUTPUT_NAME extract_random_samples)
 
-add_executable(extract_random_samples
-  EXCLUDE_FROM_ALL extract_random_samples.cpp)
-target_link_libraries(extract_random_samples lbann)
-add_dependencies(jag-utils extract_random_samples)
+  add_executable( dump_bundle-bin dump_bundle.cpp )
+  target_link_libraries(dump_bundle-bin lbann )
+  set_target_properties(dump_bundle-bin PROPERTIES OUTPUT_NAME dump_bundle)
 
-add_executable(dump_bundle
-  EXCLUDE_FROM_ALL dump_bundle.cpp)
-target_link_libraries(dump_bundle lbann)
-add_dependencies(jag-utils dump_bundle)
+  add_executable( check_images-bin check_images.cpp )
+  target_link_libraries(check_images-bin lbann )
+  set_target_properties(check_images-bin PROPERTIES OUTPUT_NAME check_images)
 
-add_executable(check_images
-  EXCLUDE_FROM_ALL check_images.cpp)
-target_link_libraries(check_images lbann)
-add_dependencies(jag-utils check_images)
+  add_executable( detect_corruption-bin detect_corruption.cpp )
+  target_link_libraries(detect_corruption-bin lbann )
+  set_target_properties(detect_corruption-bin PROPERTIES OUTPUT_NAME detect_corruption)
 
-add_executable(detect_corruption
-  EXCLUDE_FROM_ALL detect_corruption.cpp)
-target_link_libraries(detect_corruption lbann)
-add_dependencies(jag-utils detect_corruption)
+  add_executable( load_bundle2raw-bin load_bundle2raw.cpp )
+  target_link_libraries(load_bundle2raw-bin lbann )
+  set_target_properties(load_bundle2raw-bin PROPERTIES OUTPUT_NAME load_bundle2raw)
 
-add_executable(load_bundle2raw
-  EXCLUDE_FROM_ALL load_bundle2raw.cpp)
-target_link_libraries(load_bundle2raw lbann)
-add_dependencies(jag-utils load_bundle2raw)
+  add_executable( compute_min_max_images-bin compute_min_max_images.cpp )
+  target_link_libraries(compute_min_max_images-bin lbann )
+  set_target_properties(compute_min_max_images-bin PROPERTIES OUTPUT_NAME compute_min_max_images)
 
-add_executable(compute_min_max_images
-  EXCLUDE_FROM_ALL compute_min_max_images.cpp)
-target_link_libraries(compute_min_max_images lbann)
-add_dependencies(jag-utils compute_min_max_images)
+  add_executable( compute_per_channel_image_avg_min_max-bin compute_per_channel_image_avg_min_max.cpp )
+  target_link_libraries(compute_per_channel_image_avg_min_max-bin lbann )
+  set_target_properties(compute_per_channel_image_avg_min_max-bin PROPERTIES OUTPUT_NAME compute_per_channel_image_avg_min_max)
 
-add_executable(compute_per_channel_image_avg_min_max
-  EXCLUDE_FROM_ALL compute_per_channel_image_avg_min_max.cpp)
-target_link_libraries(compute_per_channel_image_avg_min_max lbann)
-add_dependencies(jag-utils compute_per_channel_image_avg_min_max)
+  add_executable( load_balance-bin load_balance.cpp )
+  target_link_libraries(load_balance-bin lbann )
+  set_target_properties(load_balance-bin PROPERTIES OUTPUT_NAME load_balance)
 
-add_executable(load_balance
-  EXCLUDE_FROM_ALL load_balance.cpp)
-target_link_libraries(load_balance lbann)
-add_dependencies(jag-utils load_balance)
+  add_executable( check_for_duplicate_samples-bin check_for_duplicate_samples.cpp )
+  target_link_libraries(check_for_duplicate_samples-bin lbann )
+  set_target_properties(check_for_duplicate_samples-bin PROPERTIES OUTPUT_NAME check_for_duplicate_samples)
 
-add_executable(check_for_duplicate_samples
-  EXCLUDE_FROM_ALL check_for_duplicate_samples.cpp)
-target_link_libraries(check_for_duplicate_samples lbann)
-add_dependencies(jag-utils extract_random_samples)
+  add_executable( test_conduit_hdf5-bin test_conduit_hdf5.cpp )
+  target_link_libraries(test_conduit_hdf5-bin lbann )
+  set_target_properties(test_conduit_hdf5-bin PROPERTIES OUTPUT_NAME test_conduit_hdf5)
 
-add_executable(test_conduit_hdf5
-  EXCLUDE_FROM_ALL test_conduit_hdf5.cpp)
-target_link_libraries(test_conduit_hdf5 lbann)
-add_dependencies(jag-utils test_conduit_hdf5)
+  add_executable( select_samples-bin select_samples.cpp )
+  target_link_libraries(select_samples-bin lbann )
+  set_target_properties(select_samples-bin PROPERTIES OUTPUT_NAME select_samples)
 
-add_executable(select_samples
-  EXCLUDE_FROM_ALL select_samples.cpp)
-target_link_libraries(select_samples lbann)
-add_dependencies(jag-utils select_samples)
+  add_executable( build_sample_id_mapping-bin build_sample_id_mapping.cpp )
+  target_link_libraries(build_sample_id_mapping-bin lbann )
+  set_target_properties(build_sample_id_mapping-bin PROPERTIES OUTPUT_NAME build_sample_id_mapping)
 
-add_executable(build_sample_id_mapping
-  EXCLUDE_FROM_ALL build_sample_id_mapping.cpp)
-target_link_libraries(build_sample_id_mapping lbann)
-add_dependencies(jag-utils build_sample_id_mapping)
+  add_executable( generate_corrupt_samples-bin generate_corrupt_samples.cpp )
+  target_link_libraries(generate_corrupt_samples-bin lbann )
+  set_target_properties(generate_corrupt_samples-bin PROPERTIES OUTPUT_NAME generate_corrupt_samples)
+  
+  add_executable( compute_hydra_normalization-bin compute_hydra_normalization.cpp )
+  target_link_libraries(compute_hydra_normalization-bin lbann )
+  set_target_properties(compute_hydra_normalization-bin PROPERTIES OUTPUT_NAME compute_hydra_normalization)
 
-add_executable(generate_corrupt_samples
-  EXCLUDE_FROM_ALL generate_corrupt_samples.cpp)
-target_link_libraries(generate_corrupt_samples lbann)
-add_dependencies(jag-utils generate_corrupt_samples)
+  add_executable( test_reading_speed-bin test_reading_speed.cpp )
+  target_link_libraries(test_reading_speed-bin lbann )
+  set_target_properties(test_reading_speed-bin PROPERTIES OUTPUT_NAME test_reading_speed)
 
-add_executable(compute_hydra_normalization
-  EXCLUDE_FROM_ALL compute_hydra_normalization.cpp)
-target_link_libraries(compute_hydra_normalization lbann)
-add_dependencies(jag-utils compute_hydra_normalization)
-
-add_executable(test_reading_speed
-  EXCLUDE_FROM_ALL test_reading_speed.cpp)
-target_link_libraries(test_reading_speed lbann)
-add_dependencies(jag-utils test_reading_speed)
-
-add_executable(convert
-  EXCLUDE_FROM_ALL convert.cpp)
-target_link_libraries(convert lbann)
-add_dependencies(jag-utils convert)
+  add_executable( convert-bin convert.cpp )
+  target_link_libraries(convert-bin lbann )
+  set_target_properties(convert-bin PROPERTIES OUTPUT_NAME convert)
 
 # Install the binaries
 install(
-  TARGETS select_samples build_sample_id_mapping build_index
+  TARGETS select_samples-bin build_sample_id_mapping-bin build_index-bin
   EXPORT LBANNTargets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  OPTIONAL
   )
-
-# The use of `OPTIONAL` here will trigger CMake warnings. These can
-# safely be ignored and tests confirm that. See these for more info:
-#
-# https://gitlab.kitware.com/cmake/cmake/issues/18258
-# https://cmake.org/pipermail/cmake/2011-August/046014.html

--- a/superbuild/lbann/CMakeLists.txt
+++ b/superbuild/lbann/CMakeLists.txt
@@ -187,14 +187,5 @@ ExternalProject_Add(LBANN
   ${LBANN_CMAKE_ARGS}
   )
 
-# Ensure the JAG utils are built
-ExternalProject_Add_Step(LBANN build-jag-utils
-  COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target jag-utils
-  COMMENT "Performing building of JAG utils for 'LBANN'"
-  DEPENDEES build
-  DEPENDERS install
-  LOG 1
-  USES_TERMINAL 1)
-
 set(LBANN_DIR ${LBANN_CMAKE_INSTALL_PREFIX}
   CACHE INTERNAL "The install prefix of LBANN.")


### PR DESCRIPTION
Reverts LLNL/lbann#1263.

[Last night's Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-NIGHTD-637) failed during compilation with the [following error message](https://lc.llnl.gov/bamboo/artifact/LBANN-NIGHTD/X86CPU/build-637/Test-errors/compiler_tests/error/build_script_error.txt):
```
CMake Error at model_zoo/jag_utils/cmake_install.cmake:47 (file):
  file INSTALL cannot find
  "/usr/WS2/lbannusr/bamboo/lbann-catalyst159-1/xml-data/build-dir/LBANN-NIGHTD-X86CPU/build/gnu.Release.catalyst.llnl.gov/lbann/build/model_zoo/jag_utils/select_samples".
Call Stack (most recent call first):
  cmake_install.cmake:146 (include)
```