### PR TITLE
Fix bug in LTFB with checkpoint file communication

### DIFF
--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -285,17 +285,12 @@ void restore_local_model(lbann_comm& comm, model& m, El::Int step) {
   // Load local model checkpoint
   persist p;
   p.set_cb_type(callback_type::model_only);
-  if (comm.am_trainer_master()) {
-    p.open_restart(checkpoint_dir);
-  } else {
-    p.m_checkpoint_dir = checkpoint_dir;
-  }
+  p.open_restart(checkpoint_dir);
   m.load_from_checkpoint_shared(p);
-  if (comm.am_trainer_master()) {
-    p.close_restart();
-  }
+  p.close_restart();
 
 }
+
 } // namespace checkpoint_file
 
 /** Get mean metric value with validation set. */


### PR DESCRIPTION
This closes #1420 by making three changes:
- The input layer only loads a checkpoint when the execution context is required (see @JaeseungYeom's comment in #1420).
- Update the checkpoint loading in LTFB to match the checkpoint callback.
- Make sure that checkpoint file names are based on the training step, not the validation step. The validation step changes over the course of an LTFB tournament round since each trainer evaluates multiple models on the validation set, so LTFB was trying to load the wrong checkpoint files.

LTFB with checkpoint file communication works for me (LeNet; 1 Pascal node with 2 proc/node; 1 proc/trainer). [Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM261-1).