### PR TITLE
Python frontend launcher will launch interactive job by default

### DIFF
--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -308,10 +308,9 @@ A typical workflow involves the following steps:
 
 5. Launching LBANN by calling :python:`run`.
 
-   + :python:`lbann.run` will detect whether the user is currently on
-     a login node or a compute node. If on a login node, a batch job
-     will be submitted to the job scheduler. If on a compute node,
-     LBANN will be run directly on the allocated nodes.
+   + :python:`lbann.run` should be run from a compute node. If a node
+     allocation is not available, the :python:`batch_job` option can
+     be set to submit a batch job to the scheduler.
 
    + A timestamped work directory will be created each time LBANN is
      run. The default location of these work directories can be set

--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -14,6 +14,7 @@ def run(
     lbann_args=[],
     overwrite_script=False,
     setup_only=False,
+    batch_job=False,
     *args,
     **kwargs,
 ):
@@ -27,13 +28,6 @@ def run(
 
     # Create batch script generator
     script = make_batch_script(*args, **kwargs)
-
-    # Check for an existing job allocation
-    has_allocation = False
-    if isinstance(script, lbann.launcher.slurm.SlurmBatchScript):
-        has_allocation = 'SLURM_JOB_ID' in os.environ
-    if isinstance(script, lbann.launcher.lsf.LSFBatchScript):
-        has_allocation = 'LSB_JOBID' in os.environ
 
     # Batch script prints start time
     script.add_command('echo "Started at $(date)"')
@@ -59,10 +53,10 @@ def run(
     status = 0
     if setup_only:
         script.write(overwrite=overwrite_script)
-    elif has_allocation:
-        status = script.run(overwrite=overwrite_script)
-    else:
+    elif batch_job:
         status = script.submit(overwrite=overwrite_script)
+    else:
+        status = script.run(overwrite=overwrite_script)
     return status
 
 def make_batch_script(*args, **kwargs):

--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -21,8 +21,6 @@ def make_batch_script(
     system=system(),
     procs_per_node=procs_per_node(),
     scheduler=scheduler(),
-    partition=partition(),
-    account=account(),
     launcher_args=[],
     environment={},
     *args,
@@ -120,8 +118,6 @@ def make_batch_script(
     return lbann.launcher.make_batch_script(
         procs_per_node=procs_per_node,
         scheduler=scheduler,
-        partition=partition,
-        account=account,
         launcher_args=launcher_args,
         environment=environment,
         *args,

--- a/python/lbann/contrib/lc/systems.py
+++ b/python/lbann/contrib/lc/systems.py
@@ -8,24 +8,22 @@ import re
 
 class SystemParams:
     """Simple data structure to describe an LC system."""
-    def __init__(self,
-                 cores_per_node, gpus_per_node,
-                 scheduler, partition, account):
+    def __init__(self, cores_per_node, gpus_per_node, scheduler):
         self.cores_per_node = cores_per_node
         self.gpus_per_node = gpus_per_node
         self.scheduler = scheduler
-        self.partition = partition
-        self.account = account
 
 # Supported LC systems
-_system_params = {'catalyst': SystemParams(24, 0, 'slurm', 'pbatch', 'brain'),
-                  'corona':  SystemParams(24, 0, 'slurm', 'pbatch', None),
-                  'pascal':   SystemParams(36, 2, 'slurm', 'pbatch', 'lc'),
-                  'quartz':   SystemParams(36, 0, 'slurm', 'pbatch', 'brain'),
-                  'surface':  SystemParams(16, 2, 'slurm', 'pbatch', 'hpclearn'),
-                  'lassen':   SystemParams(44, 4, 'lsf', 'pbatch', None),
-                  'ray':      SystemParams(40, 4, 'lsf', 'pbatch', None),
-                  'sierra':   SystemParams(44, 4, 'lsf', 'pbatch', None)}
+_system_params = {
+    'catalyst': SystemParams(24, 0, 'slurm'),
+    'corona':   SystemParams(24, 0, 'slurm'),
+    'pascal':   SystemParams(36, 2, 'slurm'),
+    'quartz':   SystemParams(36, 0, 'slurm'),
+    'surface':  SystemParams(16, 2, 'slurm'),
+    'lassen':   SystemParams(44, 4, 'lsf'),
+    'ray':      SystemParams(40, 4, 'lsf'),
+    'sierra':   SystemParams(44, 4, 'lsf'),
+}
 
 # Detect system
 _system = re.sub(r'\d+', '', socket.gethostname())
@@ -70,21 +68,11 @@ def scheduler(system = system()):
         raise RuntimeError('unknown system (' + system + ')')
     return _system_params[system].scheduler
 
-def partition(system = system()):
-    """Default scheduler partition."""
-    if not is_lc_system(system):
-        raise RuntimeError('unknown system (' + system + ')')
-    return _system_params[system].partition
-
-def account(system = system()):
-    """Default scheduler account."""
-    if not is_lc_system(system):
-        raise RuntimeError('unknown system (' + system + ')')
-    return _system_params[system].account
-
 def procs_per_node(system = system()):
     """Default number of processes per node."""
     if has_gpu(system):
         return gpus_per_node(system)
     else:
+        # Catalyst and Quartz have 2 sockets per node
+        ### @todo Think of a smarter heuristic
         return 2

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -68,13 +68,12 @@ def run(trainer, model, data_reader, optimizer,
             file if it already exists.
         setup_only (bool, optional): If true, the experiment is not
             run after the experiment directory is initialized.
+        batch_job (bool, optional): If true, the experiment is
+            submitted to the scheduler as a batch job.
         experiment_dir (str, optional, deprecated): See `work_dir`.
 
     Returns:
-        int: Exit status from scheduler. This is really only
-            meaningful if LBANN is run on an existing node
-            allocation. If a batch job is submitted, the scheduler
-            will probably return 0 trivially.
+        int: Exit status.
 
     """
 
@@ -113,7 +112,7 @@ def run(trainer, model, data_reader, optimizer,
     script.add_command('echo "Finished at $(date)"')
     script.add_command('exit ${status}')
 
-    # Write, run, or submit batch script
+    # Write, submit, or run batch script
     status = 0
     if setup_only:
         script.write(overwrite=overwrite_script)

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -27,6 +27,7 @@ def run(trainer, model, data_reader, optimizer,
         environment={},
         overwrite_script=False,
         setup_only=False,
+        batch_job=False,
         experiment_dir=None):
     """Run LBANN.
 
@@ -92,13 +93,6 @@ def run(trainer, model, data_reader, optimizer,
                                launcher_args=launcher_args,
                                environment=environment)
 
-    # Check for an existing job allocation
-    has_allocation = False
-    if isinstance(script, lbann.launcher.slurm.SlurmBatchScript):
-        has_allocation = 'SLURM_JOB_ID' in os.environ
-    if isinstance(script, lbann.launcher.lsf.LSFBatchScript):
-        has_allocation = 'LSB_JOBID' in os.environ
-
     # Batch script prints start time
     script.add_command('echo "Started at $(date)"')
 
@@ -123,10 +117,10 @@ def run(trainer, model, data_reader, optimizer,
     status = 0
     if setup_only:
         script.write(overwrite=overwrite_script)
-    elif has_allocation:
-        status = script.run(overwrite=overwrite_script)
-    else:
+    elif batch_job:
         status = script.submit(overwrite=overwrite_script)
+    else:
+        status = script.run(overwrite=overwrite_script)
     return status
 
 def make_batch_script(script_file=None,

--- a/python/lbann/launcher/lsf.py
+++ b/python/lbann/launcher/lsf.py
@@ -53,47 +53,36 @@ class LSFBatchScript(BatchScript):
                          interpreter=interpreter)
         self.nodes = nodes
         self.procs_per_node = procs_per_node
+        self.reservation = reservation
         self.launcher = launcher
         self.launcher_args = launcher_args
 
         # Configure header with LSF job options
-        self._construct_header(job_name=job_name,
-                               nodes=self.nodes,
-                               time_limit=time_limit,
-                               partition=partition,
-                               account=account,
-                               reservation=reservation)
-
-    def _construct_header(self,
-                          job_name=None,
-                          nodes=1,
-                          time_limit=None,
-                          partition=None,
-                          account=None,
-                          reservation=None):
-        """Construct script header with options for bsub."""
-        if job_name:
-            self.add_header_line('#BSUB -J {}'.format(job_name))
-        if partition:
-            self.add_header_line('#BSUB -q {}'.format(partition))
-        self.add_header_line('#BSUB -nnodes {}'.format(nodes))
+        self.add_header_line(f'#BSUB -cwd {self.work_dir}')
+        self.add_header_line(f'#BSUB -o {self.out_log_file}')
+        self.add_header_line(f'#BSUB -e {self.err_log_file}')
+        self.add_header_line(f'#BSUB -nnodes {nodes}')
         if time_limit:
-            hours, minutes = divmod(int(time_limit), 60)
-            self.add_header_line('#BSUB -W {}:{:02d}'.format(hours, minutes))
-        self.add_header_line('#BSUB -cwd {}'.format(self.work_dir))
-        self.add_header_line('#BSUB -o {}'.format(self.out_log_file))
-        self.add_header_line('#BSUB -e {}'.format(self.err_log_file))
+            minutes = int(round(max(time_limit, 0)))
+            hours, minutes = divmod(minutes, 60)
+            self.add_header_line(f'#BSUB -W {hours}:{minutes:02}')
+        if job_name:
+            self.add_header_line(f'#BSUB -J {job_name}')
+        if partition:
+            self.add_header_line(f'#BSUB -q {partition}')
         if account:
-            self.add_header_line('#BSUB -G {}'.format(account))
-        if reservation:
-            self.add_header_line('#BSUB -U {}'.format(reservation))
+            self.add_header_line(f'#BSUB -G {account}')
+        if self.reservation:
+            self.add_header_line(f'#BSUB -U {self.reservation}')
 
     def add_parallel_command(self,
                              command,
-                             launcher=None,
-                             launcher_args=None,
+                             work_dir=None,
                              nodes=None,
-                             procs_per_node=None):
+                             procs_per_node=None,
+                             reservation=None,
+                             launcher=None,
+                             launcher_args=None):
         """Add command to be executed in parallel.
 
         The command is launched with jsrun. Parallel processes are
@@ -102,32 +91,47 @@ class LSFBatchScript(BatchScript):
         Args:
             command (`str` or `Iterable` of `str`s): Command to be
                 executed in parallel.
-            launcher (str, optional): jsrun executable.
-            launcher_args (`Iterable` of `str`s, optional):
-                Command-line arguments to jsrun.
+            work_dir (str, optional): Working directory.
             nodes (int, optional): Number of compute nodes.
             procs_per_node (int, optional): Number of parallel
                 processes per compute node.
+            reservation (str, optional): Scheduler advance reservation.
+            launcher (str, optional): jsrun executable.
+            launcher_args (`Iterable` of `str`s, optional):
+                Command-line arguments to jsrun.
 
         """
-        if launcher is None:
-            launcher = self.launcher
-        if launcher_args is None:
-            launcher_args = self.launcher_args
+
+        # Use default values if needed
+        if work_dir is None:
+            work_dir = self.work_dir
         if nodes is None:
             nodes = self.nodes
         if procs_per_node is None:
             procs_per_node = self.procs_per_node
+        if reservation is None:
+            reservation = self.reservation
+        if launcher is None:
+            launcher = self.launcher
+        if launcher_args is None:
+            launcher_args = self.launcher_args
+
+        # Construct jsrun invocation
         args = [launcher]
         args.extend(make_iterable(launcher_args))
-        args.extend([
-            '--nrs {}'.format(nodes),
-            '--rs_per_host 1',
-            '--tasks_per_rs {}'.format(procs_per_node),
-            '--launch_distribution packed',
-            '--cpu_per_rs ALL_CPUS',
-            '--gpu_per_rs ALL_GPUS',
-        ])
+        args.append(f'--chdir {work_dir}')
+        if reservation:
+            args.append(f'--use_reservation {reservation}')
+            args.append(f'--np {nodes * procs_per_node}')
+        else:
+            args.extend([
+                f'--nrs {nodes}',
+                '--rs_per_host 1',
+                f'--tasks_per_rs {procs_per_node}',
+                '--launch_distribution packed',
+                '--cpu_per_rs ALL_CPUS',
+                '--gpu_per_rs ALL_GPUS',
+            ])
         args.extend(make_iterable(command))
         self.add_command(args)
 

--- a/python/lbann/launcher/slurm.py
+++ b/python/lbann/launcher/slurm.py
@@ -139,6 +139,7 @@ class SlurmBatchScript(BatchScript):
         args.append(f'--chdir={work_dir}')
         args.append(f'--nodes={nodes}')
         args.append(f'--ntasks={nodes * procs_per_node}')
+        args.append(f'--ntasks-per-node={procs_per_node}')
         if time_limit is not None:
             args.append(f'--time={_time_string(time_limit)}')
         if job_name:

--- a/python/lbann/launcher/slurm.py
+++ b/python/lbann/launcher/slurm.py
@@ -99,12 +99,17 @@ class SlurmBatchScript(BatchScript):
         Args:
             command (`str` or `Iterable` of `str`s): Command to be
                 executed in parallel.
-            launcher (str, optional): srun executable.
-            launcher_args (`Iterable` of `str`s, optional):
-                Command-line arguments to srun.
             nodes (int, optional): Number of compute nodes.
             procs_per_node (int, optional): Number of parallel
                 processes per compute node.
+            time_limit (int, optional): Job time limit, in minutes.
+            job_name (str, optional): Job name.
+            partition (str, optional): Scheduler partition.
+            account (str, optional): Scheduler account.
+            work_dir (str, optional): Working directory.
+            launcher (str, optional): srun executable.
+            launcher_args (`Iterable` of `str`s, optional):
+                Command-line arguments to srun.
 
         """
 
@@ -128,7 +133,7 @@ class SlurmBatchScript(BatchScript):
         if launcher_args is None:
             launcher_args = self.launcher_args
 
-        # Construct invocation
+        # Construct srun invocation
         args = [launcher]
         args.extend(make_iterable(launcher_args))
         if job_name:


### PR DESCRIPTION
The current launcher attempts to detect whether it is being run from within an allocation. If it is, it submits an interactive job (`srun`/`jsrun`), and otherwise submits a batch job (`sbatch`/`bsub`). This is convenient, but it causes errors when LBANN is integrated within a larger workflow, e.g. with Merlin. We need to give the user control over how their jobs are run.

This PR changes the default behavior to always launch an interactive job. If a batch job is required, the user can pass `batch_job=True` to `lbann.run` or `lbann.contrib.launcher.run`. Note that `jsrun` must be called from a compute node, so calling `lbann.run` on an LSF system without `batch_job=True` will fail. These changes supersede #1477 (close #1477).

Since we are prioritizing the case where LBANN is run within an allocation, I've taken the opportunity to remove the LC-specific defaults for scheduler partitions and accounts. LC systems already have default partitions and it's a bad idea for all our users to bill their CPU-hours to our accounts.

[Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM275-1).