### PR TITLE
Serialization methods for fp16 types in Cereal

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -27,11 +27,13 @@
 #ifndef LBANN_BASE_HPP_INCLUDED
 #define LBANN_BASE_HPP_INCLUDED
 
-#include "El.hpp"
+#include <El.hpp>
+
 #include "lbann/Elemental_extensions.hpp"
 #include "lbann/utils/cyg_profile.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/enum_iterator.hpp"
+#include "lbann/utils/serialization.hpp"
 
 // Defines, among other things, DataType.
 #include "lbann_config.hpp"

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -29,14 +29,16 @@
 
 #include <El.hpp>
 
+// Defines, among other things, DataType.
+#include "lbann_config.hpp"
+
 #include "lbann/Elemental_extensions.hpp"
 #include "lbann/utils/cyg_profile.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/enum_iterator.hpp"
+#ifdef LBANN_HAS_HALF
 #include "lbann/utils/serialization.hpp"
-
-// Defines, among other things, DataType.
-#include "lbann_config.hpp"
+#endif // LBANN_HAS_HALF
 
 // Support for OpenMP macros
 #include "lbann/utils/omp_pragma.hpp"

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -31,6 +31,7 @@ set_full_path(THIS_DIR_HEADERS
   prototext.hpp
   python.hpp
   random.hpp
+  serialization.hpp
   statistics.hpp
   summary.hpp
   summary_impl.hpp

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -40,6 +40,11 @@ set_full_path(THIS_DIR_HEADERS
   typename.hpp
   )
 
+if (LBANN_HAS_HALF)
+  list(APPEND THIS_DIR_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/serialization.hpp)
+endif (LBANN_HAS_HALF)
+
 # Add the subdirectories
 add_subdirectory(threads)
 add_subdirectory(impl)

--- a/include/lbann/utils/serialization.hpp
+++ b/include/lbann/utils/serialization.hpp
@@ -32,6 +32,8 @@
  *  Cereal's Binary, JSON, and XML archives are provided.
  */
 
+#include "lbann_config.hpp"
+
 // Half-precision support comes from here:
 #include <El.hpp>
 
@@ -44,23 +46,27 @@
  *  Extensions to Cereal for extra arithmetic types used by LBANN.
  */
 namespace cereal {
+#ifdef LBANN_HAS_HALF
+#ifdef LBANN_HAS_GPU_FP16
 
 /** @name General templates */
 ///@{
 
-/** @brief Save this GPU half-precision value as a float. */
+/** @brief Save a GPU half-precision value. */
 template <typename OutputArchiveT>
 void save(OutputArchiveT& archive, __half const& value) {
   float x = value;
   archive(x);
 }
 
+/** @brief Load a GPU half-precision value. */
 template <typename InputArchiveT>
 void load(InputArchiveT& archive, __half& value) {
   float x = 0.f;
   archive(x);
   value = x;
 }
+
 ///@}
 /** @name Binary archives */
 ///@{
@@ -72,6 +78,8 @@ void save(BinaryOutputArchive&, __half const&);
 void load(BinaryInputArchive&, __half&);
 
 ///@}
+#endif // LBANN_HAS_GPU_FP16
+
 /** @name XML archives */
 ///@{
 
@@ -98,6 +106,7 @@ void save(JSONOutputArchive&, half_float::half const&);
 void load(JSONInputArchive&, half_float::half&);
 
 ///@}
+#endif // LBANN_HAS_HALF
 }// namespace cereal
 
 #endif // LBANN_UTILS_SERIALIZATION_HPP_INCLUDED

--- a/include/lbann/utils/serialization.hpp
+++ b/include/lbann/utils/serialization.hpp
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_SERIALIZATION_HPP_INCLUDED
+#define LBANN_UTILS_SERIALIZATION_HPP_INCLUDED
+
+/** @file
+ *
+ *  Serialization functions for arithmetic types. Specializations for
+ *  Cereal's Binary, JSON, and XML archives are provided.
+ */
+
+// Half-precision support comes from here:
+#include <El.hpp>
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+
+/** @namespace cereal
+ *
+ *  Extensions to Cereal for extra arithmetic types used by LBANN.
+ */
+namespace cereal {
+
+/** @name XML archives */
+///@{
+
+// Remove the default definitions from Cereal
+inline void save(XMLOutputArchive&, half_float::half const&) = delete;
+inline void load(XMLInputArchive&, half_float::half&) = delete;
+
+/** @brief Save this half-precision value as a float for XML */
+float save_minimal(XMLOutputArchive const&,
+                   half_float::half const&) noexcept;
+
+/** @brief Load this half-precision value as a float from XML */
+void load_minimal(
+  XMLInputArchive const&, half_float::half&, float const&) noexcept;
+
+///@}
+/** @name JSON archives */
+///@{
+
+/** @brief Save this half-precision value in JSON */
+void save(JSONOutputArchive&, half_float::half const&);
+
+/** @brief Load this half-precision value from JSON */
+void load(JSONInputArchive&, half_float::half&);
+
+///@}
+}// namespace cereal
+
+#endif // LBANN_UTILS_SERIALIZATION_HPP_INCLUDED

--- a/include/lbann/utils/serialization.hpp
+++ b/include/lbann/utils/serialization.hpp
@@ -45,6 +45,33 @@
  */
 namespace cereal {
 
+/** @name General templates */
+///@{
+
+/** @brief Save this GPU half-precision value as a float. */
+template <typename OutputArchiveT>
+void save(OutputArchiveT& archive, __half const& value) {
+  float x = value;
+  archive(x);
+}
+
+template <typename InputArchiveT>
+void load(InputArchiveT& archive, __half& value) {
+  float x = 0.f;
+  archive(x);
+  value = x;
+}
+///@}
+/** @name Binary archives */
+///@{
+
+/** @brief Save this half-precision value in Binary */
+void save(BinaryOutputArchive&, __half const&);
+
+/** @brief Load this half-precision value from Binary */
+void load(BinaryInputArchive&, __half&);
+
+///@}
 /** @name XML archives */
 ///@{
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,6 +19,7 @@ set_full_path(THIS_DIR_SOURCES
   protobuf_utils.cpp
   python.cpp
   random.cpp
+  serialization.cpp
   stack_profiler.cpp
   stack_trace.cpp
   statistics.cpp

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,7 +19,6 @@ set_full_path(THIS_DIR_SOURCES
   protobuf_utils.cpp
   python.cpp
   random.cpp
-  serialization.cpp
   stack_profiler.cpp
   stack_trace.cpp
   statistics.cpp
@@ -29,6 +28,11 @@ set_full_path(THIS_DIR_SOURCES
   jag_common.cpp
   commify.cpp
 )
+
+if (LBANN_HAS_HALF)
+  list(APPEND THIS_DIR_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/serialization.cpp)
+endif (LBANN_HAS_HALF)
 
 if (LBANN_HAS_CUDA)
   # Add the CUDA source files for this directory

--- a/src/utils/serialization.cpp
+++ b/src/utils/serialization.cpp
@@ -43,6 +43,9 @@
 namespace cereal
 {
 
+#ifdef LBANN_HAS_HALF
+#ifdef LBANN_HAS_GPU_FP16
+
 /** @brief Save this half-precision value in Binary */
 void save(BinaryOutputArchive& archive, __half const& value)
 {
@@ -54,6 +57,8 @@ void load(BinaryInputArchive& archive, __half& value)
 {
   archive.loadBinary(std::addressof(value), sizeof(value));
 }
+
+#endif // LBANN_HAS_GPU_FP16
 
 // Save/load functions for XML archives
 float save_minimal(XMLOutputArchive const&,
@@ -83,4 +88,7 @@ void load(JSONInputArchive& iarchive, half_float::half& val)
   iarchive.loadValue(encoded);
   val = std::stof(encoded);
 }
+
+#endif // LBANN_HAS_HALF
+
 }// namespace cereal

--- a/src/utils/serialization.cpp
+++ b/src/utils/serialization.cpp
@@ -43,6 +43,18 @@
 namespace cereal
 {
 
+/** @brief Save this half-precision value in Binary */
+void save(BinaryOutputArchive& archive, __half const& value)
+{
+  archive.saveBinary(std::addressof(value), sizeof(value));
+}
+
+/** @brief Load this half-precision value from Binary */
+void load(BinaryInputArchive& archive, __half& value)
+{
+  archive.loadBinary(std::addressof(value), sizeof(value));
+}
+
 // Save/load functions for XML archives
 float save_minimal(XMLOutputArchive const&,
                    half_float::half const& val) noexcept

--- a/src/utils/serialization.cpp
+++ b/src/utils/serialization.cpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+/** @file
+ *
+ *  Serialization functions for arithmetic types. Specializations for
+ *  Cereal's Binary, JSON, and XML archives are provided.
+ */
+
+#include "lbann/utils/serialization.hpp"
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+
+/** @namespace cereal
+ *
+ *  Extensions to Cereal for extra arithmetic types used by LBANN.
+ */
+namespace cereal
+{
+
+// Save/load functions for XML archives
+float save_minimal(XMLOutputArchive const&,
+                   half_float::half const& val) noexcept
+{
+  return val;
+}
+
+void load_minimal(XMLInputArchive const&, half_float::half& val,
+                  float const& in_val) noexcept
+{
+  val = in_val;
+}
+
+// Save/load functions for JSON archives
+void save(JSONOutputArchive& oarchive, half_float::half const& val)
+{
+  std::ostringstream oss;
+  oss.precision(std::numeric_limits<long double>::max_digits10);
+  oss << val;
+  oarchive.saveValue(oss.str());
+}
+
+void load(JSONInputArchive& iarchive, half_float::half& val)
+{
+  std::string encoded;
+  iarchive.loadValue(encoded);
+  val = std::stof(encoded);
+}
+}// namespace cereal

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -9,12 +9,16 @@ set_full_path(THIS_DIR_SEQ_CATCH2_TEST_FILES
   image_test.cpp
   python_test.cpp
   random_test.cpp
-  serialize_half_test.cpp
   type_erased_matrix_test.cpp
 
   stubs/preset_env_accessor.hpp
   stubs/preset_env_accessor.cpp
   )
+
+if (LBANN_HAS_HALF)
+  list(APPEND THIS_DIR_SEQ_CATCH2_TEST_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/serialize_half_test.cpp)
+endif (LBANN_HAS_HALF)
 
 set(LBANN_SEQ_CATCH2_TEST_FILES
   "${LBANN_SEQ_CATCH2_TEST_FILES}"

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -9,6 +9,7 @@ set_full_path(THIS_DIR_SEQ_CATCH2_TEST_FILES
   image_test.cpp
   python_test.cpp
   random_test.cpp
+  serialize_half_test.cpp
   type_erased_matrix_test.cpp
 
   stubs/preset_env_accessor.hpp

--- a/src/utils/unit_test/serialize_half_test.cpp
+++ b/src/utils/unit_test/serialize_half_test.cpp
@@ -27,20 +27,24 @@ TEMPLATE_TEST_CASE("Serialization of half types",
   using InputArchiveT = tlist::Cadr<ArchiveTypes>; // Second entry
 
   std::stringstream ss;
-  lbann::cpu_fp16 val(4.13f), val_restore(0.f);
+  lbann::cpu_fp16 val(1.23f), val_restore(0.f);
+  lbann::fp16 val_gpu(3.21f), val_gpu_restore(0.f);
 
   // Save
   {
     OutputArchiveT oarchive(ss);
 
     CHECK_NOTHROW(oarchive(val));
+    CHECK_NOTHROW(oarchive(val_gpu));
   }
 
   // Restore
   {
     InputArchiveT iarchive(ss);
     CHECK_NOTHROW(iarchive(val_restore));
+    CHECK_NOTHROW(iarchive(val_gpu_restore));
   }
 
   CHECK(val == val_restore);
+  CHECK(val_gpu == val_gpu_restore);
 }

--- a/src/utils/unit_test/serialize_half_test.cpp
+++ b/src/utils/unit_test/serialize_half_test.cpp
@@ -1,0 +1,46 @@
+#include <catch2/catch.hpp>
+
+#include <lbann/base.hpp> // half stuff is here.
+#include <lbann/utils/serialization.hpp>
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/xml.hpp>
+
+#include <lbann/utils/h2_tmp.hpp>
+
+using namespace h2::meta;
+using BinaryArchiveTypes = TL<cereal::BinaryOutputArchive,
+                              cereal::BinaryInputArchive>;
+using JSONArchiveTypes = TL<cereal::JSONOutputArchive,
+                            cereal::JSONInputArchive>;
+using XMLArchiveTypes = TL<cereal::XMLOutputArchive,
+                           cereal::XMLInputArchive>;
+TEMPLATE_TEST_CASE("Serialization of half types",
+                   "[utilities][half][serialize]",
+                   BinaryArchiveTypes,
+                   JSONArchiveTypes,
+                   XMLArchiveTypes)
+{
+  using ArchiveTypes = TestType;
+  using OutputArchiveT = tlist::Car<ArchiveTypes>; // First entry
+  using InputArchiveT = tlist::Cadr<ArchiveTypes>; // Second entry
+
+  std::stringstream ss;
+  lbann::cpu_fp16 val(4.13f), val_restore(0.f);
+
+  // Save
+  {
+    OutputArchiveT oarchive(ss);
+
+    CHECK_NOTHROW(oarchive(val));
+  }
+
+  // Restore
+  {
+    InputArchiveT iarchive(ss);
+    CHECK_NOTHROW(iarchive(val_restore));
+  }
+
+  CHECK(val == val_restore);
+}

--- a/src/utils/unit_test/serialize_half_test.cpp
+++ b/src/utils/unit_test/serialize_half_test.cpp
@@ -28,23 +28,30 @@ TEMPLATE_TEST_CASE("Serialization of half types",
 
   std::stringstream ss;
   lbann::cpu_fp16 val(1.23f), val_restore(0.f);
+#ifdef LBANN_GPU_HAS_FP16
   lbann::fp16 val_gpu(3.21f), val_gpu_restore(0.f);
-
+#endif
   // Save
   {
     OutputArchiveT oarchive(ss);
 
     CHECK_NOTHROW(oarchive(val));
+#ifdef LBANN_GPU_HAS_FP16
     CHECK_NOTHROW(oarchive(val_gpu));
+#endif
   }
 
   // Restore
   {
     InputArchiveT iarchive(ss);
     CHECK_NOTHROW(iarchive(val_restore));
+#ifdef LBANN_GPU_HAS_FP16
     CHECK_NOTHROW(iarchive(val_gpu_restore));
+#endif
   }
 
   CHECK(val == val_restore);
+#ifdef LBANN_GPU_HAS_FP16
   CHECK(val_gpu == val_gpu_restore);
+#endif
 }

--- a/src/utils/unit_test/serialize_half_test.cpp
+++ b/src/utils/unit_test/serialize_half_test.cpp
@@ -9,6 +9,8 @@
 
 #include <lbann/utils/h2_tmp.hpp>
 
+#include <sstream>
+
 using namespace h2::meta;
 
 // (NOTE trb 04/06/2020): There seems to be an issue with Catch2 where


### PR DESCRIPTION
Adds Cereal-friendly `save`/`load` functions and associated tests for `cpu_fp16` and `fp16` types.