### PR TITLE
Channel-wise softmax layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_channelwise_softmax.py
+++ b/bamboo/unit_tests/test_unit_layer_channelwise_softmax.py
@@ -1,0 +1,177 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20200115)
+_num_samples = 15
+_sample_dims = (5,2,7)
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = np.random.normal(loc=0.5, size=(_num_samples,_sample_size)).astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:]
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# NumPy implementation
+# ==============================================
+
+def numpy_channelwise_softmax(x):
+    if x.dtype is not np.float64:
+        x = x.astype(np.float64)
+    axis = tuple(range(1,x.ndim))
+    shift = np.max(x, axis=axis, keepdims=True)
+    y = np.exp(x-shift)
+    return y / np.sum(y, axis=axis, keepdims=True)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    trainer = lbann.Trainer()
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Sum with a weights layer so that gradient checking will
+    # verify that error signals are correct.
+    x_weights = lbann.Weights(optimizer=lbann.SGD(),
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
+    x_lbann = x
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Data-parallel layout
+    # ------------------------------------------
+
+    # LBANN implementation
+    x = x_lbann
+    y = lbann.ChannelwiseSoftmax(x, data_layout='data_parallel')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel layout'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).reshape(_sample_dims).astype(np.float64)
+        y = numpy_channelwise_softmax(x)
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    mini_batch_size = num_samples() // 2
+    num_epochs = 0
+    return lbann.Model(mini_batch_size,
+                       num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -41,7 +41,27 @@
 
 namespace lbann {
 
-enum class softmax_mode {INVALID, INSTANCE, CHANNEL};
+/** @brief Which tensor dimensions to apply softmax over. */
+enum class softmax_mode {
+  INVALID,
+  /** @brief Sample-wise softmax.
+   *
+   *  Slice tensor along the sample dimension (assuming data in NCHW
+   *  format) and apply softmax independently to each slice (once per
+   *  sample).
+   */
+  INSTANCE,
+  /** @brief Position-wise softmax.
+   *
+   *  Split tensor along all but the channel dimension (assuming data
+   *  in NCHW format) and apply softmax independently to each piece
+   *  (once per spatial position per sample).
+   *
+   *  This is not to be confused with @c channelwise_softmax, which
+   *  slices along the sample and channel dimensions.
+   */
+  CHANNEL
+};
 
 /**
  *  @f[ \text{softmax}(x)_i = \frac{e^{x_i}}{\sum_j e^{x_j}} @f]

--- a/include/lbann/layers/misc/channelwise_softmax.hpp
+++ b/include/lbann/layers/misc/channelwise_softmax.hpp
@@ -1,0 +1,130 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_REGULARIZERS_CHANNELWISE_SOFTMAX_HPP_INCLUDED
+#define LBANN_LAYERS_REGULARIZERS_CHANNELWISE_SOFTMAX_HPP_INCLUDED
+
+#include "lbann/layers/data_type_layer.hpp"
+
+namespace lbann {
+
+/** @brief Apply softmax to tensor channels.
+ *
+ *  The input tensor is sliced along the first tensor dimension (the
+ *  "channel" dimension for image data in CHW format) and the softmax
+ *  function is applied to each slice:
+ *  @f[ \text{softmax}(x)_i = \frac{e^{x_i}}{\sum_j e^{x_j}} @f]
+ *
+ *  This is not to be confused with @c softmax_mode::CHANNEL for
+ *  @c softmax_layer, which applies the softmax function to entries
+ *  corresponding to the same spatial position. "Channel mode" softmax
+ *  might be described as "position-wise softmax".
+ *
+ */
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+class channelwise_softmax_layer : public data_type_layer<TensorDataType> {
+  static_assert(Layout == data_layout::DATA_PARALLEL,
+                "channelwise_softmax_layer only supports "
+                "data-parallel data layout");
+
+public:
+
+  channelwise_softmax_layer(lbann_comm* comm);
+
+  channelwise_softmax_layer(const channelwise_softmax_layer& other) = default;
+  channelwise_softmax_layer& operator=(const channelwise_softmax_layer& other) = default;
+  channelwise_softmax_layer* copy() const override;
+
+  std::string get_type() const override;
+  data_layout get_data_layout() const override;
+  El::Device get_device_allocation() const override;
+
+protected:
+
+  void setup_dims() override;
+
+  void fp_compute() override;
+  void bp_compute() override;
+
+};
+
+// =========================================================
+// Implementation
+// =========================================================
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+channelwise_softmax_layer<TensorDataType,Layout,Device>::channelwise_softmax_layer(
+  lbann_comm* comm)
+  : data_type_layer<TensorDataType>(comm)
+{}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+channelwise_softmax_layer<TensorDataType,Layout,Device>* channelwise_softmax_layer<TensorDataType,Layout,Device>::copy() const {
+  return new channelwise_softmax_layer(*this);
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+std::string channelwise_softmax_layer<TensorDataType,Layout,Device>::get_type() const {
+  return "channel-wise softmax";
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+data_layout channelwise_softmax_layer<TensorDataType,Layout,Device>::get_data_layout() const {
+  return Layout;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+El::Device channelwise_softmax_layer<TensorDataType,Layout,Device>::get_device_allocation() const {
+  return Device;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void channelwise_softmax_layer<TensorDataType,Layout,Device>::setup_dims() {
+  data_type_layer<TensorDataType>::setup_dims();
+  this->set_output_dims(this->get_input_dims());
+}
+
+// =========================================================
+// Explicit template instantiation
+// =========================================================
+
+#ifndef LBANN_CHANNELWISE_SOFTMAX_LAYER_INSTANTIATE
+
+#define PROTO_DEVICE(T, Device)                         \
+  extern template class channelwise_softmax_layer<      \
+    T, data_layout::DATA_PARALLEL, Device>;
+#define LBANN_INSTANTIATE_CPU_HALF
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+#undef LBANN_INSTANTIATE_CPU_HALF
+#undef LBANN_INSTANTIATE_GPU_HALF
+
+#endif // LBANN_CHANNELWISE_SOFTMAX_LAYER_INSTANTIATE
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_REGULARIZERS_CHANNELWISE_SOFTMAX_HPP_INCLUDED

--- a/include/lbann/layers/misc/channelwise_softmax.hpp
+++ b/include/lbann/layers/misc/channelwise_softmax.hpp
@@ -118,12 +118,8 @@ void channelwise_softmax_layer<TensorDataType,Layout,Device>::setup_dims() {
 #define PROTO_DEVICE(T, Device)                         \
   extern template class channelwise_softmax_layer<      \
     T, data_layout::DATA_PARALLEL, Device>;
-#define LBANN_INSTANTIATE_CPU_HALF
-#define LBANN_INSTANTIATE_GPU_HALF
 #include "lbann/macros/instantiate_device.hpp"
 #undef PROTO_DEVICE
-#undef LBANN_INSTANTIATE_CPU_HALF
-#undef LBANN_INSTANTIATE_GPU_HALF
 #endif // LBANN_CHANNELWISE_SOFTMAX_LAYER_INSTANTIATE
 
 } // namespace lbann

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -110,6 +110,7 @@
 #include "lbann/layers/misc/covariance.hpp"
 #include "lbann/layers/misc/variance.hpp"
 #include "lbann/layers/misc/channelwise_mean.hpp"
+#include "lbann/layers/misc/channelwise_softmax.hpp"
 #include "lbann/layers/misc/mini_batch_index.hpp"
 #include "lbann/layers/misc/mini_batch_size.hpp"
 #include "lbann/layers/misc/argmax.hpp"

--- a/src/layers/misc/CMakeLists.txt
+++ b/src/layers/misc/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   argmax.cpp
   argmin.cpp
   channelwise_mean.cpp
+  channelwise_softmax.cpp
   covariance.cpp
   mini_batch_index.cpp
   mini_batch_size.cpp
@@ -16,6 +17,7 @@ if (LBANN_HAS_CUDA)
     covariance.cu
     variance.cu
     channelwise_mean.cu
+    channelwise_softmax.cu
     one_hot.cu
     )
 endif ()

--- a/src/layers/misc/channelwise_softmax.cpp
+++ b/src/layers/misc/channelwise_softmax.cpp
@@ -1,0 +1,173 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_CHANNELWISE_SOFTMAX_LAYER_INSTANTIATE
+#include "lbann/layers/misc/channelwise_softmax.hpp"
+
+namespace lbann {
+
+namespace {
+
+/** @brief Forward prop */
+template <typename TensorDataType>
+void fp_impl(El::Int num_channels,
+             El::Int channel_size,
+             const El::AbstractDistMatrix<TensorDataType>& input,
+             El::AbstractDistMatrix<TensorDataType>& output) {
+
+  // Local matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::CPU>;
+  const auto& local_input = dynamic_cast<const LocalMat&>(input.LockedMatrix());
+  auto& local_output = dynamic_cast<LocalMat&>(output.Matrix());
+
+  // Dimensions
+  const El::Int local_mini_batch_size = local_input.Width();
+
+  // Compute softmax shifts
+  //   shift = max(x_i)
+  LocalMat local_shifts(num_channels, local_mini_batch_size);
+  El::Fill(local_shifts, std::numeric_limits<TensorDataType>::lowest());
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int k = 0; k < local_mini_batch_size; ++k) {
+    for (El::Int j = 0; j < num_channels; ++j) {
+      auto& maxval = local_shifts(j,k);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        maxval = std::max(maxval, local_input(i+j*channel_size,k));
+      }
+    }
+  }
+
+  // Compute softmax denominators
+  //   denom = sum( exp(x_i-shift) )
+  LocalMat local_denoms(num_channels, local_mini_batch_size);
+  El::Zero(local_denoms);
+  for (El::Int k = 0; k < local_mini_batch_size; ++k) {
+    for (El::Int j = 0; j < num_channels; ++j) {
+      const auto& shift = local_shifts(j,k);
+      auto& denom = local_denoms(j,k);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        const auto& x = local_input(i+j*channel_size,k);
+        denom += std::exp(x-shift);
+      }
+    }
+  }
+
+  // Compute softmax
+  //   y_i = exp(x_i-shift) / denom
+  for (El::Int k = 0; k < local_mini_batch_size; ++k) {
+    for (El::Int j = 0; j < num_channels; ++j) {
+      const auto& shift = local_shifts(j,k);
+      const auto& denom = local_denoms(j,k);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        const auto& x = local_input(i+j*channel_size,k);
+        auto& y = local_output(i+j*channel_size,k);
+        y = std::exp(x-shift) / denom;
+      }
+    }
+  }
+
+}
+
+/** @brief Backprop */
+template <typename TensorDataType>
+void bp_impl(El::Int num_channels,
+             El::Int channel_size,
+             const El::AbstractDistMatrix<TensorDataType>& output,
+             const El::AbstractDistMatrix<TensorDataType>& output_grad,
+             El::AbstractDistMatrix<TensorDataType>& input_grad) {
+
+  // Local matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::CPU>;
+  const auto& local_output = dynamic_cast<const LocalMat&>(output.LockedMatrix());
+  const auto& local_output_grad = dynamic_cast<const LocalMat&>(output_grad.LockedMatrix());
+  auto& local_input_grad = dynamic_cast<LocalMat&>(input_grad.Matrix());
+
+  // Dimensions
+  const El::Int local_mini_batch_size = local_output.Width();
+
+  // dot(y,dL/dy)
+  LocalMat local_y_dot_dy(num_channels, local_mini_batch_size);
+  El::Zero(local_y_dot_dy);
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int k = 0; k < local_mini_batch_size; ++k) {
+    for (El::Int j = 0; j < num_channels; ++j) {
+      auto& y_dot_dy = local_y_dot_dy(j,k);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        const auto& y = local_output(i+j*channel_size,k);
+        const auto& dy = local_output_grad(i+j*channel_size,k);
+        y_dot_dy += y * dy;
+      }
+    }
+  }
+
+  // dL/dx_i = y_i * ( dL/dy_i - dot(y,dL/dy) )
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE2
+  for (El::Int k = 0; k < local_mini_batch_size; ++k) {
+    for (El::Int j = 0; j < num_channels; ++j) {
+      const auto& y_dot_dy = local_y_dot_dy(j,k);
+      for (El::Int i = 0; i < channel_size; ++i) {
+        const auto& y = local_output(i+j*channel_size,k);
+        const auto& dy = local_output_grad(i+j*channel_size,k);
+        auto& dx = local_input_grad(i+j*channel_size,k);
+        dx = y * (dy - y_dot_dy);
+      }
+    }
+
+  }
+
+}
+
+} // namespace <anon>
+
+// Template instantiation
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void channelwise_softmax_layer<TensorDataType,Layout,Device>::fp_compute() {
+  const El::Int num_channels = this->get_output_dims().front();
+  const El::Int channel_size = this->get_output_size() / num_channels;
+  fp_impl(num_channels,
+          channel_size,
+          this->get_prev_activations(),
+          this->get_activations());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void channelwise_softmax_layer<TensorDataType,Layout,Device>::bp_compute() {
+  const El::Int num_channels = this->get_output_dims().front();
+  const El::Int channel_size = this->get_output_size() / num_channels;
+  bp_impl(num_channels,
+          channel_size,
+          this->get_activations(),
+          this->get_prev_error_signals(),
+          this->get_error_signals());
+}
+
+#define PROTO(T)                                        \
+  template class channelwise_softmax_layer<             \
+    T, data_layout::DATA_PARALLEL, El::Device::CPU>;
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+
+} // namespace lbann

--- a/src/layers/misc/channelwise_softmax.cu
+++ b/src/layers/misc/channelwise_softmax.cu
@@ -1,0 +1,484 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_CHANNELWISE_SOFTMAX_LAYER_INSTANTIATE
+#include "lbann/layers/misc/channelwise_softmax.hpp"
+#include "lbann/utils/cuda.hpp"
+
+namespace lbann {
+
+namespace {
+
+using Size3 = cuda::array<size_t,3>;
+
+/** @brief Max functor */
+template <class T>
+struct max_op {
+  __device__ __forceinline__
+  DataType operator()(const T& x1, const T& x2) const {
+    return cuda::max(x1, x2);
+  }
+};
+
+/** @brief Max reduction over last dimension of 3D tensor.
+ *
+ *  Each CUDA block computes the max over a subset of tensor entries
+ *  in @c vals and outputs the result to @c maxvals. This should be
+ *  repeated multiple times to fully reduce the last tensor dimension.
+ *
+ *  Block dimensions: bdimx x 1 x 1
+ *
+ *  Grid dimensions: (vals_dims[2] / bdimx) x vals_dims[1] x vals_dims[0]
+ *
+ *  maxvals: vals_dims[0] x vals_dims[1] x (vals_dims[2] / bdimx)
+ */
+template <typename TensorDataType, size_t bdimx>
+__global__ void fp_max_kernel(
+  Size3 vals_dims,
+  const TensorDataType* __restrict__ vals_buffer,
+  Size3 vals_strides,
+  TensorDataType* __restrict__ maxvals_buffer,
+  Size3 maxvals_strides) {
+
+  // Indices and dimensions
+  constexpr size_t bdimy = 1;
+  constexpr size_t bdimz = 1;
+  const size_t tid = threadIdx.x;
+  const size_t bidx = blockIdx.x;
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nthreadsz = blockDim.z * gridDim.z;
+
+  for (size_t k = gidz; k < vals_dims[0]; k += nthreadsz) {
+    for (size_t j = gidy; j < vals_dims[1]; j += nthreadsy) {
+
+      // Find largest value for each thread
+      TensorDataType maxval{-cuda::infinity<TensorDataType>()};
+      for (size_t i = gidx; i < vals_dims[2]; i += nthreadsx) {
+        const auto& val = vals_buffer[k * vals_strides[0]
+                                      + j * vals_strides[1]
+                                      + i * vals_strides[2]];
+        maxval = cuda::max(maxval, val);
+      }
+
+      // Find largest value for each block
+      maxval = cuda::block_reduce<bdimx,bdimy,bdimz,TensorDataType,max_op<TensorDataType>>(maxval);
+      if (tid == 0) {
+        const auto& pos = (k * maxvals_strides[0]
+                           + j * maxvals_strides[1]
+                           + bidx * maxvals_strides[2]);
+        maxvals_buffer[pos] = maxval;
+      }
+
+    }
+  }
+
+}
+
+/** Compute softmax denominator.
+ *
+ *  denom = sum( exp(x_i-shift) )
+ *
+ *  Block dimensions: bdimx x 1 x 1
+ *
+ *  Grid dimensions: (input_dims[2] / bdimx) x input_dims[1] x input_dims[0]
+ *
+ *  shifts and denoms are fully-packed 2D tensors with dimensions of
+ *  input_dims[0] x input_dims[1].
+ */
+template <typename TensorDataType, size_t bdimx>
+__global__ void fp_denom_kernel(
+  Size3 input_dims,
+  const TensorDataType* __restrict__ input_buffer,
+  Size3 input_strides,
+  const TensorDataType* __restrict__ shifts,
+  TensorDataType* __restrict__ denoms) {
+
+  // Indices and dimensions
+  constexpr size_t bdimy = 1;
+  constexpr size_t bdimz = 1;
+  const size_t tid = threadIdx.x;
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nthreadsz = blockDim.z * gridDim.z;
+
+  for (size_t k = gidz; k < input_dims[0]; k += nthreadsz) {
+    for (size_t j = gidy; j < input_dims[1]; j += nthreadsy) {
+
+      // Compute contribution from each thread
+      const auto& shift = shifts[j + k*input_dims[1]];
+      TensorDataType denom{0.};
+      for (size_t i = gidx; i < input_dims[2]; i += nthreadsx) {
+        const auto& x = input_buffer[k * input_strides[0]
+                                     + j * input_strides[1]
+                                     + i * input_strides[2]];
+        denom += cuda::exp(x-shift);
+      }
+
+      // Compute contribution from each block
+      denom = cuda::block_reduce<bdimx,bdimy,bdimz>(denom);
+      if (tid == 0) {
+        cuda::atomic_add(&denoms[j+k*input_dims[1]], denom);
+      }
+
+    }
+  }
+
+}
+
+/** Compute softmax.
+ *
+ *  y_i = exp(x_i-shift) / denom
+ *
+ *  Block dimensions: bdimx x bdimy x bdimz
+ *
+ *  Grid dimensions: (input_dims[2] / bdimx) x (input_dims[1] / bdimy) x (input_dims[0] / bdimz)
+ *
+ *  shifts and denoms are fully-packed 2D tensors with dimensions of
+ *  input_dims[0] x input_dims[1].
+ */
+template <typename TensorDataType>
+__global__ void fp_output_kernel(
+  Size3 input_dims,
+  const TensorDataType* __restrict__ input_buffer,
+  Size3 input_strides,
+  TensorDataType* __restrict__ output_buffer,
+  Size3 output_strides,
+  const TensorDataType* __restrict__ shifts,
+  const TensorDataType* __restrict__ denoms) {
+
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nthreadsz = blockDim.z * gridDim.z;
+  for (size_t k = gidz; k < input_dims[0]; k += nthreadsz) {
+    for (size_t j = gidy; j < input_dims[1]; j += nthreadsy) {
+      const auto& shift = shifts[j + k*input_dims[1]];
+      const auto& denom = denoms[j + k*input_dims[1]];
+      for (size_t i = gidx; i < input_dims[2]; i += nthreadsx) {
+        const auto& x = input_buffer[k * input_strides[0]
+                                     + j * input_strides[1]
+                                     + i * input_strides[2]];
+        auto& y = output_buffer[k * output_strides[0]
+                                + j * output_strides[1]
+                                + i * output_strides[2]];
+        y = cuda::exp(x-shift) / denom;
+      }
+    }
+  }
+
+}
+
+/** @brief Forward prop */
+template <typename TensorDataType>
+void fp_impl(size_t num_channels,
+             size_t channel_size,
+             const El::AbstractDistMatrix<TensorDataType>& input,
+             El::AbstractDistMatrix<TensorDataType>& output) {
+
+  // Local matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::GPU>;
+  const auto& local_input = dynamic_cast<const LocalMat&>(input.LockedMatrix());
+  auto& local_output = dynamic_cast<LocalMat&>(output.Matrix());
+
+  // Dimensions
+  const size_t local_mini_batch_size = local_input.Width();
+  // const Size3 input_dims{local_mini_batch_size, num_channels, channel_size};
+
+  // Compute softmax shifts
+  LocalMat local_shifts;
+  if (!local_input.IsEmpty()) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_mini_batch_size;
+    LocalMat maxvals(grid_dims.x * num_channels, local_mini_batch_size);
+    fp_max_kernel<TensorDataType,block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        {local_mini_batch_size, num_channels, channel_size},
+        local_input.LockedBuffer(),
+        {static_cast<size_t>(local_input.LDim()), channel_size, 1},
+        maxvals.Buffer(),
+        {static_cast<size_t>(maxvals.LDim()), grid_dims.x, 1});
+    while (grid_dims.x > 1) {
+      const size_t prev_dim = grid_dims.x;
+      grid_dims.x = (prev_dim + block_size - 1) / block_size;
+      const LocalMat prev_maxvals(std::move(maxvals));
+      maxvals.Resize(grid_dims.x * num_channels, local_mini_batch_size);
+      fp_max_kernel<TensorDataType,block_size>
+        <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+          {local_mini_batch_size, num_channels, prev_dim},
+          prev_maxvals.LockedBuffer(),
+          {static_cast<size_t>(prev_maxvals.LDim()), prev_dim, 1},
+          maxvals.Buffer(),
+          {static_cast<size_t>(maxvals.LDim()), grid_dims.x, 1});
+    }
+    local_shifts = std::move(maxvals);
+  }
+
+  // Compute softmax denominators
+  LocalMat local_denoms(num_channels, local_mini_batch_size);
+  El::Zero(local_denoms);
+  if (!local_input.IsEmpty()) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_mini_batch_size;
+    fp_denom_kernel<TensorDataType,block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        {local_mini_batch_size, num_channels, channel_size},
+        local_input.LockedBuffer(),
+        {static_cast<size_t>(local_input.LDim()), channel_size, 1},
+        local_shifts.LockedBuffer(),
+        local_denoms.Buffer());
+  }
+
+  // Compute softmax
+  if (!local_input.IsEmpty()) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_mini_batch_size;
+    fp_output_kernel<TensorDataType>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        {local_mini_batch_size, num_channels, channel_size},
+        local_input.LockedBuffer(),
+        {static_cast<size_t>(local_input.LDim()), channel_size, 1},
+        local_output.Buffer(),
+        {static_cast<size_t>(local_output.LDim()), channel_size, 1},
+        local_shifts.LockedBuffer(),
+        local_denoms.LockedBuffer());
+  }
+
+}
+
+/** Compute dot product between output and gradient w.r.t. output.
+ *
+ *  Block dimensions: bdimx x 1 x 1
+ *
+ *  Grid dimensions: (output_dims[2] / bdimx) x output_dims[1] x output_dims[0]
+ *
+ *  y_dot_dy is a fully-packed 2D tensor with dimensions of
+ *  output_dims[0] x output_dims[1].
+ */
+template <typename TensorDataType, size_t bdimx>
+__global__ void bp_y_dot_dy_kernel(
+  Size3 output_dims,
+  const TensorDataType* __restrict__ output_buffer,
+  Size3 output_strides,
+  const TensorDataType* __restrict__ output_grad_buffer,
+  Size3 output_grad_strides,
+  TensorDataType* __restrict__ y_dot_dy) {
+
+  // Indices and dimensions
+  constexpr size_t bdimy = 1;
+  constexpr size_t bdimz = 1;
+  const size_t tid = threadIdx.x;
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nthreadsz = blockDim.z * gridDim.z;
+
+  for (size_t k = gidz; k < output_dims[0]; k += nthreadsz) {
+    for (size_t j = gidy; j < output_dims[1]; j += nthreadsy) {
+
+      // Compute contribution from each thread
+      TensorDataType _y_dot_dy{0.};
+      for (size_t i = gidx; i < output_dims[2]; i += nthreadsx) {
+        const auto& y = output_buffer[k * output_strides[0]
+                                      + j * output_strides[1]
+                                      + i * output_strides[2]];
+        const auto& dy = output_grad_buffer[k * output_grad_strides[0]
+                                            + j * output_grad_strides[1]
+                                            + i * output_grad_strides[2]];
+        _y_dot_dy += y * dy;
+      }
+
+      // Compute contribution from each block
+      _y_dot_dy = cuda::block_reduce<bdimx,bdimy,bdimz>(_y_dot_dy);
+      if (tid == 0) {
+        cuda::atomic_add(&y_dot_dy[j+k*output_dims[1]], _y_dot_dy);
+      }
+
+    }
+  }
+
+}
+
+/** Compute gradient w.r.t. input.
+ *
+ *  dL/dx_i = y_i * ( dL/dy_i - dot(y,dL/dy) )
+ *
+ *  Block dimensions: bdimx x bdimy x bdimz
+ *
+ *  Grid dimensions: (output_dims[2] / bdimx) x (output_dims[1] / bdimy) x (output_dims[0] / bdimz)
+ *
+ *  y_dot_dy is a fully-packed 2D tensor with dimensions of
+ *  output_dims[0] x output_dims[1].
+ */
+template <typename TensorDataType>
+__global__ void bp_input_grad_kernel(
+  Size3 output_dims,
+  const TensorDataType* __restrict__ output_buffer,
+  Size3 output_strides,
+  const TensorDataType* __restrict__ output_grad_buffer,
+  Size3 output_grad_strides,
+  TensorDataType* __restrict__ input_grad_buffer,
+  Size3 input_grad_strides,
+  const TensorDataType* __restrict__ y_dot_dy) {
+
+  const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const size_t nthreadsx = blockDim.x * gridDim.x;
+  const size_t nthreadsy = blockDim.y * gridDim.y;
+  const size_t nthreadsz = blockDim.z * gridDim.z;
+  for (size_t k = gidz; k < output_dims[0]; k += nthreadsz) {
+    for (size_t j = gidy; j < output_dims[1]; j += nthreadsy) {
+      const auto& _y_dot_dy = y_dot_dy[j + k*output_dims[1]];
+      for (size_t i = gidx; i < output_dims[2]; i += nthreadsx) {
+        const auto& y = output_buffer[k * output_strides[0]
+                                      + j * output_strides[1]
+                                      + i * output_strides[2]];
+        const auto& dy = output_grad_buffer[k * output_grad_strides[0]
+                                            + j * output_grad_strides[1]
+                                            + i * output_grad_strides[2]];
+        auto& dx = input_grad_buffer[k * input_grad_strides[0]
+                                     + j * input_grad_strides[1]
+                                     + i * input_grad_strides[2]];
+        dx = y * (dy - _y_dot_dy);
+      }
+    }
+  }
+
+}
+
+/** @brief Backprop */
+template <typename TensorDataType>
+void bp_impl(size_t num_channels,
+             size_t channel_size,
+             const El::AbstractDistMatrix<TensorDataType>& output,
+             const El::AbstractDistMatrix<TensorDataType>& output_grad,
+             El::AbstractDistMatrix<TensorDataType>& input_grad) {
+
+  // Local matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::GPU>;
+  const auto& local_output = dynamic_cast<const LocalMat&>(output.LockedMatrix());
+  const auto& local_output_grad = dynamic_cast<const LocalMat&>(output_grad.LockedMatrix());
+  auto& local_input_grad = dynamic_cast<LocalMat&>(input_grad.Matrix());
+
+  // Dimensions
+  const size_t local_mini_batch_size = local_output.Width();
+
+  // dot(y,dL/dy)
+  LocalMat local_y_dot_dy(num_channels, local_mini_batch_size);
+  El::Zero(local_y_dot_dy);
+  if (!local_output.IsEmpty()) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_mini_batch_size;
+    bp_y_dot_dy_kernel<TensorDataType,block_size>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        {local_mini_batch_size, num_channels, channel_size},
+        local_output.LockedBuffer(),
+        {static_cast<size_t>(local_output.LDim()), channel_size, 1},
+        local_output_grad.LockedBuffer(),
+        {static_cast<size_t>(local_output_grad.LDim()), channel_size, 1},
+        local_y_dot_dy.Buffer());
+  }
+
+  // Compute gradient w.r.t. input
+  if (!local_output.IsEmpty()) {
+    constexpr size_t block_size = 256;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    grid_dims.x = (channel_size + block_size - 1) / block_size;
+    grid_dims.y = num_channels;
+    grid_dims.z = local_mini_batch_size;
+    bp_input_grad_kernel<TensorDataType>
+      <<<grid_dims, block_dims, 0, El::GPUManager::Stream()>>>(
+        {local_mini_batch_size, num_channels, channel_size},
+        local_output.LockedBuffer(),
+        {static_cast<size_t>(local_output.LDim()), channel_size, 1},
+        local_output_grad.LockedBuffer(),
+        {static_cast<size_t>(local_output_grad.LDim()), channel_size, 1},
+        local_input_grad.Buffer(),
+        {static_cast<size_t>(local_input_grad.LDim()), channel_size, 1},
+        local_y_dot_dy.LockedBuffer());
+  }
+
+}
+
+} // namespace <anon>
+
+// Template instantiation
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void channelwise_softmax_layer<TensorDataType,Layout,Device>::fp_compute() {
+  const size_t num_channels = this->get_output_dims().front();
+  const size_t channel_size = this->get_output_size() / num_channels;
+  fp_impl(num_channels,
+          channel_size,
+          this->get_prev_activations(),
+          this->get_activations());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void channelwise_softmax_layer<TensorDataType,Layout,Device>::bp_compute() {
+  const size_t num_channels = this->get_output_dims().front();
+  const size_t channel_size = this->get_output_size() / num_channels;
+  bp_impl(num_channels,
+          channel_size,
+          this->get_activations(),
+          this->get_prev_error_signals(),
+          this->get_error_signals());
+}
+
+#define PROTO(T)                                        \
+  template class channelwise_softmax_layer<             \
+    T, data_layout::DATA_PARALLEL, El::Device::GPU>;
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate.hpp"
+
+} // namespace lbann

--- a/src/layers/misc/channelwise_softmax.cu
+++ b/src/layers/misc/channelwise_softmax.cu
@@ -497,7 +497,6 @@ void channelwise_softmax_layer<TensorDataType,Layout,Device>::bp_compute() {
 #define PROTO(T)                                        \
   template class channelwise_softmax_layer<             \
     T, data_layout::DATA_PARALLEL, El::Device::GPU>;
-#define LBANN_INSTANTIATE_GPU_HALF
 #include "lbann/macros/instantiate.hpp"
 
 } // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -61,6 +61,7 @@
 #include "lbann/layers/math/matmul.hpp"
 #include "lbann/layers/math/unary.hpp"
 #include "lbann/layers/misc/channelwise_mean.hpp"
+#include "lbann/layers/misc/channelwise_softmax.hpp"
 #include "lbann/layers/misc/covariance.hpp"
 #include "lbann/layers/misc/mini_batch_index.hpp"
 #include "lbann/layers/misc/mini_batch_size.hpp"
@@ -733,6 +734,14 @@ std::unique_ptr<Layer> construct_layer_legacy(
       return lbann::make_unique<channelwise_mean_layer<TensorDataType, data_layout::DATA_PARALLEL, Device>>(comm);
     } else {
       LBANN_ERROR("channel-wise mean layer is only supported with "
+                  "a data-parallel layout");
+    }
+  }
+  if (proto_layer.has_channelwise_softmax()) {
+    if (Layout == data_layout::DATA_PARALLEL) {
+      return lbann::make_unique<channelwise_softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, Device>>(comm);
+    } else {
+      LBANN_ERROR("channel-wise softmax layer is only supported with "
                   "a data-parallel layout");
     }
   }

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -188,6 +188,7 @@ message Layer {
     Argmax argmax = 605;
     Argmin argmin = 606;
     OneHot one_hot = 607;
+    ChannelwiseSoftmax channelwise_softmax = 608;
 
   }
 
@@ -648,7 +649,9 @@ message Layer {
     int64 size = 1;
   }
 
-}// message Layer
+  message ChannelwiseSoftmax {}
+
+} // message Layer
 
 //note: I'd like to put this enum inside of Layer, but if I do the enum values
 //      become, e.g, Layer_Imcomm_EXCLUDE, which is just ugly


### PR DESCRIPTION
In our current implementation of multi-head attention, we repeatedly apply softmax to each row in a matrix. This introduces a ton of kernel launch overhead. This layer fuses these into one layer.

This is not to be confused with the "channel mode" for softmax in #1389, which would be better called "position-wise softmax."

[Tests pass on Bamboo, aside from the LeNet integration test (which is failing in Nightly and is unaffected by this PR)](https://lc.llnl.gov/bamboo/browse/LBANN-TIM257-1).