### PR TITLE
Support transposes in matrix multiply layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_matmul.py
+++ b/bamboo/unit_tests/test_unit_layer_matmul.py
@@ -87,7 +87,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_m, _k]))
     x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_k, _n]))
-    y = lbann.MatMul(x0, x1, data_layout='data_parallel', device='cpu')
+    y = lbann.MatMul(x0, x1, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='NN GEMM'))
@@ -117,7 +117,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_k, _m]))
     x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_k, _n]))
-    y = lbann.MatMul(x0, x1, transpose_a=True, data_layout='data_parallel', device='cpu')
+    y = lbann.MatMul(x0, x1, transpose_a=True, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='TN GEMM'))
@@ -147,7 +147,7 @@ def construct_model(lbann):
     # LBANN implementation
     x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_m, _k]))
     x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_n, _k]))
-    y = lbann.MatMul(x0, x1, transpose_b=True, data_layout='data_parallel', device='cpu')
+    y = lbann.MatMul(x0, x1, transpose_b=True, data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='NT GEMM'))
@@ -178,7 +178,7 @@ def construct_model(lbann):
     x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_k, _m]))
     x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_n, _k]))
     y = lbann.MatMul(x0, x1, transpose_a=True, transpose_b=True,
-                     data_layout='data_parallel', device='cpu')
+                     data_layout='data_parallel')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='TT GEMM'))

--- a/bamboo/unit_tests/test_unit_layer_matmul.py
+++ b/bamboo/unit_tests/test_unit_layer_matmul.py
@@ -68,14 +68,10 @@ def construct_model(lbann):
                                name='input1_weights')
     x_slice = lbann.Slice(lbann.Input(),
                           slice_points=tools.str_list([0, _m*_k, _m*_k+_k*_n]))
-    x0 = lbann.Sum(lbann.Reshape(x_slice,
-                                 dims=tools.str_list([_m, _k])),
-                   lbann.WeightsLayer(weights=x0_weights,
-                                      dims=tools.str_list([_m, _k])))
-    x1 = lbann.Sum(lbann.Reshape(x_slice,
-                                 dims=tools.str_list([_k, _n])),
-                   lbann.WeightsLayer(weights=x1_weights,
-                                       dims=tools.str_list([_k, _n])))
+    x0 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x0_weights, dims=str(_m*_k)))
+    x1 = lbann.Sum(x_slice,
+                   lbann.WeightsLayer(weights=x1_weights, dims=str(_k*_n)))
     x0_lbann = x0
     x1_lbann = x1
 
@@ -89,9 +85,9 @@ def construct_model(lbann):
     # ------------------------------------------
 
     # LBANN implementation
-    x0 = x0_lbann
-    x1 = x1_lbann
-    y = lbann.MatMul(x0, x1, data_layout='data_parallel')
+    x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_m, _k]))
+    x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_k, _n]))
+    y = lbann.MatMul(x0, x1, data_layout='data_parallel', device='cpu')
     z = lbann.L2Norm2(y)
     obj.append(z)
     metrics.append(lbann.Metric(z, name='NN GEMM'))
@@ -103,6 +99,97 @@ def construct_model(lbann):
         x0 = x[:_m*_k].reshape([_m,_k])
         x1 = x[_m*_k:].reshape([_k,_n])
         y = np.matmul(x0, x1)
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # TN GEMM
+    # ------------------------------------------
+
+    # LBANN implementation
+    x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_k, _m]))
+    x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_k, _n]))
+    y = lbann.MatMul(x0, x1, transpose_a=True, data_layout='data_parallel', device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='TN GEMM'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        x0 = x[:_m*_k].reshape([_k,_m])
+        x1 = x[_m*_k:].reshape([_k,_n])
+        y = np.matmul(x0.transpose(), x1)
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # NT GEMM
+    # ------------------------------------------
+
+    # LBANN implementation
+    x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_m, _k]))
+    x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_n, _k]))
+    y = lbann.MatMul(x0, x1, transpose_b=True, data_layout='data_parallel', device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='NT GEMM'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        x0 = x[:_m*_k].reshape([_m,_k])
+        x1 = x[_m*_k:].reshape([_n,_k])
+        y = np.matmul(x0, x1.transpose())
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # TT GEMM
+    # ------------------------------------------
+
+    # LBANN implementation
+    x0 = lbann.Reshape(x0_lbann, dims=tools.str_list([_k, _m]))
+    x1 = lbann.Reshape(x1_lbann, dims=tools.str_list([_n, _k]))
+    y = lbann.MatMul(x0, x1, transpose_a=True, transpose_b=True,
+                     data_layout='data_parallel', device='cpu')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='TT GEMM'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        x0 = x[:_m*_k].reshape([_k,_m])
+        x1 = x[_m*_k:].reshape([_n,_k])
+        y = np.matmul(x0.transpose(), x1.transpose())
         z = tools.numpy_l2norm2(y)
         vals.append(z)
     val = np.mean(vals)

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -37,7 +37,7 @@ namespace lbann {
  *  Matrix products are computed independently for each mini-batch
  *  sample, in a similar manner as NumPy's matmul function.
  *
- *  @todo Support >2 dimensions, transposes, matvecs, and dot products
+ *  @todo Support >2 dimensions, matvecs, and dot products
  *
  */
 template <typename TensorDataType,

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -71,9 +71,11 @@ protected:
 
 private:
 
-  /** Whether to transpose matrices from the first input tensor. */
+  /** If true, matrices from the first input tensor are transposed
+   *  before multiplication. */
   bool m_transpose_a;
-  /** Whether to transpose matrices from the second input tensor. */
+  /** If true, matrices from the second input tensor are transposed
+   *  before multiplication. */
   bool m_transpose_b;
 
 };

--- a/src/layers/math/matmul.cpp
+++ b/src/layers/math/matmul.cpp
@@ -33,31 +33,42 @@
 namespace lbann {
 
 template <typename TensorDataType>
-void fp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::CPU>& l) {
+void fp_compute_impl(matmul_layer<TensorDataType,data_layout::DATA_PARALLEL,El::Device::CPU>& l,
+                     bool transpose_input0,
+                     bool transpose_input1) {
 
   // Local data
-  const auto& local_input0 = dynamic_cast<const CPUMat&>(l.get_local_prev_activations(0));
-  const auto& local_input1 = dynamic_cast<const CPUMat&>(l.get_local_prev_activations(1));
-  auto& local_output = dynamic_cast<CPUMat&>(l.get_local_activations());
+  using LocalMat = El::Matrix<TensorDataType, El::Device::CPU>;
+  const auto& local_input0 = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(0));
+  const auto& local_input1 = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(1));
+  auto& local_output = dynamic_cast<LocalMat&>(l.get_local_activations());
   const auto& local_mini_batch_size = local_input0.Width();
 
   // Matrix dimensions
-  const auto output_dims = l.get_output_dims();
   const auto input0_dims = l.get_input_dims(0);
-  const El::Int m = *(output_dims.rbegin()+1);
-  const El::Int n = *(output_dims.rbegin());
-  const El::Int k = *(input0_dims.rbegin());
+  const auto input1_dims = l.get_input_dims(1);
+  const auto output_dims = l.get_output_dims();
+  const El::Int input0_height = *(input0_dims.rbegin()+1);
+  const El::Int input0_width = *(input0_dims.rbegin());
+  const El::Int input1_height = *(input1_dims.rbegin()+1);
+  const El::Int input1_width = *(input1_dims.rbegin());
+  const El::Int output_height = *(output_dims.rbegin()+1);
+  const El::Int output_width = *(output_dims.rbegin());
 
   // Compute matrix multiplication for each mini-batch sample
   // Note: Elemental matrices are in Fortran layout while LBANN
   // tensors are in C layout.
   LBANN_OMP_PARALLEL_FOR
   for (El::Int i = 0; i < local_mini_batch_size; ++i) {
-    CPUMat input0_v, input1_v, output_v;
-    input0_v.LockedAttach(k, m, local_input0.LockedBuffer(0,i), k);
-    input1_v.LockedAttach(n, k, local_input1.LockedBuffer(0,i), n);
-    output_v.Attach(n, m, local_output.Buffer(0,i), n);
-    El::Gemm(El::NORMAL, El::NORMAL,
+    LocalMat input0_v, input1_v, output_v;
+    input0_v.LockedAttach(input0_width, input0_height,
+                          local_input0.LockedBuffer(0,i), input0_width);
+    input1_v.LockedAttach(input1_width, input1_height,
+                          local_input1.LockedBuffer(0,i), input1_width);
+    output_v.Attach(output_width, output_height,
+                    local_output.Buffer(0,i), output_width);
+    El::Gemm(transpose_input1 ? El::TRANSPOSE : El::NORMAL,
+             transpose_input0 ? El::TRANSPOSE : El::NORMAL,
              DataType{1}, input1_v, input0_v,
              DataType{0}, output_v);
   }
@@ -65,47 +76,79 @@ void fp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El:
 }
 
 template <typename TensorDataType>
-void bp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::CPU>& l) {
+void bp_compute_impl(matmul_layer<TensorDataType,data_layout::DATA_PARALLEL,El::Device::CPU>& l,
+                     bool transpose_input0,
+                     bool transpose_input1) {
 
   // Local data
-  const auto& local_input0 = dynamic_cast<const CPUMat&>(l.get_local_prev_activations(0));
-  const auto& local_input1 = dynamic_cast<const CPUMat&>(l.get_local_prev_activations(1));
-  const auto& local_output_grad = dynamic_cast<const CPUMat&>(l.get_local_prev_error_signals());
-  auto& local_input0_grad = dynamic_cast<CPUMat&>(l.get_local_error_signals(0));
-  auto& local_input1_grad = dynamic_cast<CPUMat&>(l.get_local_error_signals(1));
+  using LocalMat = El::Matrix<TensorDataType, El::Device::CPU>;
+  const auto& local_input0 = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(0));
+  const auto& local_input1 = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(1));
+  const auto& local_output_grad = dynamic_cast<const LocalMat&>(l.get_local_prev_error_signals(0));
+  auto& local_input0_grad = dynamic_cast<LocalMat&>(l.get_local_error_signals(0));
+  auto& local_input1_grad = dynamic_cast<LocalMat&>(l.get_local_error_signals(1));
   const auto& local_mini_batch_size = local_input0.Width();
 
   // Matrix dimensions
-  const auto output_dims = l.get_output_dims();
   const auto input0_dims = l.get_input_dims(0);
-  const El::Int m = *(output_dims.rbegin()+1);
-  const El::Int n = *(output_dims.rbegin());
-  const El::Int k = *(input0_dims.rbegin());
+  const auto input1_dims = l.get_input_dims(1);
+  const auto output_dims = l.get_output_dims();
+  const El::Int input0_height = *(input0_dims.rbegin()+1);
+  const El::Int input0_width = *(input0_dims.rbegin());
+  const El::Int input1_height = *(input1_dims.rbegin()+1);
+  const El::Int input1_width = *(input1_dims.rbegin());
+  const El::Int output_height = *(output_dims.rbegin()+1);
+  const El::Int output_width = *(output_dims.rbegin());
 
   // Compute gradients for each mini-batch sample
   // Note: Elemental matrices are in Fortran layout while LBANN
   // tensors are in C layout.
   LBANN_OMP_PARALLEL_FOR
   for (El::Int i = 0; i < local_mini_batch_size; ++i) {
-    CPUMat input0_v, input1_v, output_grad_v, input0_grad_v, input1_grad_v;
-    input0_v.LockedAttach(k, m, local_input0.LockedBuffer(0,i), k);
-    input1_v.LockedAttach(n, k, local_input1.LockedBuffer(0,i), n);
-    output_grad_v.LockedAttach(n, m, local_output_grad.LockedBuffer(0,i), n);
-    input0_grad_v.Attach(k, m, local_input0_grad.Buffer(0,i), k);
-    input1_grad_v.Attach(n, k, local_input1_grad.Buffer(0,i), n);
-    El::Gemm(El::TRANSPOSE, El::NORMAL,
-             DataType{1}, input1_v, output_grad_v,
-             DataType{0}, input0_grad_v);
-    El::Gemm(El::NORMAL, El::TRANSPOSE,
-             DataType{1}, output_grad_v, input0_v,
-             DataType{0}, input1_grad_v);
+    LocalMat input0_v, input1_v, output_grad_v, input0_grad_v, input1_grad_v;
+    input0_v.LockedAttach(input0_width, input0_height,
+                          local_input0.LockedBuffer(0,i), input0_width);
+    input1_v.LockedAttach(input1_width, input1_height,
+                          local_input1.LockedBuffer(0,i), input1_width);
+    output_grad_v.LockedAttach(output_width, output_height,
+                               local_output_grad.LockedBuffer(0,i), output_width);
+    input0_grad_v.Attach(input0_width, input0_height,
+                         local_input0_grad.Buffer(0,i), input0_width);
+    input1_grad_v.Attach(input1_width, input1_height,
+                         local_input1_grad.Buffer(0,i), input1_width);
+    if (transpose_input0) {
+      El::Gemm(El::TRANSPOSE,
+               transpose_input1 ? El::TRANSPOSE : El::NORMAL,
+               DataType{1}, output_grad_v, input1_v,
+               DataType{0}, input0_grad_v);
+    }
+    else {
+      El::Gemm(transpose_input1 ? El::NORMAL : El::TRANSPOSE,
+               El::NORMAL,
+               DataType{1}, input1_v, output_grad_v,
+               DataType{0}, input0_grad_v);
+    }
+    if (transpose_input1) {
+      El::Gemm(transpose_input0 ? El::TRANSPOSE : El::NORMAL,
+               El::TRANSPOSE,
+               DataType{1}, input0_v, output_grad_v,
+               DataType{0}, input1_grad_v);
+    }
+    else {
+      El::Gemm(El::NORMAL,
+               transpose_input0 ? El::NORMAL : El::TRANSPOSE,
+               DataType{1}, output_grad_v, input0_v,
+               DataType{0}, input1_grad_v);
+    }
   }
 
 }
 
 #ifdef LBANN_HAS_GPU
 template <typename TensorDataType>
-void fp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::GPU>& l) {
+void fp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::GPU>& l,
+                     bool transpose_input0,
+                     bool transpose_input1) {
 
   // Local data
   const auto& local_input0 = dynamic_cast<const GPUMat&>(l.get_local_prev_activations(0));
@@ -141,7 +184,9 @@ void fp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El:
 
 #ifdef LBANN_HAS_GPU
 template <typename TensorDataType>
-void bp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::GPU>& l) {
+void bp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El::Device::GPU>& l,
+                     bool transpose_input0,
+                     bool transpose_input1) {
 
   // Local data
   const auto& local_input0 = dynamic_cast<const GPUMat&>(l.get_local_prev_activations(0));
@@ -187,11 +232,11 @@ void bp_compute_impl(matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,El:
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void matmul_layer<TensorDataType, Layout, Device>::fp_compute() {
-  fp_compute_impl(*this);
+  fp_compute_impl(*this, m_transpose_a, m_transpose_b);
 }
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void matmul_layer<TensorDataType, Layout, Device>::bp_compute() {
-  bp_compute_impl(*this);
+  bp_compute_impl(*this, m_transpose_a, m_transpose_b);
 }
 
 // Explicit instantiation

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -621,7 +621,11 @@ std::unique_ptr<Layer> construct_layer(
   }
   if (proto_layer.has_matmul()) {
     if (Layout == data_layout::DATA_PARALLEL) {
-      return lbann::make_unique<matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,Device>>(comm);
+      const auto& params = proto_layer.matmul();
+      return lbann::make_unique<matmul_layer<TensorDataType, data_layout::DATA_PARALLEL,Device>>(
+               comm,
+               params.transpose_a(),
+               params.transpose_b());
     } else {
       LBANN_ERROR("matrix multiply layer is only supported with "
                   "a data-parallel layout");

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -247,9 +247,13 @@ message Layer {
    *  sample, in a similar manner as NumPy's matmul function.
    */
   message MatMul {
-    /** Transpose matrices from first input tensor. */
+    /** If true, matrices from the first input tensor are transposed
+     *  before multiplication.
+     */
     bool transpose_a = 1;
-    /** Transpose matrices from second input tensor. */
+    /** If true, matrices from the second input tensor are transposed
+     *  before multiplication.
+     */
     bool transpose_b = 2;
   }
 

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -246,7 +246,12 @@ message Layer {
    *  Matrix products are computed independently for each mini-batch
    *  sample, in a similar manner as NumPy's matmul function.
    */
-  message MatMul {}
+  message MatMul {
+    /** Transpose matrices from first input tensor. */
+    bool transpose_a = 1;
+    /** Transpose matrices from second input tensor. */
+    bool transpose_b = 2;
+  }
 
   ///////////////////////
   // Activation layers //


### PR DESCRIPTION
This PR adds support for transposing the inputs to the matrix multiply layer, similar to [`tf.linalg.matmul`](https://www.tensorflow.org/api_docs/python/tf/linalg/matmul). I plan to use this in multi-head attention. [Nothing suspicious so far in Bamboo](https://lc.llnl.gov/bamboo/browse/LBANN-TIM243-1).