### PR TITLE
Allow Layer classes to return a BaseDistMatrix for activations and error signals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,12 +177,12 @@ set(LBANN_HAS_CEREAL ${CEREAL_FOUND})
 # The imported target is just called "cereal". Super.
 
 # Setup the linear algebra library
-find_package(Hydrogen 1.2.0 NO_MODULE QUIET
+find_package(Hydrogen 1.3.1 NO_MODULE QUIET
   HINTS ${Hydrogen_DIR} ${HYDROGEN_DIR} $ENV{Hydrogen_DIR} $ENV{HYDROGEN_DIR}
   PATH_SUFFIXES lib/cmake/hydrogen
   NO_DEFAULT_PATH)
 if (NOT Hydrogen_FOUND)
-  find_package(Hydrogen 1.2.0 NO_MODULE QUIET REQUIRED)
+  find_package(Hydrogen 1.3.1 NO_MODULE QUIET REQUIRED)
 endif ()
 message(STATUS "Found Hydrogen: ${Hydrogen_DIR}")
 set(LBANN_HAS_HYDROGEN ${Hydrogen_FOUND})

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -86,6 +86,7 @@ using CPUMat = El::Matrix<DataType, El::Device::CPU>;
 using GPUMat = El::Matrix<DataType, El::Device::GPU>;
 #endif // LBANN_HAS_GPU
 using AbsDistMat = El::AbstractDistMatrix<DataType>;
+using BaseDistMat = El::BaseDistMatrix;
 
 // Deprecated typedefs
 /// @todo Remove

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -310,10 +310,12 @@ private:
    */
   std::vector<std::unique_ptr<AbsDistMatrixType>> m_gradient_wrt_inputs;
 
+#ifdef LBANN_HAS_GPU
   template <typename U>
   friend class cudnn::data_parallel_layer_tensor_manager;
   template <typename U>
   friend class cudnn::entrywise_layer_tensor_manager;
+#endif // LBANN_HAS_GPU
 };
 
 #ifndef LBANN_DATA_TYPE_LAYER_INSTANTIATE

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -310,12 +310,12 @@ private:
    */
   std::vector<std::unique_ptr<AbsDistMatrixType>> m_gradient_wrt_inputs;
 
-#ifdef LBANN_HAS_GPU
+#ifdef LBANN_HAS_CUDA
   template <typename U>
   friend class cudnn::data_parallel_layer_tensor_manager;
   template <typename U>
   friend class cudnn::entrywise_layer_tensor_manager;
-#endif // LBANN_HAS_GPU
+#endif // LBANN_HAS_CUDA
 };
 
 #ifndef LBANN_DATA_TYPE_LAYER_INSTANTIATE

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -257,6 +257,15 @@ public:
   virtual void replace_weights(Layer* other_layer) = 0;
 
   // ===========================================================
+  // Tensor access functions
+  // ===========================================================
+
+  /** Get activation tensor corresponding to child layer. */
+  virtual const BaseDistMat& get_activations(const Layer& child) const = 0;
+  /** Get error signal tensor corresponding to parent layer. */
+  virtual const BaseDistMat& get_error_signals(const Layer& parent) const = 0;
+
+  // ===========================================================
   // Tensor dimension access functions
   // ===========================================================
 

--- a/include/lbann/layers/math/matmul.hpp
+++ b/include/lbann/layers/math/matmul.hpp
@@ -78,6 +78,10 @@ private:
    *  before multiplication. */
   bool m_transpose_b;
 
+  template <typename U>
+  friend void fp_compute_impl(matmul_layer<U, Layout, Device>&, bool, bool);
+  template <typename U>
+  friend void bp_compute_impl(matmul_layer<U, Layout, Device>&, bool, bool);
 };
 
 // =========================================================

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -285,7 +285,7 @@ auto data_type_layer<TensorDataType>::get_local_error_signals(int parent_index) 
 
 // Accessing matrices corresponding to parent/child layer
 template <typename TensorDataType>
-auto data_type_layer<TensorDataType>::get_activations(const data_type_layer<TensorDataType>& child) const -> const AbsDistMatrixType& {
+auto data_type_layer<TensorDataType>::get_activations(const Layer& child) const -> const BaseDistMat& {
   const int child_index = (std::find(m_child_layers.begin(),
                                      m_child_layers.end(),
                                      &child)
@@ -301,7 +301,7 @@ auto data_type_layer<TensorDataType>::get_activations(const data_type_layer<Tens
   return get_activations(child_index);
 }
 template <typename TensorDataType>
-auto data_type_layer<TensorDataType>::get_error_signals(const data_type_layer<TensorDataType>& parent) const -> const AbsDistMatrixType& {
+auto data_type_layer<TensorDataType>::get_error_signals(const Layer& parent) const -> const BaseDistMat& {
   const int parent_index = (std::find(m_parent_layers.begin(),
                                       m_parent_layers.end(),
                                       &parent)
@@ -505,20 +505,19 @@ void data_type_layer<TensorDataType>::fp_setup_inputs(El::Int mini_batch_size) {
   if (get_num_parents() < 1) { return; }
 
   // Determine distributed matrix alignment
-  const auto& alignment_dist
-    = dynamic_cast<const data_type_layer<TensorDataType>*>(m_parent_layers.front())->get_activations(*this).DistData();
+  const auto& alignment_dist = m_parent_layers.front()->get_activations(*this).DistData();
 
   // Iterate through input tensors
   for (int i = 0; i < get_num_parents(); ++i) {
 
     // Initialize input tensor
-    const auto& parent = dynamic_cast<const data_type_layer<TensorDataType>&>(*m_parent_layers[i]);
+    const auto& parent = *m_parent_layers[i];
     const auto& parent_output = parent.get_activations(*this);
     auto& input = *m_inputs[i];
     input.Empty(false);
     input.AlignWith(alignment_dist);
     if (parent_output.DistData() == input.DistData()) {
-      El::LockedView(input, parent_output);
+      El::LockedView(input, dynamic_cast<const AbsDistMatrixType&>(parent_output));
     } else {
       bool async_copy = false;
 #if defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)
@@ -579,14 +578,14 @@ void data_type_layer<TensorDataType>::bp_setup_gradient_wrt_outputs(El::Int mini
   for (int i = 0; i < get_num_children(); ++i) {
 
     // Initialize gradient w.r.t. output tensor
-    const auto& child = dynamic_cast<const data_type_layer<TensorDataType>&>(*m_child_layers[i]);
+    const auto& child = *m_child_layers[i];
     const auto& child_gradient_wrt_input = child.get_error_signals(*this);
     auto& gradient_wrt_output = *m_gradient_wrt_outputs[i];
     gradient_wrt_output.Empty(false);
     gradient_wrt_output.AlignWith(get_activations(i));
     if (child_gradient_wrt_input.DistData()
         == gradient_wrt_output.DistData()) {
-      El::LockedView(gradient_wrt_output, child_gradient_wrt_input);
+      El::LockedView(gradient_wrt_output, dynamic_cast<const AbsDistMatrixType&>(child_gradient_wrt_input));
     } else {
       bool async_copy = false;
 #if defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)


### PR DESCRIPTION
Updated the get_activations and get_error_signal functions that take a
parent or child layer as an argument have been promoted back to the
top layer abstract class.  These two functions now return a Hydrogen
BaseDistMatrix type, rather than a data type specific distributed
matrix.  Note that these updates require the use of Hydrogen v1.3.1 to
allow for the copying between BaseDistMatrix types and other abstract
distributed matrices.  Additionally, it limits the scope of the
accessor functions that return both the previous activations or error
signals.  This does require the allocation of some friend classes.