### PR TITLE
allow specifying checkpoint base directory for LTFB checkpoint method

### DIFF
--- a/include/lbann/callbacks/ltfb.hpp
+++ b/include/lbann/callbacks/ltfb.hpp
@@ -121,6 +121,7 @@ public:
     std::set<std::string> weights_names = std::set<std::string>(),
     bool low_score_wins = false,
     communication_algorithm comm_algo = communication_algorithm::sendrecv_weights,
+    const std::string& ckptdir = "",
     bool exchange_hyperparameters = false);
   ltfb(const ltfb& other);
   ltfb& operator=(const ltfb& other);
@@ -137,6 +138,9 @@ public:
    *  communication_algorithm::sendrecv_weights.
    */
   static communication_algorithm string_to_comm_algo(const std::string& str);
+
+  void set_ckpt_basedir(const std::string& dir);
+  std::string get_ckpt_basedir() const;
 
 private:
 
@@ -155,6 +159,9 @@ private:
 
   /** Inter-trainer communication scheme. */
   communication_algorithm m_comm_algo;
+
+  /** Base directory of the checkpoint state */
+  std::string m_ckpt_basedir;
 
   /** Whether to exchange training hyperparameters between trainers
   */

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -217,14 +217,20 @@ void exchange_models(lbann_comm& comm,
                      model& m,
                      El::Int step,
                      const std::set<std::string>& weights_names,
-                     const std::vector<data_type_weights<TensorDataType>*>& local_weights) {
+                     const std::vector<data_type_weights<TensorDataType>*>& local_weights,
+                     const std::string& ckpt_basedir) {
 
   // Checkpoint directories
+  const auto basedir = (ckpt_basedir.empty()?
+                          std::string("") :
+                          add_delimiter(ckpt_basedir));
   const auto local_trainer = comm.get_trainer_rank();
-  const std::string send_dir = (m.get_name()
+  const std::string send_dir = (basedir
+                                + m.get_name()
                                 + "_trainer" + std::to_string(local_trainer)
                                 + "_step" + std::to_string(step));
-  const std::string recv_dir = (m.get_name()
+  const std::string recv_dir = (basedir
+                                + m.get_name()
                                 + "_trainer" + std::to_string(partner_trainer)
                                 + "_step" + std::to_string(step));
 
@@ -276,11 +282,18 @@ void exchange_models(lbann_comm& comm,
 
 }
 
-void restore_local_model(lbann_comm& comm, model& m, El::Int step) {
+void restore_local_model(lbann_comm& comm,
+                         model& m,
+                         El::Int step,
+                         const std::string& ckpt_basedir) {
 
   // Checkpoint directories
+  const auto basedir = (ckpt_basedir.empty()?
+                          std::string("") :
+                          add_delimiter(ckpt_basedir));
   const auto local_trainer = comm.get_trainer_rank();
-  const std::string checkpoint_dir = (m.get_name()
+  const std::string checkpoint_dir = (basedir
+                                      + m.get_name()
                                       + "_trainer" + std::to_string(local_trainer)
                                       + "_step" + std::to_string(step));
 
@@ -341,12 +354,14 @@ ltfb::ltfb(El::Int batch_interval,
            std::set<std::string> weights_names,
            bool low_score_wins,
            communication_algorithm comm_algo,
+           const std::string& ckpt_basedir,
            bool exchange_hyperparameters)
   : callback_base(batch_interval),
     m_metric_name(std::move(metric_name)),
     m_weights_names(std::move(weights_names)),
     m_low_score_wins(low_score_wins),
     m_comm_algo(comm_algo),
+    m_ckpt_basedir(ckpt_basedir),
     m_exchange_hyperparameters(exchange_hyperparameters) {}
 
 ltfb::ltfb(const ltfb& other) :
@@ -355,6 +370,7 @@ ltfb::ltfb(const ltfb& other) :
   m_weights_names(other.m_weights_names),
   m_low_score_wins(other.m_low_score_wins),
   m_comm_algo(other.m_comm_algo),
+  m_ckpt_basedir(other.m_ckpt_basedir),
   m_exchange_hyperparameters(other.m_exchange_hyperparameters) {
 
   // Deep copy
@@ -374,6 +390,7 @@ ltfb& ltfb::operator=(const ltfb& other) {
   m_weights_names = other.m_weights_names;
   m_low_score_wins = other.m_low_score_wins;
   m_comm_algo = other.m_comm_algo;
+  m_ckpt_basedir = other.m_ckpt_basedir;
   m_exchange_hyperparameters = other.m_exchange_hyperparameters;
 
   // Deep copy
@@ -484,7 +501,8 @@ void ltfb::on_batch_begin(model *m) {
                                      *m,
                                      step,
                                      m_weights_names,
-                                     local_weights);
+                                     local_weights,
+                                     m_ckpt_basedir);
     break;
   default:
     LBANN_ERROR("invalid LTFB communication algorithm");
@@ -509,7 +527,7 @@ void ltfb::on_batch_begin(model *m) {
       }
       break;
     case communication_algorithm::checkpoint_file:
-      checkpoint_file::restore_local_model(comm, *m, step);
+      checkpoint_file::restore_local_model(comm, *m, step, m_ckpt_basedir);
       break;
     default:
       LBANN_ERROR("invalid LTFB communication algorithm");
@@ -546,6 +564,14 @@ ltfb::string_to_comm_algo(const std::string& str) {
 
 }
 
+void ltfb::set_ckpt_basedir(const std::string& dir) {
+  m_ckpt_basedir = dir;
+}
+
+std::string ltfb::get_ckpt_basedir() const {
+  return m_ckpt_basedir;
+}
+
 std::unique_ptr<callback_base>
 build_ltfb_callback_from_pbuf(
   const google::protobuf::Message& proto_msg,
@@ -558,6 +584,7 @@ build_ltfb_callback_from_pbuf(
     parse_set<std::string>(params.weights()),
     params.low_score_wins(),
     ltfb::string_to_comm_algo(params.communication_algorithm()),
+    params.checkpoint_basedir(),
     params.exchange_hyperparameters());
 }
 

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -84,6 +84,7 @@ message Callback {
     bool low_score_wins = 4;
     string communication_algorithm = 5;   // default: "sendrecv_weights"
     bool exchange_hyperparameters = 6;
+    string checkpoint_basedir = 7;
   }
 
   message CallbackStepLearningRate {


### PR DESCRIPTION
When LTFB callback is set to use checkpoint as the underlying method, all the checkpoint directories/files are dumped into the current directory. This PR allows specifying the base directory for checkpoint dump files and sub-directories via the prototext variable `checkpoint_basedir`. The default behaviour without this option is unchanged (in other word, dump everything to the current directory).
```
ltfb {
   ...
   communication_algorithm: "checkpoint_file"
   checkpoint_basedir: "some_dir" 
}
```