### PR TITLE
Update cnpy tag 2

### DIFF
--- a/model_zoo/jag_utils/test_ras_lipid_data_files_for_errors.cpp
+++ b/model_zoo/jag_utils/test_ras_lipid_data_files_for_errors.cpp
@@ -78,21 +78,11 @@ int main(int argc, char *argv[]) {
         std::cerr << "loading: " << filenames[j] << std::endl;
       }
 
-/*
       out << "opening: " << filenames[j] << std::endl;
       out.close();
       out.open(b, std::ofstream::out | std::ofstream::app);
-*/
 
-  try {
-  std::cerr << "still here" << std::endl;
       std::map<std::string, cnpy::NpyArray> a = cnpy::npz_load(filenames[j]);
-  std::cerr << "DONE! still here" << std::endl;
-  } catch (...) {
-
-  //} catch (std::exception const &e) {
-    std::cerr << "FAILED: "<< filenames[j] << std::endl;
-  }
 
       out << "DONE! opening: " << filenames[j] << std::endl;
       out.close();

--- a/superbuild/cnpy/CMakeLists.txt
+++ b/superbuild/cnpy/CMakeLists.txt
@@ -19,6 +19,7 @@ else ()
     CACHE STRING "The URL from which to clone CNPY")
 endif ()
 
+
 # ... then the tag.
 set(CNPY_TAG "4e8810b1a8637695171ed346ce68f6984e585ef4"
   CACHE STRING "The git tag or hash to checkout for CNPY")

--- a/superbuild/cnpy/CMakeLists.txt
+++ b/superbuild/cnpy/CMakeLists.txt
@@ -20,7 +20,7 @@ else ()
 endif ()
 
 # ... then the tag.
-set(CNPY_TAG "f19917f6c442885dcf171de485ba8b17bd178da6"
+set(CNPY_TAG "4e8810b1a8637695171ed346ce68f6984e585ef4"
   CACHE STRING "The git tag or hash to checkout for CNPY")
 
 # Where to install CNPY


### PR DESCRIPTION
Update cnpy repo tag -- needed so exceptions are thrown, instead of assert(), on file errors.