### PR TITLE
Bump minimum CMake version to 3.13.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13)
 
 project(LBANN CXX)
 


### PR DESCRIPTION
3.12 had a bug with nvcc and -pthread, which caused a problem with
Distconv. See CMake issue #18008.