### PR TITLE
Add H2 to the build system as an optional package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,13 @@ option(LBANN_WITH_CONDUIT "Enable Conduit library" ON)
 
 option(LBANN_WITH_CUDNN "Include Nvidia cuDNN" ON)
 
+option(LBANN_WITH_DIHYDROGEN "Build with DiHydrogen support" OFF)
+if (LBANN_WITH_DIHYDROGEN)
+  message(WARNING "DiHydrogen support is currently expermimental. "
+    "There is no stable interface. "
+    "Use caution before using any features.")
+endif (LBANN_WITH_DIHYDROGEN)
+
 option(LBANN_WITH_HWLOC
   "Enable topology-aware optimizations" ON)
 
@@ -186,6 +193,16 @@ if (NOT Hydrogen_FOUND)
 endif ()
 message(STATUS "Found Hydrogen: ${Hydrogen_DIR}")
 set(LBANN_HAS_HYDROGEN ${Hydrogen_FOUND})
+
+if (LBANN_WITH_DIHYDROGEN)
+  find_package(DiHydrogen CONFIG COMPONENTS Meta Patterns
+    HINTS ${DIHYDROGEN_DIR} $ENV{DIHYDROGEN_DIR}
+    ${H2_DIR} $ENV{H2_DIR}
+    PATH_SUFFIXES install/lib64/cmake install/lib/cmake
+    NO_DEFAULT_PATH)
+  find_package(DiHydrogen CONFIG REQUIRED COMPONENTS Meta Patterns)
+  set(LBANN_HAS_DIHYDROGEN TRUE)
+endif ()
 
 # Inherit half-precision stuff from Hydrogen
 set(LBANN_HAS_HALF ${HYDROGEN_HAVE_HALF}) # This is CPU-only
@@ -524,6 +541,11 @@ target_link_libraries(lbann PUBLIC ${HYDROGEN_LIBRARIES})
 target_link_libraries(lbann PUBLIC ${OpenCV_LIBRARIES})
 target_link_libraries(lbann PUBLIC ${CONDUIT_LIBRARIES})
 
+target_link_libraries(lbann PUBLIC
+  $<TARGET_NAME_IF_EXISTS:H2::H2Meta>
+  $<TARGET_NAME_IF_EXISTS:H2::H2Patterns>
+  )
+
 if (LBANN_HAS_TBINF)
   target_link_libraries(lbann PUBLIC TBinf)
 endif ()
@@ -788,6 +810,7 @@ string(APPEND _str "\n")
 #Print the true/false guys
 append_str_tf(_str
   LBANN_GNU_LINUX
+  LBANN_HAS_DIHYDROGEN
   LBANN_HAS_HYDROGEN
   LBANN_HAS_OPENCV
   LBANN_HAS_CEREAL

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -24,6 +24,7 @@
 #cmakedefine LBANN_GNU_LINUX
 
 #cmakedefine LBANN_HAS_CEREAL
+#cmakedefine LBANN_HAS_DIHYDROGEN
 #cmakedefine LBANN_HAS_OPENCV
 #cmakedefine LBANN_HAS_TBINF
 #cmakedefine LBANN_HAS_CNPY

--- a/docs/build_with_cmake.rst
+++ b/docs/build_with_cmake.rst
@@ -78,6 +78,10 @@ The following LLNL-maintained packages are **optional**.
 + `CONDUIT <https://github.com/llnl/conduit>`_ is used to ingest
   structured data produced by scientific simulations.
 
++ `DiHydrogen <https://github.com/llnl/dihydrogen>`_ is going to
+  become the linear algebra interface; currently, it can be used to
+  manage metaprogramming and some utilities.
+  
 The following third-party packages are **optional**.
 
 + `CUDA <https://developer.nvidia.com/cuda-toolkit>`_. The development
@@ -113,6 +117,10 @@ The following options are exposed in the CMake build system.
   Numpy data.
 
 + :code:`LBANN_WITH_CONDUIT` (Default: :code:`OFF`): Build with support for CONDUIT.
+
++ :code:`LBANN_WITH_DIHYDROGEN` (Default: :code:`OFF`): Build with
+  DiHydrogen support. This will replace temporary implementations in
+  LBANN with permanent implementations from DiHydrogen.
 
 + :code:`LBANN_WITH_NVPROF` (Default: :code:`OFF`): Build with extra annotations for NVPROF.
 
@@ -182,6 +190,12 @@ The latter option is recommended.
   CONDUIT installation prefix *or* the :code:`ConduitConfig.cmake`
   file. Must set :code:`LBANN_WITH_CONDUIT=ON` to enable CONDUIT
   support.
+
++ :code:`DIHYDROGEN_DIR` or :code:`H2_DIR`: The
+  path to *either* the DiHydrogen installation prefix *or* the
+  :code:`DiHydrogenConfig.cmake` file. Alternatively,
+  :code:`DiHydrogen_DIR` can be set to the path of the
+  :code:`DiHydrogenConfig.cmake` file.
 
 + :code:`HDF5_DIR`: The path to *either* the HDF5 installation prefix
   *or* the :code:`hdf5_config.cmake` file. There is a known issue with

--- a/include/lbann/utils/factory_error_policies.hpp
+++ b/include/lbann/utils/factory_error_policies.hpp
@@ -9,44 +9,44 @@
 namespace lbann
 {
 
-/** @class default_key_error_policy
- *  @brief Default policy describing how to handle unknown keys.
+/** @class default_id_error_policy
+ *  @brief Default policy describing how to handle unknown ids.
  *
- *  The policy must define "handle_unknown_key(KeyT const&)".
+ *  The policy must define "handle_unknown_id(IdT const&)".
  *
  *  The default behavior is to throw an exception.
  *
- *  @tparam KeyT The type of key.
+ *  @tparam IdT The type of id.
  *  @tparam ObjectT The type of the object being constructed by the factory.
  */
-template <typename KeyT, class ObjectT>
+template <typename IdT, class ObjectT>
 struct default_key_error_policy
 {
-  std::unique_ptr<ObjectT> handle_unknown_key(KeyT const& key) const
+  std::unique_ptr<ObjectT> handle_unknown_id(IdT const& id) const
   {
-    // This could be expanded to print the key, but that would
-    // assume that either the key can be inserted into a stream or
-    // that the key can be converted to a string, which isn't
+    // This could be expanded to print the id, but that would
+    // assume that either the id can be inserted into a stream or
+    // that the id can be converted to a string, which isn't
     // necessarily the case.
-    LBANN_ERROR("Unknown key \"", key, "\" detected.");
+    LBANN_ERROR("Unknown id \"", id, "\" detected.");
   }
 };// class default_key_error_policy
 
 /** @class nullptr_key_error_policy
- *  @brief Policy returning a nullptr if the key is unknown
+ *  @brief Policy returning a nullptr if the id is unknown
  *
  *  This class just returns "nullptr". Use of this class is not
  *  recommended as it probably indicates bad design that would better
  *  utilize exception handling. But it felt awkward to not at least
  *  provide it.
  *
- *  @tparam KeyT The type of key.
+ *  @tparam IdT The type of id.
  *  @tparam ObjectT The type of the object being constructed by the factory.
  */
-template <typename KeyT, class ObjectT>
+template <typename IdT, class ObjectT>
 struct nullptr_key_error_policy
 {
-  std::unique_ptr<ObjectT> handle_unknown_key(KeyT const&) const noexcept
+  std::unique_ptr<ObjectT> handle_unknown_id(IdT const&) const noexcept
   {
     return nullptr;
   }

--- a/include/lbann/utils/h2_tmp.hpp
+++ b/include/lbann/utils/h2_tmp.hpp
@@ -27,6 +27,24 @@
 #ifndef LBANN_UTILS_H2_TMP_HPP_
 #define LBANN_UTILS_H2_TMP_HPP_
 
+#include <lbann_config.hpp>
+
+// Disable C++17 features.
+#ifndef H2_NO_CXX17
+#define H2_NO_CXX17
+#endif // H2_NO_CXX17
+
+#ifdef LBANN_HAS_DIHYDROGEN
+
+#include <h2/meta/Core.hpp>
+#include <h2/meta/TypeList.hpp>
+#include <h2/patterns/multimethods/SwitchDispatcher.hpp>
+
+#else // !LBANN_HAS_DIHYDROGEN
+
+// WARNING: This code is deprecated and will be removed when
+// DiHydrogen becomes a required dependency of LBANN.
+
 /** @file
  *
  *  This file contains a small slice of the metaprogramming library
@@ -34,15 +52,14 @@
  *  DiHydrogen is integrated into LBANN; however, this was seen as too
  *  large a task for the present needs.
  *
- *  @note Testing for this functionality has not been included in LBANN. It is s
+ *  @note Testing for this functionality has not been included in
+ *        LBANN. It is available in the main H2 repository.
+ *
+ *  @warning This file is deprecated and will be removed when
+ *           DiHydrogen becomes a required dependency of LBANN.
  */
 
 #include <utility> // std::forward, std::declval
-
-// Disable C++17 features.
-#ifndef H2_NO_CPP17
-#define H2_NO_CPP17
-#endif // H2_NO_CPP17
 
 #ifndef H2_META_CORE_LAZY_HPP_
 #define H2_META_CORE_LAZY_HPP_
@@ -164,11 +181,11 @@ inline constexpr bool IsInvocableV()
     return IsInvocableVT<F, Args...>::value;
 }
 
-#ifndef H2_NO_CPP17
+#ifndef H2_NO_CXX17
 /** @brief Test whether F can be invoked with the given arguments. */
 template <typename F, typename... Args>
 inline constexpr bool IsInvocable = IsInvocableV<F, Args...>();
-#endif // H2_NO_CPP17
+#endif // H2_NO_CXX17
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 
@@ -846,4 +863,5 @@ public:
 }// namespace h2
 #endif // H2_MULTIMETHODS_SWITCHDISPATCHER_HPP_
 
+#endif // LBANN_HAS_DIHYDROGEN
 #endif // LBANN_UTILS_H2_TMP_HPP_

--- a/src/utils/unit_test/factory_test.cpp
+++ b/src/utils/unit_test/factory_test.cpp
@@ -83,7 +83,7 @@ TEMPLATE_TEST_CASE(
 
       THEN("The factory knows about two builders")
       {
-        auto names = factory.get_registered_keys();
+        auto names = factory.registered_ids();
         REQUIRE(std::distance(names.begin(), names.end()) == 2UL);
       }
       AND_WHEN("A builder is added with an existing key")
@@ -97,7 +97,7 @@ TEMPLATE_TEST_CASE(
 
         THEN("The factory still knows about only two factories")
         {
-          auto names = factory.get_registered_keys();
+          auto names = factory.registered_ids();
           REQUIRE(std::distance(names.begin(), names.end()) == 2UL);
         }
       }
@@ -130,7 +130,7 @@ TEMPLATE_TEST_CASE(
         THEN("The number of known factories has decreased.")
         {
           REQUIRE(success == true);
-          auto names = factory.get_registered_keys();
+          auto names = factory.registered_ids();
           REQUIRE(std::distance(names.begin(), names.end()) == 1UL);
         }
 


### PR DESCRIPTION
This PR adds initial hooks to link to various components of H2.

The file `include/lbann/h2_tmp.hpp` is deprecated by this PR, but it won't be removed until DiHydrogen becomes required (a larger effort involving Spack, superbuild stuff, etc). The factory implementation that LBANN uses is deprecated in the same sense. Changes to the source code in those files are not externally visible and they are intended to align the LBANN interface with the H2 interface to minimize impact of the switch-over later on.

Some documentation of the component-based structure of DiHydrogen is given in the flavor-text of llnl/DiHydrogen#20. That PR also discusses how to incorporate other components, such as `DistConv`.