### PR TITLE
Data store move preload

### DIFF
--- a/include/lbann/data_readers/data_reader_image.hpp
+++ b/include/lbann/data_readers/data_reader_image.hpp
@@ -41,8 +41,6 @@ class image_data_reader : public generic_data_reader {
 
   image_data_reader(bool shuffle = true);
   image_data_reader(const image_data_reader&);
-  image_data_reader(const image_data_reader&, const std::vector<int>& ds_sample_move_list);
-  image_data_reader(const image_data_reader&, const std::vector<int>& ds_sample_move_list, std::string role);
   image_data_reader& operator=(const image_data_reader&);
 
   /** Set up imagenet specific input parameters
@@ -99,7 +97,7 @@ class image_data_reader : public generic_data_reader {
   void preload_data_store() override;
 
  protected:
-   void copy_members(const image_data_reader &rhs, const std::vector<int>& ds_sample_move_list = std::vector<int>());
+   void copy_members(const image_data_reader &rhs);
 
   /// Set the default values for the width, the height, the number of channels, and the number of labels of an image
   virtual void set_defaults();

--- a/include/lbann/data_readers/data_reader_imagenet.hpp
+++ b/include/lbann/data_readers/data_reader_imagenet.hpp
@@ -35,10 +35,6 @@ namespace lbann {
 class imagenet_reader : public image_data_reader {
  public:
   imagenet_reader(bool shuffle = true);
-  imagenet_reader(const imagenet_reader&,
-                  const std::vector<int>& ds_sample_move_list);
-  imagenet_reader(const imagenet_reader&,
-                  const std::vector<int>& ds_sample_move_list, std::string role);
   imagenet_reader(const imagenet_reader&) = default;
   imagenet_reader& operator=(const imagenet_reader&) = default;
   ~imagenet_reader() override;

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -89,7 +89,7 @@ class data_reader_jag_conduit : public generic_data_reader {
 
   data_reader_jag_conduit(bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&);
-  data_reader_jag_conduit(const data_reader_jag_conduit&, const std::vector<int>& ds_sample_move_list);
+//  data_reader_jag_conduit(const data_reader_jag_conduit&, const std::vector<int>& ds_sample_move_list);
   data_reader_jag_conduit& operator=(const data_reader_jag_conduit&);
   ~data_reader_jag_conduit() override;
   data_reader_jag_conduit* copy() const override { return new data_reader_jag_conduit(*this); }
@@ -258,7 +258,7 @@ class data_reader_jag_conduit : public generic_data_reader {
   void preload_data_store() override;
 
   virtual void set_defaults();
-  virtual void copy_members(const data_reader_jag_conduit& rhs, const std::vector<int>& ds_sample_move_list = std::vector<int>());
+  virtual void copy_members(const data_reader_jag_conduit& rhs);
 
   /// add data type for independent variable
   void add_independent_variable_type(const variable_t independent);

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -89,7 +89,6 @@ class data_reader_jag_conduit : public generic_data_reader {
 
   data_reader_jag_conduit(bool shuffle = true);
   data_reader_jag_conduit(const data_reader_jag_conduit&);
-//  data_reader_jag_conduit(const data_reader_jag_conduit&, const std::vector<int>& ds_sample_move_list);
   data_reader_jag_conduit& operator=(const data_reader_jag_conduit&);
   ~data_reader_jag_conduit() override;
   data_reader_jag_conduit* copy() const override { return new data_reader_jag_conduit(*this); }

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -141,7 +141,7 @@ class data_store_conduit {
   int get_data_size() { return m_data.size(); }
 
   /// made public for debugging during development
-  void copy_members(const data_store_conduit& rhs, const std::vector<int>& = std::vector<int>());
+  void copy_members(const data_store_conduit& rhs);
 
   /** @brief Closes then reopens the debug logging file
    *

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -714,15 +714,28 @@ void generic_data_reader::instantiate_data_store(const std::vector<int>& local_l
 
   m_data_store->set_shuffled_indices(&m_shuffled_indices);
 
+  if (opts->get_bool("preload_data_store") && !opts->get_bool("data_store_cache")) {
+    if (local_list_sizes.size() != 0) {
+      m_data_store->build_preloaded_owner_map(local_list_sizes);
+    }
+  }
+
+  if (is_master()) {
+    std::cout << "generic_data_reader::instantiate_data_store time: : " << (get_time() - tm1) << std::endl;
+  }
+}
+
+void generic_data_reader::setup_data_store(int mini_batch_size) {
+  if (m_data_store == nullptr) {
+    LBANN_ERROR("m_data_store == nullptr; you shouldn't be here");
+  }
   // optionally preload the data store
+  options *opts = options::get();
   if (opts->get_bool("preload_data_store") && !opts->get_bool("data_store_cache")) {
     if(is_master()) {
       std::cerr << "generic_data_reader::instantiate_data_store - Starting the preload" << std::endl;
     }
     double tm2 = get_time();
-    if (local_list_sizes.size() != 0) {
-      m_data_store->build_preloaded_owner_map(local_list_sizes);
-    }
     preload_data_store();
     m_data_store->set_is_preloaded();
     if(is_master()) {
@@ -733,15 +746,6 @@ void generic_data_reader::instantiate_data_store(const std::vector<int>& local_l
     if (n != m_shuffled_indices.size()) {
       LBANN_ERROR("num samples loaded: ", n, " != shuffled-indices.size(): ", m_shuffled_indices.size());
     }
-  }
-  if (is_master()) {
-    std::cout << "generic_data_reader::instantiate_data_store time: : " << (get_time() - tm1) << std::endl;
-  }
-}
-
-void generic_data_reader::setup_data_store(int mini_batch_size) {
-  if (m_data_store == nullptr) {
-    LBANN_ERROR("m_data_store == nullptr; you shouldn't be here");
   }
   m_data_store->setup(mini_batch_size);
 }

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -48,19 +48,6 @@ image_data_reader::image_data_reader(const image_data_reader& rhs)
   copy_members(rhs);
 }
 
-image_data_reader::image_data_reader(const image_data_reader& rhs,const std::vector<int>& ds_sample_move_list, std::string role)
-  : generic_data_reader(rhs)
-{
-  set_role(role);
-  copy_members(rhs, ds_sample_move_list);
-}
-
-image_data_reader::image_data_reader(const image_data_reader& rhs,const std::vector<int>& ds_sample_move_list)
-  : generic_data_reader(rhs)
-{
-  copy_members(rhs, ds_sample_move_list);
-}
-
 image_data_reader& image_data_reader::operator=(const image_data_reader& rhs) {
   generic_data_reader::operator=(rhs);
   m_image_dir = rhs.m_image_dir;
@@ -74,14 +61,10 @@ image_data_reader& image_data_reader::operator=(const image_data_reader& rhs) {
   return (*this);
 }
 
-void image_data_reader::copy_members(const image_data_reader &rhs, const std::vector<int>& ds_sample_move_list) {
+void image_data_reader::copy_members(const image_data_reader &rhs) {
 
   if(rhs.m_data_store != nullptr) {
-    if(ds_sample_move_list.size() == 0) {
-      m_data_store = new data_store_conduit(rhs.get_data_store());
-    } else {
-      m_data_store = new data_store_conduit(rhs.get_data_store(), ds_sample_move_list);
-    }
+    m_data_store = new data_store_conduit(rhs.get_data_store());
     m_data_store->set_data_reader_ptr(this);
   }
 

--- a/src/data_readers/data_reader_imagenet.cpp
+++ b/src/data_readers/data_reader_imagenet.cpp
@@ -37,12 +37,6 @@ imagenet_reader::imagenet_reader(bool shuffle)
   set_defaults();
 }
 
-imagenet_reader::imagenet_reader(const imagenet_reader& rhs, const std::vector<int>& ds_sample_move_list, std::string role)
-  : image_data_reader(rhs, ds_sample_move_list, role) {}
-
-imagenet_reader::imagenet_reader(const imagenet_reader& rhs, const std::vector<int>& ds_sample_move_list)
-  : image_data_reader(rhs, ds_sample_move_list) {}
-
 imagenet_reader::~imagenet_reader() {}
 
 void imagenet_reader::set_defaults() {

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -138,7 +138,7 @@ data_reader_jag_conduit::data_reader_jag_conduit(bool shuffle)
   set_defaults();
 }
 
-void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs, const std::vector<int>& ds_sample_move_list) {
+void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs) {
   m_independent = rhs.m_independent;
   m_independent_groups = rhs.m_independent_groups;
   m_dependent = rhs.m_dependent;
@@ -185,11 +185,7 @@ void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs, c
   m_list_per_model = rhs.m_list_per_model;
 
   if(rhs.m_data_store != nullptr) {
-    if(ds_sample_move_list.size() == 0) {
-      m_data_store = new data_store_conduit(rhs.get_data_store());
-    } else {
-      m_data_store = new data_store_conduit(rhs.get_data_store(), ds_sample_move_list);
-    }
+    m_data_store = new data_store_conduit(rhs.get_data_store());
     m_data_store->set_data_reader_ptr(this);
   }
 }
@@ -197,11 +193,6 @@ void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs, c
 data_reader_jag_conduit::data_reader_jag_conduit(const data_reader_jag_conduit& rhs)
   : generic_data_reader(rhs) {
   copy_members(rhs);
-}
-
-data_reader_jag_conduit::data_reader_jag_conduit(const data_reader_jag_conduit& rhs, const std::vector<int>& ds_sample_move_list)
-  : generic_data_reader(rhs) {
-  copy_members(rhs, ds_sample_move_list);
 }
 
 data_reader_jag_conduit& data_reader_jag_conduit::operator=(const data_reader_jag_conduit& rhs) {

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -148,9 +148,6 @@ data_store_conduit::data_store_conduit(const data_store_conduit& rhs) {
   copy_members(rhs);
 }
 
-data_store_conduit::data_store_conduit(const data_store_conduit& rhs, const std::vector<int>& ds_sample_move_list) {
-  copy_members(rhs, ds_sample_move_list);
-}
 
 data_store_conduit& data_store_conduit::operator=(const data_store_conduit& rhs) {
   // check for self-assignment
@@ -168,7 +165,7 @@ void data_store_conduit::set_data_reader_ptr(generic_data_reader *reader) {
   open_informational_files();
 }
 
-void data_store_conduit::copy_members(const data_store_conduit& rhs, const std::vector<int>& ds_sample_move_list) {
+void data_store_conduit::copy_members(const data_store_conduit& rhs) {
   m_is_setup = rhs.m_is_setup;
   m_preload = rhs.m_preload;
   m_explicit_loading = rhs.m_explicit_loading;
@@ -197,40 +194,6 @@ void data_store_conduit::copy_members(const data_store_conduit& rhs, const std::
   m_cur_spill_dir_integer = rhs.m_cur_spill_dir_integer;
   m_cur_spill_dir = rhs.m_cur_spill_dir;
   m_num_files_in_cur_spill_dir = rhs.m_num_files_in_cur_spill_dir;
-
-  /// This block needed when carving a validation set from the training set
-  m_my_num_indices = 0;
-  if(ds_sample_move_list.size() == 0) {
-    m_data = rhs.m_data;
-  } else {
-    /// Move indices on the list from the data and owner maps in the RHS data store to the new data store
-    for(auto&& i : ds_sample_move_list) {
-
-      if(rhs.m_data.find(i) != rhs.m_data.end()){
-        /// Repack the nodes because they don't seem to copy correctly
-        //
-        //dah - previously this code block only contained the line:
-        //  build_node_for_sending(rhs.m_data[i]["data"], m_data[i]);
-        //However, this resulted in errors in the schema; not sure why,
-        //as it used to work; some change in the conduit library?
-        conduit::Node n2;
-        const std::vector<std::string> &names = rhs.m_data[i]["data"].child_names();
-        const std::vector<std::string> &names2 = rhs.m_data[i]["data"][names[0]].child_names();
-        for (auto t : names2) {
-          n2[names[0]][t] = rhs.m_data[i]["data"][names[0]][t];
-        }
-        build_node_for_sending(n2, m_data[i]);
-        ++m_my_num_indices;
-      }
-      rhs.m_data.erase(i);
-
-      /// Removed migrated nodes from the original data store's owner list
-      if(rhs.m_owner.find(i) != rhs.m_owner.end()) {
-        m_owner[i] = rhs.m_owner[i];
-        rhs.m_owner.erase(i);
-      }
-    }
-  }
 
   /// Clear the pointer to the data reader, this cannot be copied
   m_reader = nullptr;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -422,7 +422,7 @@ void init_data_readers(
       } else if (name == "numpy_npz_conduit_reader") {
         reader_validation = new numpy_npz_conduit_reader(*dynamic_cast<const numpy_npz_conduit_reader*>(reader));
       } else if (name == "imagenet") {
-        reader_validation = new imagenet_reader(*dynamic_cast<const imagenet_reader*>(reader), reader->get_unused_indices());
+        reader_validation = new imagenet_reader(*dynamic_cast<const imagenet_reader*>(reader));
       } else if (name == "multihead_siamese") {
   	reader_validation = new data_reader_multihead_siamese(*dynamic_cast<const data_reader_multihead_siamese*>(reader));
       } else if (name == "jag") {
@@ -450,7 +450,7 @@ void init_data_readers(
             reader_jag_conduit->set_leading_reader(leader);
           }
         } else {
-          reader_validation = new data_reader_jag_conduit(*dynamic_cast<const data_reader_jag_conduit*>(reader), reader->get_unused_indices());
+          reader_validation = new data_reader_jag_conduit(*dynamic_cast<const data_reader_jag_conduit*>(reader));
           const std::string role = "validate";
           auto reader_jag_conduit = dynamic_cast<data_reader_jag_conduit*>(reader_validation);
           reader_jag_conduit->set_leading_reader(reader_jag_conduit);
@@ -500,12 +500,6 @@ void init_data_readers(
       if (store != nullptr) {
         store->set_data_reader_ptr(reader_validation);
         reader_validation->get_data_store_ptr()->compact_nodes();
-      }
-
-      /// At this point clean up any unused samples from the main data store
-      if(reader->get_data_store_ptr() != nullptr) {
-        auto&& data_store = reader->get_data_store_ptr();
-        data_store->purge_unused_samples(reader->get_unused_indices());
       }
 
       if (master) {


### PR DESCRIPTION
Moving call to preload_data_store() from generic_data_reader::instantiate_data_store() to generic_data_reader::setup_data_store().

Preloading is now done independently by the train and validate reader. Previously only the train reader was preloaded,  and samples were later moved from the train to the validate reader.

Passes bamboo
