### PR TITLE
Moved the definition of WeightsDataType and AbsMatrixType into the

### DIFF
--- a/include/lbann/layers/learning/channelwise_fully_connected.hpp
+++ b/include/lbann/layers/learning/channelwise_fully_connected.hpp
@@ -54,6 +54,18 @@ class channelwise_fully_connected_layer
                 "only supports data parallel layout");
 
 public:
+  /** @name Public Types */
+  ///@{
+
+  /** @brief The local tensor type expected in this object. */
+  using AbsMatrixType = El::AbstractMatrix<TensorDataType>;
+
+  /** @brief The concrete weights type used by this object. */
+  using WeightsType = data_type_weights<TensorDataType>;
+
+  ///@}
+
+public:
 
   /** @param comm                   LBANN communicator.
    *  @param output_channel_dims    Output tensor dimensions,

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -129,8 +129,6 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 {
   data_type_layer<TensorDataType>::setup_data();
 
-  using WeightsType = data_type_weights<TensorDataType>;
-
   // Tensor dimensions
   const auto& input_dims = this->get_input_dims();
   const auto& output_dims = this->get_output_dims();
@@ -204,7 +202,6 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   const auto& one = El::TypeTraits<TensorDataType>::One();
 
   // Data tensors
-  using AbsLocalMat = El::AbstractMatrix<TensorDataType>;
   using LocalMat = El::Matrix<TensorDataType,Device>;
   const auto& linearity = this->get_data_type_weights(0).get_values();
   const auto& bias = this->get_data_type_weights(1).get_values();
@@ -257,7 +254,7 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   El::Gemm(
     El::NORMAL, El::NORMAL,
     one, local_linearity, local_input_reshaped,
-    zero, reinterpret_cast<AbsLocalMat&>(local_output_reshaped));
+    zero, reinterpret_cast<AbsMatrixType&>(local_output_reshaped));
 
   // Apply bias
   LocalMat ones(local_mini_batch_size * num_channels, 1);
@@ -265,7 +262,7 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   El::Gemm(
     El::NORMAL, El::TRANSPOSE,
     one, local_bias, ones,
-    one, reinterpret_cast<AbsLocalMat&>(local_output_reshaped));
+    one, reinterpret_cast<AbsMatrixType&>(local_output_reshaped));
 
 }
 
@@ -282,7 +279,6 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   auto& bias_weights = this->get_data_type_weights(1);
 
   // Data tensors
-  using AbsLocalMat = El::AbstractMatrix<TensorDataType>;
   using LocalMat = El::Matrix<TensorDataType,Device>;
   const auto& linearity = linearity_weights.get_values();
   const auto& local_input = dynamic_cast<const LocalMat&>(this->get_local_prev_activations());
@@ -347,7 +343,7 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   El::Gemm(
     El::TRANSPOSE, El::NORMAL,
     one, local_linearity, local_output_grad_reshaped,
-    zero, reinterpret_cast<AbsLocalMat&>(local_input_grad_reshaped));
+    zero, reinterpret_cast<AbsMatrixType&>(local_input_grad_reshaped));
 
   // Compute gradient w.r.t. linearity
   auto* linearity_optimizer = linearity_weights.get_optimizer();


### PR DESCRIPTION
class definition to avoid a GCC 8.2.0 warning about shadowing.