### PR TITLE
Add option to pass custom executable to Bamboo tests

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -727,7 +727,7 @@ def create_tests(setup_func,
         python_frontend_path = os.path.join(
             install_dir,
             'lib',
-            f'python{sys.version_info[0]}.{sys.version_info[1]}',
+            'python3.7',    # TODO: Generalize
             'site-packages',
         )
         sys.path.append(python_frontend_path)


### PR DESCRIPTION
This is a quick hack to allow users to pass a custom LBANN build to the Bamboo tests, e.g. Spack builds. It is similar to functionality in the old prototext-based tests (e.g. [this](https://github.com/LLNL/lbann/blob/e4c698f8258f41fc4919dac485d3e883a575b9d5/bamboo/unit_tests/test_unit_layer_identity.py#L46)).

Example usage:
```bash
python -m pytest test_something_something.py --exe=/path/to/install/bin/lbann
```

This is a short-term fix and will fail if you have previously called `scripts/build_lbann_lc.sh` and have anything inside `lbann/build` (see Issue #1289). The right solution in the long term is to make the test suite build-specific.