### PR TITLE
Fix builder error signatures

### DIFF
--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -387,7 +387,8 @@ namespace
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR(
       "Attempted to construct channelwise_fully_connected_layer ",

--- a/src/layers/learning/channelwise_scale_bias_builder.cpp
+++ b/src/layers/learning/channelwise_scale_bias_builder.cpp
@@ -33,7 +33,8 @@ namespace
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR("Attempted to instantiate layer \"channelwise_scale_bias\""
                 "with Layout=", to_string(L), ".\nThis layer is only "

--- a/src/layers/learning/embedding_builder.cpp
+++ b/src/layers/learning/embedding_builder.cpp
@@ -36,7 +36,8 @@ namespace
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR("Attempted to instantiate layer \"embedding\""
                 "with Layout=", to_string(L), ".\nThis layer is only "

--- a/src/layers/misc/channelwise_softmax.cpp
+++ b/src/layers/misc/channelwise_softmax.cpp
@@ -184,7 +184,8 @@ namespace
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR(
       "Attempted to construct channelwise_softmax_layer ",

--- a/src/layers/regularizers/instance_norm.cpp
+++ b/src/layers/regularizers/instance_norm.cpp
@@ -261,7 +261,8 @@ namespace
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR(
       "Attempted to construct instance_norm_layer ",

--- a/src/layers/transform/crop_builder.cpp
+++ b/src/layers/transform/crop_builder.cpp
@@ -35,7 +35,8 @@ namespace {
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR("Attempted to instantiate layer \"crop\" with "
                 "Layout=", to_string(L), ".\nThis layer is only "

--- a/src/layers/transform/pooling.cpp
+++ b/src/layers/transform/pooling.cpp
@@ -36,7 +36,8 @@ namespace {
 template <typename T, data_layout L, El::Device D>
 struct Builder
 {
-  static std::unique_ptr<Layer> Build(...)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
   {
     LBANN_ERROR("Attempted to instantiate layer \"pooling\" with "
                 "Layout=", to_string(L), ".\nThis layer is only "


### PR DESCRIPTION
Some compilers complain about passing non-POD data through variadic functions. This fixes that.