### PR TITLE
Pin cereal and libjpeg-turbo

### DIFF
--- a/superbuild/cereal/CMakeLists.txt
+++ b/superbuild/cereal/CMakeLists.txt
@@ -13,7 +13,7 @@ else ()
     CACHE STRING "The URL from which to clone CEREAL.")
 endif ()
 
-set(CEREAL_TAG "master" CACHE STRING "The git tag or hash to checkout for CEREAL")
+set(CEREAL_TAG "v1.3.0" CACHE STRING "The git tag or hash to checkout for CEREAL")
 
 # Where to install CEREAL
 set(CEREAL_CMAKE_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}"

--- a/superbuild/jpeg-turbo/CMakeLists.txt
+++ b/superbuild/jpeg-turbo/CMakeLists.txt
@@ -16,7 +16,7 @@ else ()
     CACHE STRING "The URL from which to clone LIBJPEG-TURBO")
 endif ()
 
-set(JPEG-TURBO_TAG "master"
+set(JPEG-TURBO_TAG "2.0.3"
   CACHE STRING "The git tag to checkout for LIBJPEG-TURBO")
 
 # Where to install LIBJPEG-TURBO


### PR DESCRIPTION
Avoids issues with upstream packages updating and breaking things.