### PR TITLE
Check labels in image data reader

### DIFF
--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -119,15 +119,13 @@ void image_data_reader::set_input_params(const int width, const int height, cons
 
 bool image_data_reader::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
   const label_t label = m_image_list[data_id].second;
-  if (label >= 0 && label < m_num_labels) {
-    Y.Set(label, mb_idx, 1);
-  }
-  else {
+  if (label < label_t{0} || label >= static_cast<label_t>(m_num_labels)) {
     LBANN_ERROR(
       "\"",this->get_type(),"\" data reader ",
       "expects data with ",m_num_labels," labels, ",
       "but data sample ",data_id," has a label of ",label);
   }
+  Y.Set(label, mb_idx, 1);
   return true;
 }
 

--- a/src/data_readers/data_reader_image.cpp
+++ b/src/data_readers/data_reader_image.cpp
@@ -119,7 +119,15 @@ void image_data_reader::set_input_params(const int width, const int height, cons
 
 bool image_data_reader::fetch_label(CPUMat& Y, int data_id, int mb_idx) {
   const label_t label = m_image_list[data_id].second;
-  Y.Set(label, mb_idx, 1);
+  if (label >= 0 && label < m_num_labels) {
+    Y.Set(label, mb_idx, 1);
+  }
+  else {
+    LBANN_ERROR(
+      "\"",this->get_type(),"\" data reader ",
+      "expects data with ",m_num_labels," labels, ",
+      "but data sample ",data_id," has a label of ",label);
+  }
   return true;
 }
 
@@ -209,12 +217,12 @@ void image_data_reader::do_preload_data_store() {
     load_conduit_nodes_from_file(data_ids[io_thread_pool->get_local_thread_id()]);
     io_thread_pool->finish_work_group();
   }
-  
+
   else {
     conduit::Node node;
     if (is_master()) {
       std::cout << "mode: NOT data_store_thread\n";
-    }  
+    }
     for (size_t data_id=0; data_id<m_shuffled_indices.size(); data_id++) {
       int index = m_shuffled_indices[data_id];
       if (m_data_store->get_index_owner(index) != rank) {


### PR DESCRIPTION
Issue #1448 was caused because the ImageNet data reader expected samples with 1000 labels, but got a label outside the valid range. This PR adds a check so that this error results in an informative error message rather than a segfault.

[Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM274-1).