### PR TITLE
Enable Distconv in transform layers

### DIFF
--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -29,11 +29,27 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/distconv.hpp"
 
 #include <lbann/proto/proto_common.hpp>
 #include <layers.pb.h>
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout Layout,
+          El::Device Device>
+class concatenate_distconv_adapter : public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+  concatenate_distconv_adapter(Layer& layer):
+      data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~concatenate_distconv_adapter() = default;
+  dc::Shape get_activations_local_shape(int index=0) const override;
+  void fp_compute();
+  void bp_compute();
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief Concatenate tensors along specified dimension. */
 template <typename TensorDataType,
@@ -90,6 +106,17 @@ private:
   template <typename U>
   friend void bp_compute_impl(concatenate_layer<U,Layout,Device>&, size_t);
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class concatenate_distconv_adapter<TensorDataType, Layout, Device>;
+ protected:
+  bool is_distconv_supported() const override { return true; }
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<
+      concatenate_distconv_adapter<TensorDataType, Layout, Device>>(*this);
+  }
+  concatenate_distconv_adapter<TensorDataType, Layout, Device>& dc() override;
+  const concatenate_distconv_adapter<TensorDataType, Layout, Device>& dc() const override;
+#endif // LBANN_HAS_DISTCONV
 };
 
 // =========================================================
@@ -206,6 +233,9 @@ void concatenate_layer<TensorDataType,Layout,Device>::setup_dims() {
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void concatenate_layer<TensorDataType,Layout,Device>::fp_setup_outputs(El::Int mini_batch_size) {
+#ifdef LBANN_HAS_DISTCONV
+  if (!this->keep_original_outputs(0)) return;
+#endif // LBANN_HAS_DISTCONV
   const auto& input0 = this->get_prev_activations(0);
   auto& output = this->get_activations();
   output.Empty(false);
@@ -220,6 +250,12 @@ void concatenate_layer<TensorDataType,Layout,Device>::fp_setup_outputs(El::Int m
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void concatenate_layer<TensorDataType,Layout,Device>::fp_compute() {
+#ifdef LBANN_HAS_DISTCONV
+  if (this->distconv_enabled()) {
+    dc().fp_compute();
+    return;
+  }
+#endif
 
   // Just make a view if there is one input
   if (this->get_num_parents() == 1) {
@@ -235,6 +271,11 @@ void concatenate_layer<TensorDataType,Layout,Device>::fp_compute() {
 template <typename TensorDataType, El::Device Device>
 void bp_setup_gradient_wrt_inputs_impl(
   concatenate_layer<TensorDataType,data_layout::MODEL_PARALLEL,Device>& l) {
+#ifdef LBANN_HAS_DISTCONV
+  if (l.distconv_enabled()) {
+    LBANN_ERROR("Model-parallel LBANN matrix not supported in distconv");
+  }
+#endif // LBANN_HAS_DISTCONV
 
   // Slice Elemental matrices
   // Note: Assume each mini-batch sample is flat.
@@ -258,10 +299,16 @@ void bp_setup_gradient_wrt_inputs_impl(
   const size_t num_inputs = l.get_num_parents();
   const auto& output_grad = l.get_prev_error_signals();
   if (num_inputs == 1) {
+#ifdef LBANN_HAS_DISTCONV
+    if (!l.keep_original_gradient_wrt_inputs(0)) return;
+#endif
     El::LockedView(l.get_error_signals(0), output_grad);
   }
   else {
     for (size_t j=0; j<num_inputs; ++j) {
+#ifdef LBANN_HAS_DISTCONV
+      if (!l.keep_original_gradient_wrt_inputs(j)) continue;
+#endif
       auto& input_grad = l.get_error_signals(j);
       input_grad.AlignWith(output_grad);
       input_grad.Resize(l.get_input_size(j), output_grad.Width());
@@ -277,6 +324,12 @@ void concatenate_layer<TensorDataType,Layout,Device>::bp_setup_gradient_wrt_inpu
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void concatenate_layer<TensorDataType,Layout,Device>::bp_compute() {
+#ifdef LBANN_HAS_DISTCONV
+  if (this->distconv_enabled()) {
+    dc().bp_compute();
+    return;
+  }
+#endif
 
   // Just make a view if there is one input
   if (this->get_num_parents() == 1) {
@@ -288,6 +341,50 @@ void concatenate_layer<TensorDataType,Layout,Device>::bp_compute() {
   bp_compute_impl(*this, m_concat_dim);
 
 }
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&
+concatenate_layer<TensorDataType, T_layout, Dev>::dc() {
+  return const_cast<concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      static_cast<const concatenate_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+const concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&
+concatenate_layer<TensorDataType, T_layout, Dev>::dc() const {
+  return dynamic_cast<const concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      data_type_layer<TensorDataType>::dc());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+dc::Shape concatenate_distconv_adapter<TensorDataType, Layout, Device>::
+get_activations_local_shape(int index) const {
+  assert_eq(index, 0);
+  auto shape = this->get_prev_activations().get_local_shape();
+  shape[-2] = this->get_activations_shape()[-2];
+  return shape;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void concatenate_distconv_adapter<TensorDataType, Layout, Device>::
+fp_compute() {
+  assert_always(this->layer().get_num_parents() == 2);
+  dc::tensor::Concatenate(this->get_activations(0),
+                          this->get_prev_activations(0),
+                          this->get_prev_activations(1),
+                          El::GPUManager::Stream());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void concatenate_distconv_adapter<TensorDataType, Layout, Device>::
+bp_compute() {
+  dc::tensor::Slice(this->get_error_signals(0),
+                    this->get_error_signals(1),
+                    this->get_prev_error_signals(0),
+                    El::GPUManager::Stream());
+}
+#endif // LBANN_HAS_DISTCONV
 
 LBANN_DEFINE_LAYER_BUILDER(concatenate);
 

--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -109,7 +109,9 @@ private:
 #ifdef LBANN_HAS_DISTCONV
   friend class concatenate_distconv_adapter<TensorDataType, Layout, Device>;
  protected:
-  bool is_distconv_supported() const override { return true; }
+  bool is_distconv_supported() const override {
+    return Device == El::Device::GPU && Layout == data_layout::DATA_PARALLEL;
+  }
   void setup_distconv_adapter() override {
     this->get_distconv_adapter_ptr() = make_unique<
       concatenate_distconv_adapter<TensorDataType, Layout, Device>>(*this);

--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -111,11 +111,11 @@ private:
  protected:
   bool is_distconv_supported() const override { return true; }
   void setup_distconv_adapter() override {
-    this->get_dc() = make_unique<
+    this->get_distconv_adapter_ptr() = make_unique<
       concatenate_distconv_adapter<TensorDataType, Layout, Device>>(*this);
   }
-  concatenate_distconv_adapter<TensorDataType, Layout, Device>& dc() override;
-  const concatenate_distconv_adapter<TensorDataType, Layout, Device>& dc() const override;
+  concatenate_distconv_adapter<TensorDataType, Layout, Device>& get_distconv_adapter() override;
+  const concatenate_distconv_adapter<TensorDataType, Layout, Device>& get_distconv_adapter() const override;
 #endif // LBANN_HAS_DISTCONV
 };
 
@@ -252,7 +252,7 @@ template <typename TensorDataType, data_layout Layout, El::Device Device>
 void concatenate_layer<TensorDataType,Layout,Device>::fp_compute() {
 #ifdef LBANN_HAS_DISTCONV
   if (this->distconv_enabled()) {
-    dc().fp_compute();
+    get_distconv_adapter().fp_compute();
     return;
   }
 #endif
@@ -326,7 +326,7 @@ template <typename TensorDataType, data_layout Layout, El::Device Device>
 void concatenate_layer<TensorDataType,Layout,Device>::bp_compute() {
 #ifdef LBANN_HAS_DISTCONV
   if (this->distconv_enabled()) {
-    dc().bp_compute();
+    get_distconv_adapter().bp_compute();
     return;
   }
 #endif
@@ -345,16 +345,16 @@ void concatenate_layer<TensorDataType,Layout,Device>::bp_compute() {
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&
-concatenate_layer<TensorDataType, T_layout, Dev>::dc() {
+concatenate_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() {
   return const_cast<concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      static_cast<const concatenate_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+      static_cast<const concatenate_layer<TensorDataType, T_layout, Dev>&>(*this).get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 const concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&
-concatenate_layer<TensorDataType, T_layout, Dev>::dc() const {
+concatenate_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() const {
   return dynamic_cast<const concatenate_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      data_type_layer<TensorDataType>::dc());
+      data_type_layer<TensorDataType>::get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>

--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -110,7 +110,9 @@ private:
   friend class concatenate_distconv_adapter<TensorDataType, Layout, Device>;
  protected:
   bool is_distconv_supported() const override {
-    return Device == El::Device::GPU && Layout == data_layout::DATA_PARALLEL;
+    // Only supported for the channel dimension
+    return Device == El::Device::GPU && Layout == data_layout::DATA_PARALLEL
+        && m_concat_dim == 0;
   }
   void setup_distconv_adapter() override {
     this->get_distconv_adapter_ptr() = make_unique<

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -33,8 +33,27 @@
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/im2col.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType,
+          data_layout T_layout = data_layout::DATA_PARALLEL,
+          El::Device Dev = El::Device::CPU>
+class pooling_distconv_adapter : public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+  pooling_distconv_adapter(Layer& layer): data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~pooling_distconv_adapter() = default;
+  void setup_distributions(tensor_overlap_constraints &constraints) override;
+  dc::Shape get_activations_local_shape(int index=0) const override;
+  void setup_layer(size_t workspace_capacity) override;
+  void fp_compute();
+  void bp_compute();
+  std::unique_ptr<dc::Pooling<TensorDataType>> m_pooling;
+};
+#endif // LBANN_HAS_DISTCONV
 
 // Forward declaration
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
@@ -263,6 +282,12 @@ protected:
 
   void fp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        dc().fp_compute();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       fp_compute_cudnn();
     } else {
       fp_compute_im2col();
@@ -271,6 +296,12 @@ protected:
 
   void bp_compute() override {
     if(this->using_gpus()) {
+#ifdef LBANN_HAS_DISTCONV
+      if (this->distconv_enabled()) {
+        dc().bp_compute();
+        return;
+      }
+#endif // LBANN_HAS_DISTCONV
       bp_compute_cudnn();
     } else {
       bp_compute_im2col();
@@ -507,6 +538,18 @@ private:
 
   }
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class pooling_distconv_adapter<TensorDataType, T_layout, Dev>;
+ protected:
+  bool is_distconv_supported() const override;
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<
+      pooling_distconv_adapter<TensorDataType, T_layout, Dev>>(*this);
+  }
+  pooling_distconv_adapter<TensorDataType, T_layout, Dev>& dc() override;
+  const pooling_distconv_adapter<TensorDataType, T_layout, Dev>& dc() const override;
+#endif // LBANN_HAS_DISTCONV
+
 #ifdef LBANN_HAS_CUDNN
   /** Copy pooling cuDNN descriptor. */
   static void copy_pooling_cudnn_desc(const cudnnPoolingDescriptor_t& src,
@@ -556,6 +599,173 @@ private:
 #endif // LBANN_HAS_CUDNN
 
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+pooling_distconv_adapter<TensorDataType, T_layout, Dev>&
+pooling_layer<TensorDataType, T_layout, Dev>::dc() {
+  return const_cast<pooling_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      static_cast<const pooling_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+const pooling_distconv_adapter<TensorDataType, T_layout, Dev>&
+pooling_layer<TensorDataType, T_layout, Dev>::dc() const {
+  return dynamic_cast<const pooling_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      data_type_layer<TensorDataType>::dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+bool pooling_layer<TensorDataType, T_layout, Dev>::is_distconv_supported() const {
+  bool cond = true;
+  for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+    cond &= (m_pool_dims[i] % 2 != 0) ||
+        (m_pool_dims[i] == m_strides[i]);
+  }
+  if (!cond) {
+    dc::MPIPrintStreamDebug() << "pooling: unsupported due to window shape: "
+                              << dc::util::join_xd_array(m_pool_dims);
+    return false;
+  }
+
+  for (int i = 0; i < this->get_num_spatial_dims(); i++) {
+    bool odd = m_pool_dims[i] % 2;
+    if (odd) {
+      int stencil = (m_pool_dims[i] - 1) / 2;
+      if (!(m_pads[i] == 0 || m_pads[i] == stencil)) {
+        dc::MPIPrintStreamDebug() << "pooling: unsupported due to padding: "
+                                  << m_pads[i];
+        return false;
+      }
+      if (!(m_strides[i] == 1 || m_strides[i] == stencil + 1)) {
+        dc::MPIPrintStreamDebug() << "pooling: unsupported due to strides";
+        return false;
+      }
+    } else {
+      if (m_pads[i] != 0) return false;
+      if (m_pool_dims[i] != m_strides[i]) return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void pooling_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_distributions(tensor_overlap_constraints &constraints) {
+  data_type_distconv_adapter<TensorDataType>::setup_distributions(
+      constraints);
+  const auto &l = dynamic_cast<const pooling_layer<TensorDataType, T_layout, Dev>&>(
+      this->layer());
+  dc::IntVector overlap(this->get_num_dims(), 0);
+  const auto &ps = l.get_parallel_strategy();
+  auto pool_dims = l.m_pool_dims;
+  std::reverse(pool_dims.begin(), pool_dims.end());
+  for(int i = 0; i < this->get_num_spatial_dims(); i++) {
+    int splits = 0;
+    switch (i) {
+      case 0: splits = ps.width_splits; break;
+      case 1: splits = ps.height_splits; break;
+      case 2: splits = ps.depth_splits; break;
+    }
+    if(splits == 1) continue;
+    int ov = 0;
+    if (pool_dims[i] % 2) {
+      ov = (pool_dims[i] - 1) / 2;
+    } else {
+      // no halo dependency is assumed for now
+      ov = 0;
+    }
+    overlap[i] = ov;
+  }
+  auto &prev_activations_dist = this->get_prev_activations_dist();
+  auto &activations_dist = this->get_activations_dist();
+  auto &error_signals_dist = this->get_error_signals_dist();
+  auto &prev_error_signals_dist = this->get_prev_error_signals_dist();
+  prev_activations_dist.set_overlap(overlap);
+  constraints.mark_updated(prev_activations_dist);
+  constraints.mark_invariant(prev_activations_dist);
+  // cudnnPoolingBackward requires activations and
+  // prev_error_signals must have the same stride
+  constraints.mark_equivalent(activations_dist, prev_error_signals_dist);
+  // cudnnPoolingBackward requires prev_activations and
+  // error_signals must have the same stride
+  constraints.mark_equivalent(error_signals_dist, prev_activations_dist);
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+dc::Shape pooling_distconv_adapter<TensorDataType, Layout, Device>::
+get_activations_local_shape(int index) const {
+  assert_eq(index, 0);
+  const auto &layer = dynamic_cast<const pooling_layer<
+    TensorDataType, Layout, Device>&>(this->layer());
+  auto filter_dims = layer.m_pool_dims;
+  std::reverse(std::begin(filter_dims), std::end(filter_dims));
+  auto strides = layer.m_strides;
+  std::reverse(std::begin(strides), std::end(strides));
+  const std::vector<int> dilations(
+      this->get_num_spatial_dims(), 1);
+  bool use_padding = layer.m_pads[0] != 0;
+  auto output_spatial_local_shape =
+      ::distconv::get_pooling_output_local_tensor_shape(
+          this->get_prev_activations(), filter_dims, strides, use_padding, dilations);
+  return output_spatial_local_shape;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void pooling_distconv_adapter<TensorDataType, Layout, Device>::
+setup_layer(size_t workspace_capacity) {
+  auto &l = dynamic_cast<pooling_layer<TensorDataType, Layout, Device>&>(
+      this->layer());
+
+  // Init the dc::Pooling layer
+  m_pooling = make_unique<dc::Pooling<TensorDataType>>(
+      dc::get_backend(), this->get_num_dims(),
+      dc::get_halo_exchange_method());
+
+  std::string mode;
+  switch(l.m_pool_mode) {
+    case pool_mode::max:
+      mode = "MAX"; break;
+    case pool_mode::average:
+      mode = "AVERAGE"; break;
+    case pool_mode::average_no_pad:
+      mode = "AVERAGE_NO_PAD"; break;
+    default:
+      LBANN_ERROR("pooling_layer: no DISTCONV implementation for pooling mode");
+  }
+
+  std::vector<int> pool_dims = l.m_pool_dims;
+  std::reverse(pool_dims.begin(), pool_dims.end());
+  std::vector<int> pads = l.m_pads;
+  std::reverse(pads.begin(), pads.end());
+  std::vector<int> strides = l.m_strides;
+  std::reverse(strides.begin(), strides.end());
+
+  m_pooling->setup(this->get_prev_activations(),
+                   this->get_activations(),
+                   this->get_error_signals(),
+                   this->get_prev_error_signals(),
+                   pool_dims, pads, strides,
+                   mode);
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void pooling_distconv_adapter<TensorDataType, Layout, Device>::
+fp_compute() {
+  m_pooling->forward(TensorDataType{1}, this->get_prev_activations(),
+                     TensorDataType{0}, this->get_activations());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void pooling_distconv_adapter<TensorDataType, Layout, Device>::
+bp_compute() {
+  m_pooling->backward(TensorDataType{1}, this->get_activations(),
+                      this->get_prev_error_signals(),
+                      this->get_prev_activations(), TensorDataType{0},
+                      this->get_error_signals());
+}
+#endif // LBANN_HAS_DISTCONV
 
 LBANN_DEFINE_LAYER_BUILDER(pooling);
 

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -617,6 +617,10 @@ pooling_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() const {
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 bool pooling_layer<TensorDataType, T_layout, Dev>::is_distconv_supported() const {
+  if (Dev != El::Device::GPU || T_layout == data_layout::DATA_PARALLEL) {
+    return false;
+  }
+
   bool cond = true;
   for(int i = 0; i < dc::get_num_spatial_dims(*this); i++) {
     cond &= (m_pool_dims[i] % 2 != 0) ||

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -85,7 +85,7 @@ protected:
   void bp_compute() override {
 #ifdef LBANN_HAS_DISTCONV
     if (this->distconv_enabled()) {
-      dc().bp_compute();
+      get_distconv_adapter().bp_compute();
       return;
     }
 #endif // LBANN_HAS_DISTCONV
@@ -107,27 +107,27 @@ protected:
     return Dev == El::Device::GPU && T_layout == data_layout::DATA_PARALLEL;
   }
   void setup_distconv_adapter() override {
-    this->get_dc() = make_unique<split_distconv_adapter<
+    this->get_distconv_adapter_ptr() = make_unique<split_distconv_adapter<
       TensorDataType, T_layout, Dev>>(*this);
   }
-  split_distconv_adapter<TensorDataType, T_layout, Dev>& dc() override;
-  const split_distconv_adapter<TensorDataType, T_layout, Dev>& dc() const override;
+  split_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() override;
+  const split_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() const override;
 #endif // LBANN_HAS_DISTCONV
 };
 
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 split_distconv_adapter<TensorDataType, T_layout, Dev>&
-split_layer<TensorDataType, T_layout, Dev>::dc() {
+split_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() {
   return const_cast<split_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      static_cast<const split_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+      static_cast<const split_layer<TensorDataType, T_layout, Dev>&>(*this).get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 const split_distconv_adapter<TensorDataType, T_layout, Dev>&
-split_layer<TensorDataType, T_layout, Dev>::dc() const {
+split_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() const {
   return dynamic_cast<const split_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      data_type_layer<TensorDataType>::dc());
+      data_type_layer<TensorDataType>::get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -30,8 +30,23 @@
 #include <vector>
 #include "lbann/layers/transform/transform.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+class split_distconv_adapter: public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+  split_distconv_adapter(Layer& layer): data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~split_distconv_adapter() = default;
+  void setup_distributions(tensor_overlap_constraints &constraints) override;
+  dc::Shape get_activations_local_shape(int index) const override;
+  std::unique_ptr<TensorDevType> setup_activations_i(int index) const override;
+  void bp_compute();
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief Present input tensor to multiple outputs. */
 template <typename TensorDataType,
@@ -68,6 +83,12 @@ protected:
   void fp_compute() override {}
 
   void bp_compute() override {
+#ifdef LBANN_HAS_DISTCONV
+    if (this->distconv_enabled()) {
+      dc().bp_compute();
+      return;
+    }
+#endif // LBANN_HAS_DISTCONV
     auto& gradient_wrt_input = this->get_error_signals();
     if (this->get_num_children() > 0) {
       El::Copy(this->get_prev_error_signals(0), gradient_wrt_input);
@@ -80,7 +101,63 @@ protected:
     }
   }
 
+#ifdef LBANN_HAS_DISTCONV
+ protected:
+  bool is_distconv_supported() const override {
+    return Dev == El::Device::GPU && T_layout == data_layout::DATA_PARALLEL;
+  }
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<split_distconv_adapter<
+      TensorDataType, T_layout, Dev>>(*this);
+  }
+  split_distconv_adapter<TensorDataType, T_layout, Dev>& dc() override;
+  const split_distconv_adapter<TensorDataType, T_layout, Dev>& dc() const override;
+#endif // LBANN_HAS_DISTCONV
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+split_distconv_adapter<TensorDataType, T_layout, Dev>&
+split_layer<TensorDataType, T_layout, Dev>::dc() {
+  return const_cast<split_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      static_cast<const split_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+const split_distconv_adapter<TensorDataType, T_layout, Dev>&
+split_layer<TensorDataType, T_layout, Dev>::dc() const {
+  return dynamic_cast<const split_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      data_type_layer<TensorDataType>::dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void split_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_distributions(tensor_overlap_constraints &constraints) {
+  data_type_distconv_adapter<TensorDataType>::setup_distributions(
+      constraints);
+
+  auto &x = this->get_prev_activations_dist();
+  auto &y = this->get_activations_dist();
+  auto &dx = this->get_error_signals_dist();
+  auto &dy = this->get_prev_error_signals_dist();
+
+  constraints.mark_equivalent(x, y);
+  constraints.mark_equivalent(dx, dy);
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+dc::Shape split_distconv_adapter<TensorDataType, T_layout, Dev>::
+get_activations_local_shape(int index) const {
+  return data_type_distconv_adapter<TensorDataType>::get_activations_local_shape(0);
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+std::unique_ptr<typename split_distconv_adapter<TensorDataType, T_layout, Dev>::TensorDevType>
+split_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_activations_i(int index) const {
+  return make_unique<TensorDevType>(this->get_prev_activations(0));
+}
+#endif // LBANN_HAS_DISTCONV
 
 LBANN_DEFINE_LAYER_BUILDER(split);
 
@@ -91,6 +168,14 @@ LBANN_DEFINE_LAYER_BUILDER(split);
 
 #include "lbann/macros/instantiate_device.hpp"
 #undef PROTO_DEVICE
+#ifdef LBANN_HAS_DISTCONV
+#define PROTO_DEVICE(T, Device) \
+  extern template class split_distconv_adapter<T, data_layout::DATA_PARALLEL, Device>; \
+  extern template class split_distconv_adapter<T, data_layout::MODEL_PARALLEL, Device>
+
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+#endif // LBANN_HAS_DISTCONV
 #endif // LBANN_SPLIT_LAYER_INSTANTIATE
 
 } // namespace lbann

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -103,7 +103,7 @@ protected:
   void fp_compute() override {
 #ifdef LBANN_HAS_DISTCONV
     if (this->distconv_enabled()) {
-      dc().fp_compute();
+      get_distconv_adapter().fp_compute();
       return;
     }
 #endif // LBANN_HAS_DISTCONV
@@ -130,26 +130,26 @@ protected:
     return Dev == El::Device::GPU && T_layout == data_layout::DATA_PARALLEL;
   }
   void setup_distconv_adapter() override {
-    this->get_dc() = make_unique<sum_distconv_adapter<TensorDataType, T_layout, Dev>>(*this);
+    this->get_distconv_adapter_ptr() = make_unique<sum_distconv_adapter<TensorDataType, T_layout, Dev>>(*this);
   }
-  sum_distconv_adapter<TensorDataType, T_layout, Dev>& dc() override;
-  const sum_distconv_adapter<TensorDataType, T_layout, Dev>& dc() const override;
+  sum_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() override;
+  const sum_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() const override;
 #endif // LBANN_HAS_DISTCONV
 };
 
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 sum_distconv_adapter<TensorDataType, T_layout, Dev>&
-sum_layer<TensorDataType, T_layout, Dev>::dc() {
+sum_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() {
   return const_cast<sum_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      static_cast<const sum_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+      static_cast<const sum_layer<TensorDataType, T_layout, Dev>&>(*this).get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 const sum_distconv_adapter<TensorDataType, T_layout, Dev>&
-sum_layer<TensorDataType, T_layout, Dev>::dc() const {
+sum_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() const {
   return dynamic_cast<const sum_distconv_adapter<TensorDataType, T_layout, Dev>&>(
-      data_type_layer<TensorDataType>::dc());
+      data_type_layer<TensorDataType>::get_distconv_adapter());
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -29,8 +29,21 @@
 
 #include "lbann/layers/transform/transform.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+class sum_distconv_adapter: public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+  sum_distconv_adapter(Layer& layer): data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~sum_distconv_adapter() = default;
+  std::unique_ptr<TensorDevType> setup_error_signals_i(int index) const override;
+  void fp_compute();
+};
+#endif // LBANN_HAS_DISTCONV
 
 template <typename TensorDataType,
           data_layout T_layout = data_layout::DATA_PARALLEL,
@@ -88,6 +101,12 @@ protected:
   }
 
   void fp_compute() override {
+#ifdef LBANN_HAS_DISTCONV
+    if (this->distconv_enabled()) {
+      dc().fp_compute();
+      return;
+    }
+#endif // LBANN_HAS_DISTCONV
     auto& output = this->get_activations();
     El::Copy(this->get_prev_activations(0), output);
     for (int i = 1; i < this->get_num_parents(); ++i) {
@@ -104,7 +123,41 @@ protected:
 
   void bp_compute() override {}
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class sum_distconv_adapter<TensorDataType, T_layout, Dev>;
+ protected:
+  bool is_distconv_supported() const override {
+    return Dev == El::Device::GPU && T_layout == data_layout::DATA_PARALLEL;
+  }
+  void setup_distconv_adapter() override {
+    this->get_dc() = make_unique<sum_distconv_adapter<TensorDataType, T_layout, Dev>>(*this);
+  }
+  sum_distconv_adapter<TensorDataType, T_layout, Dev>& dc() override;
+  const sum_distconv_adapter<TensorDataType, T_layout, Dev>& dc() const override;
+#endif // LBANN_HAS_DISTCONV
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+sum_distconv_adapter<TensorDataType, T_layout, Dev>&
+sum_layer<TensorDataType, T_layout, Dev>::dc() {
+  return const_cast<sum_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      static_cast<const sum_layer<TensorDataType, T_layout, Dev>&>(*this).dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+const sum_distconv_adapter<TensorDataType, T_layout, Dev>&
+sum_layer<TensorDataType, T_layout, Dev>::dc() const {
+  return dynamic_cast<const sum_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      data_type_layer<TensorDataType>::dc());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+std::unique_ptr<typename sum_distconv_adapter<TensorDataType, T_layout, Dev>::TensorDevType>
+sum_distconv_adapter<TensorDataType, T_layout, Dev>::setup_error_signals_i(int index) const {
+  return make_unique<TensorDevType>(this->get_prev_error_signals(0));
+}
+#endif // LBANN_HAS_DISTCONV
 
 LBANN_DEFINE_LAYER_BUILDER(sum);
 
@@ -115,6 +168,14 @@ LBANN_DEFINE_LAYER_BUILDER(sum);
 
 #include "lbann/macros/instantiate_device.hpp"
 #undef PROTO_DEVICE
+#ifdef LBANN_HAS_DISTCONV
+#define PROTO_DEVICE(T, Device) \
+  extern template class sum_distconv_adapter<T, data_layout::DATA_PARALLEL, Device>; \
+  extern template class sum_distconv_adapter<T, data_layout::MODEL_PARALLEL, Device>
+
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+#endif // LBANN_HAS_DISTCONV
 #endif // LBANN_SUM_LAYER_INSTANTIATE
 
 } // namespace lbann

--- a/src/layers/transform/CMakeLists.txt
+++ b/src/layers/transform/CMakeLists.txt
@@ -37,6 +37,8 @@ if (LBANN_HAS_CUDA)
     sort.cu
     slice.cu
     tessellate.cu
+    split.cu
+    sum.cu
     )
 endif ()
 

--- a/src/layers/transform/split.cpp
+++ b/src/layers/transform/split.cpp
@@ -34,11 +34,26 @@ namespace lbann {
 
 LBANN_LAYER_DEFAULT_BUILDER(split)
 
-#define PROTO_DEVICE(T, Device) \
-  template class split_layer<T, data_layout::DATA_PARALLEL, Device>; \
-  template class split_layer<T, data_layout::MODEL_PARALLEL, Device>; \
-  LBANN_LAYER_BUILDER_ETI(split, T, Device)
+#define PROTO(T)                                                        \
+  template class split_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>; \
+  template class split_layer<T, data_layout::MODEL_PARALLEL, El::Device::CPU>; \
+  LBANN_LAYER_BUILDER_ETI(split, T, El::Device::CPU)
 
-#include "lbann/macros/instantiate_device.hpp"
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout Layout, El::Device Dev>
+void split_distconv_adapter<TensorDataType, Layout, Dev>::bp_compute() {
+  LBANN_ERROR(this->get_name(), ": Distconv not supported");
+}
+
+#define PROTO(T)                                                        \
+  template class split_distconv_adapter<T, data_layout::DATA_PARALLEL, El::Device::CPU>; \
+  template class split_distconv_adapter<T, data_layout::MODEL_PARALLEL, El::Device::CPU>
+
+#include "lbann/macros/instantiate.hpp"
+#endif // LBANN_HAS_DISTCONV
 
 }// namespace lbann

--- a/src/layers/transform/split.cu
+++ b/src/layers/transform/split.cu
@@ -28,7 +28,9 @@
 #include "lbann/layers/transform/split.hpp"
 #include "lbann/utils/exception.hpp"
 
+#ifdef LBANN_HAS_DISTCONV
 #include "distconv/tensor/algorithms_cuda.hpp"
+#endif // LBANN_HAS_DISTCONV
 
 namespace lbann {
 

--- a/src/layers/transform/split.cu
+++ b/src/layers/transform/split.cu
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_SPLIT_LAYER_INSTANTIATE
+#include "lbann/layers/transform/split.hpp"
+#include "lbann/utils/exception.hpp"
+
+#include "distconv/tensor/algorithms_cuda.hpp"
+
+namespace lbann {
+
+LBANN_LAYER_DEFAULT_BUILDER(split)
+
+#define PROTO(T)                                                        \
+  template class split_layer<T, data_layout::DATA_PARALLEL, El::Device::GPU>; \
+  template class split_layer<T, data_layout::MODEL_PARALLEL, El::Device::GPU>; \
+  LBANN_LAYER_BUILDER_ETI(split, T, El::Device::GPU)
+
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+
+#ifdef LBANN_HAS_DISTCONV
+namespace {
+template <typename TensorDataType>
+struct accumulate_op {
+  __device__ void operator()(TensorDataType &x, const TensorDataType &y) const {
+    x += y;
+  }
+};
+
+template <typename TensorDataType>
+struct sum_op {
+  __device__ void operator()(TensorDataType &x, const TensorDataType &y,
+                             const TensorDataType &z) const {
+    x = y + z;
+  }
+};
+} // namespace
+
+template <typename TensorDataType, data_layout Layout, El::Device Dev>
+void split_distconv_adapter<TensorDataType, Layout, Dev>::bp_compute() {
+  if (Layout != data_layout::DATA_PARALLEL) {
+    LBANN_ERROR("Distconv not supported");
+  }
+  auto &error_signals = this->get_error_signals(0);
+  switch (this->layer().get_num_children()) {
+    case 0:
+      error_signals.zero(El::GPUManager::Stream());
+      break;
+    case 1:
+      dc::tensor::Copy(error_signals,
+                       this->get_prev_error_signals(0),
+                       El::GPUManager::Stream());
+      break;
+    case 2:
+      dc::tensor::Transform(error_signals,
+                            this->get_prev_error_signals(0),
+                            this->get_prev_error_signals(1),
+                            sum_op<TensorDataType>(),
+                            El::GPUManager::Stream());
+      break;
+    default:
+      dc::tensor::Copy(error_signals,
+                       this->get_prev_error_signals(1),
+                       El::GPUManager::Stream());
+      for (int i = 1; i < this->layer().get_num_children(); ++i) {
+        const auto &prev_error = this->get_prev_error_signals(i);
+        dc::tensor::Transform(error_signals, prev_error,
+                              accumulate_op<TensorDataType>(),
+                              El::GPUManager::Stream());
+      }
+  }
+  return;
+}
+
+#define PROTO(T)                                                        \
+  template class split_distconv_adapter<T, data_layout::DATA_PARALLEL, El::Device::GPU>; \
+  template class split_distconv_adapter<T, data_layout::MODEL_PARALLEL, El::Device::GPU>
+
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#endif // LBANN_HAS_DISTCONV
+
+} // namespace lbann

--- a/src/layers/transform/sum.cpp
+++ b/src/layers/transform/sum.cpp
@@ -34,11 +34,26 @@ namespace lbann {
 
 LBANN_LAYER_DEFAULT_BUILDER(sum)
 
-#define PROTO_DEVICE(T, Device)                                    \
-  template class sum_layer<T, data_layout::DATA_PARALLEL, Device>; \
-  template class sum_layer<T, data_layout::MODEL_PARALLEL, Device>; \
-  LBANN_LAYER_BUILDER_ETI(sum, T, Device)
+#define PROTO(T)                                    \
+  template class sum_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>; \
+  template class sum_layer<T, data_layout::MODEL_PARALLEL, El::Device::CPU>; \
+  LBANN_LAYER_BUILDER_ETI(sum, T, El::Device::CPU)
 
-#include "lbann/macros/instantiate_device.hpp"
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout Layout, El::Device Dev>
+void sum_distconv_adapter<TensorDataType, Layout, Dev>::fp_compute() {
+  LBANN_ERROR(this->get_name(), ": Distconv not supported");
+}
+
+#define PROTO(T)                                                        \
+  template class sum_distconv_adapter<T, data_layout::DATA_PARALLEL, El::Device::CPU>; \
+  template class sum_distconv_adapter<T, data_layout::MODEL_PARALLEL, El::Device::CPU>
+
+#include "lbann/macros/instantiate.hpp"
+#endif // LBANN_HAS_DISTCONV
 
 }// namespace lbann

--- a/src/layers/transform/sum.cu
+++ b/src/layers/transform/sum.cu
@@ -28,7 +28,9 @@
 #include "lbann/layers/transform/sum.hpp"
 #include "lbann/utils/exception.hpp"
 
+#ifdef LBANN_HAS_DISTCONV
 #include "distconv/tensor/algorithms_cuda.hpp"
+#endif // LBANN_HAS_DISTCONV
 
 namespace lbann {
 

--- a/src/layers/transform/sum.cu
+++ b/src/layers/transform/sum.cu
@@ -1,0 +1,108 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_SUM_LAYER_INSTANTIATE
+#include "lbann/layers/transform/sum.hpp"
+#include "lbann/utils/exception.hpp"
+
+#include "distconv/tensor/algorithms_cuda.hpp"
+
+namespace lbann {
+
+LBANN_LAYER_DEFAULT_BUILDER(sum)
+
+#define PROTO(T)                                                        \
+  template class sum_layer<T, data_layout::DATA_PARALLEL, El::Device::GPU>; \
+  template class sum_layer<T, data_layout::MODEL_PARALLEL, El::Device::GPU>; \
+  LBANN_LAYER_BUILDER_ETI(sum, T, El::Device::GPU)
+
+#define LBANN_INSTANTIATE_GPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+
+#ifdef LBANN_HAS_DISTCONV
+namespace {
+template <typename TensorDataType>
+struct accumulate_op {
+  __device__ void operator()(TensorDataType &x, TensorDataType &y) const {
+    x += y;
+  }
+};
+
+template <typename TensorDataType>
+struct sum_op {
+  __device__ void operator()(TensorDataType &x, TensorDataType &y, TensorDataType &z) const {
+    x = y + z;
+  }
+};
+} // namespace
+
+template <typename TensorDataType, data_layout Layout, El::Device Dev>
+void sum_distconv_adapter<TensorDataType, Layout, Dev>::fp_compute() {
+  auto &activations = this->get_activations();
+  switch (this->layer().get_num_parents()) {
+    case 0:
+      activations.zero(El::GPUManager::Stream());
+      break;
+    case 1:
+      dc::tensor::Copy(activations, this->get_prev_activations(),
+                       El::GPUManager::Stream());
+      break;
+    case 2:
+      // Optimization for layers with 2 parents (e.g.,
+      // Resnet50). Avoids loading destination tensors multiple times
+      this->get_prev_activations(1).set_outermost_dimension(
+          activations.get_shape()[-1]);
+      dc::tensor::Transform(activations,
+                            this->get_prev_activations(0),
+                            this->get_prev_activations(1),
+                            sum_op<TensorDataType>(),
+                            El::GPUManager::Stream());
+      break;
+    default:
+      for (int i = 0; i < this->layer().get_num_parents(); ++i) {
+        auto &prev_activations = this->get_prev_activations(i);
+        prev_activations.set_outermost_dimension(activations.get_shape()[-1]);
+        if (i == 0) {
+          dc::tensor::Copy(activations, prev_activations,
+                           El::GPUManager::Stream());
+        } else {
+          distconv::tensor::Transform(activations, prev_activations,
+                                      accumulate_op<TensorDataType>(),
+                                      El::GPUManager::Stream());
+        }
+      }
+  }
+}
+
+#define PROTO(T)                                                        \
+  template class sum_distconv_adapter<T, data_layout::DATA_PARALLEL, El::Device::GPU>; \
+  template class sum_distconv_adapter<T, data_layout::MODEL_PARALLEL, El::Device::GPU>
+
+#include "lbann/macros/instantiate.hpp"
+#endif // LBANN_HAS_DISTCONV
+
+} // namespace lbann


### PR DESCRIPTION
Supported layers include `split`, `sum`, `pooling` and `concatenate`. 

Depends on #1488.