### PR TITLE
Clean up back-prop memory usage

### DIFF
--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -84,7 +84,7 @@ public:
     h2::meta::tlist::MemberV<TensorDataType, supported_layer_data_type>(),
     "Must use a supported type.");
 
-  data_type_layer(lbann_comm *comm, bool persistent_error_signals=true)
+  data_type_layer(lbann_comm *comm, bool persistent_error_signals=false)
     : Layer(comm), m_persistent_error_signals{persistent_error_signals} {}
   data_type_layer(const data_type_layer<TensorDataType>& other);
   data_type_layer& operator=(const data_type_layer<TensorDataType>& other);
@@ -273,11 +273,15 @@ private:
    *  @param child The layer from which the error signal has come.
    *  @param signals The error signal from the layer.
    */
-  void set_prev_error_signal_(
+  void move_or_copy_prev_error_signal_(
     const Layer& child,
     std::unique_ptr<El::BaseDistMatrix> signal) final;
 
-  void set_prev_error_signal_(
+  void view_or_copy_prev_error_signal_(
+    const Layer& child,
+    const El::BaseDistMatrix& signal) final;
+
+  void deep_copy_prev_error_signal_(
     const Layer& child,
     const El::BaseDistMatrix& signal) final;
 

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -100,13 +100,6 @@ public:
    *  tensors.
    */
   void forward_prop() override;
-  /** Backward propagation step.
-   *  Given the objective function gradients w.r.t. the output
-   *  tensors, compute the gradients w.r.t. the input tensors and
-   *  w.r.t. the weights. This is essentially an application of the
-   *  chain rule.
-   */
-  void back_prop() override;
 
   void summarize_matrices(lbann_summary& summarizer, int step) override;
 
@@ -275,6 +268,36 @@ protected:
   bool has_weights() const noexcept { return num_weights() > 0; }
 
 private:
+
+  /** @brief Take ownership of a reference to the previous error signals.
+   *
+   *  If the underlying tensor has the right datatype, the reference
+   *  is stored explicitly. Otherwise a deep copy is made so that it
+   *  has the correct datatype.
+   *
+   *  @param child The layer from which the error signals have come.
+   *  @param signals The error signals from the layer.
+   */
+  void set_prev_error_signals_(
+    Layer const& child,
+    std::unique_ptr<El::BaseDistMatrix> signals) final;
+
+  void allocate_new_gradients_() final;
+
+  void propagate_error_signals_to_parents_() final;
+
+  void clear_prev_error_signals_() final {
+    for (auto& es : m_gradient_wrt_outputs)
+      es.reset();
+  }
+
+  /** Backward propagation step.
+   *  Given the objective function gradients w.r.t. the output
+   *  tensors, compute the gradients w.r.t. the input tensors and
+   *  w.r.t. the weights. This is essentially an application of the
+   *  chain rule.
+   */
+  void back_prop_impl_() final;
 
   // ===========================================================
   // Private access functions

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -427,6 +427,13 @@ public:
   void unfreeze();
   bool is_frozen() const;
 
+  /** @brief Set whether to keep or dynamically reallocate error signals.
+   *
+   *  Passing a value of @c true means to keep the error signals; @c
+   *  false means to dynamically reallocate them.
+   */
+  virtual void set_keep_error_signals(bool) = 0;
+
 protected:
 
   // ===========================================================
@@ -590,7 +597,7 @@ private:
    */
   virtual void allocate_new_gradients_() = 0;
 
-  /** @brief Moves all error signals to their respective parents
+  /** @brief Moves all error signals to their respective parents.
    *
    *  Error signals from this instances either are directly moved into
    *  the parent layer or, in cases in which a direct move is not
@@ -606,8 +613,8 @@ private:
    *  from the child layers are no longer needed. This ensures that
    *  the memory is released.
    *
-   *  If the layer has persistent error signal information, this
-   *  function is a no-op.
+   *  This function may do other work, but must respect the persistent
+   *  error signal flag.
    */
   virtual void clear_prev_error_signals_() = 0;
 
@@ -618,16 +625,31 @@ private:
    *  deep-copy of the signal data.
    *
    *  @param child The layer whence the signal is coming.
-   *  @param signals The error signals being sent to this layer.
+   *  @param signal The error signals being sent to this layer.
    */
   virtual void move_or_copy_prev_error_signal_(
     const Layer& child,
     std::unique_ptr<El::BaseDistMatrix> signal) = 0;
 
+  /** @brief Attempts to view the error signals from the specified
+   *         child layer.
+   *
+   *  This is a simple data view when possible; otherwise it is a
+   *  deep-copy of the signal data.
+   *
+   *  @param child The layer whence the signal is coming.
+   *  @param signal The error signals being sent to this layer.
+   */
   virtual void view_or_copy_prev_error_signal_(
     const Layer& child,
     const El::BaseDistMatrix& signal) = 0;
 
+  /** @brief Deep-copy the error signals from the specified child
+   *         layer.
+   *
+   *  @param child The layer whence the signal is coming.
+   *  @param signal The error signals being sent to this layer.
+   */
   virtual void deep_copy_prev_error_signal_(
     const Layer& child,
     const El::BaseDistMatrix& signal) = 0;

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -569,10 +569,13 @@ private:
    *  @param child  The child layer, from which the signal is moved
    *  @param signal The now-released error signal from the child layer
    */
-  friend void move_error_signal(
+  friend void attempt_move_error_signal(
     Layer& parent, Layer const& child,
     std::unique_ptr<BaseDistMat> signals);
-  friend void view_error_signal(
+  friend void attempt_view_error_signal(
+    Layer& parent, Layer const& child,
+    const BaseDistMat& signals);
+  friend void deep_copy_error_signal(
     Layer& parent, Layer const& child,
     const BaseDistMat& signals);
 
@@ -617,11 +620,15 @@ private:
    *  @param child The layer whence the signal is coming.
    *  @param signals The error signals being sent to this layer.
    */
-  virtual void set_prev_error_signal_(
-    Layer const& child,
-    std::unique_ptr<BaseDistMat> signal) = 0;
+  virtual void move_or_copy_prev_error_signal_(
+    const Layer& child,
+    std::unique_ptr<El::BaseDistMatrix> signal) = 0;
 
-  virtual void set_prev_error_signal_(
+  virtual void view_or_copy_prev_error_signal_(
+    const Layer& child,
+    const El::BaseDistMatrix& signal) = 0;
+
+  virtual void deep_copy_prev_error_signal_(
     const Layer& child,
     const El::BaseDistMatrix& signal) = 0;
 

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -232,7 +232,8 @@ public:
    *  w.r.t. the weights. This is essentially an application of the
    *  chain rule.
    */
-  virtual void back_prop() {};
+  void back_prop();
+
   /** Update step.
    *  Update the layer's internal members. Note that the optimization
    *  step for the weights happens elsewhere.
@@ -559,6 +560,21 @@ protected:
   std::string m_name;
 
 private:
+  friend void move_error_signal(
+    Layer& parent, Layer const& child,
+    std::unique_ptr<BaseDistMat> signals);
+
+  virtual void back_prop_impl_() = 0;
+
+  virtual void allocate_new_gradients_() = 0;
+
+  virtual void propagate_error_signals_to_parents_() = 0;
+
+  virtual void clear_prev_error_signals_() = 0;
+
+  virtual void set_prev_error_signals_(
+    Layer const& child,
+    std::unique_ptr<BaseDistMat> signals) = 0;
 
   // ===========================================================
   // Private access functions

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -487,12 +487,6 @@ protected:
   // Back prop step helper functions
   // ===========================================================
 
-  /** Setup gradient w.r.t. output tensors.
-   *  Called by the 'back_prop' function. Each gradient w.r.t. output
-   *  tensor is setup as a view or copy of the corresponding child
-   *  layer's gradient w.r.t. input tensor.
-   */
-  virtual void bp_setup_gradient_wrt_outputs(El::Int mini_batch_size) = 0;
   /** Setup gradient w.r.t. input tensors.
    *  Called by the 'back_prop' function. Each gradient w.r.t. input
    *  tensor is resized to match the mini-batch size.
@@ -560,21 +554,78 @@ protected:
   std::string m_name;
 
 private:
+  /** @name Implementation details of back-prop. */
+  ///@{
+
+  /** @brief Move error signals from a child to its parent.
+   *
+   *  This is a hacky workaround to C++ rules for protected member
+   *  functions. No error-checking is done, e.g., to assert that the
+   *  two layers actually have a parent-child relationship because
+   *  this is just an implementation detail. The symbol is never
+   *  exposed to the public API.
+   *
+   *  @param parent The parent layer, into which the signal is moved
+   *  @param child  The child layer, from which the signal is moved
+   *  @param signal The now-released error signal from the child layer
+   */
   friend void move_error_signal(
     Layer& parent, Layer const& child,
     std::unique_ptr<BaseDistMat> signals);
+  friend void view_error_signal(
+    Layer& parent, Layer const& child,
+    const BaseDistMat& signals);
 
+  /** @brief Computes the core back-prop steps. */
   virtual void back_prop_impl_() = 0;
 
+  /** @brief Allocates new storage for the gradients that this layer
+   *         will compute.
+   *
+   *  If the layer has persistent error signal information, this will
+   *  simply clear the gradients.
+   */
   virtual void allocate_new_gradients_() = 0;
 
+  /** @brief Moves all error signals to their respective parents
+   *
+   *  Error signals from this instances either are directly moved into
+   *  the parent layer or, in cases in which a direct move is not
+   *  possible, are deep-copied into a new tensor in the parent layer
+   *  (e.g., into a different data type or data distribution).
+   */
   virtual void propagate_error_signals_to_parents_() = 0;
 
+  /** @brief Releases the error signals propagated from the child
+   *         layers.
+   *
+   *  At the conclusion of back-prop, the error signals propagated
+   *  from the child layers are no longer needed. This ensures that
+   *  the memory is released.
+   *
+   *  If the layer has persistent error signal information, this
+   *  function is a no-op.
+   */
   virtual void clear_prev_error_signals_() = 0;
 
-  virtual void set_prev_error_signals_(
+  /** @brief Assumes ownership of the error signals from the specified
+   *         child layer.
+   *
+   *  This is a simple pointer move when possible; otherwise it is a
+   *  deep-copy of the signal data.
+   *
+   *  @param child The layer whence the signal is coming.
+   *  @param signals The error signals being sent to this layer.
+   */
+  virtual void set_prev_error_signal_(
     Layer const& child,
-    std::unique_ptr<BaseDistMat> signals) = 0;
+    std::unique_ptr<BaseDistMat> signal) = 0;
+
+  virtual void set_prev_error_signal_(
+    const Layer& child,
+    const El::BaseDistMatrix& signal) = 0;
+
+  ///@}
 
   // ===========================================================
   // Private access functions

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -341,26 +341,13 @@ auto data_type_layer<TensorDataType>::get_error_signals(const Layer& parent) con
   return get_error_signals(parent_index);
 }
 
-namespace {
-
-template <typename T>
-void set_default_memory_mode(
-  El::AbstractMatrix<T>& m, El::Device const& device) {
-#ifdef LBANN_HAS_GPU
-  switch (device) {
-  case El::Device::GPU:
-    // Allocate GPU memory with the CUDA API
-    m.SetMemoryMode(0); break;
-  case El::Device::CPU:
-    // Use pinned memory for data on the host.
-    m.SetMemoryMode(1); break;
-  default: break;
-  }
-#else
-  (void) m;
-  (void) device;
-#endif // LBANN_HAS_GPU
+template <typename TensorDataType>
+void data_type_layer<TensorDataType>::set_keep_error_signals(bool flag)
+{
+  m_persistent_error_signals = flag;
 }
+
+namespace {
 
 // Some indirection around building matrices to keep things tidy in
 // the real code. This is just to hide multiple switches without
@@ -430,7 +417,7 @@ void data_type_layer<TensorDataType>::setup_matrices(const El::Grid& grid) {
 
   // DEBUG
   {
-    char* keep_error_signals = getenv("TOM_KEEP_ERROR_SIGNALS");
+    char* keep_error_signals = getenv("LBANN_KEEP_ERROR_SIGNALS");
     if (!keep_error_signals || (std::stoi(keep_error_signals) == 0))
       m_persistent_error_signals = false;
     else
@@ -840,7 +827,6 @@ void data_type_layer<TensorDataType>::propagate_error_signals_to_parents_() {
                                 std::move(m_gradient_wrt_inputs[p_idx]));
   }
 }
-
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::allocate_new_gradients_() {

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -424,6 +424,12 @@ void data_type_layer<TensorDataType>::setup_matrices(const El::Grid& grid) {
       m_persistent_error_signals = true;
   }
 
+  // If no CUB, force persistent error signals:
+#if defined(HYDROGEN_HAVE_CUDA) && !defined(HYDROGEN_HAVE_CUB)
+  if (this->get_device_allocation() == El::Device::GPU)
+    m_persistent_error_signals = true;
+#endif
+
   // Figure out how to make new matrices
   std::unique_ptr<MatrixBuilderType> mat_builder =
     MakeMatBuilder<TensorDataType>(

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -515,8 +515,6 @@ void Layer::check_setup() {
 }
 
 void Layer::back_prop() {
-  // std::cout << "Starting backprop on layer " << this->get_name()
-  //           << " (" << typeid(*this).name() << ")" << std::endl;
   allocate_new_gradients_();
   back_prop_impl_();
   propagate_error_signals_to_parents_();

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -514,6 +514,16 @@ void Layer::check_setup() {
   }
 }
 
+void Layer::back_prop() {
+  // std::cout << "Starting backprop on layer " << this->get_name()
+  //           << " (" << typeid(*this).name() << ")" << std::endl;
+  allocate_new_gradients_();
+  back_prop_impl_();
+  propagate_error_signals_to_parents_();
+  clear_prev_error_signals_();
+}
+
+
 bool Layer::save_to_checkpoint_shared(persist& p) const {
   return true;
 }

--- a/src/layers/matrix_builder.hpp
+++ b/src/layers/matrix_builder.hpp
@@ -1,0 +1,108 @@
+ ////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef NON_PUBLIC_LBANN_SRC_LAYERS_MATRIX_BUILDER_INCLUDED
+#define NON_PUBLIC_LBANN_SRC_LAYERS_MATRIX_BUILDER_INCLUDED
+
+#include "lbann/base.hpp"
+#include "lbann/utils/memory.hpp"
+
+#include <memory>
+#include <type_traits>
+
+namespace lbann {
+namespace details {
+namespace meta {
+// Quick, forced if-then-else
+template <bool B, typename T, typename F>
+using IfThenElse = typename std::conditional<B, T, F>::type;
+}// namespace meta
+
+template <typename T>
+class MatrixBuilder
+{
+public:
+  using size_type = El::Int;
+  using data_type = T;
+  using matrix_type = El::AbstractDistMatrix<T>;
+  using matrix_ptr_type = std::unique_ptr<matrix_type>;
+
+public:
+  virtual ~MatrixBuilder() = default;
+  virtual matrix_ptr_type MakeEmpty(El::Grid const& g, El::Int root) const = 0;
+  virtual matrix_ptr_type MakeWithSize(
+    El::Grid const& g, El::Int root,
+    size_type height, size_type width) const = 0;
+
+};// class MatrixBuilder
+
+// Uses memory mode = 1 for CPU (pinned memory) and for GPU (CUB memory).
+template <typename T, data_layout L, El::Device D>
+class DefaultMemoryMatrixBuilder : public MatrixBuilder<T>
+{
+  using base_type = MatrixBuilder<T>;
+  using concrete_matrix_type =
+    meta::IfThenElse<L == data_layout::DATA_PARALLEL,
+                     El::DistMatrix<T, El::STAR, El::VC, El::ELEMENT, D>,
+                     El::DistMatrix<T, El::MC  , El::MR, El::ELEMENT, D>>;
+
+#if defined(HYDROGEN_HAVE_CUDA) && defined(HYDROGEN_HAVE_CUB)
+  // Pinned host memory; memory-pooled device memory
+  static constexpr unsigned memory_mode_ = 1U;
+#elif defined(HYDROGEN_HAVE_CUDA)
+  // Pinned host memory; default-allocated device memory
+  static constexpr unsigned memory_mode_ = (D == El::Device::CPU ? 1U : 0U);
+#else
+  // Default memory
+  static constexpr unsigned memory_mode_ =
+    El::DefaultMemoryMode<El::Device::CPU>();
+#endif // defined(HYDROGEN_HAVE_CUDA) && defined(HYDROGEN_HAVE_CUB)
+
+public:
+  using size_type = typename base_type::size_type;
+  using matrix_ptr_type = typename base_type::matrix_ptr_type;
+
+public:
+  matrix_ptr_type MakeEmpty(El::Grid const& g, El::Int root) const final
+  {
+    auto ret = make_unique<concrete_matrix_type>(g, root);
+    ret->Matrix().SetMemoryMode(memory_mode_);
+    return ret;
+  }
+
+  matrix_ptr_type MakeWithSize(El::Grid const& g, El::Int root,
+                               size_type height, size_type width) const final
+  {
+    auto ret = this->MakeEmpty(g, root);
+    ret->Resize(height, width);
+    return ret;
+  }
+
+};// class DefaultMemoryMatrixBuilder
+
+}// namespace details
+}// namespace lbann
+#endif // NON_PUBLIC_LBANN_SRC_LAYERS_MATRIX_BUILDER_INCLUDED


### PR DESCRIPTION
The goal of this PR is to dynamically allocate and free memory during back propagation, primarily to ease memory strain on the GPUs.

The current state of this is work-in-progress, but it should be done today. I'm cleaning stuff up. I'll post bamboo results when I have them.
