### PR TITLE
Fix saving of the common RNG states for distributed checkpointing

### DIFF
--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -247,7 +247,8 @@ void bernoulli_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n, double p = 0.
 void uniform_fill_procdet(AbsDistMat& mat, El::Int m, El::Int n,
                           DataType center = 0.0f, DataType radius = 1.0f);
 
-bool save_rng_to_checkpoint(persist& p, lbann_comm* comm);
+bool save_rng_to_checkpoint_shared(persist& p, lbann_comm* comm);
+bool save_rng_to_checkpoint_distributed(persist& p, lbann_comm* comm);
 bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm);
 
 template<typename DistType,typename DType=DataType>

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1279,7 +1279,7 @@ bool model::save_to_checkpoint_shared(persist& p) {
       LBANN_ERROR("Unable to save layer[",i,"]=", get_layer(i).get_name());
     }
   }
-  save_rng_to_checkpoint(p, m_comm);
+  save_rng_to_checkpoint_shared(p, m_comm);
   for (const auto& m : m_metrics) {
     m->save_to_checkpoint_shared(p);
   }
@@ -1340,7 +1340,7 @@ bool model::save_to_checkpoint_distributed(persist& p){
       LBANN_ERROR("Unable to save layer[",i,"]=", get_layer(i).get_name());
     }
   }
-  save_rng_to_checkpoint(p, m_comm);
+  save_rng_to_checkpoint_distributed(p, m_comm);
   for (const auto& m : m_metrics) {
     m->save_to_checkpoint_distributed(p);
   }


### PR DESCRIPTION
Common RNG states still need to be saved by each rank for distributed checkpointing.
