### PR TITLE
Load pretrainedmodel callback

### DIFF
--- a/include/lbann/callbacks/load_model.hpp
+++ b/include/lbann/callbacks/load_model.hpp
@@ -1,0 +1,97 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// load_model .hpp .cpp - Callbacks to load pretrained model(s)
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_LOAD_MODEL_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_LOAD_MODEL_HPP_INCLUDED
+
+#include <utility>
+
+#include "lbann/callbacks/callback.hpp"
+
+#include <google/protobuf/message.h>
+
+// Forward-declare protobuf classes
+namespace lbann_data {
+class Model;
+}
+
+namespace lbann {
+namespace callback {
+
+/**
+ * Load pretrained model from file
+ */
+class load_model : public callback_base {
+ public:
+  /**
+   * @param dir directory to load model
+   * @param extension file extension e.g., model, state ......
+   */
+  load_model(std::vector<std::string> dirs,
+             std::string extension="prototext") :
+    callback_base(), m_dirs(std::move(dirs)),
+    m_extension(std::move(extension))
+  {}
+  load_model(const load_model&) = default;
+  load_model& operator=(
+    const load_model&) = default;
+  load_model* copy() const override {
+    return new load_model(*this);
+  }
+  void on_train_begin(model *m) override;
+  /* ckptdir_is_fullpath flag if true
+ * allow user to specify full path to model weights to load
+ * and allow system to ignore appending trainer id, num of epochs/steps
+ * to default ckpt_dir*/
+  static bool load_model_weights(std::string ckpt_dir,
+                                 model *m,
+                                 bool ckptdir_is_fullpath=false);
+
+  std::string name() const override { return "load model"; }
+
+ protected:
+  friend class lbann::model;
+
+
+ private:
+  std::vector<std::string> m_dirs; //director(ies) to load pretrained model(s)
+  /// Disables the normal behavior of saving when training is complete
+  std::string m_extension; //file extension
+  persist p;
+
+};
+
+// Builder function
+std::unique_ptr<callback_base>
+build_load_model_callback_from_pbuf(
+  const google::protobuf::Message&, std::shared_ptr<lbann_summary> const&);
+
+} // namespace callback
+} // namespace lbann
+
+#endif  // LBANN_CALLBACKS_CALLBACK_LOAD_MODEL_HPP_INCLUDED

--- a/include/lbann/callbacks/save_model.hpp
+++ b/include/lbann/callbacks/save_model.hpp
@@ -67,14 +67,6 @@ class save_model : public callback_base {
     return new save_model(*this);
   }
   void on_train_end(model *m) override;
-  /* ckptdir_is_fullpath flag if true
- * allow user to specify full path to model weights to load
- * and allow system to ignore appending trainer id, num of epochs/steps
- * to default ckpt_dir*/
-  static bool load_model_weights(std::string ckpt_dir,
-                                 model *m,
-                                 bool ckptdir_is_fullpath=false);
-
   std::string name() const override { return "save model"; }
   void set_target_dir(const std::string& dir) { m_dir = dir; }
   const std::string& get_target_dir() { return m_dir; }

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -175,6 +175,7 @@
 #include "lbann/callbacks/save_images.hpp"
 #include "lbann/callbacks/save_model.hpp"
 #include "lbann/callbacks/save_model.hpp"
+#include "lbann/callbacks/load_model.hpp"
 #include "lbann/callbacks/save_topk_models.hpp"
 #include "lbann/callbacks/summary.hpp"
 #include "lbann/callbacks/sync_layers.hpp"

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -174,7 +174,6 @@
 #include "lbann/callbacks/replace_weights.hpp"
 #include "lbann/callbacks/save_images.hpp"
 #include "lbann/callbacks/save_model.hpp"
-#include "lbann/callbacks/save_model.hpp"
 #include "lbann/callbacks/load_model.hpp"
 #include "lbann/callbacks/save_topk_models.hpp"
 #include "lbann/callbacks/summary.hpp"

--- a/model_zoo/lbann2.cpp
+++ b/model_zoo/lbann2.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
 
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
-      callback::save_model::load_model_weights(opts->get_string("ckpt_dir"),
+      callback::load_model::load_model_weights(opts->get_string("ckpt_dir"),
                                                model_1.get());
     }
     // Train model

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
       for(auto&& m : models) {
-        bool loaded = callback::save_model::load_model_weights(
+        bool loaded = callback::load_model::load_model_weights(
           opts->get_string("ckpt_dir"),
           m.get(),
           opts->get_bool("ckptdir_is_fullpath"));

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -38,6 +38,7 @@ set_full_path(THIS_DIR_SOURCES
   timeline.cpp
   timer.cpp
   variable_minibatch.cpp
+  load_model.cpp
 )
 
 # Propagate the files up the tree

--- a/src/callbacks/load_model.cpp
+++ b/src/callbacks/load_model.cpp
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// load_model .hpp .cpp - Callbacks to load pretrained model(s)
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/callbacks/load_model.hpp"
+#include "lbann/callbacks/checkpoint.hpp" 
+
+#include <callbacks.pb.h>
+#include <model.pb.h>
+
+
+#include <unistd.h>
+#include <dirent.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+namespace lbann {
+namespace callback {
+
+
+void load_model::on_train_begin(model *m) {
+  for (const auto& d : m_dirs) {
+    load_model_weights(d, m, true);
+  }
+}
+
+
+bool load_model::load_model_weights(std::string ckpt_dir, model * m, bool ckptdir_is_fullpath) {
+  std::vector<std::string> weight_list = std::vector<std::string>();
+  std::string active_ckpt_dir;
+  if(ckptdir_is_fullpath) {
+    active_ckpt_dir = ckpt_dir;
+  }else {
+    size_t epochLast = std::numeric_limits<size_t>::max();;
+    size_t stepLast = std::numeric_limits<size_t>::max();;
+    execution_mode mode = execution_mode::invalid;
+    active_ckpt_dir = get_last_shared_checkpoint_filename(m, ckpt_dir);
+
+    // get last epoch and step saved.
+    int success = read_latest(active_ckpt_dir, &mode, &epochLast, &stepLast);
+    if(!success) {
+      return false;
+    }
+    active_ckpt_dir = get_shared_checkpoint_dirname(m, ckpt_dir, mode, epochLast, stepLast);
+  }
+  lbann_comm *comm = m->get_comm();
+  if(comm->am_trainer_master()) {
+    std::cout << "Loading model weights from " << active_ckpt_dir << std::endl;
+  }
+
+  DIR *weight_dir = opendir(active_ckpt_dir.c_str());
+  if(weight_dir == nullptr)
+  {
+    std::cout << "error opening " << active_ckpt_dir << "\n";
+    return false;
+  }
+  // Populate weight list
+  struct dirent *weight_file;
+  while ((weight_file = readdir(weight_dir)) != nullptr){
+    if(!strncmp(weight_file->d_name,"model_weights_",14))
+      weight_list.push_back(std::string(weight_file->d_name));
+  }
+  closedir(weight_dir);
+
+  // load weights that appear in weight list.
+  m->reload_weights(active_ckpt_dir, weight_list);
+  return true;
+}
+
+std::unique_ptr<callback_base>
+build_load_model_callback_from_pbuf(
+  const google::protobuf::Message& proto_msg, const std::shared_ptr<lbann_summary>&) {
+  const auto& params =
+    dynamic_cast<const lbann_data::Callback::CallbackLoadModel&>(proto_msg);
+  if(params.extension().size() != 0) {
+    return make_unique<load_model>(
+      parse_list<std::string>(params.dirs()),
+      params.extension());
+  }
+  else {
+    return make_unique<load_model>(
+      parse_list<std::string>(params.dirs()));
+  }
+}
+
+} // namespace callback
+} // namespace lbann

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -75,6 +75,7 @@ message Callback {
     CallbackEarlyStopping early_stopping = 43;
     CallbackTimeline timeline = 44;
     CallbackPrintModelDescription print_model_description = 45;
+    CallbackLoadModel load_model = 46;
   }
 
   message CallbackLTFB {
@@ -258,6 +259,11 @@ message Callback {
     string dir = 1;
     string extension = 2;
     bool disable_save_after_training = 3;
+  }
+
+  message CallbackLoadModel {
+    string dirs = 1;  //director(ies) to load pretrained model(s)
+    string extension = 2;
   }
 
   message CallbackReplaceWeights {

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -57,6 +57,7 @@
 #include "lbann/callbacks/replace_weights.hpp"
 #include "lbann/callbacks/save_images.hpp"
 #include "lbann/callbacks/save_model.hpp"
+#include "lbann/callbacks/load_model.hpp"
 #include "lbann/callbacks/save_topk_models.hpp"
 #include "lbann/callbacks/summary.hpp"
 #include "lbann/callbacks/sync_layers.hpp"
@@ -168,6 +169,8 @@ void register_default_builders(factory_type& factory)
                            build_save_images_callback_from_pbuf);
   factory.register_builder("CallbackSaveModel",
                            build_save_model_callback_from_pbuf);
+  factory.register_builder("CallbackLoadModel",
+                           build_load_model_callback_from_pbuf);
   factory.register_builder("CallbackSaveTopKModels",
                            build_save_topk_models_callback_from_pbuf);
   factory.register_builder("CallbackStepLearningRate",

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -32,6 +32,7 @@
 #include "lbann/callbacks/checkpoint.hpp"
 #include "lbann/callbacks/dump_weights.hpp"
 #include "lbann/callbacks/save_model.hpp"
+#include "lbann/callbacks/load_model.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -305,7 +306,7 @@ std::unique_ptr<model> build_model_from_prototext(
 #endif
 
   if (opts && opts->has_string("restart_dir")) {
-    bool loaded = callback::save_model::load_model_weights(
+    bool loaded = callback::load_model::load_model_weights(
       opts->get_string("restart_dir"),
       ret_model.get(),
       opts->get_bool("restart_dir_is_fullpath"));


### PR DESCRIPTION
Callback to load pretrained model(s) from given directories. This callback supports loading pretrained weights of multiple models from different (specified) directories (e.g., pretrained autoencoder model, pretrained inverse model for cycle GAN).

