### PR TITLE
Generalize the system-optimized LBANN launcher

### DIFF
--- a/applications/ATOM/train_atom_char_rnn.py
+++ b/applications/ATOM/train_atom_char_rnn.py
@@ -7,7 +7,7 @@ samples = np.load(data_dir, allow_pickle=True)
 dims = len(samples[0])
 
 
-pad_indx = 28 
+pad_indx = 28
 # Sample access functions
 def get_sample(index):
     sample = samples[index]
@@ -109,7 +109,7 @@ def construct_model():
       weights.update(l.weights)
     obj = lbann.ObjectiveFunction(loss)
 
-    
+
     callbacks = [lbann.CallbackPrint(),
                  lbann.CallbackTimer(),
                  lbann.CallbackStepLearningRate(step=10, amt=0.5),
@@ -157,12 +157,12 @@ def construct_data_reader():
 
 if __name__ == '__main__':
     import lbann
-    import lbann.contrib.lc.launcher
+    import lbann.contrib.launcher
     trainer = lbann.Trainer()
     model = construct_model()
     opt = lbann.Adam(learn_rate=0.001,beta1=0.9,beta2=0.99,eps=1e-8)
     data_reader = construct_data_reader()
-    status = lbann.contrib.lc.launcher.run(
+    status = lbann.contrib.launcher.run(
         trainer, model, data_reader, opt,
         account='hpcdl',
         scheduler='slurm',

--- a/applications/CANDLE/pilot2/train_ras_classifier.py
+++ b/applications/CANDLE/pilot2/train_ras_classifier.py
@@ -60,7 +60,7 @@ def construct_model():
     pred = lbann.Softmax(fc3(x))
     gt_label  = lbann.OneHot(ylabel, size=num_classes)
     loss = lbann.CrossEntropy([pred,gt_label],name='loss')
-    acc = lbann.CategoricalAccuracy([pred, gt_label]) 
+    acc = lbann.CategoricalAccuracy([pred, gt_label])
 
 
     layers = list(lbann.traverse_layer_graph(input))
@@ -70,7 +70,7 @@ def construct_model():
       weights.update(l.weights)
     obj = lbann.ObjectiveFunction(loss)
 
-    
+
     callbacks = [lbann.CallbackPrint(),
                  lbann.CallbackTimer()]
 
@@ -117,12 +117,12 @@ def construct_data_reader():
 
 if __name__ == '__main__':
     import lbann
-    import lbann.contrib.lc.launcher
+    import lbann.contrib.launcher
     trainer = lbann.Trainer()
     model = construct_model()
     opt = lbann.Adam(learn_rate=0.001,beta1=0.9,beta2=0.99,eps=1e-8)
     data_reader = construct_data_reader()
-    status = lbann.contrib.lc.launcher.run(
+    status = lbann.contrib.launcher.run(
         trainer, model, data_reader, opt,
         account='hpcdl',
         scheduler='slurm',

--- a/applications/graph/main.py
+++ b/applications/graph/main.py
@@ -3,7 +3,7 @@ import argparse
 import os.path
 
 import lbann
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 import lbann.contrib.args
 
 import dataset
@@ -142,8 +142,8 @@ model = lbann.Model(args.mini_batch_size,
 
 # Run LBANN
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
-lbann.contrib.lc.launcher.run(trainer, model, reader, opt,
-                              job_name=args.job_name,
-                              experiment_dir=args.experiment_dir,
-                              overwrite_script=True,
-                              **kwargs)
+lbann.contrib.launcher.run(trainer, model, reader, opt,
+                           job_name=args.job_name,
+                           experiment_dir=args.experiment_dir,
+                           overwrite_script=True,
+                           **kwargs)

--- a/applications/graph/main.py
+++ b/applications/graph/main.py
@@ -33,8 +33,8 @@ parser.add_argument(
     '--learning-rate', action='store', default=-1, type=float,
     help='learning rate (default: 0.025*mbsize)', metavar='VAL')
 parser.add_argument(
-    '--experiment-dir', action='store', default=None, type=str,
-    help='directory for experiment artifacts', metavar='DIR')
+    '--work-dir', action='store', default=None, type=str,
+    help='working directory', metavar='DIR')
 args = parser.parse_args()
 
 # ----------------------------------
@@ -144,6 +144,6 @@ model = lbann.Model(args.mini_batch_size,
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
 lbann.contrib.launcher.run(trainer, model, reader, opt,
                            job_name=args.job_name,
-                           experiment_dir=args.experiment_dir,
+                           work_dir=args.work_dir,
                            overwrite_script=True,
                            **kwargs)

--- a/applications/nlp/rnn/main.py
+++ b/applications/nlp/rnn/main.py
@@ -5,7 +5,7 @@ import sys
 
 import lbann
 import lbann.modules
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 import lbann.contrib.args
 
 # Local imports
@@ -113,6 +113,6 @@ opt = lbann.SGD(learn_rate=0.01, momentum=0.9)
 
 # Run LBANN
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
-lbann.contrib.lc.launcher.run(trainer, model, reader, opt,
-                              job_name=args.job_name,
-                              **kwargs)
+lbann.contrib.launcher.run(trainer, model, reader, opt,
+                           job_name=args.job_name,
+                           **kwargs)

--- a/applications/nlp/transformer/train.py
+++ b/applications/nlp/transformer/train.py
@@ -4,7 +4,7 @@ import os.path
 
 import lbann
 import lbann.models
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 from lbann.util import str_list
 
 import dataset
@@ -218,7 +218,7 @@ def make_batch_script(model_params, script_params):
     )
 
     # Create batch script
-    script = lbann.contrib.lc.launcher.make_batch_script(
+    script = lbann.contrib.launcher.make_batch_script(
         **script_params,
     )
     script.add_command('echo "Started training at $(date)"')

--- a/applications/physics/cosmology/ExaGAN/train_exagan.py
+++ b/applications/physics/cosmology/ExaGAN/train_exagan.py
@@ -1,6 +1,6 @@
 import ExaGAN
 import dataset
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 
 # ==============================================
 # Setup and launch experiment
@@ -26,8 +26,8 @@ def construct_model():
     zero = lbann.LogicalNot(one,name='is_fake')
 
     z = lbann.Reshape(lbann.Gaussian(mean=0.0,stdev=1.0, neuron_dims="64", name='noise_vec'),dims='1 64')
-    d1_real, d1_fake, d_adv, gen_img  = ExaGAN.CosmoGAN()(input,z) 
-    
+    d1_real, d1_fake, d_adv, gen_img  = ExaGAN.CosmoGAN()(input,z)
+
     d1_real_bce = lbann.SigmoidBinaryCrossEntropy([d1_real,one],name='d1_real_bce')
     d1_fake_bce = lbann.SigmoidBinaryCrossEntropy([d1_fake,zero],name='d1_fake_bce')
     d_adv_bce = lbann.SigmoidBinaryCrossEntropy([d_adv,one],name='d_adv_bce')
@@ -64,7 +64,7 @@ def construct_model():
                  lbann.CallbackReplaceWeights(source_layers=list2str(src_layers),
                                       destination_layers=list2str(dst_layers),
                                       batch_interval=2)]
-                                            
+
     # Construct model
     mini_batch_size = 64
     num_epochs = 20
@@ -109,14 +109,14 @@ def construct_data_reader():
 
 if __name__ == '__main__':
     import lbann
-    
+
     trainer = lbann.Trainer()
     model = construct_model()
     # Setup optimizer
     opt = lbann.Adam(learn_rate=0.0002,beta1=0.5,beta2=0.99,eps=1e-8)
     # Load data reader from prototext
     data_reader = construct_data_reader()
-    status = lbann.contrib.lc.launcher.run(trainer,model, data_reader, opt,
+    status = lbann.contrib.launcher.run(trainer,model, data_reader, opt,
                        scheduler='slurm',
                        #account='lbpm',
                        nodes=1,

--- a/applications/vision/alexnet.py
+++ b/applications/vision/alexnet.py
@@ -2,7 +2,7 @@ import argparse
 import lbann
 import lbann.models
 import lbann.contrib.args
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 import data.imagenet
 
 # Command-line arguments
@@ -76,7 +76,7 @@ trainer = lbann.Trainer()
 
 # Run experiment
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
-lbann.contrib.lc.launcher.run(trainer, model, data_reader, opt,
-                              job_name=args.job_name,
-                              setup_only=args.setup_only,
-                              **kwargs)
+lbann.contrib.launcher.run(trainer, model, data_reader, opt,
+                           job_name=args.job_name,
+                           setup_only=args.setup_only,
+                           **kwargs)

--- a/applications/vision/densenet.py
+++ b/applications/vision/densenet.py
@@ -1,7 +1,7 @@
 import argparse
 import lbann
 import lbann.contrib.args
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 import data.imagenet
 
 LOG = True
@@ -428,9 +428,9 @@ def run_experiment(args,
                    optimizer):
     # Note: Use `lbann.run` instead for non-LC systems.
     kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
-    lbann.contrib.lc.launcher.run(trainer, model, data_reader, optimizer,
-                                  job_name=args.job_name,
-                                  **kwargs)
+    lbann.contrib.launcher.run(trainer, model, data_reader, optimizer,
+                               job_name=args.job_name,
+                               **kwargs)
 
 
 # Main function ################################################################

--- a/applications/vision/lenet.py
+++ b/applications/vision/lenet.py
@@ -93,8 +93,8 @@ trainer = lbann.Trainer()
 # ----------------------------------
 # Run experiment
 # ----------------------------------
-# Note: Use `lbann.contrib.lc.launcher.run` instead for optimized
-# defaults on LC systems.
+# Note: Use `lbann.contrib.launcher.run` instead for optimized
+# defaults.
 
 kwargs = {}
 if args.partition: kwargs['partition'] = args.partition

--- a/applications/vision/resnet.py
+++ b/applications/vision/resnet.py
@@ -4,7 +4,7 @@ import lbann.models
 import lbann.models.resnet
 import lbann.contrib.args
 import lbann.contrib.models.wide_resnet
-import lbann.contrib.lc.launcher
+import lbann.contrib.launcher
 import data.imagenet
 
 # Command-line arguments
@@ -149,6 +149,6 @@ trainer = lbann.Trainer()
 
 # Run experiment
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
-lbann.contrib.lc.launcher.run(trainer, model, data_reader, opt,
-                              job_name=args.job_name,
-                              **kwargs)
+lbann.contrib.launcher.run(trainer, model, data_reader, opt,
+                           job_name=args.job_name,
+                           **kwargs)

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -706,7 +706,7 @@ def create_tests(setup_func,
         test_name (str, optional): Descriptive name (default: test
             file name with '.py' removed).
         **kwargs: Keyword arguments to pass into
-            `lbann.contrib.lc.launcher.run`.
+            `lbann.contrib.launcher.run`.
 
     Returns:
         Iterable of function: Tests that can interact with PyTest.
@@ -751,7 +751,7 @@ def create_tests(setup_func,
                                             'site-packages')
         sys.path.append(python_frontend_path)
         import lbann
-        import lbann.contrib.lc.launcher
+        import lbann.contrib.launcher
 
         # Setup LBANN experiment
         trainer, model, data_reader, optimizer = setup_func(lbann)
@@ -771,7 +771,7 @@ def create_tests(setup_func,
         experiment_dir = _kwargs['experiment_dir']
         stdout_log_file = os.path.join(experiment_dir, 'out.log')
         stderr_log_file = os.path.join(experiment_dir, 'err.log')
-        return_code = lbann.contrib.lc.launcher.run(
+        return_code = lbann.contrib.launcher.run(
             trainer=trainer,
             model=model,
             data_reader=data_reader,

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -758,19 +758,19 @@ def create_tests(setup_func,
 
         # Configure kwargs to LBANN launcher
         _kwargs = copy.deepcopy(kwargs)
-        if 'experiment_dir' not in _kwargs:
-            _kwargs['experiment_dir'] = os.path.join(os.path.dirname(test_file),
-                                                    'experiments',
-                                                    test_name)
+        if 'work_dir' not in _kwargs:
+            _kwargs['work_dir'] = os.path.join(os.path.dirname(test_file),
+                                               'experiments',
+                                               test_name)
         if 'job_name' not in _kwargs:
             _kwargs['job_name'] = f'lbann_{test_name}'
         if 'overwrite_script' not in _kwargs:
             _kwargs['overwrite_script'] = True
 
         # Run LBANN
-        experiment_dir = _kwargs['experiment_dir']
-        stdout_log_file = os.path.join(experiment_dir, 'out.log')
-        stderr_log_file = os.path.join(experiment_dir, 'err.log')
+        work_dir = _kwargs['work_dir']
+        stdout_log_file = os.path.join(work_dir, 'out.log')
+        stderr_log_file = os.path.join(work_dir, 'err.log')
         return_code = lbann.contrib.launcher.run(
             trainer=trainer,
             model=model,
@@ -781,7 +781,7 @@ def create_tests(setup_func,
         assert_success(return_code, stderr_log_file)
         return {
             'return_code': return_code,
-            'experiment_dir': experiment_dir,
+            'work_dir': work_dir,
             'stdout_log_file': stdout_log_file,
             'stderr_log_file': stderr_log_file,
         }

--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -312,9 +312,10 @@ A typical workflow involves the following steps:
 
    + Supported job managers are Slurm and LSF.
 
-   + LLNL users may prefer to use :python:`lbann.contrib.lc.launcher.run`.
-     This is a wrapper around :python:`lbann.run`, with defaults and
-     optimizations specifically for LC systems.
+   + LLNL users and collaborators may prefer to use
+     :python:`lbann.contrib.launcher.run`. This is similar to
+     :python:`lbann.run`, with defaults and optimizations for certain
+     systems.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 A simple example

--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -1,21 +1,68 @@
+import os, os.path
+from lbann import lbann_exe
 import lbann.launcher
+import lbann.contrib.lc.launcher
 import lbann.contrib.lc.systems
+from lbann.util import make_iterable
 
-def run(*args, **kwargs):
+def run(
+    trainer,
+    model,
+    data_reader,
+    optimizer,
+    lbann_args=[],
+    overwrite_script=False,
+    setup_only=False,
+    *args,
+    **kwargs,
+):
     """Run LBANN with system-specific optimizations.
 
-    This is intended to match the behavior of `lbann.launcher.run`,
-    with defaults and optimizations for the current system.
+    This is intended to match the behavior of `lbann.run`, with
+    defaults and optimizations for the current system. See that
+    function for a full list of options.
 
     """
 
-    # Livermore Computing
-    if lbann.contrib.lc.systems.is_lc_system():
-        import lbann.contrib.lc.launcher
-        return lbann.contrib.lc.launcher.run(*args, **kwargs):
+    # Create batch script generator
+    script = make_batch_script(*args, **kwargs)
 
-    # Default launcher
-    return lbann.launcher.run(*args, **kwargs)
+    # Check for an existing job allocation
+    has_allocation = False
+    if isinstance(script, lbann.launcher.slurm.SlurmBatchScript):
+        has_allocation = 'SLURM_JOB_ID' in os.environ
+    if isinstance(script, lbann.launcher.lsf.LSFBatchScript):
+        has_allocation = 'LSB_JOBID' in os.environ
+
+    # Batch script prints start time
+    script.add_command('echo "Started at $(date)"')
+
+    # Batch script invokes LBANN
+    lbann_command = [lbann.lbann_exe()]
+    lbann_command.extend(make_iterable(lbann_args))
+    prototext_file = os.path.join(script.work_dir, 'experiment.prototext')
+    lbann.proto.save_prototext(prototext_file,
+                               trainer=trainer,
+                               model=model,
+                               data_reader=data_reader,
+                               optimizer=optimizer)
+    lbann_command.append('--prototext={}'.format(prototext_file))
+    script.add_parallel_command(lbann_command)
+    script.add_command('status=$?')
+
+    # Batch script prints finish time and returns status
+    script.add_command('echo "Finished at $(date)"')
+    script.add_command('exit ${status}')
+
+    # Write, run, or submit batch script
+    status = 0
+    if setup_only:
+        script.write(overwrite=overwrite_script)
+    elif has_allocation:
+        status = script.run(overwrite=overwrite_script)
+    else:
+        status = script.submit(overwrite=overwrite_script)
+    return status
 
 def make_batch_script(*args, **kwargs):
     """Construct batch script manager with system-specific optimizations.
@@ -28,8 +75,7 @@ def make_batch_script(*args, **kwargs):
 
     # Livermore Computing
     if lbann.contrib.lc.systems.is_lc_system():
-        import lbann.contrib.lc.launcher
-        return lbann.contrib.lc.launcher.make_batch_script(*args, **kwargs):
+        return lbann.contrib.lc.launcher.make_batch_script(*args, **kwargs)
 
     # Default launcher
     return lbann.launcher.make_batch_script(*args, **kwargs)

--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -1,0 +1,35 @@
+import lbann.launcher
+import lbann.contrib.lc.systems
+
+def run(*args, **kwargs):
+    """Run LBANN with system-specific optimizations.
+
+    This is intended to match the behavior of `lbann.launcher.run`,
+    with defaults and optimizations for the current system.
+
+    """
+
+    # Livermore Computing
+    if lbann.contrib.lc.systems.is_lc_system():
+        import lbann.contrib.lc.launcher
+        return lbann.contrib.lc.launcher.run(*args, **kwargs):
+
+    # Default launcher
+    return lbann.launcher.run(*args, **kwargs)
+
+def make_batch_script(*args, **kwargs):
+    """Construct batch script manager with system-specific optimizations.
+
+    This is intended to match the behavior of
+    `lbann.launcher.make_batch_script`, with defaults and
+    optimizations for the current system.
+
+    """
+
+    # Livermore Computing
+    if lbann.contrib.lc.systems.is_lc_system():
+        import lbann.contrib.lc.launcher
+        return lbann.contrib.lc.launcher.make_batch_script(*args, **kwargs):
+
+    # Default launcher
+    return lbann.launcher.make_batch_script(*args, **kwargs)

--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -1,100 +1,38 @@
-import os, os.path
-from lbann import lbann_exe
 from lbann.contrib.lc.systems import *
 import lbann.launcher
 from lbann.util import make_iterable
 
-def run(trainer, model, data_reader, optimizer,
-        experiment_dir=None,
-        nodes=1,
-        procs_per_node=procs_per_node(),
-        time_limit=None,
-        scheduler=scheduler(),
-        job_name='lbann',
-        system=system(),
-        partition=partition(),
-        account=account(),
-        reservation=None,
-        overwrite_script=False,
-        launcher_args=[],
-        lbann_args=[],
-        environment={},
-        setup_only=False):
-    """Run LBANN with LC-specific optimizations.
+def run(*args, **kwargs):
+    """Run LBANN with LC-specific optimizations (deprecated).
 
-    This is intended to match the behavior of `lbann.launcher.run`,
-    with defaults and optimizations for LC systems.
+    This is deprecated. Use `lbann.contrib.launcher.run` instead.
 
     """
 
-    # Create batch script generator
-    script = make_batch_script(work_dir=experiment_dir,
-                               nodes=nodes,
-                               procs_per_node=procs_per_node,
-                               time_limit=time_limit,
-                               scheduler=scheduler,
-                               job_name=job_name,
-                               partition=partition,
-                               account=account,
-                               reservation=reservation,
-                               launcher_args=launcher_args,
-                               environment=environment)
+    import warnings
+    warnings.warn(
+        'Using deprecated function `lbann.contrib.lc.launcher.run`. '
+        'Use `lbann.contrib.launcher.run` instead.'
+    )
+    from ..launcher import run as _run
+    _run(*args, **kwargs)
 
-    # Check for an existing job allocation
-    has_allocation = False
-    if isinstance(script, lbann.launcher.slurm.SlurmBatchScript):
-        has_allocation = 'SLURM_JOB_ID' in os.environ
-    if isinstance(script, lbann.launcher.lsf.LSFBatchScript):
-        has_allocation = 'LSB_JOBID' in os.environ
-
-    # Batch script prints start time
-    script.add_command('echo "Started at $(date)"')
-
-    # Batch script invokes LBANN
-    lbann_command = [lbann.lbann_exe()]
-    lbann_command.extend(make_iterable(lbann_args))
-    prototext_file = os.path.join(script.work_dir, 'experiment.prototext')
-    lbann.proto.save_prototext(prototext_file,
-                               trainer=trainer,
-                               model=model,
-                               data_reader=data_reader,
-                               optimizer=optimizer)
-    lbann_command.append('--prototext={}'.format(prototext_file))
-    script.add_parallel_command(lbann_command)
-    script.add_command('status=$?')
-
-    # Batch script prints finish time and returns status
-    script.add_command('echo "Finished at $(date)"')
-    script.add_command('exit ${status}')
-
-    # Write, run, or submit batch script
-    status = 0
-    if setup_only:
-        script.write(overwrite=overwrite_script)
-    elif has_allocation:
-        status = script.run(overwrite=overwrite_script)
-    else:
-        status = script.submit(overwrite=overwrite_script)
-    return status
-
-def make_batch_script(script_file=None,
-                      work_dir=None,
-                      nodes=1,
-                      procs_per_node=procs_per_node(),
-                      time_limit=None,
-                      scheduler=scheduler(),
-                      job_name='lbann',
-                      system=system(),
-                      partition=partition(),
-                      account=account(),
-                      reservation=None,
-                      launcher_args=[],
-                      environment={}):
+def make_batch_script(
+    system=system(),
+    procs_per_node=procs_per_node(),
+    scheduler=scheduler(),
+    partition=partition(),
+    account=account(),
+    launcher_args=[],
+    environment={},
+    *args,
+    **kwargs,
+):
     """Construct batch script manager with LC-specific optimizations.
 
-    This is intended to match the behavior of
-    `lbann.launcher.make_batch_script`, with defaults and
-    optimizations for LC systems.
+    This is a wrapper around `lbann.launcher.make_batch_script`, with
+    defaults and optimizations for LC systems. See that function for a
+    full list of options.
 
     """
 
@@ -175,15 +113,13 @@ def make_batch_script(script_file=None,
         if 'PAMI_MAX_NUM_CACHED_PAGES' not in environment:
             environment['PAMI_MAX_NUM_CACHED_PAGES'] = 0
 
-    return lbann.launcher.make_batch_script(script_file=script_file,
-                                            work_dir=work_dir,
-                                            nodes=nodes,
-                                            procs_per_node=procs_per_node,
-                                            time_limit=time_limit,
-                                            scheduler=scheduler,
-                                            job_name=job_name,
-                                            partition=partition,
-                                            account=account,
-                                            reservation=reservation,
-                                            launcher_args=launcher_args,
-                                            environment=environment)
+    return lbann.launcher.make_batch_script(
+        procs_per_node=procs_per_node,
+        scheduler=scheduler,
+        partition=partition,
+        account=account,
+        launcher_args=launcher_args,
+        environment=environment,
+        *args,
+        **kwargs,
+    )

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -12,7 +12,7 @@ from lbann.util import make_iterable
 # ==============================================
 
 def run(trainer, model, data_reader, optimizer,
-        experiment_dir=None,
+        work_dir=None,
         nodes=1,
         procs_per_node=1,
         time_limit=None,
@@ -25,7 +25,8 @@ def run(trainer, model, data_reader, optimizer,
         lbann_args=[],
         environment={},
         overwrite_script=False,
-        setup_only=False):
+        setup_only=False,
+        experiment_dir=None):
     """Run LBANN.
 
     This is intended to interface with job schedulers on HPC
@@ -44,7 +45,7 @@ def run(trainer, model, data_reader, optimizer,
         data_reader (lbann.reader_pb2.DataReader): Data reader.
         optimizer (lbann.model.Optimizer): Default optimizer for
             model.
-        experiment_dir (str, optional): Experiment directory.
+        work_dir (str, optional): Working directory.
         nodes (int, optional): Number of compute nodes.
         procs_per_node (int, optional): Number of processes per compute
             node.
@@ -64,6 +65,7 @@ def run(trainer, model, data_reader, optimizer,
             file if it already exists.
         setup_only (bool, optional): If true, the experiment is not
             run after the experiment directory is initialized.
+        experiment_dir (str, optional, deprecated): See `work_dir`.
 
     Returns:
         int: Exit status from scheduler. This is really only
@@ -74,7 +76,9 @@ def run(trainer, model, data_reader, optimizer,
     """
 
     # Create batch script generator
-    script = make_batch_script(work_dir=experiment_dir,
+    if not work_dir:
+        work_dir = experiment_dir
+    script = make_batch_script(work_dir=work_dir,
                                nodes=nodes,
                                procs_per_node=procs_per_node,
                                time_limit=time_limit,
@@ -134,7 +138,8 @@ def make_batch_script(script_file=None,
                       account=None,
                       reservation=None,
                       launcher_args=[],
-                      environment={}):
+                      environment={},
+                      experiment_dir=None):
     """Construct batch script manager.
 
     Attempts to detect a scheduler if one is not provided.
@@ -163,6 +168,7 @@ def make_batch_script(script_file=None,
             Command-line arguments to parallel command launcher.
         environment (`dict` of `{str: str}`, optional): Environment
             variables.
+        experiment_dir (str, optional, deprecated): See `work_dir`.
 
     Returns:
         `lbann.launcher.batch_script.BatchScript`
@@ -190,6 +196,8 @@ def make_batch_script(script_file=None,
         raise RuntimeError('could not detect job scheduler')
 
     # Create work directory if not provided
+    if not work_dir:
+       work_dir = experiment_dir
     if not work_dir:
         if 'LBANN_EXPERIMENT_DIR' in os.environ:
             work_dir = os.environ['LBANN_EXPERIMENT_DIR']

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -24,6 +24,7 @@ def run(trainer, model, data_reader, optimizer,
         launcher_args=[],
         lbann_args=[],
         environment={},
+        overwrite_script=False,
         setup_only=False):
     """Run LBANN.
 
@@ -59,6 +60,8 @@ def run(trainer, model, data_reader, optimizer,
             executable.
         environment (dict of {str: str}, optional): Environment
             variables.
+        overwrite_script (bool, optional): Whether to overwrite script
+            file if it already exists.
         setup_only (bool, optional): If true, the experiment is not
             run after the experiment directory is initialized.
 
@@ -113,11 +116,11 @@ def run(trainer, model, data_reader, optimizer,
     # Write, run, or submit batch script
     status = 0
     if setup_only:
-        script.write()
+        script.write(overwrite=overwrite_script)
     elif has_allocation:
-        status = script.run()
+        status = script.run(overwrite=overwrite_script)
     else:
-        status = script.submit()
+        status = script.submit(overwrite=overwrite_script)
     return status
 
 def make_batch_script(script_file=None,


### PR DESCRIPTION
The Python frontend exposes two submodules to run LBANN:
- `lbann.launcher`: Vanilla launcher. This is very general, but the user is responsible for passing in arguments to configure the scheduler job and to setup the environment.
- `lbann.contrib.lc.launcher`: LC-specific launcher. This has good defaults and years worth of accumulated performance hacks and bug workarounds.

To make it easier for non-LLNL collaborators to run LBANN on their own systems, I've created `lbann.contrib.launcher` to generalize the LC-specific launcher. Currently, all it does is detect whether the current system is an LC system and choose whether to call into `lbann.contrib.lc.launcher` or `lbann.launcher`. In the future, we can add additional machinery to detect other computing centers and call into their optimized launchers (something like `lbann.contrib.othercenter.launcher`).

Note that `lbann.contrib.lc.launcher.run` is now deprecated in favor of `lbann.contrib.launcher.run`. It still works, but it will complain at you.