### PR TITLE
Add flexible error handling to Clara-based argument parser

### DIFF
--- a/include/lbann/utils/argument_parser.hpp
+++ b/include/lbann/utils/argument_parser.hpp
@@ -424,10 +424,10 @@ public:
   template <typename AccessPolicy>
   readonly_reference<std::string>
   add_option(std::string const& name,
-                  std::initializer_list<std::string> cli_flags,
-                  EnvVariable<AccessPolicy> env,
-                  std::string const& description,
-                  char const* default_value)
+             std::initializer_list<std::string> cli_flags,
+             EnvVariable<AccessPolicy> env,
+             std::string const& description,
+             char const* default_value)
   {
     return add_option(name, cli_flags, std::move(env),
                       description, std::string(default_value));

--- a/include/lbann/utils/argument_parser.hpp
+++ b/include/lbann/utils/argument_parser.hpp
@@ -46,6 +46,45 @@ namespace lbann
 namespace utils
 {
 
+/** @class parse_error
+ *  @brief std::exception subclass that is thrown if the parser
+ *         can not parse the arguments.
+ */
+struct parse_error : std::runtime_error
+{
+  /** @brief Construct the exception with the string to be
+   *         return by what()
+   */
+  template <typename T>
+  parse_error(T&& what_arg)
+    : std::runtime_error{std::forward<T>(what_arg)} {}
+};// parse_error
+
+/** @class strict_parsing
+ *
+ *  Allows any valid subset of parameters. This will throw an
+ *  exception for any error raised by the underlying parser.
+ */
+struct strict_parsing
+{
+  void handle_error(clara::detail::InternalParseResult result,
+                    clara::Parser& parser,
+                    std::vector<char const*>& argv);
+};// struct strict_parsing
+
+/** @class allow_extra_parameters
+ *
+ *  Ignores "unknown token" errors raised by the parser and attempts
+ *  to proceed until all tokens are processed or another error is
+ *  detected.
+ */
+struct allow_extra_parameters
+{
+  void handle_error(clara::detail::InternalParseResult result,
+                    clara::Parser& parser,
+                    std::vector<char const*>& argv);
+};// struct allow_extra_parameters
+
 /** @class argument_parser
  *  @brief Basic argument parsing with automatic help messages.
  *
@@ -118,7 +157,8 @@ namespace utils
  *  finalization. Semantically, the parser must be finalized before
  *  attempting to use any of the required arguments.
  */
-class argument_parser
+template <typename ErrorHandler>
+class argument_parser : ErrorHandler
 {
 public:
 
@@ -565,20 +605,23 @@ private:
 
 };
 
+template <typename ErrorHandler>
 inline bool
-argument_parser::option_is_defined(std::string const& option_name) const
+argument_parser<ErrorHandler>::option_is_defined(std::string const& option_name) const
 {
   return params_.count(option_name);
 }
 
+template <typename ErrorHandler>
 template <typename T>
-inline T const& argument_parser::get(std::string const& option_name) const
+inline T const& argument_parser<ErrorHandler>::get(std::string const& option_name) const
 {
   return utils::any_cast<T const&>(params_.at(option_name));
 }
 
+template <typename ErrorHandler>
 template <typename T>
-inline auto argument_parser::add_option(
+inline auto argument_parser<ErrorHandler>::add_option(
   std::string const& name,
   std::initializer_list<std::string> cli_flags,
   std::string const& description,
@@ -594,8 +637,9 @@ inline auto argument_parser::add_option(
   return param_ref;
 }
 
+template <typename ErrorHandler>
 template <typename T>
-inline auto argument_parser::add_argument(
+inline auto argument_parser<ErrorHandler>::add_argument(
   std::string const& name,
   std::string const& description,
   T default_value)
@@ -609,8 +653,9 @@ inline auto argument_parser::add_argument(
   return param_ref;
 }
 
+template <typename ErrorHandler>
 template <typename T>
-inline auto argument_parser::add_required_argument(
+inline auto argument_parser<ErrorHandler>::add_required_argument(
   std::string const& name,
   std::string const& description)
   -> readonly_reference<T>
@@ -641,13 +686,104 @@ inline auto argument_parser::add_required_argument(
   ret->operator() (description).required();
   return param_ref;
 }
+
+template <typename ErrorHandler>
+argument_parser<ErrorHandler>::argument_parser()
+{
+  params_["print help"] = false;
+  parser_ |= clara::ExeName(exe_name_);
+  parser_ |= clara::Help(utils::any_cast<bool&>(params_["print help"]));
+
+  // Work around a bug in Clara logic
+  parser_.m_exeName.set(exe_name_);
+}
+
+template <typename ErrorHandler>
+void argument_parser<ErrorHandler>::parse(int argc, char const* const argv[])
+{
+  parse_no_finalize(argc, argv);
+  finalize();
+}
+
+template <typename ErrorHandler>
+void argument_parser<ErrorHandler>::parse_no_finalize(int argc, char const* const argv[])
+{
+  std::vector<char const*> newargv(argv, argv+argc);
+  auto parse_result =
+    parser_.parse(clara::Args(newargv.size(), newargv.data()));
+
+  if (!parse_result)
+    this->handle_error(parse_result, parser_, newargv);
+}
+
+template <typename ErrorHandler>
+void argument_parser<ErrorHandler>::finalize() const
+{
+  if (!help_requested() && required_.size())
+    throw missing_required_arguments(required_);
+}
+
+template <typename ErrorHandler>
+auto argument_parser<ErrorHandler>::add_flag(
+  std::string const& name,
+  std::initializer_list<std::string> cli_flags,
+  std::string const& description)
+  -> readonly_reference<bool>
+{
+  return add_flag_impl_(name, std::move(cli_flags), description, false);
+}
+
+template <typename ErrorHandler>
+std::string const& argument_parser<ErrorHandler>::get_exe_name() const noexcept
+{
+  return exe_name_;
+}
+
+template <typename ErrorHandler>
+bool argument_parser<ErrorHandler>::help_requested() const
+{
+  return utils::any_cast<bool>(params_.at("print help"));
+}
+
+template <typename ErrorHandler>
+void argument_parser<ErrorHandler>::print_help(std::ostream& out) const
+{
+  out << parser_ << std::endl;
+}
+
+template <typename ErrorHandler>
+auto argument_parser<ErrorHandler>::add_flag_impl_(
+  std::string const& name,
+  std::initializer_list<std::string> cli_flags,
+  std::string const& description,
+  bool default_value)
+  -> readonly_reference<bool>
+{
+  params_[name] = default_value;
+  auto& param_ref = any_cast<bool&>(params_[name]);
+  clara::Opt option(param_ref);
+  for (auto const& f : cli_flags)
+    option[f];
+  parser_ |= option(description).optional();
+  return param_ref;
+}
+
 }// namespace utils
 
-utils::argument_parser& global_argument_parser();
+using default_arg_parser_type = utils::argument_parser<utils::strict_parsing>;
+
+default_arg_parser_type& global_argument_parser();
 
 }// namespace lbann
 
 /** @brief Write the parser's help string to the given @c ostream */
-std::ostream& operator<<(std::ostream&, lbann::utils::argument_parser const&);
+template <typename ErrorHandler>
+std::ostream& operator<<(
+  std::ostream& os,
+  lbann::utils::argument_parser<ErrorHandler> const& parser)
+{
+  parser.print_help(os);
+  return os;
+}
 
 #endif /* LBANN_UTILS_ARGUMENT_PARSER_HPP_INCLUDED */

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -827,7 +827,7 @@ void print_help(std::ostream& os)
        "  --saveme=<string>  You can suppress writing the file via the option:\n"
        "  --saveme=0\n"
        "\n"
-       "Some prototext values can be over-riden on the command line;\n"
+       "Some prototext values can be overriden on the command line;\n"
        "(notes: use '1' or '0' for bool; if no value is given for a flag,\n"
        "        e.g: --disable_cuda, then a value of '1' is assigned)\n"
        "\n"

--- a/src/utils/argument_parser.cpp
+++ b/src/utils/argument_parser.cpp
@@ -33,97 +33,75 @@
 #include <iostream>
 #include <string>
 
+namespace
+{
+/** @brief Check a raw argument for a given token.
+ *
+ *  Returns "true" when EITHER:
+ *
+ *    - testtoken == rawargument is true.
+ *    - rawargument has an equals sign and the substring up to (but not
+ *      including) the equals sign compares equal to testtoken.
+ */
+bool token_match(std::string const& testtoken,
+                 std::string const& rawargument)
+{
+  return (rawargument.compare(0, rawargument.find('='), testtoken) == 0);
+}
+}// namespace <anon>
+
 namespace lbann
 {
 namespace utils
 {
-
-argument_parser::argument_parser()
+void strict_parsing::handle_error(
+  clara::detail::InternalParseResult result,
+  clara::Parser&,
+  std::vector<char const*>&)
 {
-  params_["print help"] = false;
-  parser_ |= clara::ExeName(exe_name_);
-  parser_ |= clara::Help(utils::any_cast<bool&>(params_["print help"]));
-
-  // Work around a bug in Clara logic
-  parser_.m_exeName.set(exe_name_);
+  throw parse_error(
+    lbann::build_string(
+      "Arguments could not be parsed.\n\nMessage: ",
+      result.errorMessage()));
 }
 
-void argument_parser::parse(int argc, char const* const argv[])
+void allow_extra_parameters::handle_error(
+  clara::detail::InternalParseResult parse_result,
+  clara::Parser& parser_,
+  std::vector<char const*>& newargv)
 {
-  parse_no_finalize(argc, argv);
-  finalize();
-}
-
-void argument_parser::parse_no_finalize(int argc, char const* const argv[])
-{
-
-  auto parse_result = parser_.parse(clara::Args(argc, argv));
-  if (!parse_result)
-    throw parse_error(
-      lbann::build_string(
-        "Arguments could not be parsed.\n\nMessage: ",
-        parse_result.errorMessage()));
-}
-
-void argument_parser::finalize() const
-{
-  if (!help_requested() && required_.size())
-    throw missing_required_arguments(required_);
-}
-
-auto argument_parser::add_flag(
-  std::string const& name,
-  std::initializer_list<std::string> cli_flags,
-  std::string const& description)
-  -> readonly_reference<bool>
-{
-  return add_flag_impl_(name, std::move(cli_flags), description, false);
-}
-
-std::string const& argument_parser::get_exe_name() const noexcept
-{
-  return exe_name_;
-}
-
-bool argument_parser::help_requested() const
-{
-  return utils::any_cast<bool>(params_.at("print help"));
-}
-
-void argument_parser::print_help(std::ostream& out) const
-{
-  out << parser_ << std::endl;
-}
-
-auto argument_parser::add_flag_impl_(
-  std::string const& name,
-  std::initializer_list<std::string> cli_flags,
-  std::string const& description,
-  bool default_value)
-  -> readonly_reference<bool>
-{
-  params_[name] = default_value;
-  auto& param_ref = any_cast<bool&>(params_[name]);
-  clara::Opt option(param_ref);
-  for (auto const& f : cli_flags)
-    option[f];
-  parser_ |= option(description).optional();
-  return param_ref;
+  do
+  {
+    std::string const base_text = "Unrecognised token: ";
+    std::string const err_text = parse_result.errorMessage();
+    if ((err_text.size() > base_text.size())
+        && (err_text.substr(0, base_text.size()).compare(base_text) == 0))
+    {
+      auto const token = err_text.substr(base_text.size());
+      auto iter = std::find_if(newargv.begin(), newargv.end(),
+                               [&token](char const* str)
+                               {
+                                 return token_match(token, str);
+                               });
+      newargv.erase(newargv.cbegin() + 1, iter + 1);
+      parse_result = parser_.parse(clara::Args(newargv.size(), newargv.data()));
+    }
+    else
+    {
+      throw parse_error(
+        lbann::build_string(
+          "Arguments could not be parsed.\n\nMessage: ",
+          parse_result.errorMessage()));
+    }
+  } while (!parse_result);
 }
 
 }// namespace utils
 
-utils::argument_parser& global_argument_parser()
+default_arg_parser_type& global_argument_parser()
 {
-  static utils::argument_parser args;
+  static default_arg_parser_type args;
   return args;
 }
 
 }// namespace lbann
-
-std::ostream& operator<<(std::ostream& os,
-                         lbann::utils::argument_parser const& parser)
-{
-  parser.print_help(os);
-  return os;
-}

--- a/src/utils/unit_test/argument_parser_test.cpp
+++ b/src/utils/unit_test/argument_parser_test.cpp
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
@@ -31,525 +31,575 @@
 
 #include "stubs/preset_env_accessor.hpp"
 
-SCENARIO ("Testing the argument parser", "[parser][utilities]")
+TEMPLATE_TEST_CASE ("Testing the argument parser", "[parser][utilities]",
+                    lbann::utils::strict_parsing,
+                    lbann::utils::allow_extra_parameters)
 {
-  GIVEN ("An argument parser")
+  using error_handler = TestType;
+  using parser_type = lbann::utils::argument_parser<error_handler>;
+
+  parser_type parser;
+  SECTION("Passing default arguments")
   {
-    lbann::utils::argument_parser parser;
-    WHEN ("The default arguments are passed")
+      char const* argv[] = { "argument_parser_test.exe" };
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(
+        parser.get_exe_name() == "argument_parser_test.exe");
+  }
+
+  SECTION("Short help flag")
+  {
+    char const* argv[] = {"argument_parser_test.exe", "-h"};
+    int const argc = sizeof(argv) / sizeof(argv[0]);
+
+    CHECK_FALSE(parser.help_requested());
+    REQUIRE_NOTHROW(parser.parse(argc, argv));
+    CHECK(parser.help_requested());
+  }
+
+  SECTION("Long help flag")
+  {
+    char const* argv[] = {"argument_parser_test.exe", "--help"};
+    int const argc = sizeof(argv) / sizeof(argv[0]);
+
+    CHECK_FALSE(parser.help_requested());
+    REQUIRE_NOTHROW(parser.parse(argc, argv));
+    CHECK(parser.help_requested());
+  }
+
+  SECTION("Boolean flags are false by default")
+  {
+    auto flag_v =
+      parser.add_flag(
+        "flag v", {"-v", "--flag-v"}, "print verbosely");
+
+    CHECK(parser.option_is_defined("flag v"));
+    CHECK_FALSE(flag_v);
+
+    SECTION("Short flag sets flag to true")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "-v"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      CHECK_FALSE(parser.template get<bool>("flag v"));
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<bool>("flag v"));
+      CHECK(flag_v);
+    }
+
+    SECTION("Long flag sets flag to true")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "--flag-v"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      CHECK_FALSE(parser.template get<bool>("flag v"));
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<bool>("flag v"));
+      CHECK(flag_v);
+    }
+  }
+
+  SECTION("Numeric option")
+  {
+    auto param_t =
+      parser.add_option("parameter t", {"-t", "--param-t"},
+                        "Docstring for \"parameter t\"", 1);
+
+    CHECK(parser.option_is_defined("parameter t"));
+    CHECK(parser.template get<int>("parameter t") == 1);
+    CHECK(param_t == 1);
+
+    SECTION ("Short flag")
+    {
+      char const* argv[] = {"argument_parser_test.exe", "-t", "9"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(
+        parser.template get<int>("parameter t") == 9);
+      CHECK(param_t == 9);
+    }
+
+    SECTION ("Long flag")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "--param-t", "13"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<int>("parameter t") == 13);
+      CHECK(param_t == 13);
+    }
+  }
+
+  SECTION("String-valued option")
+  {
+    auto param_n =
+      parser.add_option("parameter n", {"-n", "--param-n", "--parameter-n"},
+                        "Docstring for \"parameter t\"",
+                        "<unregistered parameter value>");
+
+    CHECK(parser.option_is_defined("parameter n"));
+    CHECK(parser.template get<std::string>("parameter n")
+          == "<unregistered parameter value>");
+
+    SECTION("The short option is passed on the command line")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "-n", "short form of param n"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(
+        parser.template get<std::string>("parameter n")
+        == "short form of param n");
+      CHECK(param_n == "short form of param n");
+    }
+
+    SECTION ("First long option")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "--param-n",
+           "first long form of param n"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(
+        parser.template get<std::string>("parameter n")
+        == "first long form of param n");
+      CHECK(param_n == "first long form of param n");
+    }
+
+    SECTION ("Second long option")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "--parameter-n",
+           "second long form of param n"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(
+        parser.template get<std::string>("parameter n")
+        == "second long form of param n");
+      CHECK(param_n == "second long form of param n");
+    }
+  }
+
+  SECTION ("Required numeric argument")
+  {
+    auto required_int =
+      parser.template add_required_argument<int>(
+        "required", "This argument is required.");
+
+    CHECK(parser.option_is_defined("required"));
+
+    SECTION("Missing required argument")
+    {
+      char const* argv[] = {"argument_parser_test.exe"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      parser.parse_no_finalize(argc,argv);
+      REQUIRE_THROWS_AS(
+        parser.finalize(),
+        typename parser_type::missing_required_arguments);
+    }
+
+    SECTION("Required argument is passed")
+    {
+      char const* argv[] = {"argument_parser_test.exe","13"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(required_int == 13);
+    }
+
+    SECTION("Another is added option and passed in the arguments")
+    {
+      auto required_string =
+        parser.template add_required_argument<std::string>(
+          "required string", "This argument is also required.");
+
+      char const* argv[] = {"argument_parser_test.exe","13","bananas"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(required_int == 13);
+      CHECK(required_string == "bananas");
+    }
+  }
+
+  SECTION("More complex argument relationships")
+  {
+    auto optional_int =
+      parser.add_argument(
+        "optional", "This argument is optional.", -1);
+
+    CHECK(parser.option_is_defined("optional"));
+    CHECK(parser.template get<int>("optional") == -1);
+    CHECK(optional_int == -1);
+
+    SECTION("Only default arguments passed")
     {
       int const argc = 1;
-      char const* argv[] = { "argument_parser_test.exe" };
-      THEN ("The parser recognizes the executable name")
-      {
-        REQUIRE_NOTHROW(parser.parse(argc, argv));
-        REQUIRE(
-          parser.get_exe_name() == "argument_parser_test.exe");
-      }
+      char const* argv[] = {"argument_parser_test.exe"};
+
+      REQUIRE_NOTHROW(parser.parse(argc,argv));
+      CHECK(parser.template get<int>("optional") == -1);
+      CHECK(optional_int == -1);
     }
-    WHEN ("The short help flag is passed")
+
+    SECTION("Option is passed in the arguments")
     {
       int const argc = 2;
-      char const* argv[] = {"argument_parser_test.exe", "-h"};
-      THEN ("The parser notes that help has been requested.")
-      {
-        REQUIRE_FALSE(parser.help_requested());
-        REQUIRE_NOTHROW(parser.parse(argc, argv));
-        REQUIRE(parser.help_requested());
-      }
-    }
-    WHEN ("The long help flag is passed")
-    {
-      int const argc = 2;
-      char const* argv[argc] = {"argument_parser_test.exe", "--help"};
-      THEN ("The parser notes that help has been requested.")
-      {
-        REQUIRE_NOTHROW(parser.parse(argc, argv));
-        REQUIRE(parser.help_requested());
-      }
-    }
-    WHEN ("A boolean flag is added")
-    {
-      auto verbose =
-        parser.add_flag(
-          "verbose", {"-v", "--verbose"}, "print verbosely");
-      THEN ("The flag's option name is known")
-      {
-        REQUIRE(parser.option_is_defined("verbose"));
-        REQUIRE_FALSE(verbose);
-      }
-      AND_WHEN("The flag is passed")
-      {
-        int const argc = 2;
-        char const* argv[]
-          = {"argument_parser_test.exe", "--verbose"};
-        REQUIRE_FALSE(parser.get<bool>("verbose"));
-        THEN ("The verbose flag is registered")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.get<bool>("verbose"));
-          REQUIRE(verbose);
-        }
-      }
-    }
-    WHEN ("An option is added")
-    {
-      auto num_threads =
-        parser.add_option("number of threads", {"-t", "--num_threads"},
-                          "The number of threads to use in this test.", 1);
-      THEN ("The option is registered with the parser.")
-      {
-        REQUIRE(parser.option_is_defined("number of threads"));
-        REQUIRE(parser.template get<int>("number of threads") == 1);
-        REQUIRE(num_threads == 1);
-      }
-      AND_WHEN ("The short option is passed on the command line")
-      {
-        int const argc = 3;
-        char const* argv[] = {"argument_parser_test.exe", "-t", "9"};
-        THEN ("The new value is registered.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(
-            parser.template get<int>("number of threads") == 9);
-          REQUIRE(num_threads == 9);
-        }
-      }
-      AND_WHEN ("The long option is passed on the command line")
-      {
-        int const argc = 3;
-        char const* argv[]
-          = {"argument_parser_test.exe", "--num_threads", "13"};
-        THEN ("The new value is registered.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(
-            parser.template get<int>("number of threads") == 13);
-          REQUIRE(num_threads == 13);
-        }
-      }
-    }
-    WHEN ("A string-valued option is added")
-    {
-      auto name =
-        parser.add_option("my name", {"-n", "--name", "--my_name"},
-                          "The number of threads to use in this test.",
-                          "<unregistered name>");
-      THEN ("The option is registered with the parser.")
-      {
-        REQUIRE(parser.option_is_defined("my name"));
-        REQUIRE(parser.template get<std::string>("my name")
-                == "<unregistered name>");
-      }
-      AND_WHEN ("The short option is passed on the command line")
-      {
-        int const argc = 3;
-        char const* argv[]
-          = {"argument_parser_test.exe", "-n", "Banana Joe"};
-        THEN ("The new value is registered.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(
-            parser.template get<std::string>("my name")
-            == "Banana Joe");
-          REQUIRE(name == "Banana Joe");
-        }
-      }
-      AND_WHEN ("The first long option is passed on the command line")
-      {
-        int const argc = 3;
-        char const* argv[]
-          = {"argument_parser_test.exe", "--name", "Plantain Pete"};
-        THEN ("The new value is registered.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(
-            parser.template get<std::string>("my name")
-            == "Plantain Pete");
-          REQUIRE(name == "Plantain Pete");
-        }
-      }
-      AND_WHEN ("The second long option is passed on the command line")
-      {
-        int const argc = 3;
-        char const* argv[]
-          = {"argument_parser_test.exe", "--my_name",
-             "Jackfruit Jill"};
-        THEN ("The new value is registered.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(
-            parser.template get<std::string>("my name")
-            == "Jackfruit Jill");
-          REQUIRE(name == "Jackfruit Jill");
-        }
-      }
+      char const* argv[] = {"argument_parser_test.exe","13"};
+
+      REQUIRE_NOTHROW(parser.parse(argc,argv));
+      CHECK(parser.template get<int>("optional") == 13);
+      CHECK(optional_int == 13);
     }
 
-    WHEN ("A required argument is added")
+    SECTION("Another optional argument is added")
     {
-      auto required_int =
-        parser.add_required_argument<int>(
-        "required", "This argument is required.");
-      THEN ("The option is recognized")
-      {
-        REQUIRE(parser.option_is_defined("required"));
-      }
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
-
-        THEN ("Finalization fails.")
-        {
-          parser.parse_no_finalize(argc,argv);
-          REQUIRE_THROWS_AS(
-            parser.finalize(),
-            lbann::utils::argument_parser::missing_required_arguments);
-        }
-      }
-      AND_WHEN("The option is passed in the arguments")
-      {
-        int const argc = 2;
-        char const* argv[argc] = {"argument_parser_test.exe","13"};
-
-        THEN ("Parsing is successful and the value is updated.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(required_int == 13);
-        }
-      }
-      AND_WHEN("Another is added option and passed in the arguments")
-      {
-        auto required_string =
-          parser.add_required_argument<std::string>(
-            "required string", "This argument is also required.");
-
-        int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe","13","bananas"};
-
-        THEN ("Parsing is successful and the values are updated.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(required_int == 13);
-          REQUIRE(required_string == "bananas");
-        }
-      }
-    }
-
-    WHEN ("An optional argument is added")
-    {
-      auto optional_int =
+      auto optional_string =
         parser.add_argument(
-          "optional", "This argument is optional.", -1);
-      THEN ("The option is recognized")
-      {
-        REQUIRE(parser.option_is_defined("optional"));
-        REQUIRE(parser.template get<int>("optional") == -1);
-        REQUIRE(optional_int == -1);
-      }
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
+          "optional string", "This argument is also optional.",
+          "pickles");
 
-        THEN ("Parsing succeeds with no update to the value.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc,argv));
-          REQUIRE(parser.template get<int>("optional") == -1);
-          REQUIRE(optional_int == -1);
-        }
-      }
-      AND_WHEN("The option is passed in the arguments")
+      SECTION("Parsing both arguments works")
       {
-        int const argc = 2;
-        char const* argv[argc] = {"argument_parser_test.exe","13"};
-
-        THEN ("Parsing is successful and the value is updated.")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc,argv));
-          REQUIRE(parser.template get<int>("optional") == 13);
-          REQUIRE(optional_int == 13);
-        }
-      }
-      AND_WHEN("Another argument is added and passed in the arguments")
-      {
-        auto optional_string =
-          parser.add_argument(
-            "optional string", "This argument is also optional.",
-            "pickles");
-
         int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe","42","bananas"};
+        char const* argv[] = {"argument_parser_test.exe","42","bananas"};
 
-        THEN ("Parsing is successful and the values are updated.")
-        {
-          REQUIRE(optional_int == -1);
-          REQUIRE(optional_string == "pickles");
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(optional_int == 42);
-          REQUIRE(optional_string == "bananas");
-        }
+        CHECK(optional_int == -1);
+        CHECK(optional_string == "pickles");
+        REQUIRE_NOTHROW(parser.parse(argc, argv));
+        CHECK(optional_int == 42);
+        CHECK(optional_string == "bananas");
       }
-      AND_WHEN("A required argument is added and passed in the arguments")
+
+      SECTION("A required argument is added and passed in the arguments")
       {
         auto required_string =
-          parser.add_required_argument<std::string>(
+          parser.template add_required_argument<std::string>(
             "required string", "This argument is required.");
 
-        AND_WHEN("The arguments are passed in the add order")
+        SECTION("Bad ordering of the arguments")
         {
           int const argc = 3;
-          char const* argv[argc] = {
+          char const* argv[] = {
             "argument_parser_test.exe","42","bananas"};
-          THEN ("Parsing fails because required must come first")
-          {
-            REQUIRE_THROWS(parser.parse(argc,argv));
-            REQUIRE(required_string == "42");
-          }
+
+          REQUIRE_THROWS(parser.parse(argc,argv));
+          CHECK(required_string == "42");
         }
-        AND_WHEN("The arguments are passed in the right order")
+
+        SECTION("Correct ordering of the arguments")
         {
           int const argc = 3;
-          char const* argv[argc] = {
+          char const* argv[] = {
             "argument_parser_test.exe","bananas","42"};
-          THEN ("The arguments must be reversed")
-          {
-            REQUIRE(optional_int == -1);
-            REQUIRE_NOTHROW(parser.parse(argc, argv));
-            REQUIRE(optional_int == 42);
-            REQUIRE(required_string == "bananas");
-          }
+
+          CHECK(optional_int == -1);
+          REQUIRE_NOTHROW(parser.parse(argc, argv));
+          CHECK(optional_int == 42);
+          CHECK(required_string == "bananas");
         }
       }
     }
+  }
 
-    WHEN ("A flag with env variable override is added")
+  SECTION("A flag with env variable override is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+
+    auto verbose =
+      parser.add_flag("verbose", {"-v"},
+                      TestENV("VALUE_IS_TRUE"), "");
+
+    CHECK(parser.option_is_defined("verbose"));
+    CHECK(verbose);
+
+    SECTION("Command line flag overrides environment variable")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      char const* argv[]
+        = {"argument_parser_test.exe", "-v"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
 
-      auto verbose =
-        parser.add_flag("verbose", {"-v"},
-                        TestENV("VALUE_IS_TRUE"), "");
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<bool>("verbose"));
+      CHECK(verbose);
+    }
+  }
 
-      THEN("The flag registers as true.")
-      {
-        REQUIRE(parser.option_is_defined("verbose"));
-        REQUIRE(verbose);
-      }
+  SECTION("A flag with false-valued env variable override is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
 
-      AND_WHEN ("The flag is passed on the command line")
-      {
-        int const argc = 2;
-        char const* argv[]
-          = {"argument_parser_test.exe", "-v"};
+    auto verbose =
+      parser.add_flag("verbose", {"-v"},
+                      TestENV("VALUE_IS_FALSE"), "");
 
-        THEN ("The verbose flag is registered")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.get<bool>("verbose"));
-          REQUIRE(verbose);
-        }
-      }
+    CHECK(parser.option_is_defined("verbose"));
+    CHECK_FALSE(verbose);
+
+    SECTION("Command line flag overrides environment variable")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "-v"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<bool>("verbose"));
+      CHECK(verbose);
+    }
+  }
+
+  SECTION("A flag with false-valued env variable override is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+
+    auto verbose =
+      parser.add_flag("verbose", {"-v"},
+                      TestENV("VALUE_IS_UNDEFINED"), "");
+
+    CHECK(parser.option_is_defined("verbose"));
+    CHECK_FALSE(verbose);
+
+    SECTION("Command line flag overrides environment variable")
+    {
+      char const* argv[]
+        = {"argument_parser_test.exe", "-v"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<bool>("verbose"));
+      CHECK(verbose);
+    }
+  }
+
+  SECTION("A defined environment varible is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+
+    parser.add_option(
+      "apple", {"-a"}, TestENV("APPLE"),
+      "Apple pie tastes good.", 1.23);
+
+    CHECK(parser.option_is_defined("apple"));
+
+    SECTION("The option is not passed in the arguments")
+    {
+      int const argc = 1;
+      char const* argv[] = {"argument_parser_test.exe"};
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<double>("apple") == 3.14);
     }
 
-    WHEN ("A flag with false-valued env variable override is added")
+    SECTION("The option is passed in the arguments")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      int const argc = 3;
+      char const* argv[] = {"argument_parser_test.exe", "-a", "5.0"};
 
-      auto verbose =
-        parser.add_flag("verbose", {"-v"},
-                        TestENV("VALUE_IS_FALSE"), "");
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<double>("apple") == 5.0);
+    }
+  }
 
-      THEN("The flag registers as false.")
-      {
-        REQUIRE(parser.option_is_defined("verbose"));
-        REQUIRE_FALSE(verbose);
-      }
+  SECTION("An undefined environment varible is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
 
-      AND_WHEN ("The flag is passed on the command line")
-      {
-        int const argc = 2;
-        char const* argv[]
-          = {"argument_parser_test.exe", "-v"};
+    parser.add_option(
+      "platypus", {"-p"}, TestENV("DOESNT_EXIST"),
+      "This variable won't exist.", 1.23);
 
-        THEN ("The verbose flag is registered")
-        {
+    CHECK(parser.option_is_defined("platypus"));
+
+    SECTION("The option is not passed in the arguments")
+    {
+      int const argc = 1;
+      char const* argv[] = {"argument_parser_test.exe"};
+
           REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.get<bool>("verbose"));
-          REQUIRE(verbose);
-        }
-      }
+          CHECK(parser.template get<double>("platypus") == 1.23);
+    }
+    SECTION("The option is passed in the arguments")
+    {
+      int const argc = 3;
+      char const* argv[] = {"argument_parser_test.exe", "-p", "2.0"};
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<double>("platypus") == 2.0);
+    }
+  }
+
+  SECTION("A defined string environment varible is added")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+
+    parser.add_option(
+      "pizza", {"-p"}, TestENV("PIZZA"),
+      "Mmmm pizza.", "mushroom");
+
+    CHECK(parser.option_is_defined("pizza"));
+
+    SECTION("The option is not passed in the arguments")
+    {
+      int const argc = 1;
+      char const* argv[] = {"argument_parser_test.exe"};
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<std::string>("pizza") == "pepperoni");
     }
 
-    WHEN ("A flag with false-valued env variable override is added")
+    SECTION("The option is passed in the arguments")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      int const argc = 3;
+      char const* argv[] = {"argument_parser_test.exe", "-p", "hawaiian"};
 
-      auto verbose =
-        parser.add_flag("verbose", {"-v"},
-                        TestENV("VALUE_IS_UNDEFINED"), "");
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<std::string>("pizza") == "hawaiian");
+    }
+  }
 
-      THEN("The flag registers as false.")
-      {
-        REQUIRE(parser.option_is_defined("verbose"));
-        REQUIRE_FALSE(verbose);
-      }
+  SECTION("An undefined environment varible is added to a string option")
+  {
+    using namespace lbann::utils::stubs;
+    using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
 
-      AND_WHEN ("The flag is passed on the command line")
-      {
-        int const argc = 2;
-        char const* argv[]
-          = {"argument_parser_test.exe", "-v"};
+    parser.add_option(
+      "parameter p", {"-p"}, TestENV("DOESNT_EXIST"),
+      "This variable won't exist.", "parameter p test string");
 
-        THEN ("The verbose flag is registered")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.get<bool>("verbose"));
-          REQUIRE(verbose);
-        }
-      }
+    CHECK(parser.option_is_defined("parameter p"));
+
+    SECTION("The option is not passed in the arguments")
+    {
+      int const argc = 1;
+      char const* argv[] = {"argument_parser_test.exe"};
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<std::string>("parameter p")
+            == "parameter p test string");
     }
 
-    WHEN ("A defined environment varible is added")
+    SECTION("The option is passed in the arguments")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      int const argc = 3;
+      char const* argv[] = {"argument_parser_test.exe", "-p",
+                            "parameter p argument value"};
 
-      parser.add_option(
-        "apple", {"-a"}, TestENV("APPLE"),
-        "Apple pie tastes good.", 1.23);
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+      CHECK(parser.template get<std::string>("parameter p")
+            == "parameter p argument value");
+    }
+  }
+}
 
-      REQUIRE(parser.option_is_defined("apple"));
+// Testing for cases of ignored arguments
+TEST_CASE("Partial argument parsing", "[tdd][parser][utilities]")
+{
+  lbann::utils::argument_parser<lbann::utils::allow_extra_parameters> parser;
+  auto flag_v =
+    parser.add_flag(
+      "flag v", {"-v", "--flag-v"}, "Docstring for \"flag v\"");
+  auto param_s =
+    parser.add_option("parameter s", {"-s", "--param-s"},
+                      "Docstring for \"parameter s\"",
+                      "default value of s");
+  auto param_t =
+    parser.add_option("parameter t", {"-t", "--param-t"},
+                      "Docstring for \"parameter t\"", 1);
 
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
+  CHECK(parser.option_is_defined("parameter t"));
+  CHECK(parser.option_is_defined("flag v"));
 
-        THEN("The option has the value defined in the environment")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<double>("apple") == 3.14);
-        }
-      }
+  SECTION("Incomplete argument sets are fine.")
+  {
+    char const* argv[] = {"argument_parser_test.exe", "-t", "9"};
+    int const argc = sizeof(argv) / sizeof(argv[0]);
+    REQUIRE_NOTHROW(parser.parse(argc, argv));
 
-      AND_WHEN("The option is passed in the arguments")
-      {
-        int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe", "-a", "5.0"};
-        THEN("The option has the value defined in command line args")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<double>("apple") == 5.0);
-        }
-      }
+    CHECK_FALSE(parser.template get<bool>("flag v"));
+    CHECK_FALSE(flag_v);
+
+    CHECK(parser.template get<int>("parameter t") == 9);
+    CHECK(param_t == 9);
+  }
+
+  SECTION("Unknown arguments are ok.")
+  {
+    char const* argv[] = {"argument_parser_test.exe",
+                          "-o", "-v", "-a", "-t", "2", "-p", "13"};
+    int const argc = sizeof(argv) / sizeof(argv[0]);
+
+    REQUIRE_NOTHROW(parser.parse(argc, argv));
+
+    CHECK(parser.template get<bool>("flag v"));
+    CHECK(flag_v);
+
+    CHECK(parser.template get<int>("parameter t") == 2);
+    CHECK(param_t == 2);
+  }
+
+  SECTION("Arguments with equals assignments are ok")
+  {
+    SECTION("Short form")
+    {
+      char const* argv[] = {"argument_parser_test.exe", "-t=32"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
+
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
+
+      CHECK(parser.template get<int>("parameter t") == 32);
+      CHECK(param_t == 32);
     }
 
-    WHEN ("An undefined environment varible is added")
+    SECTION("Long form")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      char const* argv[] = {"argument_parser_test.exe", "--param-t=121"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
 
-      parser.add_option(
-        "platypus", {"-p"}, TestENV("DOESNT_EXIST"),
-        "This variable won't exist.", 1.23);
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
 
-      REQUIRE(parser.option_is_defined("platypus"));
-
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
-
-        THEN("The option has the default value")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<double>("platypus") == 1.23);
-        }
-      }
-      AND_WHEN("The option is passed in the arguments")
-      {
-        int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe", "-p", "2.0"};
-        THEN("The option has the value defined in the command line args")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<double>("platypus") == 2.0);
-        }
-      }
+      CHECK(parser.template get<int>("parameter t") == 121);
+      CHECK(param_t == 121);
     }
 
-    WHEN ("A defined string environment varible is added")
+    SECTION("String parameter with equals sign in it")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      char const* argv[] = {"argument_parser_test.exe",
+                            "--param-s=something=other"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
 
-      parser.add_option(
-        "pizza", {"-p"}, TestENV("PIZZA"),
-        "Mmmm pizza.", "mushroom");
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
 
-      REQUIRE(parser.option_is_defined("pizza"));
-
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
-
-        THEN("The option has the value defined in the environment")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<std::string>("pizza") == "pepperoni");
-        }
-      }
-
-      AND_WHEN("The option is passed in the arguments")
-      {
-        int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe", "-p", "hawaiian"};
-        THEN("The option has the value defined in the command line args")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<std::string>("pizza") == "hawaiian");
-        }
-      }
+      CHECK(parser.template get<std::string>("parameter s") == "something=other");
+      CHECK(param_s == "something=other");
     }
 
-    WHEN ("An undefined environment varible is added to a string option")
+    SECTION("Unknown parameters may also use equals signs")
     {
-      using namespace lbann::utils::stubs;
-      using TestENV = lbann::utils::EnvVariable<PresetEnvAccessor>;
+      char const* argv[] = {"argument_parser_test.exe", "--flag-v",
+                            "--param-q=121", "--param-t=21"};
+      int const argc = sizeof(argv) / sizeof(argv[0]);
 
-      parser.add_option(
-        "platypus", {"-p"}, TestENV("DOESNT_EXIST"),
-        "This variable won't exist.", "so cute");
+      REQUIRE_NOTHROW(parser.parse(argc, argv));
 
-      REQUIRE(parser.option_is_defined("platypus"));
-
-      AND_WHEN("The option is not passed in the arguments")
-      {
-        int const argc = 1;
-        char const* argv[argc] = {"argument_parser_test.exe"};
-
-        THEN("The option has the default value")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<std::string>("platypus") == "so cute");
-        }
-      }
-      AND_WHEN("The option is passed in the arguments")
-      {
-        int const argc = 3;
-        char const* argv[argc] = {"argument_parser_test.exe", "-p", "llama"};
-        THEN("The option has the value defined in the command line args")
-        {
-          REQUIRE_NOTHROW(parser.parse(argc, argv));
-          REQUIRE(parser.template get<std::string>("platypus") == "llama");
-        }
-      }
+      CHECK(parser.template get<int>("parameter t") == 21);
+      CHECK(flag_v);
     }
   }
 }


### PR DESCRIPTION
This refactors the argument parser to have a statically-bound error-handling policy for argument parsing. It implements two such policies: one to provide good error semantics and one to allow ignoring recognized. The latter is a requirement of a request from @bvanessen that the clara argument parser temporarily coexist with the current options class.

I think the core of this is good -- making error-handling flexible is a usually a worthwhile task. However, I cannot stress enough that allowing arbitrary arguments to float around unchecked is a bad UI choice. Part of the argument parser's job is to validate input from finicky, unreliable humans. A user might type "--dataflie-dir" when they meant "--datafile-dir" (or they may have done something even crazier like used underscores instead of dashes). Without rigid error checking, this will slide by unnoticed and cause much confusion. This should be like anything else: if we try to open the file "/I/am/a/flie.ext" instead of "/I/am/a/file.ext", we would throw an error...

Anyway, the test has been updated. I've also taken the opportunity to clean that test up a bit. If @bvanessen wants this quickly, I can finish that in a separate PR.