### PR TITLE
Add option to build with NVSHMEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,16 @@ if (LBANN_HAS_CUDA)
   else ()
     set(LBANN_HAS_NCCL2 FALSE)
   endif ()
+
+  if (LBANN_WITH_NVSHMEM)
+    find_package(NVSHMEM REQUIRED)
+    set_property(TARGET cuda::toolkit PROPERTY
+      INTERFACE_COMPILE_OPTIONS $<$<COMPILE_LANGUAGE:CUDA>:-arch=sm_70>)
+    # Build LBANN as a static library to get around a bug in NVSHMEM
+    set(BUILD_SHARED_LIBS OFF)
+  endif ()
+  set(LBANN_HAS_NVSHMEM "${NVSHMEM_FOUND}")
+
 endif (LBANN_HAS_CUDA)
 
 # This shouldn't be here, but is ok for now. This will occasionally be
@@ -568,6 +578,11 @@ endif ()
 
 if (LBANN_HAS_PYTHON)
   target_link_libraries(lbann PUBLIC Python::Python)
+endif ()
+
+if (LBANN_HAS_NVSHMEM)
+  set_property(TARGET lbann PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+  target_link_libraries(lbann PUBLIC NVSHMEM::NVSHMEM)
 endif ()
 
 if (TARGET LBANN_CXX_FLAGS_werror)

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -37,6 +37,10 @@
 
 #cmakedefine LBANN_HAS_CUDA
 #cmakedefine LBANN_HAS_CUDNN
+#cmakedefine LBANN_HAS_NVSHMEM
+#ifndef LBANN_HAS_CUDA
+#undef LBANN_HAS_NVSHMEM
+#endif
 
 #cmakedefine LBANN_HAS_HALF
 #cmakedefine LBANN_HAS_GPU_FP16

--- a/cmake/modules/FindNVSHMEM.cmake
+++ b/cmake/modules/FindNVSHMEM.cmake
@@ -1,0 +1,46 @@
+# Output variables
+#
+#   NVSHMEM_FOUND
+#   NVSHMEM_LIBRARY
+#   NVSHMEM_INCLUDE_DIRS
+#
+# Also creates an imported target NVSHMEM::NVSHMEM
+
+# Find the library
+find_library(NVSHMEM_LIBRARY nvshmem
+  HINTS ${NVSHMEM_DIR} $ENV{NVSHMEM_DIR}
+  PATH_SUFFIXES lib lib64
+  NO_DEFAULT_PATH
+  DOC "The location of NVSHMEM library.")
+find_library(NVSHMEM_LIBRARY nvshmem)
+
+# Find the header
+find_path(NVSHMEM_INCLUDE_DIRS nvshmem.h
+  HINTS ${NVSHMEM_DIR} $ENV{NVSHMEM_DIR}
+  PATH_SUFFIXES include
+  NO_DEFAULT_PATH
+  DOC "The location of NVSHMEM headers.")
+find_path(NVSHMEM_INCLUDE_DIRS nvshmemx.h)
+
+# Handle the find_package arguments
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  NVSHMEM DEFAULT_MSG NVSHMEM_LIBRARY NVSHMEM_INCLUDE_DIRS)
+
+# Build the imported target
+if (NOT TARGET NVSHMEM::NVSHMEM)
+  add_library(NVSHMEM::NVSHMEM INTERFACE IMPORTED)
+  set_property(TARGET NVSHMEM::NVSHMEM PROPERTY
+    INTERFACE_LINK_LIBRARIES ${NVSHMEM_LIBRARY})
+  set_property(TARGET NVSHMEM::NVSHMEM PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${NVSHMEM_INCLUDE_DIRS})
+endif ()
+
+if (NVSHMEM_FOUND)
+  # Workaround for separable compilation with cooperative threading. see
+  # https://stackoverflow.com/questions/53492528/cooperative-groupsthis-grid-causes-any-cuda-api-call-to-return-unknown-erro.
+  # Adding this to INTERFACE_COMPILE_OPTIONS does not seem to solve the problem.
+  # It seems that CMake does not add necessary options for device linking when cuda_add_executable/library is NOT used. See also
+  # https://github.com/dealii/dealii/pull/5405
+  string(APPEND CMAKE_CUDA_FLAGS " -gencode=arch=compute_70,code=compute_70")
+endif ()

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -26,6 +26,7 @@ set_full_path(THIS_DIR_HEADERS
   omp_diagnostics.hpp
   opencv.hpp
   options.hpp
+  nvshmem.hpp
   profiling.hpp
   prototext.hpp
   python.hpp

--- a/include/lbann/utils/nvshmem.hpp
+++ b/include/lbann/utils/nvshmem.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_NVSHMEM_HPP_INCLUDED
+#define LBANN_UTILS_NVSHMEM_HPP_INCLUDED
+
+#include "lbann/base.hpp"
+#ifdef LBANN_HAS_NVSHMEM
+#include "nvshmem.h"
+#include "nvshmemx.h"
+
+#include "lbann/comm.hpp"
+
+namespace lbann {
+namespace nvshmem {
+
+/// Initialize NVSHMEM library
+void initialize(MPI_Comm comm);
+/// Finalize NVSHMEM library
+void finalize();
+
+} // namespace nvshmem
+} // namespace lbann
+
+#endif // LBANN_HAS_NVSHMEM
+
+#endif // LBANN_UTILS_NVSHMEM_HPP_INCLUDED

--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -113,6 +113,10 @@ def make_batch_script(
         if 'PAMI_MAX_NUM_CACHED_PAGES' not in environment:
             environment['PAMI_MAX_NUM_CACHED_PAGES'] = 0
 
+        # Configure NVSHMEM to load Spectrum MPI
+        if 'NVSHMEM_MPI_LIB_NAME' not in environment:
+            environment['NVSHMEM_MPI_LIB_NAME'] = 'libmpi_ibm.so'
+
     return lbann.launcher.make_batch_script(
         procs_per_node=procs_per_node,
         scheduler=scheduler,

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -44,6 +44,7 @@ fi
 
 C_FLAGS=
 CXX_FLAGS=-DLBANN_SET_EL_RNG
+CUDA_FLAGS=
 Fortran_FLAGS=
 CLEAN_BUILD=0
 DATATYPE=float
@@ -75,6 +76,8 @@ USE_NINJA=0
 # by enabling LIBJPEG_TURBO_DIR
 WITH_LIBJPEG_TURBO=ON
 #LIBJPEG_TURBO_DIR="/p/lscratchh/brainusr/libjpeg-turbo-1.5.2"
+WITH_NVSHMEM=0
+NVSHMEM_DIR=
 
 function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
 
@@ -126,6 +129,7 @@ Options:
   ${C}--with-conduit              Build with conduit interface
   ${C}--ninja                     Generate ninja files instead of makefiles
   ${C}--ninja-processes${N} <val> Number of parallel processes for ninja.
+  ${C}--nvshmem${N}               Enable NVSHMEM
 EOF
 }
 
@@ -269,6 +273,9 @@ while :; do
             ;;
         --reconfigure)
             RECONFIGURE=1
+            ;;
+        --nvshmem)
+            WITH_NVSHMEM=1
             ;;
         -?*)
             # Unknown option
@@ -442,6 +449,16 @@ fi
 CXX_FLAGS="${CXX_FLAGS} -ldl"
 C_FLAGS="${CXX_FLAGS}"
 
+# Hacks to build with NVSHMEM
+if [ ${WITH_NVSHMEM} -ne 0 ]; then
+    if [ "${CLUSTER}" == "lassen" ]; then
+        NVSHMEM_DIR=/usr/workspace/wsb/brain/nvshmem/nvshmem_0.3.3/cuda-10.1_ppc64le
+        CUDA_FLAGS="-gencode=arch=compute_70,code=sm_70"
+    else
+        echo "NVSHMEM is currently only supported on Lassen"
+        exit 1
+    fi
+fi
 
 # Set environment variables
 CC=${C_COMPILER}
@@ -782,6 +799,7 @@ cmake \
 -D LBANN_SB_BUILD_LBANN=ON \
 -D CMAKE_CXX_FLAGS="${CXX_FLAGS}" \
 -D CMAKE_C_FLAGS="${C_FLAGS}" \
+-D CMAKE_CUDA_FLAGS="${CUDA_FLAGS}" \
 -D CMAKE_C_COMPILER=${C_COMPILER} \
 -D CMAKE_CXX_COMPILER=${CXX_COMPILER} \
 -D CMAKE_Fortran_COMPILER=${Fortran_COMPILER} \
@@ -798,6 +816,8 @@ cmake \
 -D LBANN_CONDUIT_DIR=${CONDUIT_DIR} \
 -D LBANN_BUILT_WITH_SPECTRUM=${WITH_SPECTRUM} \
 -D OPENBLAS_ARCH_COMMAND=${OPENBLAS_ARCH} \
+-D LBANN_WITH_NVSHMEM=${WITH_NVSHMEM} \
+-D LBANN_SB_FWD_LBANN_NVSHMEM_DIR=${NVSHMEM_DIR} \
 ${SUPERBUILD_DIR}
 EOF
 )

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -48,6 +48,9 @@
 #ifdef LBANN_HAS_PYTHON
 #include "lbann/utils/python.hpp"
 #endif
+#ifdef LBANN_HAS_NVSHMEM
+#include "lbann/utils/nvshmem.hpp"
+#endif
 
 #include <iostream>
 #include <string>
@@ -93,14 +96,26 @@ world_comm_ptr initialize(int& argc, char**& argv, int seed) {
   }
   hwloc_topology_destroy(topo);
 #endif
+
   // Initialize local random number generators.
   init_random(seed);
   init_data_seq_random(seed);
+
+#ifdef LBANN_HAS_NVSHMEM
+  // Initialize NVSHMEM
+  // tym (3/3/20): I get an error when initializing NVSHMEM with
+  // anything other than MPI_COMM_WORLD.
+  // nvshmem::initialize(comm->get_trainer_comm().GetMPIComm()); /// @todo Restore
+  nvshmem::initialize(MPI_COMM_WORLD);
+#endif // LBANN_HAS_NVSHMEM
 
   return comm;
 }
 
 void finalize(lbann_comm* comm) {
+#ifdef LBANN_HAS_NVSHMEM
+  nvshmem::finalize();
+#endif // LBANN_HAS_NVSHMEM
   MPI_Errhandler_free( &err_handle );
 #ifdef LBANN_HAS_CUDNN
   cudnn::destroy();

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
   argument_parser.cpp
@@ -32,6 +33,7 @@ if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
     cuda.cu
+    nvshmem.cu
     )
 endif ()
 

--- a/src/utils/nvshmem.cu
+++ b/src/utils/nvshmem.cu
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/nvshmem.hpp"
+#ifdef LBANN_HAS_NVSHMEM
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+namespace nvshmem {
+
+void initialize(MPI_Comm comm) {
+  nvshmemx_init_attr_t attr;
+  attr.mpi_comm = &comm;
+  auto status = nvshmemx_init_attr(NVSHMEMX_INIT_WITH_MPI_COMM, &attr);
+  if (status != 0) {
+    nvshmem_finalize();
+    LBANN_ERROR("failed to initialize NVSHMEM (status ",status,")");
+  }
+}
+
+void finalize() {
+  nvshmem_finalize();
+}
+
+} // namespace nvshmem
+} // namespace lbann
+
+#endif // LBANN_HAS_NVSHMEM

--- a/src/utils/nvshmem.cu
+++ b/src/utils/nvshmem.cu
@@ -36,7 +36,6 @@ void initialize(MPI_Comm comm) {
   attr.mpi_comm = &comm;
   auto status = nvshmemx_init_attr(NVSHMEMX_INIT_WITH_MPI_COMM, &attr);
   if (status != 0) {
-    nvshmem_finalize();
     LBANN_ERROR("failed to initialize NVSHMEM (status ",status,")");
   }
 }


### PR DESCRIPTION
This PR adds CMake options to build LBANN with NVSHMEM (`LBANN_WITH_NVSHMEM` and `NVSHMEM_DIR`). If you are on Lassen, you can run `build_lbann_lc.sh` has the `--nvshmem` flag. If LBANN is built with NVSHMEM, it will be initialized/finalized inside `lbann::initialize`/`lbann::finalize`.

[Bamboo is green, aside from an integration test failure that is also in `develop`](https://lc.llnl.gov/bamboo/browse/LBANN-TIM270-1).