### PR TITLE
Cnpy extended

### DIFF
--- a/include/lbann/utils/cnpy_llnl.hpp
+++ b/include/lbann/utils/cnpy_llnl.hpp
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_CNPY_LLNL_HPP
+#define LBANN_UTILS_CNPY_LLNL_HPP
+
+#include <cnpy.h>
+
+nammespace cnpy {
+
+std::ifstream open_file(std::string fname);
+
+npz_t load(std::istream);
+
+} //namespace cnpy 
+
+#endif  //LBANN_UTILS_CNPY_LLNL_HPP

--- a/include/lbann/utils/cnpy_llnl.hpp
+++ b/include/lbann/utils/cnpy_llnl.hpp
@@ -31,10 +31,51 @@
 
 nammespace cnpy {
 
+/**
+ * This file contains additional function for the cnpy package
+ * ( https://github.com/davidHysom/lbann/pull/new/cnpy_extended )
+ * The original code only loads a numpy array for a filename;
+ * we have need (e.g, our sample_list class) to open a file
+ * prior to loading, and to load from a filestream instead of
+ * a filename.
+ *
+ * load(std::istream), below, is largely a re-write of the 
+ * original cnpy::npz_t cnpy::npz_load(std::string fname) function.
+ *
+ * The MIT license from the cnpy package is included below.
+ */
+
 std::ifstream open_file(std::string fname);
 
 npz_t load(std::istream);
 
 } //namespace cnpy 
+
+
+
+/** License from the original cnpy repo: 
+ *
+ * The MIT License
+ *
+ * Copyright (c) Carl Rogers, 2011
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 
 #endif  //LBANN_UTILS_CNPY_LLNL_HPP

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -26,6 +26,7 @@ set_full_path(THIS_DIR_SOURCES
   lbann_library.cpp
   jag_common.cpp
   commify.cpp
+  cnpy_llnl.cpp
 )
 
 if (LBANN_HAS_CUDA)

--- a/src/utils/cnpy_llnl.cpp
+++ b/src/utils/cnpy_llnl.cpp
@@ -1,0 +1,46 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+/// @todo Rename this file to file.cpp.
+
+#include "lbann/utils/cnyp_llnl.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+namespace cnpy {
+
+std::ifstream open_file(std::string fname) {
+  //TODO
+}
+
+npz_t load(std::istream) {
+  //TODO
+}
+
+} // namespace cnpy
+
+} // namespace lbann


### PR DESCRIPTION
Adds functionality to the cnpy package to open an npz file and return an std::istream; load an npz file from a given std::istream. This functionality is needed to enable data_reader_npz_ras_lipid (and possibly future npz based reader) to work with our sample_list class.