### PR TITLE
Fix incorrect sbatch option in SLURM job launcher

### DIFF
--- a/python/lbann/launcher/slurm.py
+++ b/python/lbann/launcher/slurm.py
@@ -77,7 +77,7 @@ class SlurmBatchScript(BatchScript):
             days, hours = divmod(hours, 24)
             self.add_header_line('#SBATCH --time={}-{:02d}:{:02d}:{:02d}'
                                  .format(days, hours, minutes, seconds))
-        self.add_header_line('#SBATCH --workdir={}'.format(self.work_dir))
+        self.add_header_line('#SBATCH --chdir={}'.format(self.work_dir))
         self.add_header_line('#SBATCH --output={}'.format(self.out_log_file))
         self.add_header_line('#SBATCH --error={}'.format(self.err_log_file))
         if partition:


### PR DESCRIPTION
When I try running LBANN with the Python frontend from a login node, I get an error like:
```
sbatch: unrecognized option '--workdir=/path/to/workdir'
Try "sbatch --help" for more information
```
It turns out that [SLURM 17.11.0rc1](https://github.com/SchedMD/slurm/blob/351deed1bac0f693628829c2c91e856184cb1897/NEWS#L1932) changed the `--workdir` option for `sbatch` to `--chdir`. It appears that LC has updated the SLURM version on their systems, so we should also update the SLURM launcher.

[Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM262-1).