### PR TITLE
Initialize RNGs for trainers differently by default

### DIFF
--- a/model_zoo/models/jag/gan/vanilla/gan.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan.prototext
@@ -1,7 +1,7 @@
 trainer {
+  random_init_trainers_identically: false
 }
 model {
-  random_init_trainers_identically: false
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/jag/gan/vanilla/gan.prototext
+++ b/model_zoo/models/jag/gan/vanilla/gan.prototext
@@ -1,7 +1,7 @@
 trainer {
 }
 model {
-  random_init_models_differently: true
+  random_init_trainers_identically: false
   objective_function {
     l2_weight_regularization {
       scale_factor: 0.0001

--- a/model_zoo/models/jag/wae.prototext
+++ b/model_zoo/models/jag/wae.prototext
@@ -1,7 +1,7 @@
 trainer {
 }
 model {
-  random_init_models_differently: true
+  random_init_trainers_identically: false
   serialize_io: true
   objective_function {
     l2_weight_regularization {

--- a/model_zoo/models/jag/wae.prototext
+++ b/model_zoo/models/jag/wae.prototext
@@ -1,7 +1,7 @@
 trainer {
+  random_init_trainers_identically: false
 }
 model {
-  random_init_trainers_identically: false
   serialize_io: true
   objective_function {
     l2_weight_regularization {

--- a/model_zoo/models/jag/wae_cycle_gan/wae.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae.prototext
@@ -1,7 +1,7 @@
 trainer {
+  random_init_trainers_identically: false
 }
 model {
-  random_init_trainers_identically: false
   serialize_io: true
   name: "wae_model"
   objective_function {

--- a/model_zoo/models/jag/wae_cycle_gan/wae.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae.prototext
@@ -1,7 +1,7 @@
 trainer {
 }
 model {
-  random_init_models_differently: true
+  random_init_trainers_identically: false
   serialize_io: true
   name: "wae_model"
   objective_function {

--- a/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
@@ -1,7 +1,7 @@
 trainer {
+  random_init_trainers_identically: false
 }
 model {
-  random_init_trainers_identically: false
   name: "wae_model"
   serialize_io: true
   objective_function {

--- a/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
+++ b/model_zoo/models/jag/wae_cycle_gan/wae_nobn.prototext
@@ -1,7 +1,7 @@
 trainer {
 }
 model {
-  random_init_models_differently: true
+  random_init_trainers_identically: false
   name: "wae_model"
   serialize_io: true
   objective_function {

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -64,8 +64,8 @@ message Model {
   repeated Callback callback = 20;
 
   int64 random_seed = 30;
-  // If true, models will have their model rank mixed into their random seed.
-  bool random_init_models_differently = 31;
+  // If false, trainers will have their trainer rank mixed into their random seed.
+  bool random_init_trainers_identically = 31;
 
   Summarizer summarizer = 32;
 }

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -64,8 +64,6 @@ message Model {
   repeated Callback callback = 20;
 
   int64 random_seed = 30;
-  // If false, trainers will have their trainer rank mixed into their random seed.
-  bool random_init_trainers_identically = 31;
 
   Summarizer summarizer = 32;
 }

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -49,15 +49,13 @@ message Trainer {
   // background.
   int64 num_parallel_readers = 3;
 
-
-  // If false, trainers will have their trainer rank mixed into their random seed.
-  bool random_init_trainers_identically = 4;
-
   // -------------------------------
   // Advanced options
   // -------------------------------
 
+  // If false, trainers will have their trainer rank mixed into their random seed.
+  bool random_init_trainers_identically = 4;
+
   // Algorithmic block size for Hydrogen
   int64 hydrogen_block_size = 100;
-
 }

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -49,6 +49,10 @@ message Trainer {
   // background.
   int64 num_parallel_readers = 3;
 
+
+  // If false, trainers will have their trainer rank mixed into their random seed.
+  bool random_init_trainers_identically = 4;
+
   // -------------------------------
   // Advanced options
   // -------------------------------

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -182,16 +182,16 @@ std::unique_ptr<model> build_model_from_prototext(
 
   // Initialize models differently if needed.
 #ifndef LBANN_DETERMINISTIC
-  if (pb_model->random_init_models_differently()) {
+  if (!pb_model->random_init_trainers_identically()) {
     random_seed = random_seed + comm->get_trainer_rank();
     // Reseed here so that setup is done with this new seed.
     init_random(random_seed);
     init_data_seq_random(random_seed);
   }
 #else
-  if (pb_model->random_init_models_differently()) {
+  if (!pb_model->random_init_trainers_identically()) {
     if (master) {
-      std::cout << "WARNING: Ignoring random_init_models_differently " <<
+      std::cout << "WARNING: forcing 'random_init_trainers_identically' " <<
         "due to sequential consistency" << std::endl;
     }
   }

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -182,14 +182,14 @@ std::unique_ptr<model> build_model_from_prototext(
 
   // Initialize models differently if needed.
 #ifndef LBANN_DETERMINISTIC
-  if (!pb_model->random_init_trainers_identically()) {
+  if (!pb_trainer->random_init_trainers_identically()) {
     random_seed = random_seed + comm->get_trainer_rank();
     // Reseed here so that setup is done with this new seed.
     init_random(random_seed);
     init_data_seq_random(random_seed);
   }
 #else
-  if (!pb_model->random_init_trainers_identically()) {
+  if (!pb_trainer->random_init_trainers_identically()) {
     if (master) {
       std::cout << "WARNING: forcing 'random_init_trainers_identically' " <<
         "due to sequential consistency" << std::endl;

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<model> build_model_from_prototext(
   // Initialize models differently if needed.
 #ifndef LBANN_DETERMINISTIC
   if (!pb_trainer->random_init_trainers_identically()) {
-    random_seed = random_seed + comm->get_trainer_rank();
+    hash_combine(random_seed, comm->get_trainer_rank());
     // Reseed here so that setup is done with this new seed.
     init_random(random_seed);
     init_data_seq_random(random_seed);


### PR DESCRIPTION
Basically change the interface ```random_init_models_differently: true``` to ```random_init_trainers_identically: false```

Passed baboo tests https://lc.llnl.gov/bamboo/browse/LBANN-JAES35