### PR TITLE
Fix layer freezing

### DIFF
--- a/include/lbann/layers/learning/fully_connected.hpp
+++ b/include/lbann/layers/learning/fully_connected.hpp
@@ -212,7 +212,7 @@ protected:
 
     // Initialize freeze state
     for (auto&& w : this->get_data_type_weights()) {
-      if (this->is_frozen()) {
+      if (this->m_frozen) {
         w->freeze();
       } else {
         w->unfreeze();

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -492,6 +492,9 @@ void data_type_layer<TensorDataType>::replace_weights(Layer* other_layer) {
   const std::vector<WeightsType*>& other_layer_weights =
     dynamic_cast<data_type_layer<TensorDataType>*>(other_layer)->get_data_type_weights();
   for (size_t i = 0; i < m_weights.size(); ++i) {
+    if (m_weights[i] == nullptr) {
+      continue;
+    }
     m_weights[i]->set_values(other_layer_weights[i]->get_values());
   }
 

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -492,10 +492,9 @@ void data_type_layer<TensorDataType>::replace_weights(Layer* other_layer) {
   const std::vector<WeightsType*>& other_layer_weights =
     dynamic_cast<data_type_layer<TensorDataType>*>(other_layer)->get_data_type_weights();
   for (size_t i = 0; i < m_weights.size(); ++i) {
-    if (m_weights[i] == nullptr) {
-      continue;
+    if (m_weights[i]) {
+      m_weights[i]->set_values(other_layer_weights[i]->get_values());
     }
-    m_weights[i]->set_values(other_layer_weights[i]->get_values());
   }
 
 }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -358,7 +358,8 @@ void Layer::unfreeze() {
 bool Layer::is_frozen() const {
   for(auto& w : get_weights()) {
     if (w->is_frozen() != m_frozen) {
-      LBANN_ERROR("layer and weights of them are inconsistently frozen");
+      LBANN_ERROR("layer ", get_name(), " and weight ", w->get_name(), \
+                  " of it are inconsistently frozen");
     }
   }
   return m_frozen;

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -219,7 +219,7 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 
   // Initialize freeze state
   for (auto&& w : this->get_data_type_weights()) {
-    if (this->is_frozen()) {
+    if (this->m_frozen) {
       w->freeze();
     } else {
       w->unfreeze();


### PR DESCRIPTION
- This addresses the issue of inconsistently frozen layer and its weight (reported in the issue #1474).
This occurs during `setup_data()` of the recently refactored fully connected layers.
Basically, the issue is the misuse of `is_frozen()` interface which checks if the layer and its weights are consistently frozen/unfrozen. This has been used during the setup to freeze newly created weights of a frozen layer (i.e., before they are frozen). 
- Another issue that this PR addresses is checking weight pointer for _nullptr_ in `replace_weights` in `data_type_layer`.
- This passed the bamboo tests on _pascal_. However, it fails with `test_compiler_build_script` on _ray_ although I can build/run it myself on _ray_ and _lassen_.