### PR TITLE
Add a warning to the documentation for IBV_FORK_SAFE

### DIFF
--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -209,7 +209,7 @@ for a list of available preprocessing transforms.
              that doesn't interact with Infiniband all that well by
              default. Users may encounter hangs on clusters that use
              Infiniband. To avoid this, ensure that
-             :code:`IBV_FORK_SAFE=1` is exported into the environment
+             :bash:`IBV_FORK_SAFE=1` is exported into the environment
              when running LBANN.
 
 ------------------------------------------------

--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -205,10 +205,10 @@ consistent and some preprocessing is typically required. See
 <https://github.com/LLNL/lbann/blob/develop/src/proto/transforms.proto>`_
 for a list of available preprocessing transforms.
 
-.. warning:: The python data reader will trigger some process forking
-             that doesn't interact with Infiniband all that well by
+.. warning:: The Python data reader will trigger some process forking
+             that doesn't interact with InfiniBand all that well by
              default. Users may encounter hangs on clusters that use
-             Infiniband. To avoid this, ensure that
+             InfiniBand. To avoid this, ensure that
              :bash:`IBV_FORK_SAFE=1` is exported into the environment
              when running LBANN.
 

--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -205,6 +205,13 @@ consistent and some preprocessing is typically required. See
 <https://github.com/LLNL/lbann/blob/develop/src/proto/transforms.proto>`_
 for a list of available preprocessing transforms.
 
+.. warning:: The python data reader will trigger some process forking
+             that doesn't interact with Infiniband all that well by
+             default. Users may encounter hangs on clusters that use
+             Infiniband. To avoid this, ensure that
+             :code:`IBV_FORK_SAFE=1` is exported into the environment
+             when running LBANN.
+
 ------------------------------------------------
 Python frontend
 ------------------------------------------------


### PR DESCRIPTION
Since I'm _sure_ all our users meticulously comb through our documentation before punching more-or-less arbitrary strings into their terminal, I figured I'd at least give us some future protection, however theoretical, from encountering issues related to `IBV_FORK_SAFE` and the Python data reader.