### PR TITLE
Fix compilation error in softmax layer

### DIFF
--- a/src/layers/activations/softmax.cpp
+++ b/src/layers/activations/softmax.cpp
@@ -33,7 +33,7 @@ namespace {
 
 #ifdef LBANN_ENABLE_SOFTMAX_THRESHOLD
 /** Minimum output value to avoid denormalized floats */
-constexpr DataType threshold_val = std::sqrt(std::numeric_limits<DataType>::min());
+const DataType threshold_val = std::sqrt(std::numeric_limits<DataType>::min());
 #endif // LBANN_ENABLE_SOFTMAX_THRESHOLD
 
 void fp(lbann_comm& comm,


### PR DESCRIPTION
It turns out `std::sqrt` is not `constexpr`. The softmax unit test and LeNet integration tests both pass on Pascal and Catalyst.