### PR TITLE
Add --ntasks-per-node to srun invocation in Python frontend

### DIFF
--- a/python/lbann/launcher/slurm.py
+++ b/python/lbann/launcher/slurm.py
@@ -115,11 +115,22 @@ class SlurmBatchScript(BatchScript):
             nodes = self.nodes
         if procs_per_node is None:
             procs_per_node = self.procs_per_node
+
+        # srun invocation
+        # Note: When running within a salloc allocation, some srun
+        # arguments are overloaded by the salloc arguments. We add
+        # some redundant arguments to make sure srun launches
+        # correctly.
         args = [launcher]
         args.extend(make_iterable(launcher_args))
         args.append('--nodes={}'.format(nodes))
         args.append('--ntasks={}'.format(nodes * procs_per_node))
+        args.append('--ntasks-per-node={}'.format(procs_per_node))
+
+        # LBANN invocation
         args.extend(make_iterable(command))
+
+        # Add to batch script
         self.add_command(args)
 
     def submit(self, overwrite=False):


### PR DESCRIPTION
This is intended to fix some possible errors when LBANN is launched within a SLURM allocation. Arguments passed to salloc sometimes override arguments to srun (according to [this bug report](https://bugs.schedmd.com/show_bug.cgi?id=1543)), so we pass `--ntasks-per-node` redundantly to make sure srun launches with the right parameters.

See the [Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM273-1).