### PR TITLE
Refactor Bamboo helper function for Python frontend

### DIFF
--- a/bamboo/clean.sh
+++ b/bamboo/clean.sh
@@ -18,6 +18,7 @@ rm -rf ${LBANN_DIR}/bamboo/integration_tests/__pycache__
 rm -f ${LBANN_DIR}/bamboo/integration_tests/*.tfevents.*
 rm -f ${LBANN_DIR}/bamboo/integration_tests/error/*
 rm -f ${LBANN_DIR}/bamboo/integration_tests/output/*
+rm -rf ${LBANN_DIR}/bamboo/integration_tests/experiments/*
 
 # Unit Tests
 rm -rf ${LBANN_DIR}/bamboo/unit_tests/ckpt*

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -662,21 +662,25 @@ def assert_failure(return_code, expected_error, error_file_name):
             efn=error_file_name))
 
 
-def create_tests(setup_func, test_name):
+def create_tests(setup_func,
+                 test_file,
+                 test_name_base=None,
+                 nodes=1,
+                 procs_per_node=None):
     """Create functions that can interact with PyTest.
 
-    This function creates tests that involve setting up and running an
-    LBANN experiment with the Python frontend. `setup_func` should be
-    a function that takes in the LBANN Python module and outputs
-    objects for an LBANN experiment. A test succeeds if LBANN runs and
-    exits with an exit code of 0, and fails otherwise.
+    This function creates tests that involve running an LBANN
+    experiment with the Python frontend. `setup_func` should be a
+    function that takes in the LBANN Python module and outputs objects
+    for an LBANN experiment. A test succeeds if LBANN runs and exits
+    with an exit code of 0, and fails otherwise.
 
     PyTest detects tests by loading in a Python script and looking for
     functions prefixed with 'test_'. After you call this function
     within a script to generate test functions, make sure to add the
     test functions to the script's scope. For example:
 
-        _test_funcs = tools.create_tests(setup_func, test_name)
+        _test_funcs = tools.create_tests(setup_func, __file__)
         for t in _test_funcs:
             globals()[t.__name__] = t
 
@@ -685,42 +689,53 @@ def create_tests(setup_func, test_name):
             Python frontend. It takes in the LBANN Python module as
             input and returns a `(lbann.Trainer, lbann.Model,
             lbann.reader_pb2.DataReader, lbann.Optimizer)`.
-        test_name (str): Descriptive name. Should be prefixed with
-            'test_'.
+        test_file (str): Python script being run by PyTest. In most
+            cases, use `__file__`.
+        test_name (str, optional): Descriptive name (default: test
+            file name with '.py' removed).
+        nodes (int, optional): Number of compute nodes (default: 1).
+        procs_per_node (int, optional): Number of parallel processes
+            per compute node (default: system-specific default,
+            usually number of GPUs per node).
 
     Returns:
         Iterable of function: Tests that can interact with PyTest.
+            Each function returns a dict containing log files and
+            other output data.
 
     """
 
+    # Make sure test name is valid
+    test_file = os.path.realpath(test_file)
+    if not test_name_base:
+        # Create test name by removing '.py' from file name
+        test_name_base = os.path.splitext(os.path.basename(test_file))[0]
+    if not re.match('^test_.', test_name_base):
+        # Make sure test name is prefixed with 'test_'
+        test_name_base = 'test_' + test_name_base
+
     # Basic test function
     def test_func(cluster, executables, dir_name, compiler_name):
-        process_executable(test_name, compiler_name, executables)
+        process_executable(test_name_base, compiler_name, executables)
+        test_name = '{}_{}'.format(test_name_base, compiler_name)
 
-        # Choose LBANN build and load Python frontend
-        if compiler_name == 'exe':
-            exe = executables[compiler_name]
-            bin_dir = os.path.dirname(exe)
-            install_dir = os.path.dirname(bin_dir)
-            build_path = '{i}/lib/python3.7/site-packages'.format(i=install_dir)
-        else:
-            if compiler_name == 'clang6':
-                path = 'clang.Release'
-            elif compiler_name == 'clang6_debug':
-                path = 'clang.Debug'
-            elif compiler_name == 'gcc7':
-                path = 'gnu.Release'
-            elif compiler_name == 'clang6_debug':
-                path = 'gnu.Debug'
-            elif compiler_name == 'intel19':
-                path = 'intel.Release'
-            elif compiler_name == 'intel19_debug':
-                path = 'intel.Debug'
-            path = '{p}.{c}.llnl.gov'.format(p=path, c=cluster)
-            build_path = '{d}/build/{p}/install/lib/python3.7/site-packages'.format(
-                d=dir_name, p=path)
-        print('build_path={b}'.format(b=build_path))
-        sys.path.append(build_path)
+        # Load LBANN Python frontend
+        build_names = {
+            'clang6': 'clang.Release.{}.llnl.gov'.format(cluster),
+            'clang6_debug': 'clang.Debug.{}.llnl.gov'.format(cluster),
+            'gcc7': 'gnu.Release.{}.llnl.gov'.format(cluster),
+            'gcc7_debug': 'gnu.Debug.{}.llnl.gov'.format(cluster),
+            'intel19': 'intel.Release.{}.llnl.gov'.format(cluster),
+            'intel19_debug': 'intel.Debug.{}.llnl.gov'.format(cluster),
+        }
+        python_frontend_path = os.path.join(dir_name,
+                                            'build',
+                                            build_names[compiler_name],
+                                            'install',
+                                            'lib',
+                                            'python3.7',
+                                            'site-packages')
+        sys.path.append(python_frontend_path)
         import lbann
         import lbann.contrib.lc.launcher
 
@@ -728,14 +743,14 @@ def create_tests(setup_func, test_name):
         trainer, model, data_reader, optimizer = setup_func(lbann)
 
         # Run LBANN experiment
-        kwargs = {
-            'nodes': 1,
-            'overwrite_script': True
-        }
-        experiment_dir = '{d}/bamboo/unit_tests/experiments/{t}_{c}'.format(
-            d=dir_name, t=test_name, c=compiler_name)
-        error_file_name = '{e}/err.log'.format(
-            e=experiment_dir, c=compiler_name)
+        experiment_dir = os.path.join(os.path.dirname(test_file),
+                                      'experiments',
+                                      test_name)
+        stdout_log_file = os.path.join(experiment_dir, 'out.log')
+        stderr_log_file = os.path.join(experiment_dir, 'err.log')
+        kwargs = {}
+        if procs_per_node:
+            kwargs['procs_per_node'] = procs_per_node
         return_code = lbann.contrib.lc.launcher.run(
             trainer=trainer,
             model=model,
@@ -743,32 +758,33 @@ def create_tests(setup_func, test_name):
             optimizer=optimizer,
             experiment_dir=experiment_dir,
             job_name='lbann_{}'.format(test_name),
+            nodes=nodes,
+            overwrite_script=True,
             **kwargs)
-        assert_success(return_code, error_file_name)
+        assert_success(return_code, stderr_log_file)
+        return {
+            'return_code': return_code,
+            'experiment_dir': experiment_dir,
+            'stdout_log_file': stdout_log_file,
+            'stderr_log_file': stderr_log_file,
+        }
 
     # Specific test functions for different build configurations
-    def test_func_exe(cluster, dirname, exe):
-        if exe is None:
-            e = 'test_{}_exe: Non-local testing'.format(test_name)
-            print('Skip - ' + e)
-            pytest.skip(e)
-        exes = {'exe': exe}
-        test_func(cluster, exes, dirname, 'exe')
     def test_func_clang6(cluster, exes, dirname):
-        test_func(cluster, exes, dirname, 'clang6')
+        return test_func(cluster, exes, dirname, 'clang6')
     def test_func_gcc7(cluster, exes, dirname):
-        test_func(cluster, exes, dirname, 'gcc7')
+        return test_func(cluster, exes, dirname, 'gcc7')
     def test_func_intel19(cluster, exes, dirname):
-        test_func(cluster, exes, dirname, 'intel19')
-    test_func_exe.__name__ = '{}_exe'.format(test_name)
-    test_func_clang6.__name__ = '{}_clang6'.format(test_name)
-    test_func_gcc7.__name__ = '{}_gcc7'.format(test_name)
-    test_func_intel19.__name__ = '{}_intel19'.format(test_name)
+        return test_func(cluster, exes, dirname, 'intel19')
+    test_func_clang6.__name__ = '{}_clang6'.format(test_name_base)
+    test_func_gcc7.__name__ = '{}_gcc7'.format(test_name_base)
+    test_func_intel19.__name__ = '{}_intel19'.format(test_name_base)
 
-    return (test_func_exe,
-            test_func_clang6,
-            test_func_gcc7,
-            test_func_intel19)
+    return (
+        test_func_gcc7,
+        test_func_clang6,
+        test_func_intel19,
+    )
 
 
 def create_python_data_reader(lbann,

--- a/bamboo/integration_tests/experiments/.gitignore
+++ b/bamboo/integration_tests/experiments/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/bamboo/unit_tests/test_unit_datareader_python.py
+++ b/bamboo/unit_tests/test_unit_datareader_python.py
@@ -127,7 +127,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_argmax.py
+++ b/bamboo/unit_tests/test_unit_layer_argmax.py
@@ -148,7 +148,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_channelwise_scale_bias.py
+++ b/bamboo/unit_tests/test_unit_layer_channelwise_scale_bias.py
@@ -167,7 +167,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_embedding.py
+++ b/bamboo/unit_tests/test_unit_layer_embedding.py
@@ -224,7 +224,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_entrywise_batch_normalization.py
+++ b/bamboo/unit_tests/test_unit_layer_entrywise_batch_normalization.py
@@ -174,7 +174,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_entrywise_scale_bias.py
+++ b/bamboo/unit_tests/test_unit_layer_entrywise_scale_bias.py
@@ -214,7 +214,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_log_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_log_softmax.py
@@ -204,7 +204,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_one_hot.py
+++ b/bamboo/unit_tests/test_unit_layer_one_hot.py
@@ -136,7 +136,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_slice.py
+++ b/bamboo/unit_tests/test_unit_layer_slice.py
@@ -246,7 +246,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_softmax.py
@@ -209,7 +209,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test


### PR DESCRIPTION
One of the problems with PR #1291 is that we have a lot of boilerplate to setup and run LBANN with the Python frontend. This PR generalizes the `create_tests` function in the Bamboo utilities so that it is not specifically tied to the `unit_test` directory. It also provides options to run with more than one node.

My plan is to implement the integration tests by calling `create_tests` and writing wrapper functions that parse the log files after LBANN finishes (e.g. to check mini-batch times or accuracies). One complication is that the `_exe` tests have a different signature from the `_gcc7`, `_clang6`, and `_intel19` tests.  I've removed the `_exe` tests for simplicity. This becomes moot if we run the tests in the build directory since we no longer need to maintain different versions of the test for each build configuration.