### PR TITLE
Implement matrix multiply layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_matmul.py
+++ b/bamboo/unit_tests/test_unit_layer_matmul.py
@@ -68,14 +68,14 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, _m*_k, _m*_k+_k*_n]))
-    x0 = lbann.Sum([lbann.Reshape(x_slice,
-                                  dims=tools.str_list([_m, _k])),
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=tools.str_list([_m, _k]))])
-    x1 = lbann.Sum([lbann.Reshape(x_slice,
-                                  dims=tools.str_list([_k, _n])),
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=tools.str_list([_k, _n]))])
+    x0 = lbann.Sum(lbann.Reshape(x_slice,
+                                 dims=tools.str_list([_m, _k])),
+                   lbann.WeightsLayer(weights=x0_weights,
+                                      dims=tools.str_list([_m, _k])))
+    x1 = lbann.Sum(lbann.Reshape(x_slice,
+                                 dims=tools.str_list([_k, _n])),
+                   lbann.WeightsLayer(weights=x1_weights,
+                                       dims=tools.str_list([_k, _n])))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -85,16 +85,16 @@ def construct_model(lbann):
     callbacks = []
 
     # ------------------------------------------
-    # Data-parallel layout
+    # NN GEMM
     # ------------------------------------------
 
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MatMul([x0, x1], data_layout='data_parallel')
+    y = lbann.MatMul(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
-    metrics.append(lbann.Metric(z, name='data-parallel layout'))
+    metrics.append(lbann.Metric(z, name='NN GEMM'))
 
     # NumPy implementation
     vals = []

--- a/bamboo/unit_tests/test_unit_layer_matmul.py
+++ b/bamboo/unit_tests/test_unit_layer_matmul.py
@@ -91,7 +91,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MatMul([x0, x1], data_layout='data_parallel', device='cpu')
+    y = lbann.MatMul([x0, x1], data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout'))

--- a/bamboo/unit_tests/test_unit_layer_matmul.py
+++ b/bamboo/unit_tests/test_unit_layer_matmul.py
@@ -1,0 +1,178 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20191111)
+_m = 11
+_n = 3
+_k = 5
+_samples = np.random.normal(size=(27,_m*_k+_k*_n)).astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index].reshape(-1)
+def num_samples():
+    return _samples.shape[0]
+def sample_dims():
+    return (_samples.shape[-1],)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    trainer = lbann.Trainer()
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Sum with weights layers so that gradient checking will
+    # verify that error signals are correct.
+    x0_weights = lbann.Weights(optimizer=lbann.SGD(),
+                               initializer=lbann.ConstantInitializer(value=0.0),
+                               name='input0_weights')
+    x1_weights = lbann.Weights(optimizer=lbann.SGD(),
+                               initializer=lbann.ConstantInitializer(value=0.0),
+                               name='input1_weights')
+    x_slice = lbann.Slice(lbann.Input(),
+                          slice_points=tools.str_list([0, _m*_k, _m*_k+_k*_n]))
+    x0 = lbann.Sum([lbann.Reshape(x_slice,
+                                  dims=tools.str_list([_m, _k])),
+                    lbann.WeightsLayer(weights=x0_weights,
+                                       dims=tools.str_list([_m, _k]))])
+    x1 = lbann.Sum([lbann.Reshape(x_slice,
+                                  dims=tools.str_list([_k, _n])),
+                    lbann.WeightsLayer(weights=x1_weights,
+                                       dims=tools.str_list([_k, _n]))])
+    x0_lbann = x0
+    x1_lbann = x1
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Data-parallel layout
+    # ------------------------------------------
+
+    # LBANN implementation
+    x0 = x0_lbann
+    x1 = x1_lbann
+    y = lbann.MatMul([x0, x1], data_layout='data_parallel', device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel layout'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        x0 = x[:_m*_k].reshape([_m,_k])
+        x1 = x[_m*_k:].reshape([_k,_n])
+        y = np.matmul(x0, x1)
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    mini_batch_size = num_samples() // 2
+    num_epochs = 0
+    return lbann.Model(mini_batch_size,
+                       num_epochs,
+                       layers=lbann.traverse_layer_graph(x0_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/include/lbann/layers/math/CMakeLists.txt
+++ b/include/lbann/layers/math/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_HEADERS
   unary.hpp
   binary.hpp
   clamp.hpp
+  matmul.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -37,8 +37,6 @@ class matmul_layer : public Layer {
   static_assert(Layout == data_layout::DATA_PARALLEL,
                 "matmul_layer only supports "
                 "data-parallel data layout");
-  static_assert(Device == El::Device::CPU,
-                "matmul_layer only supports CPU");
 
 public:
 
@@ -155,6 +153,10 @@ void matmul_layer<Layout,Device>::setup_dims() {
 #ifndef LBANN_MATMUL_LAYER_INSTANTIATE
 extern template class matmul_layer<
   data_layout::DATA_PARALLEL, El::Device::CPU>;
+#ifdef LBANN_HAS_GPU
+extern template class matmul_layer<
+  data_layout::DATA_PARALLEL, El::Device::GPU>;
+#endif // LBANN_HAS_GPU
 #endif // LBANN_MATMUL_LAYER_INSTANTIATE
 
 } // namespace lbann

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -1,0 +1,162 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYER_MATH_MATMUL_HPP_INCLUDED
+#define LBANN_LAYER_MATH_MATMUL_HPP_INCLUDED
+
+#include "lbann/layers/layer.hpp"
+
+namespace lbann {
+
+template <data_layout Layout = data_layout::DATA_PARALLEL,
+          El::Device Device = El::Device::CPU>
+class matmul_layer : public Layer {
+  static_assert(Layout == data_layout::DATA_PARALLEL,
+                "matmul_layer only supports "
+                "data-parallel data layout");
+  static_assert(Device == El::Device::CPU,
+                "matmul_layer only supports CPU");
+
+public:
+
+  matmul_layer(lbann_comm *comm);
+  matmul_layer(const matmul_layer& other) = default;
+  matmul_layer& operator=(const matmul_layer& other) = default;
+  matmul_layer* copy() const override;
+  std::string get_type() const override;
+  data_layout get_data_layout() const override;
+  El::Device get_device_allocation() const override;
+
+protected:
+
+  void setup_dims() override;
+  void fp_compute() override;
+  void bp_compute() override;
+
+};
+
+// =========================================================
+// Implementation
+// =========================================================
+
+template <data_layout Layout, El::Device Device>
+matmul_layer<Layout,Device>::matmul_layer(lbann_comm *comm)
+  : Layer(comm) {
+  this->m_expected_num_parent_layers = 2;
+}
+
+template <data_layout Layout, El::Device Device>
+matmul_layer<Layout,Device>* matmul_layer<Layout,Device>::copy() const {
+  return new matmul_layer(*this);
+}
+
+template <data_layout Layout, El::Device Device>
+std::string matmul_layer<Layout,Device>::get_type() const {
+  return "matrix multiply";
+}
+
+template <data_layout Layout, El::Device Device>
+data_layout matmul_layer<Layout,Device>::get_data_layout() const {
+  return Layout;
+}
+
+template <data_layout Layout, El::Device Device>
+El::Device matmul_layer<Layout,Device>::get_device_allocation() const {
+  return Device;
+}
+
+template <data_layout Layout, El::Device Device>
+void matmul_layer<Layout,Device>::setup_dims() {
+  Layer::setup_dims();
+
+  // Input dimensions
+  const auto& input0_dims = this->get_input_dims(0);
+  const auto& input1_dims = this->get_input_dims(1);
+
+  // Lambdas to help print error messages
+  auto print_name = [this] () -> std::string {
+    return this->get_type() + " layer \"" + this->get_name() + "\"";
+  };
+  auto print_inputs = [this, &input0_dims, &input1_dims] () -> std::string {
+    auto print_dims = [] (const decltype(input0_dims)& dims) -> std::string {
+      std::ostringstream ss;
+      for (size_t i = 0; i < dims.size(); ++i) {
+        ss << (i > 0 ? "x" : "") << dims[i];
+      }
+      return ss.str();
+    };
+    const auto& parents = this->get_parent_layers();
+    return lbann::build_string(
+      parents[0]->get_type()," layer \"",parents[0]->get_name(),"\" ",
+      "outputs ",print_dims(input0_dims),", ",
+      parents[1]->get_type()," layer \"",parents[1]->get_name(),"\" ",
+      "outputs ",print_dims(input1_dims));
+  };
+
+  // Check input dimensions
+  if (input0_dims.size() != input1_dims.size()) {
+    LBANN_ERROR("input tensors in ",print_name()," "
+                "have different numbers of dimensions ",
+                "(",print_inputs(),")");
+  }
+  if (input0_dims.size() != 2) {
+    /// @todo Support >2 dimensions, matvecs, and dot products
+    LBANN_ERROR("input tensors in ",print_name()," are not 2D ",
+                "(",print_inputs(),")");
+  }
+
+  // Get dimensions for matrix multiply
+  /// @todo Support transposes, matvecs, and dot products
+  const auto m = *(input0_dims.rbegin()+1);
+  const auto n = *(input1_dims.rbegin());
+  const auto k = *(input0_dims.rbegin());
+  if (*(input1_dims.rbegin()+1) != k || m < 1 || n < 1 || k < 1) {
+    LBANN_ERROR("input tensors in ",print_name()," ",
+                "are not compatible with matrix multiplication ",
+                "(",print_inputs(),")");
+  }
+
+  // Set output dimensions
+  /// @todo Support transposes, matvecs, and dot products
+  std::vector<int> output_dims(input0_dims);
+  *(output_dims.rbegin()+1) = m;
+  output_dims.back() = n;
+  this->set_output_dims(output_dims);
+
+}
+
+// =========================================================
+// Explicit template instantiation
+// =========================================================
+
+#ifndef LBANN_MATMUL_LAYER_INSTANTIATE
+extern template class matmul_layer<
+  data_layout::DATA_PARALLEL, El::Device::CPU>;
+#endif // LBANN_MATMUL_LAYER_INSTANTIATE
+
+} // namespace lbann
+
+#endif // LBANN_LAYER_MATH_MATMUL_HPP_INCLUDED

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -31,6 +31,15 @@
 
 namespace lbann {
 
+/** @brief Matrix multiplication.
+ *
+ *  Takes two 2D input tensors and outputs their matrix product.
+ *  Matrix products are computed independently for each mini-batch
+ *  sample, in a similar manner as NumPy's matmul function.
+ *
+ *  @todo Support >2 dimensions, transposes, matvecs, and dot products
+ *
+ */
 template <data_layout Layout = data_layout::DATA_PARALLEL,
           El::Device Device = El::Device::CPU>
 class matmul_layer : public Layer {
@@ -121,13 +130,11 @@ void matmul_layer<Layout,Device>::setup_dims() {
                 "(",print_inputs(),")");
   }
   if (input0_dims.size() != 2) {
-    /// @todo Support >2 dimensions, matvecs, and dot products
     LBANN_ERROR("input tensors in ",print_name()," are not 2D ",
                 "(",print_inputs(),")");
   }
 
   // Get dimensions for matrix multiply
-  /// @todo Support transposes, matvecs, and dot products
   const auto m = *(input0_dims.rbegin()+1);
   const auto n = *(input1_dims.rbegin());
   const auto k = *(input0_dims.rbegin());
@@ -138,10 +145,9 @@ void matmul_layer<Layout,Device>::setup_dims() {
   }
 
   // Set output dimensions
-  /// @todo Support transposes, matvecs, and dot products
   std::vector<int> output_dims(input0_dims);
   *(output_dims.rbegin()+1) = m;
-  output_dims.back() = n;
+  *(output_dims.rbegin()) = n;
   this->set_output_dims(output_dims);
 
 }

--- a/include/lbann/utils/cublas.hpp
+++ b/include/lbann/utils/cublas.hpp
@@ -155,7 +155,18 @@ void geam(cublasHandle_t const& handle,
           DataType beta,
           DataType const * B, int ldb,
           DataType * C, int ldc);
-
+void gemm_strided_batched(cublasHandle_t const& handle,
+                          cublasOperation_t transa, cublasOperation_t transb,
+                          int m, int n, int k,
+                          DataType alpha,
+                          DataType const * A, int lda,
+                          long long int strideA,
+                          DataType const * B, int ldb,
+                          long long int strideB,
+                          DataType beta,
+                          DataType * C, int ldc,
+                          long long int strideC,
+                          int batchCount);
 } // namespace cublas
 } // namespace lbann
 

--- a/src/layers/math/CMakeLists.txt
+++ b/src/layers/math/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   unary.cpp
   binary.cpp
   clamp.cpp
+  matmul.cpp
   )
 
 if (LBANN_HAS_CUDA)

--- a/src/layers/math/matmul.cpp
+++ b/src/layers/math/matmul.cpp
@@ -51,7 +51,6 @@ void matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::fp_compute() {
   // Compute matrix multiplication for each mini-batch sample
   // Note: Elemental matrices are in Fortran layout while LBANN
   // tensors are in C layout.
-  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
   LBANN_OMP_PARALLEL_FOR
   for (El::Int i = 0; i < local_mini_batch_size; ++i) {
     CPUMat input0_v, input1_v, output_v;
@@ -86,7 +85,6 @@ void matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::bp_compute() {
   // Compute gradients for each mini-batch sample
   // Note: Elemental matrices are in Fortran layout while LBANN
   // tensors are in C layout.
-  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
   LBANN_OMP_PARALLEL_FOR
   for (El::Int i = 0; i < local_mini_batch_size; ++i) {
     CPUMat input0_v, input1_v, output_grad_v, input0_grad_v, input1_grad_v;
@@ -126,9 +124,8 @@ void matmul_layer<data_layout::DATA_PARALLEL,El::Device::GPU>::fp_compute() {
   const El::Int k = *(input0_dims.rbegin());
 
   // Compute matrix multiplication for each mini-batch sample
-  // Note: BLAS expects matrices in Fortran layout while LBANN tensors
-  // are in C layout.
-  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
+  // Note: cuBLAS expects matrices in Fortran layout while LBANN
+  // tensors are in C layout.
   auto&& handle = El::GPUManager::cuBLASHandle();
   cublas::gemm_strided_batched(
     handle, CUBLAS_OP_N, CUBLAS_OP_N, n, m, k,
@@ -165,9 +162,8 @@ void matmul_layer<data_layout::DATA_PARALLEL,El::Device::GPU>::bp_compute() {
   const El::Int k = *(input0_dims.rbegin());
 
   // Compute gradients for each mini-batch sample
-  // Note: BLAS expects matrices in Fortran layout while LBANN tensors
-  // are in C layout.
-  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
+  // Note: cuBLAS expects matrices in Fortran layout while LBANN
+  // tensors are in C layout.
   auto&& handle = El::GPUManager::cuBLASHandle();
   cublas::gemm_strided_batched(
     handle, CUBLAS_OP_T, CUBLAS_OP_N, k, m, n,

--- a/src/layers/math/matmul.cpp
+++ b/src/layers/math/matmul.cpp
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_MATMUL_LAYER_INSTANTIATE
+#include "lbann/layers/math/matmul.hpp"
+
+namespace lbann {
+
+template <>
+void matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::fp_compute() {
+
+  // Local data
+  const auto& local_input0 = dynamic_cast<const CPUMat&>(get_local_prev_activations(0));
+  const auto& local_input1 = dynamic_cast<const CPUMat&>(get_local_prev_activations(1));
+  auto& local_output = dynamic_cast<CPUMat&>(get_local_activations());
+  const auto& local_mini_batch_size = local_input0.Width();
+
+  // Matrix dimensions
+  const auto output_dims = this->get_output_dims();
+  const auto input0_dims = this->get_input_dims(0);
+  const El::Int m = *(output_dims.rbegin()+1);
+  const El::Int n = *(output_dims.rbegin());
+  const El::Int k = *(input0_dims.rbegin());
+
+  // Compute matrix multiplication for each mini-batch sample
+  // Note: Elemental matrices are in Fortran layout while LBANN
+  // tensors are in C layout.
+  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int i = 0; i < local_mini_batch_size; ++i) {
+    CPUMat input0_v, input1_v, output_v;
+    input0_v.LockedAttach(k, m, local_input0.LockedBuffer(0,i), k);
+    input1_v.LockedAttach(n, k, local_input1.LockedBuffer(0,i), n);
+    output_v.Attach(n, m, local_output.Buffer(0,i), n);
+    El::Gemm(El::NORMAL, El::NORMAL,
+             DataType{1}, input1_v, input0_v,
+             DataType{0}, output_v);
+  }
+
+}
+
+template <>
+void matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>::bp_compute() {
+
+  // Local data
+  const auto& local_input0 = dynamic_cast<const CPUMat&>(get_local_prev_activations(0));
+  const auto& local_input1 = dynamic_cast<const CPUMat&>(get_local_prev_activations(1));
+  const auto& local_output_grad = dynamic_cast<const CPUMat&>(get_local_prev_error_signals());
+  auto& local_input0_grad = dynamic_cast<CPUMat&>(get_local_error_signals(0));
+  auto& local_input1_grad = dynamic_cast<CPUMat&>(get_local_error_signals(1));
+  const auto& local_mini_batch_size = local_input0.Width();
+
+  // Matrix dimensions
+  const auto output_dims = this->get_output_dims();
+  const auto input0_dims = this->get_input_dims(0);
+  const El::Int m = *(output_dims.rbegin()+1);
+  const El::Int n = *(output_dims.rbegin());
+  const El::Int k = *(input0_dims.rbegin());
+
+  // Compute gradients for each mini-batch sample
+  // Note: Elemental matrices are in Fortran layout while LBANN
+  // tensors are in C layout.
+  /// @todo Support >2 tensor dimensions, transposes, matvecs, dot products
+  LBANN_OMP_PARALLEL_FOR
+  for (El::Int i = 0; i < local_mini_batch_size; ++i) {
+    CPUMat input0_v, input1_v, output_grad_v, input0_grad_v, input1_grad_v;
+    input0_v.LockedAttach(k, m, local_input0.LockedBuffer(0,i), k);
+    input1_v.LockedAttach(n, k, local_input1.LockedBuffer(0,i), n);
+    output_grad_v.LockedAttach(n, m, local_output_grad.LockedBuffer(0,i), n);
+    input0_grad_v.Attach(k, m, local_input0_grad.Buffer(0,i), k);
+    input1_grad_v.Attach(n, k, local_input1_grad.Buffer(0,i), n);
+    El::Gemm(El::TRANSPOSE, El::NORMAL,
+             DataType{1}, input1_v, output_grad_v,
+             DataType{0}, input0_grad_v);
+    El::Gemm(El::NORMAL, El::TRANSPOSE,
+             DataType{1}, output_grad_v, input0_v,
+             DataType{0}, input1_grad_v);
+  }
+
+}
+
+// Explicit instantiation
+template class matmul_layer<data_layout::DATA_PARALLEL, El::Device::CPU>;
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -55,6 +55,7 @@
 #include "lbann/layers/loss/top_k_categorical_accuracy.hpp"
 #include "lbann/layers/math/binary.hpp"
 #include "lbann/layers/math/clamp.hpp"
+#include "lbann/layers/math/matmul.hpp"
 #include "lbann/layers/math/unary.hpp"
 #include "lbann/layers/misc/channelwise_mean.hpp"
 #include "lbann/layers/misc/covariance.hpp"
@@ -603,6 +604,14 @@ std::unique_ptr<Layer> construct_layer(
   if (proto_layer.has_clamp()) {
     const auto& params = proto_layer.clamp();
     return lbann::make_unique<clamp_layer<Layout, Device>>(comm, params.min(), params.max());
+  }
+  if (proto_layer.has_matmul()) {
+    if (Layout == data_layout::DATA_PARALLEL && Device == El::Device::CPU) {
+      return lbann::make_unique<matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(comm);
+    } else {
+      LBANN_ERROR("matrix multiply layer is only supported with "
+                  "a data-parallel layout and CPU");
+    }
   }
 
   // Activation layers

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -606,11 +606,11 @@ std::unique_ptr<Layer> construct_layer(
     return lbann::make_unique<clamp_layer<Layout, Device>>(comm, params.min(), params.max());
   }
   if (proto_layer.has_matmul()) {
-    if (Layout == data_layout::DATA_PARALLEL && Device == El::Device::CPU) {
-      return lbann::make_unique<matmul_layer<data_layout::DATA_PARALLEL,El::Device::CPU>>(comm);
+    if (Layout == data_layout::DATA_PARALLEL) {
+      return lbann::make_unique<matmul_layer<data_layout::DATA_PARALLEL,Device>>(comm);
     } else {
       LBANN_ERROR("matrix multiply layer is only supported with "
-                  "a data-parallel layout and CPU");
+                  "a data-parallel layout");
     }
   }
 

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -147,6 +147,7 @@ message Layer {
     LogicalOr logical_or = 467;
     LogicalXor logical_xor = 468;
     Clamp clamp = 469;
+    MatMul matmul = 470;
 
     // Regularization layers
     BatchNormalization batch_normalization = 19;
@@ -237,6 +238,9 @@ message Layer {
     double min = 1;
     double max = 2;
   }
+
+  /** Batched matrix multiplication. */
+  message MatMul {}
 
   ///////////////////////
   // Activation layers //

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -239,7 +239,12 @@ message Layer {
     double max = 2;
   }
 
-  /** Batched matrix multiplication. */
+  /** @brief Matrix multiplication.
+   *
+   *  Takes two 2D input tensors and outputs their matrix product.
+   *  Matrix products are computed independently for each mini-batch
+   *  sample, in a similar manner as NumPy's matmul function.
+   */
   message MatMul {}
 
   ///////////////////////

--- a/src/utils/cublas.cpp
+++ b/src/utils/cublas.cpp
@@ -43,23 +43,25 @@ struct cuBLAS_Caller;
 template <>
 struct cuBLAS_Caller<float> {
   WRAP_CUBLAS(cublasSaxpy, axpy)
-  WRAP_CUBLAS(cublasSdot , dot )
+  WRAP_CUBLAS(cublasSdot, dot)
   WRAP_CUBLAS(cublasSnrm2, nrm2)
   WRAP_CUBLAS(cublasSscal, scal)
   WRAP_CUBLAS(cublasSgemv, gemv)
   WRAP_CUBLAS(cublasSgemm, gemm)
   WRAP_CUBLAS(cublasSgeam, geam)
+  WRAP_CUBLAS(cublasSgemmStridedBatched, gemm_strided_batched)
 };
 
 template <>
 struct cuBLAS_Caller<double> {
   WRAP_CUBLAS(cublasDaxpy, axpy)
-  WRAP_CUBLAS(cublasDdot , dot )
+  WRAP_CUBLAS(cublasDdot, dot)
   WRAP_CUBLAS(cublasDnrm2, nrm2)
   WRAP_CUBLAS(cublasDscal, scal)
   WRAP_CUBLAS(cublasDgemv, gemv)
   WRAP_CUBLAS(cublasDgemm, gemm)
   WRAP_CUBLAS(cublasDgeam, geam)
+  WRAP_CUBLAS(cublasDgemmStridedBatched, gemm_strided_batched)
 };
 
 } // namespace
@@ -176,6 +178,24 @@ void geam(cublasHandle_t const& handle,
           DataType * C, int ldc) {
   cuBLAS_Caller<DataType>{}.geam(handle, transa, transb, m, n,
                                  &alpha, A, lda, &beta, B, ldb, C, ldc);
+}
+
+void gemm_strided_batched(cublasHandle_t const& handle,
+                          cublasOperation_t transa, cublasOperation_t transb,
+                          int m, int n, int k,
+                          DataType alpha,
+                          DataType const * A, int lda,
+                          long long int strideA,
+                          DataType const * B, int ldb,
+                          long long int strideB,
+                          DataType beta,
+                          DataType * C, int ldc,
+                          long long int strideC,
+                          int batchCount) {
+  cuBLAS_Caller<DataType>{}.gemm_strided_batched(
+    handle, transa, transb, m, n, k,
+    &alpha, A, lda, strideA, B, ldb, strideB,
+    &beta, C, ldc, strideC, batchCount);
 }
 
 } // namespace cublas


### PR DESCRIPTION
`matmul_layer` is similar to NumPy's `matmul` function, which performs batched GEMMs. Currently it only supports 2D input tensors, NN GEMMs, and data-parallel data.

This operation is used for multi-headed attention in transformer models and for negative sampling in Skip-gram models.

[Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM234-1).