### PR TITLE
Specify a layer's parents in Python frontend with positional args

### DIFF
--- a/applications/vision/alexnet.py
+++ b/applications/vision/alexnet.py
@@ -33,15 +33,15 @@ args = parser.parse_args()
 imagenet_labels = 1000
 
 # Construct layer graph
-input = lbann.Input()
-images = lbann.Identity(input)
-labels = lbann.Identity(input)
+input_ = lbann.Input()
+images = lbann.Identity(input_)
+labels = lbann.Identity(input_)
 preds = lbann.models.AlexNet(imagenet_labels)(images)
 probs = lbann.Softmax(preds)
-cross_entropy = lbann.CrossEntropy([probs, labels])
-top1 = lbann.CategoricalAccuracy([probs, labels])
-top5 = lbann.TopKCategoricalAccuracy([probs, labels], k=5)
-layers = list(lbann.traverse_layer_graph(input))
+cross_entropy = lbann.CrossEntropy(probs, labels)
+top1 = lbann.CategoricalAccuracy(probs, labels)
+top5 = lbann.TopKCategoricalAccuracy(probs, labels, k=5)
+layers = list(lbann.traverse_layer_graph(input_))
 
 # Setup objective function
 weights = set()

--- a/applications/vision/lenet.py
+++ b/applications/vision/lenet.py
@@ -21,9 +21,9 @@ args = parser.parse_args()
 # ----------------------------------
 
 # Input data
-input = lbann.Input()
-images = lbann.Identity(input)
-labels = lbann.Identity(input)
+input_ = lbann.Input()
+images = lbann.Identity(input_)
+labels = lbann.Identity(input_)
 
 # LeNet
 x = lbann.Convolution(images,
@@ -62,8 +62,8 @@ x = lbann.FullyConnected(x, num_neurons = 10, has_bias = True)
 probs = lbann.Softmax(x)
 
 # Loss function and accuracy
-loss = lbann.CrossEntropy([probs, labels])
-acc = lbann.CategoricalAccuracy([probs, labels])
+loss = lbann.CrossEntropy(probs, labels)
+acc = lbann.CategoricalAccuracy(probs, labels)
 
 # ----------------------------------
 # Setup experiment
@@ -74,7 +74,7 @@ mini_batch_size = 64
 num_epochs = 20
 model = lbann.Model(mini_batch_size,
                     num_epochs,
-                    layers=lbann.traverse_layer_graph(input),
+                    layers=lbann.traverse_layer_graph(input_),
                     objective_function=loss,
                     metrics=[lbann.Metric(acc, name='accuracy', unit='%')],
                     callbacks=[lbann.CallbackPrintModelDescription(),

--- a/applications/vision/resnet.py
+++ b/applications/vision/resnet.py
@@ -104,15 +104,15 @@ else:
         width=args.width)
 
 # Construct layer graph
-input = lbann.Input()
-images = lbann.Identity(input)
-labels = lbann.Identity(input)
+input_ = lbann.Input()
+images = lbann.Identity(input_)
+labels = lbann.Identity(input_)
 preds = resnet(images)
 probs = lbann.Softmax(preds)
-cross_entropy = lbann.CrossEntropy([probs, labels])
-top1 = lbann.CategoricalAccuracy([probs, labels])
-top5 = lbann.TopKCategoricalAccuracy([probs, labels], k=5)
-layers = list(lbann.traverse_layer_graph(input))
+cross_entropy = lbann.CrossEntropy(probs, labels)
+top1 = lbann.CategoricalAccuracy(probs, labels)
+top5 = lbann.TopKCategoricalAccuracy(probs, labels, k=5)
+layers = list(lbann.traverse_layer_graph(input_))
 
 # Setup objective function
 l2_reg_weights = set()

--- a/bamboo/integration_tests/test_integration_alexnet.py
+++ b/bamboo/integration_tests/test_integration_alexnet.py
@@ -70,8 +70,8 @@ def construct_model(lbann):
     labels = lbann.Identity(input_)
     x = lbann.models.AlexNet(1000)(images)
     probs = lbann.Softmax(x)
-    cross_entropy = lbann.CrossEntropy([probs, labels])
-    top5 = lbann.TopKCategoricalAccuracy([probs, labels], k=5)
+    cross_entropy = lbann.CrossEntropy(probs, labels)
+    top5 = lbann.TopKCategoricalAccuracy(probs, labels, k=5)
     layers = list(lbann.traverse_layer_graph(x))
 
     # Setup objective function

--- a/bamboo/integration_tests/test_integration_lenet.py
+++ b/bamboo/integration_tests/test_integration_lenet.py
@@ -71,8 +71,8 @@ def construct_model(lbann):
     labels = lbann.Identity(input_)
     x = lbann.models.LeNet(10)(images)
     probs = lbann.Softmax(x)
-    loss = lbann.CrossEntropy([probs, labels])
-    acc = lbann.CategoricalAccuracy([probs, labels])
+    loss = lbann.CrossEntropy(probs, labels)
+    acc = lbann.CategoricalAccuracy(probs, labels)
 
     # Objects for LBANN model
     callbacks = [lbann.CallbackPrint(), lbann.CallbackTimer()]

--- a/bamboo/integration_tests/test_integration_resnet50.py
+++ b/bamboo/integration_tests/test_integration_resnet50.py
@@ -70,8 +70,8 @@ def construct_model(lbann):
     labels = lbann.Identity(input_)
     x = lbann.models.ResNet50(1000, bn_statistics_group_size=-1)(images)
     probs = lbann.Softmax(x)
-    cross_entropy = lbann.CrossEntropy([probs, labels])
-    top5 = lbann.TopKCategoricalAccuracy([probs, labels], k=5)
+    cross_entropy = lbann.CrossEntropy(probs, labels)
+    top5 = lbann.TopKCategoricalAccuracy(probs, labels, k=5)
     layers = list(lbann.traverse_layer_graph(x))
 
     # Setup objective function

--- a/bamboo/unit_tests/test_unit_layer_channelwise_scale_bias.py
+++ b/bamboo/unit_tests/test_unit_layer_channelwise_scale_bias.py
@@ -68,7 +68,7 @@ def construct_model(lbann):
     x0 = lbann.WeightsLayer(weights=x_weights,
                             dims=tools.str_list(_sample_dims))
     x1 = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
-    x = lbann.Sum([x0, x1])
+    x = lbann.Sum(x0, x1)
 
     # Apply channel-wise scale/bias
     scale_values = tools.str_list(np.nditer(_scale))

--- a/bamboo/unit_tests/test_unit_layer_clamp.py
+++ b/bamboo/unit_tests/test_unit_layer_clamp.py
@@ -66,10 +66,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_convolution.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution.py
@@ -137,10 +137,10 @@ def construct_model(lbann):
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
                               initializer=lbann.ConstantInitializer(value=0.0),
                               name='input_weights')
-    x0 = lbann.WeightsLayer(weights=x_weights,
-                            dims=tools.str_list(_sample_dims))
-    x1 = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
-    x = lbann.Sum([x0, x1])
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_covariance.py
+++ b/bamboo/unit_tests/test_unit_layer_covariance.py
@@ -66,12 +66,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, slice_size, 2*slice_size]))
-    x0 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=str(slice_size))])
-    x1 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=str(slice_size))])
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(slice_size)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(slice_size)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -87,7 +85,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.Covariance([x0, x1], data_layout='data_parallel')
+    y = lbann.Covariance(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout, unbiased'))
@@ -117,7 +115,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.Covariance([x0, x1], data_layout='model_parallel')
+    y = lbann.Covariance(x0, x1, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout, unbiased'))
@@ -147,7 +145,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.Covariance([x0, x1], biased=True, data_layout='data_parallel')
+    y = lbann.Covariance(x0, x1, biased=True, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout, biased'))
@@ -177,7 +175,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.Covariance([x0, x1], biased=True, data_layout='model_parallel')
+    y = lbann.Covariance(x0, x1, biased=True, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout, biased'))

--- a/bamboo/unit_tests/test_unit_layer_cross_entropy.py
+++ b/bamboo/unit_tests/test_unit_layer_cross_entropy.py
@@ -95,12 +95,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, slice_size, 2*slice_size]))
-    x0 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=str(slice_size))])
-    x1 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=str(slice_size))])
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(slice_size)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(slice_size)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -116,7 +114,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.CrossEntropy([x0, x1], data_layout='data_parallel')
+    y = lbann.CrossEntropy(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout'))
@@ -146,7 +144,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.CrossEntropy([x0, x1], data_layout='model_parallel')
+    y = lbann.CrossEntropy(x0, x1, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout'))

--- a/bamboo/unit_tests/test_unit_layer_elu.py
+++ b/bamboo/unit_tests/test_unit_layer_elu.py
@@ -64,10 +64,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_entrywise_batch_normalization.py
+++ b/bamboo/unit_tests/test_unit_layer_entrywise_batch_normalization.py
@@ -65,12 +65,13 @@ def construct_model(lbann):
     # the zero-valued tensor by the mini-batch index.
     x = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
     x0 = lbann.WeightsLayer(weights=x_weights,
                             dims=tools.str_list(_sample_dims))
-    x1 = lbann.Divide([lbann.MiniBatchIndex(), lbann.MiniBatchSize()])
+    x1 = lbann.Divide(lbann.MiniBatchIndex(), lbann.MiniBatchSize())
     x1 = lbann.Tessellate(lbann.Reshape(x1, dims='1 1 1'), dims=tools.str_list(_sample_dims))
-    x = lbann.Sum([x, lbann.Multiply([x0, x1])])
+    x = lbann.Sum(x, lbann.Multiply(x0, x1))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_entrywise_scale_bias.py
+++ b/bamboo/unit_tests/test_unit_layer_entrywise_scale_bias.py
@@ -63,11 +63,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights,
-                            dims=tools.str_list(_sample_dims))
-    x1 = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_fully_connected.py
+++ b/bamboo/unit_tests/test_unit_layer_fully_connected.py
@@ -61,10 +61,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_input_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_input_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_input_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_identity.py
+++ b/bamboo/unit_tests/test_unit_layer_identity.py
@@ -60,10 +60,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_l1_norm.py
+++ b/bamboo/unit_tests/test_unit_layer_l1_norm.py
@@ -64,10 +64,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu.py
@@ -64,10 +64,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_log_sigmoid.py
@@ -62,10 +62,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_log_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_log_softmax.py
@@ -75,10 +75,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
+++ b/bamboo/unit_tests/test_unit_layer_mean_absolute_error.py
@@ -69,12 +69,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, slice_size, 2*slice_size]))
-    x0 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=str(slice_size))])
-    x1 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=str(slice_size))])
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(slice_size)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(slice_size)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -90,7 +88,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MeanAbsoluteError([x0, x1], data_layout='data_parallel')
+    y = lbann.MeanAbsoluteError(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout'))
@@ -120,7 +118,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MeanAbsoluteError([x0, x1], data_layout='model_parallel')
+    y = lbann.MeanAbsoluteError(x0, x1, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout, unbiased'))

--- a/bamboo/unit_tests/test_unit_layer_mean_squared_error.py
+++ b/bamboo/unit_tests/test_unit_layer_mean_squared_error.py
@@ -66,12 +66,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, slice_size, 2*slice_size]))
-    x0 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=str(slice_size))])
-    x1 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=str(slice_size))])
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(slice_size)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(slice_size)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -87,7 +85,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MeanSquaredError([x0, x1], data_layout='data_parallel')
+    y = lbann.MeanSquaredError(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout'))
@@ -117,7 +115,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.MeanSquaredError([x0, x1], data_layout='model_parallel')
+    y = lbann.MeanSquaredError(x0, x1, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout, unbiased'))

--- a/bamboo/unit_tests/test_unit_layer_one_hot.py
+++ b/bamboo/unit_tests/test_unit_layer_one_hot.py
@@ -60,7 +60,7 @@ def construct_model(lbann):
     y1 = lbann.OneHot(x, size=one_hot_size)
     y2 = lbann.Concatenation([lbann.Constant(value=i+1, num_neurons='1')
                               for i in range(one_hot_size)])
-    y = lbann.Multiply([y1, y2])
+    y = lbann.Multiply(y1, y2)
     z = lbann.L2Norm2(y)
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_relu.py
+++ b/bamboo/unit_tests/test_unit_layer_relu.py
@@ -64,10 +64,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_selu.py
+++ b/bamboo/unit_tests/test_unit_layer_selu.py
@@ -80,10 +80,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_sigmoid.py
+++ b/bamboo/unit_tests/test_unit_layer_sigmoid.py
@@ -62,10 +62,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_slice.py
+++ b/bamboo/unit_tests/test_unit_layer_slice.py
@@ -58,22 +58,22 @@ def construct_model(lbann):
 
     """
 
-    # LBANN objects
+    # Input data
+    # Note: Sum with a weights layer so that gradient checking will
+    # verify that error signals are correct.
+    x_weights = lbann.Weights(optimizer=lbann.SGD(),
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
+    x_lbann = x
+
+    # Objects for LBANN model
     obj = []
     metrics = []
     callbacks = []
-
-    # --------------------------
-    # LBANN input data
-    # --------------------------
-    # Note: Sum with a weights layer so that gradient checking will
-    # verify that error signals are correct.
-    w = lbann.Weights(optimizer=lbann.SGD(),
-                      initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=w,
-                            dims=tools.str_list(_sample_dims))
-    x1 = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
-    x_lbann = lbann.Sum([x0, x1])
 
     # --------------------------
     # Slice along axis 0

--- a/bamboo/unit_tests/test_unit_layer_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_softmax.py
@@ -76,10 +76,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_softplus.py
+++ b/bamboo/unit_tests/test_unit_layer_softplus.py
@@ -62,10 +62,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_softsign.py
+++ b/bamboo/unit_tests/test_unit_layer_softsign.py
@@ -60,10 +60,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_squared_difference.py
+++ b/bamboo/unit_tests/test_unit_layer_squared_difference.py
@@ -66,12 +66,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, slice_size, 2*slice_size]))
-    x0 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x0_weights,
-                                       dims=str(slice_size))])
-    x1 = lbann.Sum([x_slice,
-                    lbann.WeightsLayer(weights=x1_weights,
-                                       dims=str(slice_size))])
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(slice_size)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(slice_size)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -87,7 +85,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.SquaredDifference([x0, x1], data_layout='data_parallel')
+    y = lbann.SquaredDifference(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='data-parallel layout'))
@@ -117,7 +115,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = x0_lbann
     x1 = x1_lbann
-    y = lbann.SquaredDifference([x0, x1], data_layout='model_parallel')
+    y = lbann.SquaredDifference(x0, x1, data_layout='model_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='model-parallel layout, unbiased'))

--- a/bamboo/unit_tests/test_unit_layer_tessellate.py
+++ b/bamboo/unit_tests/test_unit_layer_tessellate.py
@@ -64,9 +64,10 @@ def construct_model(lbann):
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
                               initializer=lbann.ConstantInitializer(value=0.0),
                               name='input_weights')
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=tools.str_list(_sample_dims))
-    x1 = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
-    x = lbann.Sum([x0, x1])
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/bamboo/unit_tests/test_unit_layer_variance.py
+++ b/bamboo/unit_tests/test_unit_layer_variance.py
@@ -60,10 +60,12 @@ def construct_model(lbann):
     # Note: Sum with a weights layer so that gradient checking will
     # verify that error signals are correct.
     x_weights = lbann.Weights(optimizer=lbann.SGD(),
-                              initializer=lbann.ConstantInitializer(value=0.0))
-    x0 = lbann.WeightsLayer(weights=x_weights, dims=str(_sample_size))
-    x1 = lbann.Identity(lbann.Input())
-    x = lbann.Sum([x0, x1])
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_size)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_size)))
     x_lbann = x
 
     # Objects for LBANN model

--- a/python/lbann/models/resnet.py
+++ b/python/lbann/models/resnet.py
@@ -130,7 +130,7 @@ class BasicBlock(lbann.modules.Module):
         self.instance += 1
         y1 = self.branch1(x) if self.branch1 else x
         y2 = self.branch2b(self.branch2a(x))
-        z = lbann.Add([y1, y2],
+        z = lbann.Add(y1, y2,
                       name='{0}_sum_instance{1}'.format(self.name,self.instance))
         return lbann.Relu(z, name='{0}_relu_instance{1}'.format(self.name,self.instance))
 
@@ -198,7 +198,7 @@ class BottleneckBlock(lbann.modules.Module):
         self.instance += 1
         y1 = self.branch1(x) if self.branch1 else x
         y2 = self.branch2c(self.branch2b(self.branch2a(x)))
-        z = lbann.Add([y1, y2],
+        z = lbann.Add(y1, y2,
                       name='{0}_sum_instance{1}'.format(self.name,self.instance))
         return lbann.Relu(z, name='{0}_relu_instance{1}'.format(self.name,self.instance))
 

--- a/python/lbann/modules.py
+++ b/python/lbann/modules.py
@@ -318,7 +318,7 @@ class LSTMCell(Module):
         prev_output, prev_cell = prev_state
 
         # Apply linearity
-        input_concat = lbann.Concatenation([x, prev_output],
+        input_concat = lbann.Concatenation(x, prev_output,
                                            name=name + '_input',
                                            data_layout=self.data_layout)
         fc = self.fc(input_concat)
@@ -346,19 +346,19 @@ class LSTMCell(Module):
                            data_layout=self.data_layout)
 
         # Cell state
-        cell_forget = lbann.Multiply([f, prev_cell],
+        cell_forget = lbann.Multiply(f, prev_cell,
                                      name=name + '_cell_forget',
                                      data_layout=self.data_layout)
-        cell_input = lbann.Multiply([i, cell_update],
+        cell_input = lbann.Multiply(i, cell_update,
                                     name=name + '_cell_input',
                                     data_layout=self.data_layout)
-        cell = lbann.Add([cell_forget, cell_input], name=name + '_cell',
+        cell = lbann.Add(cell_forget, cell_input, name=name + '_cell',
                          data_layout=self.data_layout)
 
         # Output
         cell_act = lbann.Tanh(cell, name=name + '_cell_activation',
                               data_layout=self.data_layout)
-        output = lbann.Multiply([o, cell_act], name=name,
+        output = lbann.Multiply(o, cell_act, name=name,
                                 data_layout=self.data_layout)
 
         # Return output and state
@@ -445,7 +445,7 @@ class GRU(Module):
             prev_state: State from previous GRU step.
 
         Returns:
-            (Layer, Layer): The output (out)  and state (hn). 
+            (Layer, Layer): The output (out)  and state (hn).
                           The state can be passed directly into
                            the next GRU step.
 
@@ -480,26 +480,45 @@ class GRU(Module):
                            data_layout=self.data_layout)
         Whn_prev = lbann.Identity(fc2_slice, name=name + '_Wnh',
                            data_layout=self.data_layout)
-        
-        rt = lbann.Sigmoid(lbann.Add([Wir_x,Whr_prev], data_layout=self.data_layout), name=name + '_reset_gate',
-                           data_layout=self.data_layout)
 
-        zt = lbann.Sigmoid(lbann.Add([Wiz_x,Whz_prev], data_layout=self.data_layout), name=name + '_update_gate',
-                           data_layout=self.data_layout)
-        
-        nt = lbann.Tanh(lbann.Add([Win_x,
-                        lbann.Multiply([rt,Whn_prev], data_layout=self.data_layout)], data_layout=self.data_layout),
-                        name=name + '_new_gate', data_layout=self.data_layout)
+        rt = \
+            lbann.Sigmoid(
+                lbann.Add(Wir_x, Whr_prev, data_layout=self.data_layout),
+                name=name + '_reset_gate',
+                data_layout=self.data_layout
+            )
 
-        ht = lbann.Add([
-                       lbann.Multiply([
-                             lbann.WeightedSum([
-                                 lbann.Constant(value=1.0, hint_layer=zt, data_layout=self.data_layout),
-                                 zt],
-                                 scaling_factors='1 -1', data_layout=self.data_layout),
-                             nt], data_layout=self.data_layout),
-                       lbann.Multiply([zt,prev_state], data_layout=self.data_layout)], name=name+ '_output', 
-                       data_layout=self.data_layout)
-        
+        zt = \
+            lbann.Sigmoid(
+                lbann.Add(Wiz_x, Whz_prev, data_layout=self.data_layout),
+                name=name + '_update_gate',
+                data_layout=self.data_layout,
+            )
+
+        nt = \
+            lbann.Tanh(
+                lbann.Add(
+                    Win_x,
+                    lbann.Multiply(rt, Whn_prev, data_layout=self.data_layout),
+                    data_layout=self.data_layout,
+                ),
+                name=name + '_new_gate', data_layout=self.data_layout,
+            )
+
+        ht = \
+            lbann.Add(
+                lbann.Multiply(
+                    lbann.WeightedSum(
+                        lbann.Constant(value=1.0, hint_layer=zt, data_layout=self.data_layout),
+                        zt,
+                        scaling_factors='1 -1', data_layout=self.data_layout
+                    ),
+                    nt,
+                    data_layout=self.data_layout
+                ),
+                lbann.Multiply(zt, prev_state, data_layout=self.data_layout),
+                name=name+ '_output', data_layout=self.data_layout,
+            )
+
         # Return output
         return ht, ht


### PR DESCRIPTION
When you specify a layer with the Python frontend, the first argument specifies the parent layers:
```python
z = lbann.Sum([x, y])
```
This is a little ugly and unintuitive. I've changed the API a bit so that all positional arguments specify parents:
```python
z = lbann.Sum(x, y)
```
The old API still works and you can still specify parents with the `parents` keyword argument.

I've gone ahead and updated the vision models, NLP models, and Bamboo tests to use the new API. The important files to review are `python/lbann/layer.py` and `python/lbann/modules.py` [Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM235-1).