### PR TITLE
Updated the I/O layers to properly support ETI with multiple data types

### DIFF
--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -249,7 +249,7 @@ class generic_input_layer : public io_layer<TensorDataType> {
 
   void fetch_data_in_background(int future_active_buffer, execution_mode mode) {
     int active_buffer = future_active_buffer % m_io_buffers.size();
-    generic_io_buffer* io_buffer = m_io_buffers[active_buffer];
+    generic_io_buffer<TensorDataType>* io_buffer = m_io_buffers[active_buffer];
     std::lock_guard<std::mutex> guard(dr_mutex);
     setup_next_io_buffer(io_buffer);
     io_buffer->fetch_to_local_matrix(get_data_reader(mode), mode);
@@ -271,7 +271,7 @@ class generic_input_layer : public io_layer<TensorDataType> {
 
     increment_active_buffer_idx(mode);
 
-    generic_io_buffer* io_buffer = m_io_buffers[get_active_buffer_idx(mode) % m_io_buffers.size()];
+    generic_io_buffer<TensorDataType>* io_buffer = m_io_buffers[get_active_buffer_idx(mode) % m_io_buffers.size()];
 
     // If there is no valid data and there is not already a background
     // thread to fetch the data, queue up the background thread
@@ -320,13 +320,13 @@ class generic_input_layer : public io_layer<TensorDataType> {
       int next_active_buffer = get_active_buffer_idx(mode) + 1;
       std::future<void> background_fetch_done = this->m_model->get_execution_context().get_io_thread_pool().submit_job(
         std::bind(&generic_input_layer::fetch_data_in_background, this, next_active_buffer, mode));
-      generic_io_buffer* next_io_buffer = m_io_buffers[next_active_buffer % m_io_buffers.size()];
+      generic_io_buffer<TensorDataType>* next_io_buffer = m_io_buffers[next_active_buffer % m_io_buffers.size()];
       next_io_buffer->set_data_fetch_future(std::move(background_fetch_done), mode);
       next_io_buffer->set_fetch_data_in_background(true, mode);
     }
   }
 
-  void setup_next_io_buffer(generic_io_buffer* io_buffer) {
+  void setup_next_io_buffer(generic_io_buffer<TensorDataType>* io_buffer) {
     int mini_batch_size = get_current_mini_batch_size();
     for (int i = 0; i < this->get_num_children(); ++i) {
       io_buffer->fp_setup_data(mini_batch_size, i);
@@ -578,7 +578,7 @@ class generic_input_layer : public io_layer<TensorDataType> {
    */
   El::Matrix<El::Int>* get_sample_indices_per_mb() override {
     execution_mode mode = this->m_model->get_execution_context().get_execution_mode();
-    generic_io_buffer* io_buffer = m_io_buffers[get_active_buffer_idx(mode) % m_io_buffers.size()];
+    generic_io_buffer<TensorDataType>* io_buffer = m_io_buffers[get_active_buffer_idx(mode) % m_io_buffers.size()];
     return io_buffer->get_sample_indices_fetched_per_mb(this->m_model->get_execution_context().get_execution_mode());
   }
 
@@ -849,7 +849,7 @@ class generic_input_layer : public io_layer<TensorDataType> {
   }
 
  protected:
-  std::vector<generic_io_buffer*> m_io_buffers;
+  std::vector<generic_io_buffer<TensorDataType>*> m_io_buffers;
   io_buffer_map_t m_active_buffer;
 
   dataset m_training_dataset;

--- a/include/lbann/layers/io/input/input_layer.hpp
+++ b/include/lbann/layers/io/input/input_layer.hpp
@@ -46,6 +46,14 @@ class input_layer : public generic_input_layer<TensorDataType> {
   static_assert(T_layout == data_layout::DATA_PARALLEL,
                 "input layer only supports DATA_PARALLEL data layout");
  public:
+  /** @name Public Types */
+  ///@{
+
+  /** @brief The local tensor type expected for IO in this object. */
+  using IODataType = DataType;
+
+  ///@}
+ public:
 
   /// @todo make the map and vector references
   input_layer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode,
@@ -56,7 +64,7 @@ class input_layer : public generic_input_layer<TensorDataType> {
     initialize_io_buffer(comm, std::min(num_parallel_readers, data_type_layer<TensorDataType>::m_comm->get_procs_per_trainer()), data_readers);
     initialize_io_buffer(comm, std::min(num_parallel_readers, data_type_layer<TensorDataType>::m_comm->get_procs_per_trainer()), data_readers);
     for (auto io_buffer : this->m_io_buffers) {
-      io_buffer->fetch_data_fn = new fetch_data_functor(target_mode);
+      io_buffer->fetch_data_fn = new fetch_data_functor<IODataType>(target_mode);
       io_buffer->update_data_reader_fn = new update_data_reader_functor();
     }
   }
@@ -77,14 +85,19 @@ class input_layer : public generic_input_layer<TensorDataType> {
 };
 
 #ifndef LBANN_INPUT_LAYER_INSTANTIATE
-extern template class input_layer<
-  DataType, partitioned_io_buffer<DataType>,
-  data_layout::DATA_PARALLEL, El::Device::CPU>;
-#ifdef LBANN_HAS_GPU
-extern template class input_layer<
-  DataType, partitioned_io_buffer<DataType>,
-  data_layout::DATA_PARALLEL, El::Device::GPU>;
-#endif // LBANN_HAS_GPU
+
+#define PROTO_DEVICE(T, Device)         \
+  extern template class input_layer<    \
+    T, partitioned_io_buffer<T>,        \
+    data_layout::DATA_PARALLEL, Device>
+
+#define LBANN_INSTANTIATE_CPU_HALF
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+#undef LBANN_INSTANTIATE_CPU_HALF
+#undef LBANN_INSTANTIATE_GPU_HALF
+
 #endif // LBANN_INPUT_LAYER_INSTANTIATE
 
 } // namespace lbann

--- a/src/io/data_buffers/generic_io_buffer.cpp
+++ b/src/io/data_buffers/generic_io_buffer.cpp
@@ -28,19 +28,22 @@
 #include "lbann/utils/exception.hpp"
 
 namespace lbann {
-generic_io_buffer::generic_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers)
+template <typename TensorDataType>
+generic_io_buffer<TensorDataType>::generic_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers)
   : m_comm(comm), fetch_data_fn(nullptr),  update_data_reader_fn(nullptr) {}
 
-generic_io_buffer::generic_io_buffer(const generic_io_buffer& rhs)
+template <typename TensorDataType>
+generic_io_buffer<TensorDataType>::generic_io_buffer(const generic_io_buffer& rhs)
 : m_comm(rhs.m_comm)
 {
   if (rhs.fetch_data_fn)
-    fetch_data_fn = new fetch_data_functor(*(rhs.fetch_data_fn));
+    fetch_data_fn = new fetch_data_functor<IODataType>(*(rhs.fetch_data_fn));
   if (rhs.update_data_reader_fn)
     update_data_reader_fn = new update_data_reader_functor(*(rhs.update_data_reader_fn));
 }
 
-generic_io_buffer& generic_io_buffer::operator=(const generic_io_buffer& rhs) {
+template <typename TensorDataType>
+generic_io_buffer<TensorDataType>& generic_io_buffer<TensorDataType>::operator=(const generic_io_buffer<TensorDataType>& rhs) {
   m_comm = rhs.m_comm;
   if (fetch_data_fn) {
     delete fetch_data_fn;
@@ -51,11 +54,17 @@ generic_io_buffer& generic_io_buffer::operator=(const generic_io_buffer& rhs) {
     update_data_reader_fn = nullptr;
   }
   if (rhs.fetch_data_fn)
-    fetch_data_fn = new fetch_data_functor(*(rhs.fetch_data_fn));
+    fetch_data_fn = new fetch_data_functor<IODataType>(*(rhs.fetch_data_fn));
   if (rhs.update_data_reader_fn)
     update_data_reader_fn = new update_data_reader_functor(*(rhs.update_data_reader_fn));
 
   return (*this);
 }
+
+#define PROTO(T)                      \
+  template class generic_io_buffer<T>
+
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
 
 } // namespace lbann

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -31,10 +31,10 @@ namespace lbann {
 
 template <typename TensorDataType>
 partitioned_io_buffer<TensorDataType>::partitioned_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers, int num_child_layers)
-  : generic_io_buffer(comm, num_parallel_readers, data_readers) {
-  m_data_buffers[execution_mode::training] = new data_buffer<TensorDataType>(comm, num_child_layers);
-  m_data_buffers[execution_mode::validation] = new data_buffer<TensorDataType>(comm, num_child_layers);
-  m_data_buffers[execution_mode::testing] = new data_buffer<TensorDataType>(comm, num_child_layers);
+  : generic_io_buffer<TensorDataType>(comm, num_parallel_readers, data_readers) {
+  m_data_buffers[execution_mode::training] = new data_buffer<IODataType>(comm, num_child_layers);
+  m_data_buffers[execution_mode::validation] = new data_buffer<IODataType>(comm, num_child_layers);
+  m_data_buffers[execution_mode::testing] = new data_buffer<IODataType>(comm, num_child_layers);
 }
 
 template <typename TensorDataType>
@@ -46,7 +46,7 @@ partitioned_io_buffer<TensorDataType>::~partitioned_io_buffer() {
 
 template <typename TensorDataType>
 partitioned_io_buffer<TensorDataType>::partitioned_io_buffer(const partitioned_io_buffer& other)
-  : generic_io_buffer(other) {
+  : generic_io_buffer<TensorDataType>(other) {
   for (const auto& buf : other.m_data_buffers) {
     m_data_buffers[buf.first] = buf.second->copy();
   }
@@ -59,7 +59,7 @@ partitioned_io_buffer<TensorDataType>* partitioned_io_buffer<TensorDataType>::co
 
 template <typename TensorDataType>
 partitioned_io_buffer<TensorDataType>& partitioned_io_buffer<TensorDataType>::operator=(const partitioned_io_buffer& other) {
-  generic_io_buffer::operator=(other);
+  generic_io_buffer<TensorDataType>::operator=(other);
   for (auto& buf : m_data_buffers) {
     if (buf.second) delete buf.second;
     buf.second = buf.second->copy();
@@ -76,13 +76,13 @@ void partitioned_io_buffer<TensorDataType>::fp_setup_data(El::Int cur_mini_batch
 
 template <typename TensorDataType>
 void partitioned_io_buffer<TensorDataType>::setup_data(El::Int num_neurons, El::Int num_targets, El::Int max_mini_batch_size) {
-  El::Int local_mini_batch_size = max_mini_batch_size / m_comm->get_procs_per_trainer();
-  El::Int partial_mini_batch_size = max_mini_batch_size % m_comm->get_procs_per_trainer();
-  if(partial_mini_batch_size > 0 && m_comm->get_rank_in_trainer() < partial_mini_batch_size) {
+  El::Int local_mini_batch_size = max_mini_batch_size / this->m_comm->get_procs_per_trainer();
+  El::Int partial_mini_batch_size = max_mini_batch_size % this->m_comm->get_procs_per_trainer();
+  if(partial_mini_batch_size > 0 && this->m_comm->get_rank_in_trainer() < partial_mini_batch_size) {
     local_mini_batch_size++;
   }
   for (const auto& it : m_data_buffers) {
-    data_buffer<TensorDataType> *data_buffer = it.second;
+    data_buffer<IODataType> *data_buffer = it.second;
     int i = 0;
     for (const auto& buf : data_buffer->m_input_buffers) {
       if(i == 0) {
@@ -106,9 +106,9 @@ int partitioned_io_buffer<TensorDataType>::fetch_to_local_matrix(generic_data_re
 
   /// Coordinate all available readers so that the perform I/O in the same step
   /// Check to make sure that the local matrix has space for data
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   buf->m_num_samples_fetched = 0;
-  if (m_comm->get_rank_in_trainer() < num_parallel_readers && (buf->m_input_buffers[0]->Height() != 0 && buf->m_input_buffers[0]->Width() != 0)) {
+  if (this->m_comm->get_rank_in_trainer() < num_parallel_readers && (buf->m_input_buffers[0]->Height() != 0 && buf->m_input_buffers[0]->Width() != 0)) {
     for(auto& m : buf->m_input_buffers) {
       El::Zeros_seq(*m, m->Height(), m->Width());
     }
@@ -116,9 +116,9 @@ int partitioned_io_buffer<TensorDataType>::fetch_to_local_matrix(generic_data_re
     /// Each data reader needs to either have independent / split
     /// data, or take an offset / stride
     if(buf->m_input_buffers.size() == 2) {
-      buf->m_num_samples_fetched = (*fetch_data_fn)(buf->m_input_buffers[0]->Matrix(), buf->m_input_buffers[1]->Matrix(), buf->m_indices_fetched_per_mb, data_reader);
+      buf->m_num_samples_fetched = (*this->fetch_data_fn)(buf->m_input_buffers[0]->Matrix(), buf->m_input_buffers[1]->Matrix(), buf->m_indices_fetched_per_mb, data_reader);
     }else {
-      buf->m_num_samples_fetched = (*fetch_data_fn)(buf->m_input_buffers[0]->Matrix(), buf->m_indices_fetched_per_mb, data_reader);
+      buf->m_num_samples_fetched = (*this->fetch_data_fn)(buf->m_input_buffers[0]->Matrix(), buf->m_indices_fetched_per_mb, data_reader);
     }
     bool data_valid = (buf->m_num_samples_fetched > 0);
     if(data_valid) {
@@ -130,7 +130,7 @@ int partitioned_io_buffer<TensorDataType>::fetch_to_local_matrix(generic_data_re
 
 template <typename TensorDataType>
 void partitioned_io_buffer<TensorDataType>::distribute_from_local_matrix(generic_data_reader *data_reader, execution_mode mode, AbsDistMatrixType& sample, AbsDistMatrixType& response) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   Copy(*buf->m_input_buffers[0], sample);
   Copy(*buf->m_input_buffers[1], response);
   buf->m_num_samples_fetched = 0;
@@ -139,7 +139,7 @@ void partitioned_io_buffer<TensorDataType>::distribute_from_local_matrix(generic
 
 template <typename TensorDataType>
 void partitioned_io_buffer<TensorDataType>::distribute_from_local_matrix(generic_data_reader *data_reader, execution_mode mode, AbsDistMatrixType& sample) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   Copy(*buf->m_input_buffers[0], sample);
   buf->m_num_samples_fetched = 0;
   return;
@@ -150,7 +150,7 @@ bool partitioned_io_buffer<TensorDataType>::update_data_set(generic_data_reader 
   int num_iterations_per_epoch = data_reader->get_num_iterations_per_epoch();
   int current_step_in_epoch = data_reader->get_current_step_in_epoch(); // Get the current step before the update function increments it
 
-  (*update_data_reader_fn)(true, data_reader);
+  (*this->update_data_reader_fn)(true, data_reader);
 
   if(current_step_in_epoch == (num_iterations_per_epoch - 1)) {
     return true;
@@ -161,13 +161,13 @@ bool partitioned_io_buffer<TensorDataType>::update_data_set(generic_data_reader 
 
 template <typename TensorDataType>
 void partitioned_io_buffer<TensorDataType>::set_fetch_data_in_background(bool flag, execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   buf->m_fetch_data_in_background = flag;
 }
 
 template <typename TensorDataType>
 bool partitioned_io_buffer<TensorDataType>::is_data_fetched_in_background(execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   return buf->m_fetch_data_in_background;
 }
 
@@ -176,31 +176,31 @@ bool partitioned_io_buffer<TensorDataType>::is_data_fetched_in_background(execut
  */
 template <typename TensorDataType>
 El::Matrix<El::Int>* partitioned_io_buffer<TensorDataType>::get_sample_indices_fetched_per_mb(execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   return &(buf->m_indices_fetched_per_mb);
 }
 
 template <typename TensorDataType>
 int partitioned_io_buffer<TensorDataType>::num_samples_ready(execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   return buf->m_num_samples_fetched;
 }
 
 template <typename TensorDataType>
 void partitioned_io_buffer<TensorDataType>::set_data_fetch_future(std::future<void> future, execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   buf->m_data_fetch_future = std::move(future);
 }
 
 template <typename TensorDataType>
 std::future<void> partitioned_io_buffer<TensorDataType>::get_data_fetch_future(execution_mode mode) {
-  data_buffer<TensorDataType> *buf = get_data_buffer(mode);
+  data_buffer<IODataType> *buf = get_data_buffer(mode);
   return std::move(buf->m_data_fetch_future);
 }
 
 template <typename TensorDataType>
 int partitioned_io_buffer<TensorDataType>::compute_max_num_parallel_readers(long data_set_size, int mini_batch_size, int requested_num_parallel_readers) const {
-  return partitioned_io_buffer<TensorDataType>::compute_max_num_parallel_readers(data_set_size, mini_batch_size, requested_num_parallel_readers, m_comm);
+  return partitioned_io_buffer<TensorDataType>::compute_max_num_parallel_readers(data_set_size, mini_batch_size, requested_num_parallel_readers, this->m_comm);
 }
 
 template <typename TensorDataType>
@@ -249,20 +249,20 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
   bool apportioned = data_reader->is_partitioned();
 
   /// Check to make sure that there is enough data for all of the parallel readers
-  int num_parallel_readers_per_model = compute_max_num_parallel_readers(data_reader->get_num_data(), max_mini_batch_size, m_comm->get_procs_per_trainer());
+  int num_parallel_readers_per_model = compute_max_num_parallel_readers(data_reader->get_num_data(), max_mini_batch_size, this->m_comm->get_procs_per_trainer());
   data_reader->set_num_parallel_readers(num_parallel_readers_per_model);
   if(num_parallel_readers_per_model == 0
-     || (num_parallel_readers_per_model != m_comm->get_procs_per_trainer() && num_parallel_readers_per_model != max_mini_batch_size)) {
+     || (num_parallel_readers_per_model != this->m_comm->get_procs_per_trainer() && num_parallel_readers_per_model != max_mini_batch_size)) {
     throw lbann_exception(
       std::string{} + __FILE__ + " " + std::to_string(__LINE__)
       + " :: partitioned_io_buffer: number of parallel readers is " + std::to_string(num_parallel_readers_per_model)
-      + " and there are " + std::to_string(m_comm->get_procs_per_trainer()) + " processes in the model");
+      + " and there are " + std::to_string(this->m_comm->get_procs_per_trainer()) + " processes in the model");
   }
 
   /// Set the basic parameters for stride and offset of the data reader
-  int batch_stride = m_comm->get_num_trainers() * max_mini_batch_size;
-  int base_offset  = m_comm->get_rank_in_trainer();
-  int model_offset = m_comm->get_trainer_rank() * max_mini_batch_size;
+  int batch_stride = this->m_comm->get_num_trainers() * max_mini_batch_size;
+  int base_offset  = this->m_comm->get_rank_in_trainer();
+  int model_offset = this->m_comm->get_trainer_rank() * max_mini_batch_size;
 
   if (apportioned) {
     batch_stride = max_mini_batch_size;
@@ -279,7 +279,7 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
   data_reader->set_model_offset(model_offset);
   data_reader->set_initial_position();
 
-  int min_stride_across_models = max_mini_batch_size * m_comm->get_num_trainers();  /// Given that each model has to have at least one reader, what is the minimum stride
+  int min_stride_across_models = max_mini_batch_size * this->m_comm->get_num_trainers();  /// Given that each model has to have at least one reader, what is the minimum stride
   if (apportioned) {
     min_stride_across_models = max_mini_batch_size;
   }
@@ -291,7 +291,7 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
 
   int num_whole_mini_batches_per_model = floor(data_reader->get_num_data() / min_stride_across_models);
   int global_partial_mini_batch_size = data_reader->get_num_data() - (num_whole_mini_batches_per_model * min_stride_across_models);
-  int per_model_partial_mini_batch_size = global_partial_mini_batch_size / m_comm->get_num_trainers();
+  int per_model_partial_mini_batch_size = global_partial_mini_batch_size / this->m_comm->get_num_trainers();
   int world_master_remainder_data = 0;
 
   // Compute how many full "parallel" mini-batches are available
@@ -299,8 +299,8 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
 
   int world_master_remainder_adjustment = data_reader->get_num_data()
                                           - (num_whole_mini_batches_per_model * min_stride_across_models)
-                                          - (per_model_partial_mini_batch_size * m_comm->get_num_trainers());
-  if(m_comm->get_trainer_rank() == 0) {
+                                          - (per_model_partial_mini_batch_size * this->m_comm->get_num_trainers());
+  if(this->m_comm->get_trainer_rank() == 0) {
     world_master_remainder_data = world_master_remainder_adjustment;
     world_master_remainder_adjustment = 0;
   }
@@ -333,7 +333,7 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
 
   ///  The last mini-batch may be partial and thus may have a smaller stride
   if(per_model_partial_mini_batch_size > 0 || world_master_remainder_adjustment > 0) {
-    data_reader->set_stride_to_last_mini_batch((last_mini_batch_threshold - data_reader->get_base_offset() - data_reader->get_model_offset() - last_mini_batch_offset) + m_comm->get_trainer_rank() * per_model_partial_mini_batch_size + m_comm->get_rank_in_trainer());
+    data_reader->set_stride_to_last_mini_batch((last_mini_batch_threshold - data_reader->get_base_offset() - data_reader->get_model_offset() - last_mini_batch_offset) + this->m_comm->get_trainer_rank() * per_model_partial_mini_batch_size + this->m_comm->get_rank_in_trainer());
   }
 
   //  cout << "[" << m_comm->get_rank_in_world() << "] " << m_comm->get_trainer_rank() << " model rank, "<< m_comm->get_rank_in_trainer() << " rank in model, num_whole_mini_batches_per_model " << num_whole_mini_batches_per_model << " parallel_readers_with_extra_mini_batch " << /*parallel_readers_with_extra_mini_batch <<*/ " partial_mini_batch_size=" << per_model_partial_mini_batch_size << " last mini bath size=" << data_reader->get_last_mini_batch_size() << " world_master_remainder_data=" << world_master_remainder_data << " with a last stride of " << data_reader->get_stride_to_last_mini_batch() << " and stride of " << data_reader->get_stride_to_next_mini_batch() << " and there are " << num_parallel_readers_per_model << " parallel readers per model" << " last mini batch offset = " << last_mini_batch_offset <<  " parallel reader with extra minibatch = " << /*parallel_readers_with_extra_mini_batch << */" model bracket = " << (/*parallel_readers_with_extra_mini_batch **/ max_mini_batch_size + per_model_partial_mini_batch_size + world_master_remainder_data) <<" base ofset "<< data_reader->get_base_offset() << " model offset " << data_reader->get_model_offset() <<endl;
@@ -352,10 +352,10 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
   }
 
   /// Check to make sure that there is enough data for all of the parallel readers
-  int num_parallel_readers_per_model = compute_max_num_parallel_readers(data_reader->get_num_data(), max_mini_batch_size, m_comm->get_procs_per_trainer());
+  int num_parallel_readers_per_model = compute_max_num_parallel_readers(data_reader->get_num_data(), max_mini_batch_size, this->m_comm->get_procs_per_trainer());
   data_reader->set_num_parallel_readers(num_parallel_readers_per_model);
   if(num_parallel_readers_per_model == 0
-     || (num_parallel_readers_per_model != m_comm->get_procs_per_trainer() && num_parallel_readers_per_model != max_mini_batch_size)) {
+     || (num_parallel_readers_per_model != this->m_comm->get_procs_per_trainer() && num_parallel_readers_per_model != max_mini_batch_size)) {
     throw lbann_exception(
       std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
       " :: generic_data_distribution: number of parallel readers is zero");
@@ -363,7 +363,7 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
 
   /// Set the basic parameters for stride and offset of the data reader
   int batch_stride = max_mini_batch_size;
-  int base_offset  = m_comm->get_rank_in_trainer();
+  int base_offset  = this->m_comm->get_rank_in_trainer();
   /// Set mini-batch size and stride
   data_reader->set_mini_batch_size(max_mini_batch_size);
   data_reader->set_stride_to_next_mini_batch(batch_stride);
@@ -389,6 +389,10 @@ void partitioned_io_buffer<TensorDataType>::calculate_num_iterations_per_epoch_s
   return;
 }
 
-template class partitioned_io_buffer<DataType>;
+#define PROTO(T)                          \
+  template class partitioned_io_buffer<T>
+
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
 
 } // namespace lbann

--- a/src/layers/io/input/input_layer.cpp
+++ b/src/layers/io/input/input_layer.cpp
@@ -29,11 +29,11 @@
 
 namespace lbann {
 
-template class input_layer<
-  DataType, partitioned_io_buffer<DataType>, data_layout::DATA_PARALLEL, El::Device::CPU>;
-#ifdef LBANN_HAS_GPU
-template class input_layer<
-  DataType, partitioned_io_buffer<DataType>, data_layout::DATA_PARALLEL, El::Device::GPU>;
-#endif // LBANN_HAS_GPU
+#define PROTO_DEVICE(T, Device) \
+  template class input_layer<T, partitioned_io_buffer<T>, data_layout::DATA_PARALLEL, Device>
+
+#define LBANN_INSTANTIATE_CPU_HALF
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate_device.hpp"
 
 }// namespace lbann


### PR DESCRIPTION
Updated the I/O layers to properly support ETI with multiple data
types.  Added the TensorDataType to the generic_input_layer and
templated the io_buffers on the TensorDataType.  Also introduced an
IODataType for use within the io_buffers that is set to DataType.
This allows the data readers to operate with the compile defined
DataType.  The covnersion from IODataType to TensorDataType happens
inside of the io_buffer when the local matrices are distributed to the
input layer.