### PR TITLE
Add ParallelStrategy to Layer.

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -83,6 +83,73 @@ namespace callback {
 class sync_layers;
 } // namespace callback
 
+/** Represents a parallel strategy for a layer. */
+struct ParallelStrategy {
+  /** Number of process groups the sample dimension is split over. */
+  int sample_groups = 0;
+  /** Number of groups the sample dimension is split over. */
+  int sample_splits = 0;
+  /** Number of process groups the depth dimension is split over. */
+  int depth_groups = 0;
+  /** Number of groups the depth dimension is split over. */
+  int depth_splits = 0;
+  /** Number of process groups the height dimension is split over. */
+  int height_groups = 0;
+  /** Number of groups the height dimension is split over. */
+  int height_splits = 0;
+  /** Number of process groups the width dimension is split over. */
+  int width_groups = 0;
+  /** Number of groups the width dimension is split over. */
+  int width_splits = 0;
+  /** Number of process groups the channel dimension is split over. */
+  int channel_groups = 0;
+  /** Number of groups the channel dimension is split over. */
+  int channel_splits = 0;
+  /** Number of process groups the filter dimension is split over. */
+  int filter_groups = 0;
+  /** Number of groups the filter dimension is split over. */
+  int filter_splits = 0;
+  /** Number of times the layer is replicated (for FC layers right now). */
+  int replications = 0;
+  bool operator==(const ParallelStrategy &ps) const {
+    return sample_groups == ps.sample_groups &&
+        sample_splits == ps.sample_splits &&
+        depth_groups == ps.depth_groups &&
+        depth_splits == ps.depth_splits &&
+        height_groups == ps.height_groups &&
+        height_splits == ps.height_splits &&
+        width_groups == ps.width_groups &&
+        width_splits == ps.width_splits &&
+        channel_groups == ps.channel_groups &&
+        channel_splits == ps.channel_splits &&
+        filter_groups == ps.filter_groups &&
+        filter_splits == ps.filter_splits &&
+        replications == ps.replications;
+  }
+  bool operator!=(const ParallelStrategy &ps) const {
+    return !(*this == ps);
+  }
+};
+
+inline std::ostream &operator<<(std::ostream &os,
+                                const ParallelStrategy &ps) {
+  os << "{" << ps.sample_groups
+     << "/" << ps.sample_splits
+     << ", " << ps.depth_groups
+     << "/" << ps.depth_splits
+     << ", " << ps.height_groups
+     << "/" << ps.height_splits
+     << ", " << ps.width_groups
+     << "/" << ps.width_splits
+     << ", " << ps.channel_groups
+     << "/" << ps.channel_splits
+     << ", " << ps.filter_groups
+     << "/" << ps.filter_splits
+     << ", " << ps.replications
+     << "}";
+  return os;
+}
+
 /**
  * @brief Neural network tensor operation.
  *
@@ -140,6 +207,15 @@ public:
 
   /** Human-readable description. */
   virtual description get_description() const;
+
+  /** Get the parallel strategy for the layer. */
+  inline ParallelStrategy& get_parallel_strategy() {
+    return m_parallel_strategy;
+  }
+  /** Get the parallel strategy for the layer. */
+  const ParallelStrategy& get_parallel_strategy() const {
+    return m_parallel_strategy;
+  }
 
   /** Forward propagation step.
    *  Apply a mathematical operation to input tensors to obtain output
@@ -501,6 +577,9 @@ private:
    *  more elaborate setup based on the hint layer.
    */
   const Layer* m_hint_layer = nullptr;
+
+  /** Parallel strategy for the layer. */
+  ParallelStrategy m_parallel_strategy;
 
 private:
   friend std::vector<const weights*> extract_weights(Layer const& l);

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -20,6 +20,7 @@ class Layer(abc.ABC):
         data_layout (str, optional): Data distribution scheme.
         datatype (lbann.DataType, optional): Data type used for activations and weights.
         hint_layer (Layer, optional): Hint for output dimensions.
+        parallel_strategy (dictionary, optional): Data partitioning scheme.
 
     """
 
@@ -34,7 +35,8 @@ class Layer(abc.ABC):
                  device=None,
                  data_layout=None,
                  datatype=None,
-                 hint_layer=None):
+                 hint_layer=None,
+                 parallel_strategy={}):
         Layer.global_count += 1
         self.parents = []
         self.children = []
@@ -44,6 +46,7 @@ class Layer(abc.ABC):
         self.data_layout = data_layout
         self.datatype = datatype
         self.hint_layer = hint_layer
+        self.parallel_strategy = parallel_strategy
 
         # Initialize parents, children, and weights
         for arg in args:
@@ -67,6 +70,8 @@ class Layer(abc.ABC):
             proto.datatype = self.datatype
         if self.hint_layer:
             proto.hint_layer = self.hint_layer.name
+        for k, v in self.parallel_strategy.items():
+            setattr(proto.parallel_strategy, k, v)
         return proto
 
     def add_parent(self, parent):
@@ -101,11 +106,11 @@ classes = lbann.core.util.generate_classes_from_protobuf_message(
     skip_fields = set([
         'name', 'parents', 'children', 'data_layout', 'device_allocation', 'datatype',
         'weights', 'num_neurons_from_data_reader', 'freeze', 'hint_layer',
-        'weights_data', 'top', 'bottom', 'type', 'motif_layer']),
+        'parallel_strategy', 'weights_data', 'top', 'bottom', 'type', 'motif_layer']),
     base_class = Layer,
     base_kwargs = set([
         'parents', 'children', 'weights',
-        'name', 'device', 'data_layout', 'datatype', 'hint_layer']),
+        'name', 'device', 'data_layout', 'datatype', 'hint_layer', 'parallel_strategy']),
     base_has_export_proto = True)
 for c in classes:
     globals()[c.__name__] = c

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -216,6 +216,22 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
 
 #undef TEMPLATE_INSTANTIATION
 
+    // Set up parallel strategy.
+    ParallelStrategy& ps = l->get_parallel_strategy();
+    ps.sample_groups = proto_layer.parallel_strategy().sample_groups();
+    ps.sample_splits = proto_layer.parallel_strategy().sample_splits();
+    ps.height_groups = proto_layer.parallel_strategy().height_groups();
+    ps.height_splits = proto_layer.parallel_strategy().height_splits();
+    ps.width_groups = proto_layer.parallel_strategy().width_groups();
+    ps.width_splits = proto_layer.parallel_strategy().width_splits();
+    ps.channel_groups = proto_layer.parallel_strategy().channel_groups();
+    ps.channel_splits = proto_layer.parallel_strategy().channel_splits();
+    ps.filter_groups = proto_layer.parallel_strategy().filter_groups();
+    ps.filter_splits = proto_layer.parallel_strategy().filter_splits();
+    ps.replications = proto_layer.parallel_strategy().replications();
+    ps.depth_groups = proto_layer.parallel_strategy().depth_groups();
+    ps.depth_splits = proto_layer.parallel_strategy().depth_splits();
+
     // Check that layer has been constructed
     if (l == nullptr) {
       err << "could not construct layer " << name;

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -47,6 +47,7 @@ message Layer {
   bool num_neurons_from_data_reader = 53;
   bool freeze = 5;
   string hint_layer = 56;
+  ParallelStrategy parallel_strategy = 58;
 
   repeated WeightsData weights_data = 153;
   string top = 154;
@@ -718,4 +719,25 @@ message WeightsData {
   repeated float data = 4 [packed=true];
 
   Imcomm imcomm = 55;
+}
+
+//========================================================================
+// Parallel strategies for generalized layer-wise parallelism
+//========================================================================
+message ParallelStrategy {
+  int64 sample_groups = 1;
+  int64 sample_splits = 2;
+  int64 height_groups = 3;
+  int64 height_splits = 4;
+  int64 width_groups = 5;
+  int64 width_splits = 6;
+  int64 channel_groups = 7;
+  int64 channel_splits = 8;
+  int64 filter_groups = 9;
+  int64 filter_splits = 10;
+  // For fully-connected layers.
+  int64 replications = 11;
+  int64 procs_per_replica = 12;
+  int64 depth_groups = 13;
+  int64 depth_splits = 14;
 }


### PR DESCRIPTION
Describes how layer input and output tensors should be partitioned. It
is currently just ignored.