### PR TITLE
data readers: absolute sample counts are broken

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -669,12 +669,6 @@ class generic_data_reader {
   double get_use_percent() const;
 
   /**
-   * Returns the percent of the shuffled indices that are to be
-   * used. Code in this method was formerly in select_subset_of_data()
-   */
-  size_t get_num_indices_to_use() const;
-
-  /**
    * Return the percent of the dataset to be used for validation.
    */
   double get_validation_percent() const;
@@ -789,6 +783,12 @@ class generic_data_reader {
   std::string m_role;
 
   bool m_master;
+
+  /**
+   * Returns the number of the shuffled indices that are to be
+   * used. Code in this method was formerly in select_subset_of_data()
+   */
+  size_t get_num_indices_to_use() const;
 
   friend class data_reader_merge_features;
   friend class data_reader_merge_samples;

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -712,11 +712,6 @@ class generic_data_reader {
     return false;
   }
 
-  /// returns the percent of shuffled indices that are used;
-  /// the returned value  depends on the values returned by
-  /// get_absolute_sample_count() and get_use_percent().
-  double get_percent_to_use();
-
   /**
    * Called before fetch_datum/label/response to allow initialization.
    */
@@ -783,6 +778,14 @@ class generic_data_reader {
   std::string m_role;
 
   bool m_master;
+
+  /** @brief Print the return values from various get_X methods to file
+   *
+   * For use in unit testing. Only the master prints.
+   * Currently only prints values from get_X methods that only depend
+   * on the data_reader (i.e, not on the trainer, model, etc)
+   */
+  void print_get_methods(const std::string filename);
 
   /**
    * Returns the number of the shuffled indices that are to be

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -672,7 +672,7 @@ class generic_data_reader {
    * Returns the percent of the shuffled indices that are to be
    * used. Code in this method was formerly in select_subset_of_data()
    */
-  double get_percent_to_use() const;
+  size_t get_num_indices_to_use() const;
 
   /**
    * Return the percent of the dataset to be used for validation.

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -843,4 +843,28 @@ void generic_data_reader::preload_data_store() {
 
 }
 
+void generic_data_reader::print_get_methods(const std::string filename) {
+  if (!is_master()) {
+    return;
+  }
+  std::ofstream out(filename.c_str());
+  if (!out) {
+    LBANN_ERROR("failed to open ", filename, " for writing");
+  }
+
+  out << "get_file_dir " << get_file_dir() << std::endl;
+  out << "get_local_file_dir " << get_local_file_dir() << std::endl;
+  out << "get_data_index_list " << get_data_index_list() << std::endl;
+  out << "get_data_filename " << get_data_filename()  << std::endl;
+  out << "get_label_filename " << get_label_filename() << std::endl;
+  out << "get_role " << get_role() << std::endl;
+  out << "get_type " << get_type() << std::endl;
+  out << "get_num_data " << get_num_data() << std::endl;
+  out << "get_absolute_sample_count" << get_absolute_sample_count() << std::endl;
+  out << "get_use_percent " << get_use_percent() << std::endl;
+  out << "get_validation_percent " << get_validation_percent() << std::endl;
+  out.close();
+}
+
+
 }  // namespace lbann

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -511,6 +511,11 @@ void init_data_readers(
         reader_validation->get_data_store_ptr()->compact_nodes();
       }
 
+      size_t ntrain = reader->get_num_data();
+      if (ntrain == 0) {
+        LBANN_ERROR("num train samples = 0; something is wrong");
+      }
+
       if (master) {
         size_t num_train = reader->get_num_data();
         size_t num_validate = reader_validation->get_num_data();


### PR DESCRIPTION
This PR addresses Issue #1399.

An exception is now thrown if the number of train samples is zero.