### PR TITLE
Add options for bias and transpose in channel-wise FC layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_channelwise_fully_connected.py
+++ b/bamboo/unit_tests/test_unit_layer_channelwise_fully_connected.py
@@ -92,17 +92,26 @@ def construct_model(lbann):
     ).astype(np.float32)
     bias = np.random.normal(size=(output_channel_size,1)).astype(np.float32)
 
-    # Compute metric value
+    # With bias
     x = (_samples
          .reshape((-1,input_channel_size))
          .transpose()
          .astype(np.float64))
     y = np.matmul(linearity.astype(np.float64), x) + bias.astype(np.float64)
     z = tools.numpy_l2norm2(y) / _num_samples
-    val = z
+    val_with_bias = z
+
+    # Without bias
+    x = (_samples
+         .reshape((-1,input_channel_size))
+         .transpose()
+         .astype(np.float64))
+    y = np.matmul(linearity.astype(np.float64), x)
+    z = tools.numpy_l2norm2(y) / _num_samples
+    val_without_bias = z
 
     # ------------------------------------------
-    # Data-parallel layout
+    # Data-parallel layout, non-transpose, bias
     # ------------------------------------------
 
     # LBANN implementation
@@ -126,14 +135,114 @@ def construct_model(lbann):
     )
     z = lbann.L2Norm2(y)
     obj.append(z)
-    metrics.append(lbann.Metric(z, name='data-parallel layout'))
+    metrics.append(lbann.Metric(z, name='data-parallel layout, non-transpose, bias'))
 
     # NumPy implementation
-    tol = 8 * val * np.finfo(np.float32).eps
+    tol = 8 * val_with_bias * np.finfo(np.float32).eps
     callbacks.append(lbann.CallbackCheckMetric(
         metric=metrics[-1].name,
-        lower_bound=val-tol,
-        upper_bound=val+tol,
+        lower_bound=val_with_bias-tol,
+        upper_bound=val_with_bias+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Data-parallel layout, non-transpose, no bias
+    # ------------------------------------------
+
+    # LBANN implementation
+    linearity_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(linearity, order='F'))
+        )
+    )
+    x = x_lbann
+    y = lbann.ChannelwiseFullyConnected(
+        x,
+        weights=(linearity_weights),
+        output_channel_dims=output_channel_dims,
+        bias=False,
+    )
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel layout, non-transpose, no bias'))
+
+    # NumPy implementation
+    tol = 8 * val_without_bias * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val_without_bias-tol,
+        upper_bound=val_without_bias+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Data-parallel layout, transpose, bias
+    # ------------------------------------------
+
+    # LBANN implementation
+    linearity_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(linearity, order='C'))
+        )
+    )
+    bias_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(bias))
+        )
+    )
+    x = x_lbann
+    y = lbann.ChannelwiseFullyConnected(
+        x,
+        weights=(linearity_weights, bias_weights),
+        output_channel_dims=output_channel_dims,
+        transpose=True,
+    )
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel layout, transpose, bias'))
+
+    # NumPy implementation
+    tol = 8 * val_with_bias * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val_with_bias-tol,
+        upper_bound=val_with_bias+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Data-parallel layout, transpose, no bias
+    # ------------------------------------------
+
+    # LBANN implementation
+    linearity_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(linearity, order='C'))
+        )
+    )
+    x = x_lbann
+    y = lbann.ChannelwiseFullyConnected(
+        x,
+        weights=(linearity_weights),
+        output_channel_dims=output_channel_dims,
+        bias=False,
+        transpose=True,
+    )
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel layout, transpose, no bias'))
+
+    # NumPy implementation
+    tol = 8 * val_without_bias * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val_without_bias-tol,
+        upper_bound=val_without_bias+tol,
         error_on_failure=True,
         execution_modes='test'))
 

--- a/include/lbann/layers/learning/channelwise_fully_connected.hpp
+++ b/include/lbann/layers/learning/channelwise_fully_connected.hpp
@@ -39,10 +39,11 @@ namespace lbann {
  *  row-vector convention:
  *    @f[ y(i,*) = \text{vec}( x(i,*) ) W^T + b @f]
  *
- *  Two weights are required: the linearity and the bias. If weights
- *  aren't provided, the linearity weights are initialized with He
- *  normal initialization and the bias weights are initialized to
- *  zero.
+ *  Two weights are required if bias is applied: the linearity and the
+ *  bias. Only the linearity weights are required if bias is not
+ *  applied. If weights aren't provided, the linearity weights are
+ *  initialized with He normal initialization and the bias weights are
+ *  initialized to zero.
  *
  */
 template <typename TensorDataType, data_layout Layout, El::Device Device>
@@ -54,26 +55,19 @@ class channelwise_fully_connected_layer
                 "only supports data parallel layout");
 
 public:
-  /** @name Public Types */
-  ///@{
-
-  /** @brief The local tensor type expected in this object. */
-  using AbsMatrixType = El::AbstractMatrix<TensorDataType>;
-
-  /** @brief The concrete weights type used by this object. */
-  using WeightsType = data_type_weights<TensorDataType>;
-
-  ///@}
-
-public:
 
   /** @param comm                   LBANN communicator.
    *  @param output_channel_dims    Output tensor dimensions,
    *                                excluding the first dimension.
+   *  @param bias                   Whether to apply bias.
+   *  @param transpose              Whether to apply transpose of
+   *                                weights matrix.
    */
   channelwise_fully_connected_layer(
     lbann_comm* comm,
-    std::vector<size_t> output_channel_dims);
+    std::vector<size_t> output_channel_dims,
+    bool bias,
+    bool transpose);
 
   channelwise_fully_connected_layer(
     const channelwise_fully_connected_layer& other) = default;
@@ -85,6 +79,7 @@ public:
   std::string get_type() const override;
   data_layout get_data_layout() const override;
   El::Device get_device_allocation() const override;
+  description get_description() const override;
 
 protected:
 
@@ -93,6 +88,13 @@ protected:
 
   void fp_compute() override;
   void bp_compute() override;
+
+private:
+
+  /** Whether to apply bias. */
+  bool m_has_bias;
+  /** Whether to transpose linearity. */
+  bool m_transpose;
 
 };
 

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -42,8 +42,12 @@ template <typename TensorDataType, data_layout Layout, El::Device Device>
 channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 ::channelwise_fully_connected_layer(
   lbann_comm* comm,
-  std::vector<size_t> output_channel_dims)
-  : data_type_layer<TensorDataType>(comm)
+  std::vector<size_t> output_channel_dims,
+  bool bias,
+  bool transpose)
+  : data_type_layer<TensorDataType>(comm),
+    m_has_bias{bias},
+    m_transpose{transpose}
 {
 
   // Initialize output tensor dimensions
@@ -90,6 +94,17 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 ::get_device_allocation() const
 {
   return Device;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+description
+channelwise_fully_connected_layer<TensorDataType,Layout,Device>
+::get_description() const
+{
+  auto desc = data_type_layer<TensorDataType>::get_description();
+  desc.add("Bias", m_has_bias);
+  desc.add("Transpose", m_transpose);
+  return desc;
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
@@ -143,8 +158,19 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
     output_channel_dims.begin(), output_channel_dims.end(),
     1, std::multiplies<size_t>());
 
-  // Construct default weights if needed
-  this->set_num_data_type_weights(2);
+  // Set number of weights
+  using WeightsType = data_type_weights<TensorDataType>;
+  if ((m_has_bias && this->num_weights() > 2)
+      || (!m_has_bias && this->num_weights() > 1)) {
+    LBANN_ERROR(
+      "attempted to setup ",
+      this->get_type()," layer \"",this->get_name(),"\" ",
+      "with an invalid number of weights ",
+      "(",this->num_weights(),")");
+  }
+  this->set_num_data_type_weights(m_has_bias ? 2 : 1);
+
+  // Create default linearity weights if needed
   if (!this->has_data_type_weights(0)) {
     auto w = make_unique<WeightsType>(this->get_comm());
     auto init = make_unique<he_initializer<TensorDataType>>(probability_distribution::gaussian);
@@ -155,32 +181,41 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
     this->set_data_type_weights(0, w.get());
     this->m_model->add_weights(std::move(w));
   }
-  if (!this->has_data_type_weights(1)) {
-    auto w = make_unique<WeightsType>(this->get_comm());
-    auto opt = this->m_model->template create_optimizer<TensorDataType>();
-    w->set_name(this->get_name() + "_bias_weights");
-    w->set_optimizer(std::move(opt));
-    this->set_data_type_weights(1, w.get());
-    this->m_model->add_weights(std::move(w));
-  }
-  auto& linearity_weights = this->get_data_type_weights(0);
-  auto& bias_weights = this->get_data_type_weights(1);
 
-  // Initialize variance scaling initialization for linearity weights
-  auto* cast_initializer = dynamic_cast<variance_scaling_initializer<TensorDataType>*>(linearity_weights.get_initializer());
-  if (cast_initializer != nullptr) {
-    cast_initializer->set_fan_in(input_channel_size);
-    cast_initializer->set_fan_out(output_channel_size);
+  // Setup linearity weights
+  {
+    auto& linearity_weights = this->get_data_type_weights(0);
+    auto dist = this->get_prev_activations().DistData();
+    dist.colDist = El::STAR;
+    dist.rowDist = El::STAR;
+    auto* cast_initializer = dynamic_cast<variance_scaling_initializer<TensorDataType>*>(linearity_weights.get_initializer());
+    if (cast_initializer != nullptr) {
+      cast_initializer->set_fan_in(input_channel_size);
+      cast_initializer->set_fan_out(output_channel_size);
+    }
+    linearity_weights.set_dims(
+      m_transpose ? input_channel_dims : output_channel_dims,
+      m_transpose ? output_channel_dims : input_channel_dims);
+    linearity_weights.set_matrix_distribution(dist);
   }
 
-  // Initialize weights
-  auto dist = this->get_prev_activations().DistData();
-  dist.colDist = El::STAR;
-  dist.rowDist = El::STAR;
-  linearity_weights.set_dims(output_channel_dims, input_channel_dims);
-  linearity_weights.set_matrix_distribution(dist);
-  bias_weights.set_dims(output_channel_dims);
-  bias_weights.set_matrix_distribution(dist);
+  // Setup bias weights if needed
+  if (m_has_bias) {
+    auto dist = this->get_prev_activations().DistData();
+    dist.colDist = El::STAR;
+    dist.rowDist = El::STAR;
+    if (!this->has_data_type_weights(1)) {
+      auto w = make_unique<WeightsType>(this->get_comm());
+      auto opt = this->m_model->template create_optimizer<TensorDataType>();
+      w->set_name(this->get_name() + "_bias_weights");
+      w->set_optimizer(std::move(opt));
+      this->set_data_type_weights(1, w.get());
+      this->m_model->add_weights(std::move(w));
+    }
+    auto& bias_weights = this->get_data_type_weights(1);
+    bias_weights.set_dims(output_channel_dims);
+    bias_weights.set_matrix_distribution(dist);
+  }
 
   // Initialize freeze state
   for (auto&& w : this->get_data_type_weights()) {
@@ -204,11 +239,9 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   // Data tensors
   using LocalMat = El::Matrix<TensorDataType,Device>;
   const auto& linearity = this->get_data_type_weights(0).get_values();
-  const auto& bias = this->get_data_type_weights(1).get_values();
   const auto& local_input = dynamic_cast<const LocalMat&>(this->get_local_prev_activations());
   auto& local_output = dynamic_cast<LocalMat&>(this->get_local_activations());
   const auto& local_linearity = dynamic_cast<const LocalMat&>(linearity.LockedMatrix());
-  const auto& local_bias = dynamic_cast<const LocalMat&>(bias.LockedMatrix());
 
   // Tensor dimensions
   const auto& local_mini_batch_size = local_input.Width();
@@ -252,17 +285,21 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 
   // Apply linearity
   El::Gemm(
-    El::NORMAL, El::NORMAL,
+    m_transpose ? El::TRANSPOSE : El::NORMAL,
+    El::NORMAL,
     one, local_linearity, local_input_reshaped,
-    zero, reinterpret_cast<AbsMatrixType&>(local_output_reshaped));
+    zero, reinterpret_cast<LocalMat&>(local_output_reshaped));
 
   // Apply bias
-  LocalMat ones(local_mini_batch_size * num_channels, 1);
-  El::Fill(ones, one);
-  El::Gemm(
-    El::NORMAL, El::TRANSPOSE,
-    one, local_bias, ones,
-    one, reinterpret_cast<AbsMatrixType&>(local_output_reshaped));
+  if (m_has_bias) {
+    const auto& bias = this->get_data_type_weights(1).get_values();
+    LocalMat ones(local_mini_batch_size * num_channels, 1);
+    El::Fill(ones, one);
+    El::Gemm(
+      El::NORMAL, El::TRANSPOSE,
+      one, reinterpret_cast<const LocalMat&>(bias.LockedMatrix()), ones,
+      one, reinterpret_cast<LocalMat&>(local_output_reshaped));
+  }
 
 }
 
@@ -276,7 +313,6 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 
   // Weights
   auto& linearity_weights = this->get_data_type_weights(0);
-  auto& bias_weights = this->get_data_type_weights(1);
 
   // Data tensors
   using LocalMat = El::Matrix<TensorDataType,Device>;
@@ -341,9 +377,10 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 
   // Compute gradient w.r.t. input
   El::Gemm(
-    El::TRANSPOSE, El::NORMAL,
+    m_transpose ? El::NORMAL : El::TRANSPOSE,
+    El::NORMAL,
     one, local_linearity, local_output_grad_reshaped,
-    zero, reinterpret_cast<AbsMatrixType&>(local_input_grad_reshaped));
+    zero, reinterpret_cast<LocalMat&>(local_input_grad_reshaped));
 
   // Compute gradient w.r.t. linearity
   auto* linearity_optimizer = linearity_weights.get_optimizer();
@@ -351,24 +388,35 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
     TensorDataType dst_scale, gradient_scale;
     auto& linearity_gradient = linearity_optimizer->get_gradient_buffer(
       dst_scale, gradient_scale, true);
-    El::Gemm(
-      El::NORMAL, El::TRANSPOSE,
-      gradient_scale, local_output_grad_reshaped, local_input_reshaped,
-      dst_scale, linearity_gradient.Matrix());
+    if (m_transpose) {
+      El::Gemm(
+        El::NORMAL, El::TRANSPOSE,
+        gradient_scale, local_input_reshaped, local_output_grad_reshaped,
+        dst_scale, linearity_gradient.Matrix());
+    }
+    else {
+      El::Gemm(
+        El::NORMAL, El::TRANSPOSE,
+        gradient_scale, local_output_grad_reshaped, local_input_reshaped,
+        dst_scale, linearity_gradient.Matrix());
+    }
   }
 
   // Compute gradient w.r.t. bias
-  auto* bias_optimizer = bias_weights.get_optimizer();
-  if (bias_optimizer != nullptr) {
-    TensorDataType dst_scale, gradient_scale;
-    auto& bias_gradient = bias_optimizer->get_gradient_buffer(
-      dst_scale, gradient_scale, true);
-    LocalMat ones(local_mini_batch_size * num_channels, 1);
-    El::Fill(ones, one);
-    El::Gemv(
-      El::NORMAL,
-      gradient_scale, local_output_grad_reshaped, ones,
-      dst_scale, bias_gradient.Matrix());
+  if (m_has_bias) {
+    auto& bias_weights = this->get_data_type_weights(1);
+    auto* bias_optimizer = bias_weights.get_optimizer();
+    if (bias_optimizer != nullptr) {
+      TensorDataType dst_scale, gradient_scale;
+      auto& bias_gradient = bias_optimizer->get_gradient_buffer(
+        dst_scale, gradient_scale, true);
+      LocalMat ones(local_mini_batch_size * num_channels, 1);
+      El::Fill(ones, one);
+      El::Gemv(
+        El::NORMAL,
+        gradient_scale, local_output_grad_reshaped, ones,
+        dst_scale, bias_gradient.Matrix());
+    }
   }
 
 }
@@ -399,20 +447,14 @@ struct Builder
 template <typename TensorDataType, El::Device Device>
 struct Builder<TensorDataType,data_layout::DATA_PARALLEL,Device>
 {
-  static std::unique_ptr<Layer> Build(
-    lbann_comm* comm, lbann_data::Layer const& proto_layer)
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&... args)
   {
-    const auto& params = proto_layer.channelwise_fully_connected();
-    std::vector<size_t> output_channel_dims;
-    const size_t num_output_channel_dims = params.output_channel_dims_size();
-    for (size_t i=0; i<num_output_channel_dims; ++i) {
-      output_channel_dims.push_back(params.output_channel_dims(i));
-    }
     using LayerType = channelwise_fully_connected_layer<
       TensorDataType,
       data_layout::DATA_PARALLEL,
       Device>;
-    return make_unique<LayerType>(comm, output_channel_dims);
+    return make_unique<LayerType>(std::forward<Args>(args)...);
   }
 };
 
@@ -423,7 +465,20 @@ std::unique_ptr<Layer> build_channelwise_fully_connected_layer_from_pbuf(
   lbann_comm* comm, lbann_data::Layer const& proto_layer)
 {
   using BuilderType = Builder<TensorDataType, Layout, Device>;
-  return BuilderType::Build(comm, proto_layer);
+  LBANN_ASSERT_MSG_HAS_FIELD(proto_layer, channelwise_fully_connected);
+  const auto& params = proto_layer.channelwise_fully_connected();
+  std::vector<size_t> output_channel_dims;
+  const size_t num_output_channel_dims = params.output_channel_dims_size();
+  for (size_t i=0; i<num_output_channel_dims; ++i) {
+    output_channel_dims.push_back(params.output_channel_dims(i));
+  }
+  const bool has_bias = (params.has_bias()
+                         ? params.bias().value()
+                         : true);
+  const bool transpose = (params.has_transpose()
+                          ? params.transpose().value()
+                          : false);
+  return BuilderType::Build(comm, output_channel_dims, has_bias, transpose);
 }
 
 // =========================================================

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -624,15 +624,24 @@ message Layer {
    *  row-vector convention:
    *    @f[ y(i,*) = \text{vec}( x(i,*) ) W^T + b @f]
    *
-   *  Two weights are required: the linearity and the bias. If weights
-   *  aren't provided, the linearity weights are initialized with He
-   *  normal initialization and the bias weights are initialized to
-   *  zero.
+   *  Two weights are required if bias is applied: the linearity and the
+   *  bias. Only the linearity weights are required if bias is not
+   *  applied. If weights aren't provided, the linearity weights are
+   *  initialized with He normal initialization and the bias weights are
+   *  initialized to zero.
    *
    */
   message ChannelwiseFullyConnected {
-    /// Output tensor dimensions, excluding the first dimension
+    /// Output tensor dimensions, excluding the first dimension.
     repeated uint64 output_channel_dims = 1;
+    /** @brief Whether to apply bias.
+     *  @details Default: true
+     */
+    google.protobuf.BoolValue bias = 2;
+    /** @brief Whether to apply transpose of weights matrix.
+     *  @details Default: false
+     */
+    google.protobuf.BoolValue transpose = 3;
   }
 
   //////////////////


### PR DESCRIPTION
The default options are `bias=True` and `transpose=False`, so this shouldn't affect any existing models. [Bamboo is green](https://lc.llnl.gov/bamboo/browse/LBANN-TIM263-1).