### PR TITLE
Add option in Python frontend for custom executable

### DIFF
--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -1,5 +1,5 @@
 import os, os.path
-from lbann import lbann_exe
+import lbann
 import lbann.launcher
 import lbann.contrib.lc.launcher
 import lbann.contrib.lc.systems
@@ -10,6 +10,7 @@ def run(
     model,
     data_reader,
     optimizer,
+    lbann_exe=lbann.lbann_exe(),
     lbann_args=[],
     overwrite_script=False,
     setup_only=False,
@@ -38,7 +39,7 @@ def run(
     script.add_command('echo "Started at $(date)"')
 
     # Batch script invokes LBANN
-    lbann_command = [lbann.lbann_exe()]
+    lbann_command = [lbann_exe]
     lbann_command.extend(make_iterable(lbann_args))
     prototext_file = os.path.join(script.work_dir, 'experiment.prototext')
     lbann.proto.save_prototext(prototext_file,

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -22,6 +22,7 @@ def run(trainer, model, data_reader, optimizer,
         account=None,
         reservation=None,
         launcher_args=[],
+        lbann_exe=lbann.lbann_exe(),
         lbann_args=[],
         environment={},
         overwrite_script=False,
@@ -57,6 +58,7 @@ def run(trainer, model, data_reader, optimizer,
         reservation (str, optional): Scheduler reservation name.
         launcher_args (str, optional): Command-line arguments to
             launcher.
+        lbann_exe (str, optional): LBANN executable.
         lbann_args (str, optional): Command-line arguments to LBANN
             executable.
         environment (dict of {str: str}, optional): Environment
@@ -101,7 +103,7 @@ def run(trainer, model, data_reader, optimizer,
     script.add_command('echo "Started at $(date)"')
 
     # Batch script invokes LBANN
-    lbann_command = [lbann.lbann_exe()]
+    lbann_command = [lbann_exe]
     lbann_command.extend(make_iterable(lbann_args))
     prototext_file = os.path.join(script.work_dir, 'experiment.prototext')
     lbann.proto.save_prototext(prototext_file,


### PR DESCRIPTION
This is a convenience for users to launch `lbann_inf` and the other custom drivers via the [`lbann.run`](https://github.com/LLNL/lbann/blob/f706d56a6cf9b67c4b2853fd6d6acc7cbe7e66cd/python/lbann/launcher/__init__.py#L14) function.

Once experiments become sufficiently complicated (e.g. launching LBANN multiple times or running post-processing on results), I would recommend calling [`lbann.launcher.make_batch_script`](https://github.com/LLNL/lbann/blob/f706d56a6cf9b67c4b2853fd6d6acc7cbe7e66cd/python/lbann/launcher/__init__.py#L130) and using the [`BatchScript` class](https://github.com/LLNL/lbann/blob/f706d56a6cf9b67c4b2853fd6d6acc7cbe7e66cd/python/lbann/launcher/batch_script.py#L6) (there is also [`lbann.contrib.launcher.make_batch_script`](https://github.com/LLNL/lbann/blob/f706d56a6cf9b67c4b2853fd6d6acc7cbe7e66cd/python/lbann/contrib/launcher.py#L67) with system-specific defaults). 

[Here is the Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM271-1). So far it's passing on Catalyst and it has the same failure on Ray as the weekly build. I don't think it's introducing any errors.