### PR TITLE
Enable Distconv in convolutions

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -1,0 +1,333 @@
+import functools
+import math
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+def make_random_array(shape, seed):
+    """Hacked function to generate a random array.
+
+    NumPy's RNG produces different values with different NumPy
+    versions. This function is helpful when array values must be
+    identical across all runs, e.g. when checking against precomputed
+    metric values.
+
+    Args:
+        shape (Iterable of int): Array dimensions
+        seed (int): Parameter for RNG. Must be non-zero.
+    Returns:
+        numpy.ndarray: Array of `np.float32`. Values will be in
+            [-0.5,0.5).
+
+    """
+    size = functools.reduce(operator.mul, shape)
+    eps = np.finfo(np.float32).eps
+    x = (seed / np.linspace(math.sqrt(eps), 0.1, size)) % 1 - 0.5
+    return x.reshape(shape).astype(np.float32)
+
+# Data
+_num_samples = 23
+_sample_dims = [6,11,7]
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = make_random_array([_num_samples] + _sample_dims, 7)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:].reshape(-1)
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# PyTorch convolution
+# ==============================================
+
+def pytorch_convolution(data,
+                        kernel,
+                        bias=None,
+                        stride=1,
+                        padding=0,
+                        dilation=1,
+                        groups=1):
+    """Wrapper around PyTorch convolution.
+
+    Input and output data are NumPy arrays.
+
+    """
+
+    # Convert input data to PyTorch tensors with 64-bit floats
+    import torch
+    import torch.nn.functional
+    if type(data) is np.ndarray:
+        data = torch.from_numpy(data)
+    if type(kernel) is np.ndarray:
+        kernel = torch.from_numpy(kernel)
+    if type(bias) is np.ndarray:
+        bias = torch.from_numpy(bias)
+    if data.dtype is not torch.float64:
+        data = data.astype(torch.float64)
+    if kernel.dtype is not torch.float64:
+        kernel = kernel.astype(torch.float64)
+    if bias.dtype is not torch.float64:
+        bias = bias.astype(torch.float64)
+
+    # Perform convolution with PyTorch
+    output = None
+    if len(kernel.shape) == 3:
+        output = torch.nn.functional.conv1d(
+            data, kernel, bias, stride, padding, dilation, groups
+        )
+    if len(kernel.shape) == 4:
+        output = torch.nn.functional.conv2d(
+            data, kernel, bias, stride, padding, dilation, groups
+        )
+    if len(kernel.shape) == 5:
+        output = torch.nn.functional.conv3d(
+            data, kernel, bias, stride, padding, dilation, groups
+        )
+    if output is None:
+        raise ValueError('PyTorch only supports 1D, 2D, and 3D convolution')
+
+    # Return output as NumPy array
+    return output.numpy()
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    trainer = lbann.Trainer()
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def create_parallel_strategy(num_height_groups):
+    return {"height_groups": num_height_groups}
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Sum with a weights layer so that gradient checking will
+    # verify that error signals are correct.
+    x_weights = lbann.Weights(optimizer=lbann.SGD(),
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
+    x_lbann = x
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Basic 3x3 convolution
+    # ------------------------------------------
+    # 3x3 conv, stride=1, pad=1, dilation=1, bias
+
+    # Convolution settings
+    kernel_dims = (5, _sample_dims[0], 3, 3)
+    strides = (1, 1)
+    pads = (1, 1)
+    dilations = (1, 1)
+    kernel = make_random_array(kernel_dims, 11)
+    bias = make_random_array([kernel_dims[0]], 123)
+
+    # Apply convolution
+    kernel_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(kernel))),
+        name='kernel1'
+    )
+    bias_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(bias))),
+        name='bias1'
+    )
+    x = x_lbann
+    y = lbann.Convolution(x,
+                          weights=(kernel_weights, bias_weights),
+                          num_dims=3,
+                          num_output_channels=kernel_dims[0],
+                          has_vectors=True,
+                          conv_dims=tools.str_list(kernel_dims[2:]),
+                          conv_strides=tools.str_list(strides),
+                          conv_pads=tools.str_list(pads),
+                          conv_dilations=tools.str_list(dilations),
+                          has_bias=True,
+                          parallel_strategy=create_parallel_strategy(4))
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='basic 3x3 convolution'))
+
+    # PyTorch implementation
+    try:
+        x = _samples
+        y = pytorch_convolution(
+            x, kernel, bias=bias,
+            stride=strides, padding=pads, dilation=dilations
+        )
+        z = tools.numpy_l2norm2(y) / _num_samples
+        val = z
+    except:
+        # Precomputed value
+        val = 153.84937996554953
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # 2x4 strided convolution
+    # ------------------------------------------
+
+    # Convolution settings
+    kernel_dims = (3, _sample_dims[0], 2, 4)
+    strides = (3, 1)
+    pads = (3, 0)
+    dilations = (1, 1)
+    num_groups = 1
+    kernel = make_random_array(kernel_dims, 19)
+
+    # Apply convolution
+    kernel_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(kernel))),
+        name='kernel2'
+    )
+    x = x_lbann
+    y = lbann.Convolution(x,
+                          weights=(kernel_weights),
+                          num_dims=3,
+                          num_output_channels=kernel_dims[0],
+                          has_vectors=True,
+                          conv_dims=tools.str_list(kernel_dims[2:]),
+                          conv_strides=tools.str_list(strides),
+                          conv_pads=tools.str_list(pads),
+                          conv_dilations=tools.str_list(dilations),
+                          num_groups=num_groups,
+                          has_bias=False,
+                          parallel_strategy=create_parallel_strategy(4))
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='2x4 convolution'))
+
+    # PyTorch implementation
+    try:
+        x = _samples
+        y = pytorch_convolution(
+            x, kernel, bias=None,
+            stride=strides, padding=pads,
+            dilation=dilations, groups=num_groups
+        )
+        z = tools.numpy_l2norm2(y) / _num_samples
+        val = z
+    except:
+        # Precomputed value
+        val = 19.24587403346207
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    mini_batch_size = num_samples() // 2
+    num_epochs = 0
+    return lbann.Model(mini_batch_size,
+                       num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+# Note: Create test name by removing ".py" from file name
+_test_name = os.path.splitext(os.path.basename(current_file))[0]
+for test in tools.create_tests(setup_experiment, _test_name, procs_per_node=4):
+    globals()[test.__name__] = test

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -37,11 +37,43 @@
 #include "lbann/utils/random.hpp"
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/im2col.hpp"
+#include "lbann/utils/distconv.hpp"
 
 #include <vector>
 #include <omp.h>
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, El::Device Device>
+class base_convolution_adapter: public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+
+  base_convolution_adapter(Layer& layer): data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~base_convolution_adapter() = default;
+
+  void setup_fp_tensors() override;
+  void setup_bp_tensors() override;
+  void setup_layer(size_t workspace_capacity) override;
+
+  void fp_compute_convolution();
+  void fp_apply_bias();
+
+  void bp_compute_convolution_data();
+  void bp_compute_convolution_filter();
+
+  std::unique_ptr<dc::Convolution<TensorDataType>> m_conv;
+  std::unique_ptr<TensorDevType> m_kernel;
+  std::unique_ptr<TensorDevType> m_bias;
+  std::unique_ptr<TensorDevType> m_kernel_gradient;
+  std::unique_ptr<TensorDevType> m_bias_gradient;
+
+  std::string m_fwd_algo;
+  std::string m_bwd_data_algo;
+  std::string m_bwd_filter_algo;
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief Computation kernels for convolution and deconvolution layers.
  */
@@ -1236,7 +1268,186 @@ private:
 
 #endif // LBANN_HAS_CUDNN
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class base_convolution_adapter<TensorDataType, Device>;
+ protected:
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<
+      base_convolution_adapter<TensorDataType, Device>>(*this);
+  }
+  base_convolution_adapter<TensorDataType, Device>& dc() override;
+  const base_convolution_adapter<TensorDataType, Device>& dc() const override;
+#endif // LBANN_HAS_DISTCONV
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, El::Device Device>
+const base_convolution_adapter<TensorDataType, Device>&
+base_convolution_layer<TensorDataType, Device>::dc() const {
+  return dynamic_cast<const base_convolution_adapter<
+    TensorDataType, Device>&>(data_type_layer<TensorDataType>::dc());
+}
+
+template <typename TensorDataType, El::Device Device>
+base_convolution_adapter<TensorDataType, Device>&
+base_convolution_layer<TensorDataType, Device>::dc() {
+  return const_cast<base_convolution_adapter<TensorDataType, Device>&>(
+      static_cast<const base_convolution_layer<TensorDataType, Device>&>(*this).dc());
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::setup_fp_tensors() {
+  data_type_distconv_adapter<TensorDataType>::setup_fp_tensors();
+  auto &layer = dynamic_cast<
+    base_convolution_layer<TensorDataType, Device>&>(this->layer());
+  const auto &input_dist = this->get_prev_activations_dist();
+
+  const auto& kernel_dims = layer.get_kernel_dims();
+  std::stringstream ss;
+  dc::util::print_vector(ss, kernel_dims.begin(), kernel_dims.end());
+
+  // assumes no partitioning on channel/filter dimensions
+  assert_eq(input_dist.get_split_shape()[-2], 1);
+  auto shared_dist = dc::Dist::make_shared_distribution(
+      input_dist.get_locale_shape());
+
+  dc::Shape kernel_shape(kernel_dims);
+  std::reverse(kernel_shape.begin(), kernel_shape.end());
+  const dc::LocaleMPI loc(dc::get_mpi_comm(), false);
+  m_kernel = make_unique<TensorDevType>(kernel_shape, loc, shared_dist);
+  assert0(dc::tensor::View(
+      *m_kernel, layer.get_data_type_weights(0).get_values().LockedBuffer()));
+
+  if (layer.m_bias_scaling_factor != TensorDataType(0)) {
+    dc::Shape bias_shape(layer.get_num_dims(), 1);
+    bias_shape[dc::get_channel_dim()] = layer.get_output_dims()[0];
+    m_bias = make_unique<TensorDevType>(bias_shape, loc, shared_dist);
+    assert0(dc::tensor::View(
+        *m_bias, layer.get_data_type_weights(1).get_values().LockedBuffer()));
+  }
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::setup_bp_tensors() {
+  data_type_distconv_adapter<TensorDataType>::setup_bp_tensors();
+  auto &l = dynamic_cast<
+    base_convolution_layer<TensorDataType, Device>&>(this->layer());
+
+  const auto shared_dist = dc::Dist::make_shared_distribution(
+      this->get_prev_error_signals_dist().get_locale_shape());
+  dc::Shape kernel_shape(l.get_kernel_dims());
+  std::reverse(kernel_shape.begin(), kernel_shape.end());
+  const dc::LocaleMPI loc(dc::get_mpi_comm(), false);
+
+  m_kernel_gradient = make_unique<TensorDevType>(kernel_shape, loc, shared_dist);
+  // Gradient buffer is needed for auto-tuning the bp filter algorithm
+  assert0(dc::tensor::View(
+      *m_kernel_gradient,
+      l.get_data_type_weights(0).get_optimizer()->get_gradient().Buffer()));
+
+  // Bias tensor. Shared by all procs
+  if (l.m_bias_scaling_factor != TensorDataType(0)) {
+    auto* bias_optimizer = l.get_data_type_weights(1).get_optimizer();
+    if (bias_optimizer != nullptr) {
+      dc::Shape bias_shape(this->get_num_dims(), 1);
+      bias_shape[dc::get_channel_dim()] = l.get_output_dims()[0];
+      m_bias_gradient = make_unique<TensorDevType>(bias_shape, loc, shared_dist);
+      // setup_bias_gradients needs strides of the bias tensor,
+      // which is set when its view is set.
+      assert0(dc::tensor::View(
+          *m_bias_gradient,
+          l.get_data_type_weights(1).get_optimizer()->get_gradient().Buffer()));
+    }
+  }
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::setup_layer(
+size_t workspace_capacity) {
+  data_type_distconv_adapter<TensorDataType>::setup_layer(workspace_capacity);
+  auto &layer = dynamic_cast<base_convolution_layer<TensorDataType, Device>&>(this->layer());
+  m_conv = make_unique<dc::Convolution<TensorDataType>>(
+      dc::get_backend(), layer.get_num_dims(),
+      dc::get_halo_exchange_method());
+  if (layer.m_bias_scaling_factor != TensorDataType(0)) {
+    m_conv->setup_bias(*m_bias);
+    m_conv->setup_bias_gradient(*m_bias_gradient);
+  }
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::fp_compute_convolution() {
+  auto &l = dynamic_cast<base_convolution_layer<
+    TensorDataType, Device>&>(this->layer());
+  assert0(dc::tensor::View(
+      *m_kernel, l.get_data_type_weights(0).get_values().LockedBuffer()));
+  m_conv->forward(TensorDataType{1}, this->get_prev_activations(),
+                  *m_kernel, TensorDataType{0}, this->get_activations());
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::fp_apply_bias() {
+  auto &l = dynamic_cast<base_convolution_layer<
+    TensorDataType, Device>&>(this->layer());
+  if (l.m_bias_scaling_factor == TensorDataType(0)) return;
+  assert0(dc::tensor::View(
+      *m_bias, l.get_data_type_weights(1).get_values().LockedBuffer()));
+  m_conv->apply_bias(l.m_bias_scaling_factor, *m_bias,
+                     TensorDataType{1}, this->get_activations());
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_data() {
+  auto &l = dynamic_cast<base_convolution_layer<
+    TensorDataType, Device>&>(this->layer());
+  assert0(dc::tensor::View(
+      *m_kernel, l.get_data_type_weights(0).get_values().LockedBuffer()));
+  m_conv->backward_data(TensorDataType{1}, *m_kernel,
+                        this->get_prev_error_signals(),
+                        TensorDataType{0}, this->get_error_signals());
+}
+
+template <typename TensorDataType, El::Device Device>
+void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_filter() {
+  auto &l = dynamic_cast<base_convolution_layer<
+    TensorDataType, Device>&>(this->layer());
+  const bool has_local_data = this->get_prev_activations().get_local_size() > 0 &&
+      this->get_prev_error_signals().get_local_size() > 0;
+  if (l.m_bias_scaling_factor != TensorDataType(0)
+      && l.get_data_type_weights(1).get_optimizer() != nullptr) {
+    auto* bias_optimizer = l.get_data_type_weights(1).get_optimizer();
+    TensorDataType dst_scale{0}, gradient_scale{0};
+    auto& bias_gradient = bias_optimizer->get_gradient_buffer(
+        dst_scale, gradient_scale, true);
+    assert0(dc::tensor::View(*m_bias_gradient,
+                             bias_gradient.Buffer()));
+    if (has_local_data) {
+      m_conv->backward_bias(gradient_scale,
+                            this->get_prev_error_signals(),
+                            dst_scale, *m_bias_gradient, false);
+    } else {
+      m_bias_gradient->scale(dst_scale, El::GPUManager::Stream());
+    }
+  }
+
+  auto* kernel_optimizer = l.get_data_type_weights(0).get_optimizer();
+  if (kernel_optimizer == nullptr) return;
+  TensorDataType dst_scale{0}, gradient_scale{0};
+  auto& kernel_gradient = kernel_optimizer->get_gradient_buffer(
+      dst_scale, gradient_scale, true);
+  assert0(dc::tensor::View(
+      *m_kernel_gradient, kernel_gradient.Buffer()));
+  if (has_local_data) {
+    m_conv->backward_filter(gradient_scale,
+                            this->get_prev_activations(),
+                            this->get_prev_error_signals(),
+                            dst_scale,
+                            *m_kernel_gradient, false);
+  } else {
+    m_kernel_gradient->scale(dst_scale, El::GPUManager::Stream());
+  }
+}
+#endif // LBANN_HAS_DISTCONV
 
 #ifndef LBANN_BASE_CONVOLUTION_LAYER_INSTANTIATE
 

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -159,8 +159,8 @@ protected:
     if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
       if (this->distconv_enabled()) {
-        this->dc().fp_compute_convolution();
-        this->dc().fp_apply_bias();
+        this->get_distconv_adapter().fp_compute_convolution();
+        this->get_distconv_adapter().fp_apply_bias();
         return;
       }
 #endif // LBANN_HAS_DISTCONV
@@ -176,12 +176,12 @@ protected:
     if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
       if (this->distconv_enabled()) {
-        if (this->dc().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
-          this->dc().m_conv->backward_data_exchange_halo(
-              this->dc().get_prev_error_signals());
+        if (this->get_distconv_adapter().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
+          this->get_distconv_adapter().m_conv->backward_data_exchange_halo(
+              this->get_distconv_adapter().get_prev_error_signals());
         }
-        this->dc().bp_compute_convolution_filter();
-        this->dc().bp_compute_convolution_data();
+        this->get_distconv_adapter().bp_compute_convolution_filter();
+        this->get_distconv_adapter().bp_compute_convolution_data();
         return;
       }
 #endif // LBANN_HAS_DISTCONV
@@ -197,13 +197,13 @@ protected:
   friend class convolution_distconv_adapter<TensorDataType, Layout, Device>;
  protected:
   void setup_distconv_adapter() override {
-    this->get_dc() = make_unique<
+    this->get_distconv_adapter_ptr() = make_unique<
       convolution_distconv_adapter<TensorDataType, Layout, Device>>(*this);
   }
 
   bool is_distconv_supported() const override {
     const auto& kernel_dims = get_kernel_dims();
-    for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+    for(int i = 0; i < dc::get_num_spatial_dims(*this); i++) {
       if (kernel_dims[2 + i] != kernel_dims[2]) {
         dc::MPIRootPrintStreamDebug()
             << "Nonsymmetric kernel not supported";
@@ -233,10 +233,10 @@ setup_distributions(tensor_overlap_constraints &constraints) {
   std::reverse(kernel_dims.begin(), kernel_dims.end());
   auto dilations = l.m_dilations;
   std::reverse(dilations.begin(), dilations.end());
-  dc::IntVector overlap(this->get_num_dims(), 0);
+  dc::IntVector overlap(dc::get_num_dims(l), 0);
   const auto &ps = l.get_parallel_strategy();
   // i=0 -> width; i=1 -> height; i=2: -> depth;
-  for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+  for(int i = 0; i < dc::get_num_spatial_dims(l); i++) {
     int splits = 0;
     switch (i) {
       case 0: splits = ps.width_splits; break;

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
 
@@ -36,6 +37,21 @@ namespace lbann {
 namespace callback {
 class imcomm;
 }
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+class convolution_distconv_adapter: public base_convolution_adapter<TensorDataType, Device> {
+ public:
+  using TensorDevType = typename base_convolution_adapter<TensorDataType, Device>::TensorDevType;
+
+  convolution_distconv_adapter(Layer& layer): base_convolution_adapter<TensorDataType, Device>(layer) {}
+  virtual ~convolution_distconv_adapter() = default;
+
+  void setup_distributions(tensor_overlap_constraints &constraints) override;
+  void setup_layer(size_t workspace_capacity) override;
+  dc::Shape get_activations_local_shape(int index=0) const override;
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief Standard deep learning convolution.
  *
@@ -141,6 +157,13 @@ protected:
 
   void fp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        this->dc().fp_compute_convolution();
+        this->dc().fp_apply_bias();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       base_convolution_layer<TensorDataType, Device>::apply_convolution_cudnn(true);
       base_convolution_layer<TensorDataType, Device>::apply_bias_cudnn();
     } else {
@@ -151,6 +174,17 @@ protected:
 
   void bp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        if (this->dc().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
+          this->dc().m_conv->backward_data_exchange_halo(
+              this->dc().get_prev_error_signals());
+        }
+        this->dc().bp_compute_convolution_filter();
+        this->dc().bp_compute_convolution_data();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       base_convolution_layer<TensorDataType, Device>::compute_gradients_cudnn(false);
       base_convolution_layer<TensorDataType, Device>::apply_transposed_convolution_cudnn(false);
     } else {
@@ -159,7 +193,133 @@ protected:
     }
   }
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class convolution_distconv_adapter<TensorDataType, Layout, Device>;
+ protected:
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<
+      convolution_distconv_adapter<TensorDataType, Layout, Device>>(*this);
+  }
+
+  bool is_distconv_supported() const override {
+    const auto& kernel_dims = get_kernel_dims();
+    for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+      if (kernel_dims[2 + i] != kernel_dims[2]) {
+        dc::MPIRootPrintStreamDebug()
+            << "Nonsymmetric kernel not supported";
+        return false;
+      }
+      if (kernel_dims[2 + i] !=
+          this->m_pads[i] / this->m_dilations[i] * 2 + 1) {
+        dc::MPIRootPrintStreamDebug()
+            << "Unsupported as padding does not match the kernel size";
+        return false;
+      }
+    }
+    return true;
+  }
+#endif // LBANN_HAS_DISTCONV
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void convolution_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_distributions(tensor_overlap_constraints &constraints) {
+  base_convolution_adapter<TensorDataType, Dev>::setup_distributions(
+      constraints);
+  auto &l = dynamic_cast<convolution_layer<
+    TensorDataType, T_layout, Dev>&>(this->layer());
+  auto kernel_dims = l.get_kernel_dims();
+  std::reverse(kernel_dims.begin(), kernel_dims.end());
+  auto dilations = l.m_dilations;
+  std::reverse(dilations.begin(), dilations.end());
+  dc::IntVector overlap(this->get_num_dims(), 0);
+  const auto &ps = l.get_parallel_strategy();
+  // i=0 -> width; i=1 -> height; i=2: -> depth;
+  for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+    int splits = 0;
+    switch (i) {
+      case 0: splits = ps.width_splits; break;
+      case 1: splits = ps.height_splits; break;
+      case 2: splits = ps.depth_splits; break;
+    }
+    if (splits > 1) {
+      overlap[i] = (kernel_dims[i] - 1) / 2 * dilations[i];
+    }
+  }
+  auto &prev_activations_dist = this->get_prev_activations_dist();
+  prev_activations_dist.set_overlap(overlap);
+  constraints.mark_updated(prev_activations_dist);
+  constraints.mark_invariant(prev_activations_dist);
+  auto &prev_error_signals_dist = this->get_prev_error_signals_dist();
+  prev_error_signals_dist.set_overlap(overlap);
+  constraints.mark_updated(prev_error_signals_dist);
+  constraints.mark_invariant(prev_error_signals_dist);
+  // To deal with strides, error signals must have the same size
+  // of overlap
+  auto &error_signals_dist = this->get_error_signals_dist();
+  error_signals_dist.set_overlap(overlap);
+  constraints.mark_updated(error_signals_dist);
+  constraints.mark_invariant(error_signals_dist);
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+dc::Shape convolution_distconv_adapter<TensorDataType, Layout, Device>::
+get_activations_local_shape(int index) const {
+  assert_eq(index, 0);
+  const auto &layer = dynamic_cast<const convolution_layer<
+    TensorDataType, Layout, Device>&>(this->layer());
+  auto filter_dims = layer.get_kernel_dims();
+  std::reverse(std::begin(filter_dims), std::end(filter_dims));
+  auto strides = layer.m_strides;
+  std::reverse(std::begin(strides), std::end(strides));
+  auto dilations = layer.m_dilations;
+  std::reverse(std::begin(dilations), std::end(dilations));
+  const auto output_spatial_local_shape =
+      ::distconv::get_convolution_output_local_tensor_shape(
+          this->get_prev_activations(),
+          filter_dims, strides, true, dilations,
+          layer.m_groups);
+  return output_spatial_local_shape;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void convolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
+    size_t workspace_capacity) {
+  base_convolution_adapter<TensorDataType, Device>::setup_layer(
+      workspace_capacity);
+  auto &layer = dynamic_cast<convolution_layer<
+    TensorDataType, Layout, Device>&>(this->layer());
+
+  if (dc::is_deterministic()) {
+    dc::MPIRootPrintStreamDebug() << "Using deterministic convolution algorithms";
+    this->m_fwd_algo = "DETERMINISTIC";
+    this->m_bwd_data_algo = "DETERMINISTIC";
+    this->m_bwd_filter_algo = "DETERMINISTIC";
+  } else {
+    this->m_fwd_algo = dc::get_convolution_fwd_algorithm();
+    this->m_bwd_data_algo = dc::get_convolution_bwd_data_algorithm();
+    this->m_bwd_filter_algo = dc::get_convolution_bwd_filter_algorithm();
+  }
+
+  std::vector<int> pads = layer.m_pads;
+  std::reverse(pads.begin(), pads.end());
+  std::vector<int> strides = layer.m_strides;
+  std::reverse(strides.begin(), strides.end());
+  std::vector<int> dilations = layer.m_dilations;
+  std::reverse(dilations.begin(), dilations.end());
+
+  this->m_conv->setup(this->get_prev_activations(),
+                      *(this->m_kernel), this->get_activations(),
+                      this->get_error_signals(),
+                      *this->m_kernel_gradient,
+                      this->get_prev_error_signals(),
+                      pads, strides, dilations, layer.m_groups,
+                      this->m_fwd_algo, this->m_bwd_data_algo,
+                      this->m_bwd_filter_algo,
+                      workspace_capacity);
+}
+#endif // LBANN_HAS_DISTCONV
 
 // Builder function
 LBANN_DEFINE_LAYER_BUILDER(convolution);

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -173,8 +173,8 @@ protected:
     if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
       if (this->distconv_enabled()) {
-        this->dc().fp_compute_convolution();
-        this->dc().fp_apply_bias();
+        this->get_distconv_adapter().fp_compute_convolution();
+        this->get_distconv_adapter().fp_apply_bias();
         return;
       }
 #endif // LBANN_HAS_DISTCONV
@@ -190,12 +190,12 @@ protected:
     if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
       if (this->distconv_enabled()) {
-        if (this->dc().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
-          this->dc().m_conv->backward_data_exchange_halo(
-              this->dc().get_prev_error_signals());
+        if (this->get_distconv_adapter().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
+          this->get_distconv_adapter().m_conv->backward_data_exchange_halo(
+              this->get_distconv_adapter().get_prev_error_signals());
         }
-        this->dc().bp_compute_convolution_filter();
-        this->dc().bp_compute_convolution_data();
+        this->get_distconv_adapter().bp_compute_convolution_filter();
+        this->get_distconv_adapter().bp_compute_convolution_data();
         return;
       }
 #endif // LBANN_HAS_DISTCONV
@@ -211,13 +211,13 @@ protected:
   friend class deconvolution_distconv_adapter<TensorDataType, Layout, Device>;
  protected:
   void setup_distconv_adapter() override {
-    this->get_dc() = make_unique<
+    this->get_distconv_adapter_ptr() = make_unique<
       deconvolution_distconv_adapter<TensorDataType, Layout, Device>>(*this);
   }
 
   bool is_distconv_supported() const override {
     const auto& kernel_dims = get_kernel_dims();
-    for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+    for(int i = 0; i < dc::get_num_spatial_dims(*this); i++) {
       auto pad = this->m_pads[i];
       if (pad != 0) {
         dc::MPIPrintStreamDebug() << this->get_name()

--- a/include/lbann/layers/learning/deconvolution.hpp
+++ b/include/lbann/layers/learning/deconvolution.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
 
@@ -36,6 +37,21 @@ namespace lbann {
 namespace callback {
 class imcomm;
 }
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+class deconvolution_distconv_adapter: public base_convolution_adapter<TensorDataType, Device> {
+ public:
+  using TensorDevType = typename base_convolution_adapter<TensorDataType, Device>::TensorDevType;
+
+  deconvolution_distconv_adapter(Layer& layer): base_convolution_adapter<TensorDataType, Device>(layer) {}
+  virtual ~deconvolution_distconv_adapter() = default;
+
+  void setup_distributions(tensor_overlap_constraints &constraints) override;
+  void setup_layer(size_t workspace_capacity) override;
+  dc::Shape get_activations_local_shape(int index=0) const override;
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief Transpose of the convolution layer. */
 template <typename TensorDataType, data_layout Layout = data_layout::DATA_PARALLEL, El::Device Device = El::Device::CPU>
@@ -155,6 +171,13 @@ protected:
 
   void fp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        this->dc().fp_compute_convolution();
+        this->dc().fp_apply_bias();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       base_convolution_layer<TensorDataType, Device>::apply_transposed_convolution_cudnn(true);
       base_convolution_layer<TensorDataType, Device>::apply_bias_cudnn();
     } else {
@@ -165,6 +188,17 @@ protected:
 
   void bp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        if (this->dc().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
+          this->dc().m_conv->backward_data_exchange_halo(
+              this->dc().get_prev_error_signals());
+        }
+        this->dc().bp_compute_convolution_filter();
+        this->dc().bp_compute_convolution_data();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       base_convolution_layer<TensorDataType, Device>::compute_gradients_cudnn(true);
       base_convolution_layer<TensorDataType, Device>::apply_convolution_cudnn(false);
     } else {
@@ -173,7 +207,124 @@ protected:
     }
   }
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class deconvolution_distconv_adapter<TensorDataType, Layout, Device>;
+ protected:
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<
+      deconvolution_distconv_adapter<TensorDataType, Layout, Device>>(*this);
+  }
+
+  bool is_distconv_supported() const override {
+    const auto& kernel_dims = get_kernel_dims();
+    for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+      auto pad = this->m_pads[i];
+      if (pad != 0) {
+        dc::MPIPrintStreamDebug() << this->get_name()
+                                  << " unsupported as padding must be zero";
+        return false;
+      }
+      auto stride_size = this->m_strides[i];
+      auto filter_size = kernel_dims[2+i];
+      if (!(filter_size % 2 == 0 && filter_size == stride_size)) {
+        dc::MPIPrintStreamDebug() << this->get_name()
+                                  << " unsupported due to filter and stride sizes";
+        return false;
+      }
+    }
+    return true;
+  }
+#endif // LBANN_HAS_DISTCONV
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void deconvolution_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_distributions(tensor_overlap_constraints &constraints) {
+  base_convolution_adapter<TensorDataType, Dev>::setup_distributions(
+      constraints);
+
+  // Assumes zero halo all tensor for now
+  // prev activations
+  for (auto &d: this->m_prev_activations_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_activations_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_prev_error_signals_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_error_signals_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+dc::Shape deconvolution_distconv_adapter<TensorDataType, Layout, Device>::
+get_activations_local_shape(int index) const {
+  assert_eq(index, 0);
+  const auto &layer = dynamic_cast<const deconvolution_layer<
+    TensorDataType, Layout, Device>&>(this->layer());
+  auto filter_dims = layer.get_kernel_dims();
+  std::reverse(std::begin(filter_dims), std::end(filter_dims));
+  auto strides = layer.m_strides;
+  std::reverse(std::begin(strides), std::end(strides));
+  auto dilations = layer.m_dilations;
+  std::reverse(std::begin(dilations), std::end(dilations));
+  const auto output_spatial_local_shape =
+      ::distconv::get_deconvolution_output_local_tensor_shape(
+          this->get_prev_activations(),
+          filter_dims, strides, false, dilations,
+          layer.m_groups);
+  return output_spatial_local_shape;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void deconvolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
+    size_t workspace_capacity) {
+  base_convolution_adapter<TensorDataType, Device>::setup_layer(
+      workspace_capacity);
+  auto &layer = dynamic_cast<deconvolution_layer<
+    TensorDataType, Layout, Device>&>(this->layer());
+
+  if (dc::is_deterministic()) {
+    dc::MPIRootPrintStreamDebug() << "Using deterministic convolution algorithms";
+    this->m_fwd_algo = "DETERMINISTIC";
+    this->m_bwd_data_algo = "DETERMINISTIC";
+    this->m_bwd_filter_algo = "DETERMINISTIC";
+  } else {
+    this->m_fwd_algo = dc::get_convolution_bwd_data_algorithm();
+    this->m_bwd_data_algo = dc::get_convolution_fwd_algorithm();
+    this->m_bwd_filter_algo = dc::get_convolution_bwd_filter_algorithm();
+  }
+
+  std::vector<int> pads = layer.m_pads;
+  std::reverse(pads.begin(), pads.end());
+  std::vector<int> strides = layer.m_strides;
+  std::reverse(strides.begin(), strides.end());
+  std::vector<int> dilations = layer.m_dilations;
+  std::reverse(dilations.begin(), dilations.end());
+
+  this->m_conv->setup(this->get_prev_activations(),
+                      *(this->m_kernel), this->get_activations(),
+                      this->get_error_signals(),
+                      *this->m_kernel_gradient,
+                      this->get_prev_error_signals(),
+                      pads, strides, dilations, layer.m_groups,
+                      this->m_fwd_algo, this->m_bwd_data_algo,
+                      this->m_bwd_filter_algo,
+                      workspace_capacity, false, true);
+}
+#endif // LBANN_HAS_DISTCONV
 
 #ifndef LBANN_DECONVOLUTION_LAYER_INSTANTIATE
 


### PR DESCRIPTION
This is a follow-up to a prior PR #1488 and adds support for convolution and deconvolution. Deconvolution only works for very limited cases at this point, but it should correctly fall back to the base LBANN implementation when necessary.

Bamboo test: https://lc.llnl.gov/bamboo/browse/LBANN-NAOYAM5-2