### PR TITLE
fix the compilation error in debug mode

### DIFF
--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -612,7 +612,7 @@ private :
     flush_profile_file();
   }
 
-  void DEBUG() { 
+  void DEBUG_DS() { 
     if (!m_debug) {
       return;
     }
@@ -621,12 +621,12 @@ private :
   }
 
   template <typename T, typename... Types>
-  void DEBUG(T var1, Types... var2) {
+  void DEBUG_DS(T var1, Types... var2) {
     if (!m_debug) {
       return;
     }
     (*m_debug) << var1 << " ";
-    DEBUG(var2...) ;
+    DEBUG_DS(var2...) ;
     flush_debug_file();
   }
 };

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -69,7 +69,7 @@ public:
   {
 #if defined(LBANN_HAS_CUDNN) && defined(LBANN_DETERMINISTIC)
     /// @todo GPU implementation of dropout with sequential consistency
-    if (Dev == El::Device::GPU && get_comm()->am_trainer_master()) {
+    if (Dev == El::Device::GPU && this->get_comm()->am_trainer_master()) {
       std::cerr << "Warning: GPU dropout currently does not guarantee "
                 << "sequential consistency" << std::endl;
     }

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -317,7 +317,7 @@ void data_store_conduit::error_check_compacted_node(const conduit::Node &nd, int
 }
 
 
-//n.b. Do not put any PROFILE or DEBUG statements in this method,
+//n.b. Do not put any PROFILE or DEBUG_DS statements in this method,
 //     since the threading from the data_reader will cause you grief
 void data_store_conduit::set_conduit_node(int data_id, const conduit::Node &node, bool already_have) {
 
@@ -334,7 +334,7 @@ void data_store_conduit::set_conduit_node(int data_id, const conduit::Node &node
   {
     //std::lock_guard<std::mutex> lock(m_mutex);
     if (already_have == false && m_data.find(data_id) != m_data.end()) {
-      DEBUG("m_data.size: ", m_data.size(), " ERROR: duplicate data_id: ", data_id);
+      DEBUG_DS("m_data.size: ", m_data.size(), " ERROR: duplicate data_id: ", data_id);
       LBANN_ERROR("duplicate data_id: ", data_id, " in data_store_conduit::set_conduit_node; role: ", m_reader->get_role());
     }
   }
@@ -617,7 +617,7 @@ int data_store_conduit::build_indices_i_will_send(int current_pos, int mb_size) 
   m_indices_to_send.clear();
   m_indices_to_send.resize(m_np_in_trainer);
   int k = 0;
-  DEBUG("build_indices_i_will_send; cur pos: ", current_pos, " mb_size: ", mb_size, " m_data.size: ", m_data.size());
+  DEBUG_DS("build_indices_i_will_send; cur pos: ", current_pos, " mb_size: ", mb_size, " m_data.size: ", m_data.size());
   for (int i = current_pos; i < current_pos + mb_size; i++) {
     auto index = (*m_shuffled_indices)[i];
     /// If this rank owns the index send it to the (i%m_np)'th rank
@@ -862,14 +862,14 @@ void data_store_conduit::set_shuffled_indices(const std::vector<int> *indices) {
 }
 
 void data_store_conduit::exchange_sample_sizes() {
-  DEBUG("starting data_store_conduit::exchange_sample_sizes");
+  DEBUG_DS("starting data_store_conduit::exchange_sample_sizes");
   int my_count = m_sample_sizes.size();
   std::vector<int> all_counts(m_np_in_trainer);
   m_comm->all_gather(&my_count, 1, all_counts.data(), 1,  m_comm->get_trainer_comm());
 
   if (m_debug) {
     for (size_t h=0; h<all_counts.size(); h++) {
-      DEBUG("num samples owned by P_", h, " is ", all_counts[h]);
+      DEBUG_DS("num samples owned by P_", h, " is ", all_counts[h]);
     }
   }
 
@@ -882,7 +882,7 @@ void data_store_conduit::exchange_sample_sizes() {
 
   std::vector<size_t> others;
   for (int k=0; k<m_np_in_trainer; k++) {
-    DEBUG("sample sizes for P_", k);
+    DEBUG_DS("sample sizes for P_", k);
     others.resize(all_counts[k]*2);
     if (m_rank_in_trainer == k) {
       m_comm->broadcast<size_t>(k, my_sizes.data(), all_counts[k]*2,  m_comm->get_trainer_comm());
@@ -892,9 +892,9 @@ void data_store_conduit::exchange_sample_sizes() {
       for (size_t i=0; i<others.size(); i += 2) {
         if (m_sample_sizes.find(others[i]) != m_sample_sizes.end()) {
           if (m_debug) {
-            DEBUG("SAMPLE SIZES for P_", k);
+            DEBUG_DS("SAMPLE SIZES for P_", k);
             for (size_t h=0; h<others.size(); h += 2) {
-              DEBUG(others[h], " SIZE: ", others[h+1]);
+              DEBUG_DS(others[h], " SIZE: ", others[h+1]);
             }
           }
           LBANN_ERROR("m_sample_sizes.find(others[i]) != m_sample_sizes.end() for data_id: ", others[i]);
@@ -1304,7 +1304,7 @@ void data_store_conduit::exchange_images(std::vector<char> &work, map_is_t &imag
 void data_store_conduit::exchange_owner_maps() {
   PROFILE("starting exchange_owner_maps;",
           "my owner map size: ", m_owner.size());
-  DEBUG("starting exchange_owner_maps;",
+  DEBUG_DS("starting exchange_owner_maps;",
         "size: ", m_owner.size());
 
   int my_count = m_my_num_indices;
@@ -1328,10 +1328,10 @@ void data_store_conduit::exchange_owner_maps() {
         if (m_owner.find(others[i]) != m_owner.end()) {
 
           if (m_debug) {
-            DEBUG("data_store_conduit::exchange_owner_maps, duplicate data_id: ", others[i], "; k= ", k, "\nmy current m_owner map: ");
-            for (auto t : m_owner) DEBUG("data_id: ", t.first, " owner: ", t.second);
-            DEBUG("\nowner map (partial or whole) from P_", k);
-            for (auto t : others) DEBUG(t, " ");
+            DEBUG_DS("data_store_conduit::exchange_owner_maps, duplicate data_id: ", others[i], "; k= ", k, "\nmy current m_owner map: ");
+            for (auto t : m_owner) DEBUG_DS("data_id: ", t.first, " owner: ", t.second);
+            DEBUG_DS("\nowner map (partial or whole) from P_", k);
+            for (auto t : others) DEBUG_DS(t, " ");
           }
 
           LBANN_ERROR("duplicate data_id: ", others[i], " role: ", m_reader->get_role(), "; m_owner[", others[i],"] = ", m_owner[others[i]], " for role: ", m_reader->get_role(), " m_owner.size: ", m_owner.size(), " m_data.size(): ", m_data.size());
@@ -1588,7 +1588,7 @@ void data_store_conduit::write_checkpoint(std::string dir_name) {
 
   // save conduit Nodes
   m_metadata << get_conduit_dir() << "\n";
-  DEBUG("m_data.size: ", m_data.size());
+  DEBUG_DS("m_data.size: ", m_data.size());
   for (auto t : m_data) {
     spill_conduit_node(t.second["data"], t.first);
   }
@@ -1727,9 +1727,9 @@ void data_store_conduit::open_next_conduit_spill_directory() {
   m_num_files_in_cur_spill_dir = 0;
   m_cur_spill_dir_integer += 1;
   m_cur_spill_dir = get_conduit_dir() + "/" + to_string(m_cur_spill_dir_integer);
-  DEBUG("calling file::directory_exists(", m_cur_spill_dir, ")");
+  DEBUG_DS("calling file::directory_exists(", m_cur_spill_dir, ")");
   bool exists = file::directory_exists(m_cur_spill_dir);
-  DEBUG("exists? ", exists);
+  DEBUG_DS("exists? ", exists);
   if (!exists) {
     file::make_directory(m_cur_spill_dir);
   }


### PR DESCRIPTION
- The issue with accessing a member variable in a template class
   - "dropout.hpp:72:35: error: there are no arguments to 'get_comm' that depend on a template parameter, so a declaration of 'get_comm' must be available"
- name collision issue
  - "data_store_conduit.hpp:615:8: note: in expansion of macro 'DEBUG'"
  - "data_store_conduit.cpp:337:83: error: expression cannot be used as a function"
