### PR TITLE
Fix bug when slice layer has only one output

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_slice.py
+++ b/bamboo/unit_tests/test_unit_layer_slice.py
@@ -148,13 +148,13 @@ def construct_model(lbann):
     # --------------------------
 
     # LBANN implementation
-    slice_points = (0, 1, 2, 3)
+    slice_points = (1, 3)
     x = x_lbann
     x_slice = lbann.Slice(x, axis=2, slice_points=tools.str_list(slice_points))
     y = []
     for _ in range(len(slice_points)-1):
         y.append(lbann.L2Norm2(x_slice))
-    z = lbann.Add(y[0], y[2])
+    z = y[0]
     obj.append(z)
     metrics.append(lbann.Metric(z, name='axis2'))
 
@@ -166,7 +166,7 @@ def construct_model(lbann):
         for j in range(len(slice_points)-1):
             x_slice = x[:,:,slice_points[j]:slice_points[j+1]]
             y.append(tools.numpy_l2norm2(x_slice))
-        z = y[0] + y[2]
+        z = y[0]
         vals.append(z)
     val = np.mean(vals)
     tol = 8 * val * np.finfo(np.float32).eps

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -227,15 +227,10 @@ void fp_setup_outputs_impl(
 
   const size_t num_outputs = l.get_num_children();
   const auto& input = l.get_prev_activations();
-  if (num_outputs == 1) {
-    El::LockedView(l.get_activations(0), input);
-  }
-  else {
-    for (size_t j=0; j<num_outputs; ++j) {
-      auto& output = l.get_activations(j);
-      output.AlignWith(input);
-      output.Resize(l.get_output_size(j), input.Width());
-    }
+  for (size_t j=0; j<num_outputs; ++j) {
+    auto& output = l.get_activations(j);
+    output.AlignWith(input);
+    output.Resize(l.get_output_size(j), input.Width());
   }
 
 }
@@ -255,28 +250,13 @@ void slice_layer<TensorDataType,Layout,Device>::bp_setup_gradient_wrt_inputs(El:
   const auto& output0_grad = this->get_prev_error_signals(0);
   auto& input_grad = this->get_error_signals();
   input_grad.Empty(false);
-  if (this->get_num_children() == 1) {
-    El::LockedView(input_grad, output0_grad);
-  }
-  else {
-    input_grad.AlignWith(output0_grad);
-    El::Zeros(input_grad, this->get_input_size(), output0_grad.Width());
-  }
+  input_grad.AlignWith(output0_grad);
+  El::Zeros(input_grad, this->get_input_size(), output0_grad.Width());
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void slice_layer<TensorDataType,Layout,Device>::bp_compute() {
-
-  // Just make a view if there is one input
-  if (this->get_num_children() == 1) {
-    // Tensor views have already been setup in
-    // bp_setup_gradient_wrt_inputs
-    return;
-  }
-
-  // Perform concatenation
   bp_compute_impl(*this);
-
 }
 
 #ifndef LBANN_SLICE_LAYER_INSTANTIATE

--- a/src/layers/transform/slice.cpp
+++ b/src/layers/transform/slice.cpp
@@ -167,12 +167,6 @@ template <typename TensorDataType>
 void fp_compute_impl(
   slice_layer<TensorDataType,data_layout::DATA_PARALLEL,El::Device::CPU>& l) {
 
-  // Just make a view if there is one output
-  if (l.get_num_children() == 1) {
-    El::LockedView(l.get_activations(0), l.get_prev_activations());
-    return;
-  }
-
   // Check that number of dimensions is valid
   /// @todo Support tensors with arbitrary number of dimensions
   const auto& input_dims = l.get_input_dims();

--- a/src/layers/transform/slice.cu
+++ b/src/layers/transform/slice.cu
@@ -186,12 +186,6 @@ template <typename TensorDataType>
 void fp_compute_impl(
   slice_layer<TensorDataType,data_layout::DATA_PARALLEL,El::Device::GPU>& l) {
 
-  // Just make a view if there is one output
-  if (l.get_num_children() == 1) {
-    El::LockedView(l.get_activations(0), l.get_prev_activations());
-    return;
-  }
-
   // Check that number of dimensions is valid
   /// @todo Support tensors with arbitrary number of dimensions
   const auto& input_dims = l.get_input_dims();


### PR DESCRIPTION
When a slice layer has only one child, it just outputs a view of the input tensor, possibly resulting in incorrect dimensions. This is a sensible optimization in the concat layer, but was accidentally copy-pasted to the slice layer. I've removed this behavior and updated the Bamboo unit test to cover this case.

[Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM260-1).