### PR TITLE
Updating the build script

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -311,7 +311,7 @@ fi
 # Load packages
 if [ ${USE_MODULES} -ne 0 ]; then
     module load git
-    module load cmake/3.12.1
+    module load cmake/3.14.5
 else
     use git
 fi

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -617,7 +617,9 @@ if [ "${WITH_CUDA}" == "ON" ]; then
 
     # NCCL
     if [[ -z $NCCL_DIR ]]; then
-        NCCL_VER=${NCCL_VER:-2.4.8-1}
+        # Subsequent 2.4.X versions are known to have a performance
+        # regression. See the release notes.
+        NCCL_VER=${NCCL_VER:-2.4.2-1}
         NCCL_DIR=/usr/workspace/wsb/brain/nccl2/nccl_${NCCL_VER}+cuda${CUDA_TOOLKIT_VERSION}_${ARCH}
     fi
     if [[ ! -d $NCCL_DIR ]]; then


### PR DESCRIPTION
The build script is officially obsolete, but Distconv still relies on that.

This PR updates the CUDA, cuDNN and NCCL versions. CUDA 10.1 is the new default version with cuDNN 7.6.4 and NCCL 2.4.8. Build works on Lassen and Pascal. It also updates the default version of CMake.