### PR TITLE
Fix bug in model zoo CMake

### DIFF
--- a/model_zoo/CMakeLists.txt
+++ b/model_zoo/CMakeLists.txt
@@ -41,5 +41,5 @@ install(
 
 # Install the relevant prototext
 install(FILES README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/model_zoo)
-install(DIRECTORY data_readers models optimizers tests vision
+install(DIRECTORY data_readers models optimizers tests
   DESTINATION ${CMAKE_INSTALL_DATADIR}/model_zoo)


### PR DESCRIPTION
PR #1335 moved `model_zoo/vision` to `applications/vision`, but forgot to update the CMake. A Bamboo build is in progress.

As an aside, it's odd that we copy the entire model zoo to the install directory.