### PR TITLE
Support the "channel" mode in softmax layers

### DIFF
--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -41,6 +41,8 @@
 
 namespace lbann {
 
+enum class softmax_mode {INVALID, INSTANCE, CHANNEL};
+
 /**
  *  @f[ \text{softmax}(x)_i = \frac{e^{x_i}}{\sum_j e^{x_j}} @f]
  */
@@ -57,15 +59,22 @@ public:
 
 public:
 
-  softmax_layer(lbann_comm *comm)
-    : data_type_layer<TensorDataType>(comm)
+  softmax_layer(lbann_comm *comm,
+                softmax_mode mode)
+    : data_type_layer<TensorDataType>(comm),
+      m_mode(mode)
 #ifdef LBANN_HAS_CUDNN
     , m_tensors_cudnn_desc(this)
 #endif // LBANN_HAS_CUDNN
-  {}
+  {
+    if(mode == softmax_mode::INVALID) {
+      LBANN_ERROR("invalid softmax mode");
+    }
+  }
 
   softmax_layer(const softmax_layer& other)
     : data_type_layer<TensorDataType>(other),
+      m_mode(other.m_mode),
       m_workspace(other.m_workspace ?
                   other.m_workspace->Copy() : nullptr)
 #ifdef LBANN_HAS_CUDNN
@@ -75,17 +84,6 @@ public:
 #ifdef LBANN_HAS_CUDNN
     m_tensors_cudnn_desc.set_layer(this);
 #endif // LBANN_HAS_CUDNN
-  }
-
-  softmax_layer& operator=(const softmax_layer& other) {
-    data_type_layer<TensorDataType>::operator=(other);
-    m_workspace.reset(other.m_workspace ?
-                      other.m_workspace->Copy() : nullptr);
-#ifdef LBANN_HAS_CUDNN
-    m_tensors_cudnn_desc = other.m_tensors_cudnn_desc;
-    m_tensors_cudnn_desc.set_layer(this);
-#endif // LBANN_HAS_CUDNN
-    return *this;
   }
 
   ~softmax_layer() = default;
@@ -130,6 +128,9 @@ public:
 
 private:
 
+  /** Softmax mode. */
+  const softmax_mode m_mode;
+
   /** Workspace for column-wise reductions. */
   std::unique_ptr<AbsDistMatrixType> m_workspace;
 
@@ -144,7 +145,6 @@ private:
 #else
   const TensorDataType threshold_val = 0;
 #endif // LBANN_ENABLE_SOFTMAX_THRESHOLD
-
 
 };
 

--- a/src/layers/activations/softmax.cpp
+++ b/src/layers/activations/softmax.cpp
@@ -36,7 +36,12 @@ void fp(lbann_comm& comm,
         const El::AbstractDistMatrix<TensorDataType>& input,
         El::AbstractDistMatrix<TensorDataType>& output,
         El::AbstractDistMatrix<TensorDataType>& workspace,
-        TensorDataType threshold_val) {
+        TensorDataType threshold_val,
+        softmax_mode mode) {
+
+  if(mode != softmax_mode::INSTANCE) {
+    LBANN_ERROR("Unsupported softmax mode");
+  }
 
   // Local matrices
   const auto& local_input = input.LockedMatrix();
@@ -96,7 +101,12 @@ void bp(lbann_comm& comm,
         const El::AbstractDistMatrix<TensorDataType>& gradient_wrt_output,
         El::AbstractDistMatrix<TensorDataType>& gradient_wrt_input,
         El::AbstractDistMatrix<TensorDataType>& workspace,
-        TensorDataType threshold_val) {
+        TensorDataType threshold_val,
+        softmax_mode mode) {
+
+  if(mode != softmax_mode::INSTANCE) {
+    LBANN_ERROR("Unsupported softmax mode");
+  }
 
   // Local matrices
   const auto& local_output = output.LockedMatrix();
@@ -141,7 +151,8 @@ void softmax_layer<TensorDataType, Layout, Device>::fp_compute() {
      this->get_prev_activations(),
      this->get_activations(),
      *this->m_workspace,
-     this->threshold_val);
+     this->threshold_val,
+     this->m_mode);
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
@@ -151,7 +162,8 @@ void softmax_layer<TensorDataType, Layout, Device>::bp_compute() {
      this->get_prev_error_signals(),
      this->get_error_signals(),
      *this->m_workspace,
-     this->threshold_val);
+     this->threshold_val,
+     this->m_mode);
 }
 
 #define PROTO(T)                                      \

--- a/src/layers/activations/softmax.cu
+++ b/src/layers/activations/softmax.cu
@@ -268,13 +268,13 @@ __global__ void bp_kernel(size_t height,
 template <typename TensorDataType>
 void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, El::Device::GPU>& l) {
 
-  cudnnSoftmaxMode_t softmax_mode;
+  cudnnSoftmaxMode_t cudnn_softmax_mode;
   switch(l.m_mode) {
     case softmax_mode::INSTANCE:
-      softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
+      cudnn_softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
       break;
     case softmax_mode::CHANNEL:
-      softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
+      cudnn_softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
       break;
     default:
       LBANN_ERROR("Unsupported softmax mode");
@@ -287,7 +287,7 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   if (!local_input.IsEmpty()) {
     CHECK_CUDNN(cudnnSoftmaxForward(cudnn::get_handle(),
                                     CUDNN_SOFTMAX_ACCURATE,
-                                    softmax_mode,
+                                    cudnn_softmax_mode,
                                     &one,
                                     l.m_tensors_cudnn_desc.get_prev_activations(),
                                     local_input.LockedBuffer(),
@@ -304,13 +304,13 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
 template <typename TensorDataType>
 void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, El::Device::GPU>& l) {
 
-  cudnnSoftmaxMode_t softmax_mode;
+  cudnnSoftmaxMode_t cudnn_softmax_mode;
   switch(l.m_mode) {
     case softmax_mode::INSTANCE:
-      softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
+      cudnn_softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
       break;
     case softmax_mode::CHANNEL:
-      softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
+      cudnn_softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
       break;
     default:
       LBANN_ERROR("Unsupported softmax mode");
@@ -324,7 +324,7 @@ void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   if (!local_output.IsEmpty()) {
     CHECK_CUDNN(cudnnSoftmaxBackward(cudnn::get_handle(),
                                      CUDNN_SOFTMAX_ACCURATE,
-                                     softmax_mode,
+                                     cudnn_softmax_mode,
                                      &one,
                                      l.m_tensors_cudnn_desc.get_activations(),
                                      local_output.LockedBuffer(),

--- a/src/layers/activations/softmax.cu
+++ b/src/layers/activations/softmax.cu
@@ -267,6 +267,19 @@ __global__ void bp_kernel(size_t height,
 
 template <typename TensorDataType>
 void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, El::Device::GPU>& l) {
+
+  cudnnSoftmaxMode_t softmax_mode;
+  switch(l.m_mode) {
+    case softmax_mode::INSTANCE:
+      softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
+      break;
+    case softmax_mode::CHANNEL:
+      softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
+      break;
+    default:
+      LBANN_ERROR("Unsupported softmax mode");
+  }
+
   constexpr TensorDataType zero = 0;
   constexpr TensorDataType one = 1;
   const auto& local_input = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_prev_activations());
@@ -274,7 +287,7 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   if (!local_input.IsEmpty()) {
     CHECK_CUDNN(cudnnSoftmaxForward(cudnn::get_handle(),
                                     CUDNN_SOFTMAX_ACCURATE,
-                                    CUDNN_SOFTMAX_MODE_INSTANCE,
+                                    softmax_mode,
                                     &one,
                                     l.m_tensors_cudnn_desc.get_prev_activations(),
                                     local_input.LockedBuffer(),
@@ -290,6 +303,19 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
 
 template <typename TensorDataType>
 void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, El::Device::GPU>& l) {
+
+  cudnnSoftmaxMode_t softmax_mode;
+  switch(l.m_mode) {
+    case softmax_mode::INSTANCE:
+      softmax_mode = CUDNN_SOFTMAX_MODE_INSTANCE;
+      break;
+    case softmax_mode::CHANNEL:
+      softmax_mode = CUDNN_SOFTMAX_MODE_CHANNEL;
+      break;
+    default:
+      LBANN_ERROR("Unsupported softmax mode");
+  }
+
   constexpr TensorDataType zero = 0;
   constexpr TensorDataType one = 1;
   const auto& local_output = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_activations());
@@ -298,7 +324,7 @@ void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   if (!local_output.IsEmpty()) {
     CHECK_CUDNN(cudnnSoftmaxBackward(cudnn::get_handle(),
                                      CUDNN_SOFTMAX_ACCURATE,
-                                     CUDNN_SOFTMAX_MODE_INSTANCE,
+                                     softmax_mode,
                                      &one,
                                      l.m_tensors_cudnn_desc.get_activations(),
                                      local_output.LockedBuffer(),
@@ -312,6 +338,10 @@ void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
 
 template <typename TensorDataType>
 void fp_compute_impl(softmax_layer<TensorDataType, data_layout::MODEL_PARALLEL, El::Device::GPU>& l) {
+
+  if(l.m_mode != softmax_mode::INSTANCE) {
+    LBANN_ERROR("Unsupported softmax mode");
+  }
 
   // Local matrices
   const auto& local_input = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_prev_activations());
@@ -392,6 +422,10 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::MODEL_PARALLEL, 
 
 template <typename TensorDataType>
 void bp_compute_impl(softmax_layer<TensorDataType, data_layout::MODEL_PARALLEL, El::Device::GPU>& l) {
+
+  if(l.m_mode != softmax_mode::INSTANCE) {
+    LBANN_ERROR("Unsupported softmax mode");
+  }
 
   // Local matrices
   const auto& local_output = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_activations());

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -679,7 +679,14 @@ std::unique_ptr<Layer> construct_layer_legacy(
   CONSTRUCT_LAYER(relu);
   CONSTRUCT_LAYER(selu);
   CONSTRUCT_LAYER(sigmoid);
-  CONSTRUCT_LAYER(softmax);
+  if (proto_layer.has_softmax()) {
+    const auto& params = proto_layer.softmax();
+    const auto& mode_str = params.softmax_mode();
+    softmax_mode mode = softmax_mode::INVALID;
+    if(mode_str == "instance" || mode_str.empty()) { mode = softmax_mode::INSTANCE; }
+    if(mode_str == "channel") { mode = softmax_mode::CHANNEL; }
+    return lbann::make_unique<softmax_layer<TensorDataType, Layout, Device>>(comm, mode);
+  }
   CONSTRUCT_LAYER(softplus);
   CONSTRUCT_LAYER(softsign);
 

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -288,7 +288,9 @@ message Layer {
   /**
    *  @f[ \text{softmax}(x)_i = \frac{e^{x_i}}{\sum_j e^{x_j}} @f]
    */
-  message Softmax {}
+  message Softmax {
+    string softmax_mode = 1; // default: "instance"; should be "instance" or "channel"
+  }
 
   message Softplus {}
   message Softsign {}


### PR DESCRIPTION
This PR adds partial support of the "channel" mode (per sample per spatial pixel softmax) in softmax layers. For the time being, the cuDNN implementation only supports this new mode. The default softmax mode is set to “instance,” which is supported by the existing CPU/GPU/cuDNN implementations.

For the details of the softmax modes, please refer to the cuDNN documentation:
https://docs.nvidia.com/deeplearning/sdk/cudnn-archived/cudnn_765/cudnn-api/index.html#cudnnSoftmaxMode_t