### PR TITLE
fix bugs in using conduit_io_handle

### DIFF
--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -38,7 +38,7 @@
 #include <map>
 #include <memory>
 
-//#define _USE_IO_HANDLE_
+#define _USE_IO_HANDLE_
 #ifdef _USE_IO_HANDLE_
 #include "lbann/data_readers/sample_list_conduit_io_handle.hpp"
 #else
@@ -464,7 +464,10 @@ class data_reader_jag_conduit : public generic_data_reader {
   bool m_list_per_trainer;
   bool m_list_per_model;
 
-  void preload_helper(const hid_t& h, const std::string &sample_name, const std::string &field_name, int data_id, conduit::Node &node); 
+  void preload_helper(const file_handle_t& h,
+    const std::string &sample_name,
+    const std::string &field_name,
+    int data_id, conduit::Node &node);
 };
 
 /**

--- a/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
+++ b/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
@@ -6,6 +6,8 @@
 #include "conduit/conduit_relay.hpp"
 #include "conduit/conduit_relay_io_handle.hpp"
 #include <utility>
+#include <locale>
+#include <algorithm>
 
 namespace lbann {
 
@@ -24,18 +26,26 @@ class sample_list_conduit_io_handle : public sample_list_open_files<sample_name_
   ~sample_list_conduit_io_handle() override;
 
   bool is_file_handle_valid(const file_handle_t& h) const override;
+  void setup(const std::string& protocol, const std::string& root_path);
 
  protected:
   void obtain_sample_names(file_handle_t& h, std::vector<std::string>& sample_names) const override;
   file_handle_t open_file_handle_for_read(const std::string& path) override;
   void close_file_handle(file_handle_t& h) override;
   void clear_file_handle(file_handle_t& h) override;
+
+  /// conduit io_handle protocol (e.g, hdf5, bin, json)
+  std::string m_protocol;
+  /// root path in case of the path-based protocol (hdf5)
+  std::string m_root_path;
 };
 
 
 template <typename sample_name_t>
 inline sample_list_conduit_io_handle<sample_name_t>::sample_list_conduit_io_handle()
-: sample_list_open_files<sample_name_t, file_handle_t>() {}
+: sample_list_open_files<sample_name_t, file_handle_t>(),
+  m_protocol(""), m_root_path("")
+{}
 
 template <typename sample_name_t>
 inline sample_list_conduit_io_handle<sample_name_t>::~sample_list_conduit_io_handle() {
@@ -51,10 +61,24 @@ inline sample_list_conduit_io_handle<sample_name_t>::~sample_list_conduit_io_han
 
 template <typename sample_name_t>
 inline void sample_list_conduit_io_handle<sample_name_t>
+::setup(const std::string& protocol, const std::string& root_path) {
+  m_protocol = protocol;
+  std::transform(m_protocol.begin(), m_protocol.end(), m_protocol.begin(),
+                 [](unsigned char c){ return std::tolower(c); });
+
+  m_root_path = root_path;
+}
+
+template <typename sample_name_t>
+inline void sample_list_conduit_io_handle<sample_name_t>
 ::obtain_sample_names(sample_list_conduit_io_handle<sample_name_t>::file_handle_t& h, std::vector<std::string>& sample_names) const {
   sample_names.clear();
   if (h != nullptr) {
-    h->list_child_names("/", sample_names);
+    if (m_root_path.empty()) {
+      h->list_child_names(sample_names);
+    } else {
+      h->list_child_names(m_root_path, sample_names);
+    }
   }
 }
 
@@ -93,7 +117,11 @@ template <typename sample_name_t>
 inline typename sample_list_conduit_io_handle<sample_name_t>::file_handle_t sample_list_conduit_io_handle<sample_name_t>
 ::open_file_handle_for_read(const std::string& file_path) {
   file_handle_t h = new conduit::relay::io::IOHandle;
-  h->open(file_path, "hdf5");
+  if (m_protocol == "bin") {
+    h->open(file_path);
+  } else {
+    h->open(file_path, m_protocol);
+  }
   return h;
 }
 

--- a/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
+++ b/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
@@ -5,6 +5,7 @@
 #include "conduit/conduit.hpp"
 #include "conduit/conduit_relay.hpp"
 #include "conduit/conduit_relay_io_handle.hpp"
+#include <utility>
 
 namespace lbann {
 
@@ -57,10 +58,35 @@ inline void sample_list_conduit_io_handle<sample_name_t>
   }
 }
 
+template <typename IOHandle>
+struct has_is_open {
+  template <typename IOH>
+  static constexpr
+  decltype(std::declval<IOH>().is_open(), bool())
+  test_is_open(int) {
+    return true;
+  }
+
+  template <typename IOH>
+  static constexpr bool test_is_open(...) {
+    return false;
+  }
+
+  static constexpr bool value = test_is_open<IOHandle>(int());
+};
+
 template <typename sample_name_t>
 inline bool sample_list_conduit_io_handle<sample_name_t>
 ::is_file_handle_valid(const sample_list_conduit_io_handle<sample_name_t>::file_handle_t& h) const {
-  return ((h != nullptr) && (h->is_open()));
+#if defined(__cpp_if_constexpr) // c++17
+  // In case that 'if constexpr' is enabled,
+  // check to see if is_open() method exists.
+  constexpr bool is_open_supported = has_is_open<decltype(*h)>::value;
+  if constexpr (is_open_supported) {
+    return ((h != nullptr) && (h->is_open()));
+  }
+#endif
+  return (h != nullptr);
 }
 
 template <typename sample_name_t>

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -862,7 +862,11 @@ void data_reader_jag_conduit::load() {
   select_subset_of_data();
 }
 
-void data_reader_jag_conduit::preload_helper(const hid_t& h, const std::string &sample_name, const std::string &field_name, int data_id, conduit::Node &node) {
+void data_reader_jag_conduit::preload_helper(
+  const data_reader_jag_conduit::file_handle_t& h,
+  const std::string &sample_name,
+  const std::string &field_name,
+  int data_id, conduit::Node &node) {
   const std::string path = sample_name + field_name;
   const std::string key2 = '/' + LBANN_DATA_ID_STR(data_id) + field_name;
   read_node(h, path, node[key2]);

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -930,6 +930,9 @@ void data_reader_jag_conduit::do_preload_data_store() {
 void data_reader_jag_conduit::load_list_of_samples(const std::string sample_list_file, size_t stride, size_t offset) {
   // load the sample list
   double tm1 = get_time();
+#ifdef _USE_IO_HANDLE_
+  m_sample_list.setup("hdf5", "/");
+#endif
   m_sample_list.load(sample_list_file, stride, offset);
   double tm2 = get_time();
 


### PR DESCRIPTION
- Check the existence of `is_open()` method, and use it to check whether a file handle is valid only when the method is available. conduit_io_handle provides no method to check is file is successfully open. However, std::fstream does.
- replace the hard-coded argument type of preload_helper() with file_handle_t.

Not to merge, but to communicate.

There are still a bunch of compilation error in data_store_conduit.cpp regarding the hard-coded `conduit::relay::io::hdf5_*()`