### PR TITLE
Lbann inf load model

### DIFF
--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -79,11 +79,13 @@ int main(int argc, char *argv[]) {
     // Load layer weights from checkpoint if checkpoint directory given
     if(opts->has_string("ckpt_dir")){
       for(auto&& m : models) {
-        bool loaded = callback::load_model::load_model_weights(
-          opts->get_string("ckpt_dir"),
-          m.get(),
-          opts->get_bool("ckptdir_is_fullpath"));
-        if(!loaded)  LBANN_ERROR("Unable to reload model");
+        auto&& dirs = parse_list<std::string>(opts->get_string("ckpt_dir"));
+        for(auto&& d : dirs) { //load file from each (space limited) directory
+          bool loaded = callback::load_model::load_model_weights(d,
+               m.get(),
+               opts->get_bool("ckptdir_is_fullpath"));
+           if(!loaded)  LBANN_ERROR("Unable to reload model");
+        }
       }
     }else {
       LBANN_ERROR("Unable to reload model");

--- a/src/callbacks/load_model.cpp
+++ b/src/callbacks/load_model.cpp
@@ -46,7 +46,8 @@ namespace callback {
 
 void load_model::on_train_begin(model *m) {
   for (const auto& d : m_dirs) {
-    load_model_weights(d, m, true);
+    bool loaded = load_model_weights(d, m, true);
+    if(!loaded)  LBANN_ERROR("Unable to reload model");
   }
 }
 


### PR DESCRIPTION
1. Extend lbann_inf to support loading pretrained models from multiple directories
2. Improve error reporting in load model callback, in particular, trainer should exit if model to load doesn't exist.