### PR TITLE
Un-superbuild-ify the script that just builds LBANN

### DIFF
--- a/scripts/build_lbann_from_source.sh
+++ b/scripts/build_lbann_from_source.sh
@@ -257,7 +257,7 @@ fi
 
 source ${SPACK_ENV_DIR}/${SUPERBUILD}
 
-ninja
+ninja install
 
 echo "To rebuild the environment:"
 echo "    ${SPACK_ENV_CMD}"

--- a/spack_environments/cmake_lbann.sh
+++ b/spack_environments/cmake_lbann.sh
@@ -5,10 +5,10 @@ LBANN_COMPILER_CMD=
 
 if [[ ${SYS} = "Darwin" ]]; then
 LBANN_FWD_CMD=$(cat << EOF
-  -D LBANN_SB_FWD_LBANN_HWLOC_DIR=/usr/local/opt/hwloc \
-  -D LBANN_SB_FWD_LBANN_OpenMP_CXX_LIB_NAMES=omp \
-  -D LBANN_SB_FWD_LBANN_OpenMP_CXX_FLAGS="-fopenmp=libomp" \
-  -D LBANN_SB_FWD_LBANN_OpenMP_omp_LIBRARY=/usr/local/opt/llvm/lib/libomp.dylib
+  -D HWLOC_DIR=/usr/local/opt/hwloc \
+  -D OpenMP_CXX_LIB_NAMES=omp \
+  -D OpenMP_CXX_FLAGS="-fopenmp=libomp" \
+  -D OpenMP_omp_LIBRARY=/usr/local/opt/llvm/lib/libomp.dylib
 EOF
 )
 LBANN_COMPILER_CMD=$(cat << EOF
@@ -28,7 +28,6 @@ cmake \
   -D CMAKE_CXX_FLAGS="${CXX_FLAGS}" \
   -D CMAKE_C_FLAGS="${C_FLAGS}" \
   \
-  -D LBANN_SB_BUILD_LBANN=ON \
   -D LBANN_DATATYPE:STRING=float \
   -D LBANN_SEQUENTIAL_INITIALIZATION:BOOL=OFF \
   -D LBANN_WITH_ALUMINUM:BOOL=ON \
@@ -44,14 +43,14 @@ cmake \
   -D LBANN_DETERMINISTIC=${DETERMINISTIC} \
 ${LBANN_FWD_CMD}  \
 ${LBANN_COMPILER_CMD}  \
-  ${LBANN_HOME}/superbuild
+  ${LBANN_HOME}
 EOF
 )
 
 if [[ ${VERBOSE} -ne 0 ]]; then
-    echo "${CONFIGURE_COMMAND}" 2>1 | tee cmake_superbuild_invocation.txt
+    echo "${CONFIGURE_COMMAND}" 2>1 | tee lbann_cmake_invocation.txt
 else
-    echo "${CONFIGURE_COMMAND}" > cmake_superbuild_invocation.txt
+    echo "${CONFIGURE_COMMAND}" > lbann_cmake_invocation.txt
 fi
 eval ${CONFIGURE_COMMAND}
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
This just builds LBANN. So just call LBANN's CMake instead of the meaningless indirection and overhead of the superbuild.