### PR TITLE
Merging data_reader_hdf5 and slab extensions

### DIFF
--- a/include/lbann/data_readers/CMakeLists.txt
+++ b/include/lbann/data_readers/CMakeLists.txt
@@ -18,5 +18,10 @@ set_full_path(THIS_DIR_HEADERS
   data_reader_synthetic.hpp
   )
 
+if (LBANN_HAS_DISTCONV)
+  list(APPEND THIS_DIR_HEADERS
+    "${CMAKE_CURRENT_SOURCE_DIR}/data_reader_hdf5.hpp")
+endif ()
+
 # Propagate the files up the tree
 set(HEADERS "${HEADERS}" "${THIS_DIR_HEADERS}" PARENT_SCOPE)

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -1,0 +1,84 @@
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_DATA_READER_HDF5_HPP
+#define LBANN_DATA_READER_HDF5_HPP
+#include "data_reader_image.hpp"
+#include "hdf5.h"
+#include "conduit/conduit.hpp"
+
+namespace lbann {
+/**
+ * Data reader for data stored in hdf5 files will need to assume the file contains x
+ */
+class hdf5_reader : public generic_data_reader {
+ public:
+  hdf5_reader(const bool shuffle);
+  hdf5_reader(const hdf5_reader&);
+  hdf5_reader& operator=(const hdf5_reader&);
+  ~hdf5_reader() override {}
+
+  hdf5_reader* copy() const override { return new hdf5_reader(*this); }
+
+  void copy_members(const hdf5_reader& rhs);
+
+  std::string get_type() const override {
+    return "data_reader_hdf5_images";
+  }
+  //void set_input_params(int width, int height, int depth, int num_ch, int num_labels);
+  void load() override;
+  void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
+
+  int get_num_responses() const override {
+    return get_linearized_response_size();
+  }
+  int get_linearized_data_size() const override {
+    return m_num_features;
+  }
+  int get_linearized_response_size() const override {
+    return m_num_response_features;
+  }
+  const std::vector<int> get_data_dims() const override {
+    return m_data_dims;
+  }
+ protected:
+  void read_hdf5_hyperslab(hsize_t h_data, hsize_t filespace, int rank,
+                           short *sample);
+  void read_hdf5_sample(int data_id, short *sample);
+  //void set_defaults() override;
+  bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
+  void fetch_datum_conduit(Mat& X, int data_id);
+  bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;
+  bool fetch_response(CPUMat& Y, int data_id, int mb_idx) override;
+  void gather_responses(float *responses);
+  /// Whether to fetch a label from the last column.
+  bool m_has_labels = false;
+  /// Whether to fetch a response from the last column.
+  bool m_has_responses = true;
+  int m_image_depth=0;
+  size_t m_num_features;
+  static constexpr int m_num_response_features = 4;
+  float m_all_responses[m_num_response_features];
+  std::vector<std::string> m_file_paths;
+  MPI_Comm m_comm;
+  std::vector<int> m_data_dims;
+  std::vector<hsize_t> m_hyperslab_dims;
+  hid_t m_fapl;
+  hid_t m_dxpl;
+  MPI_Comm m_response_gather_comm;
+  bool m_use_data_store;
+ private:
+  static const std::string HDF5_KEY_DATA, HDF5_KEY_LABELS, HDF5_KEY_RESPONSES;
+};
+}
+#endif // LBANN_DATA_READER_HDF5_HPP

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -48,6 +48,16 @@ namespace lbann {
 
 class generic_data_reader;
 
+/** Create a hash function for hashing a std::pair type */
+struct size_t_pair_hash
+{
+  template <class T1, class T2>
+  std::size_t operator() (const std::pair<T1, T2> &pair) const
+  {
+    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+  }
+};
+
 class data_store_conduit {
 
  public:
@@ -55,6 +65,9 @@ class data_store_conduit {
   // need to quickly change from unordered_map to map for debugging
   using map_ii_t = std::unordered_map<int,int>;
   using map_is_t = std::unordered_map<int,size_t>;
+
+  // Hash map for tracking the node and hyperslab partition ID
+  using map_pssi_t = std::unordered_map<std::pair<size_t,size_t>,int,size_t_pair_hash>;
 
   // not currently used; will be in the future
   using map_ss_t = std::unordered_map<size_t,size_t>;
@@ -113,13 +126,13 @@ class data_store_conduit {
   //=================================================================
   // methods for setting and querying the data store's mode
   //=================================================================
-  /** @brief Returns true if preloading is turned on 
+  /** @brief Returns true if preloading is turned on
    *
    * See notes in: is_explicitly_loading()
    */
   bool is_preloading() const { return m_preloading; }
 
-  /** @brief Returns true if explicitly loading is turned on 
+  /** @brief Returns true if explicitly loading is turned on
    *
    * 'explicitly loading' means that the data that will be owned
    * by each rank is passed into the data store during the first epoch.
@@ -130,7 +143,7 @@ class data_store_conduit {
    */
   bool is_explicitly_loading() const { return m_explicitly_loading; }
 
-  /** @brief Returns true if all loading has been completed 
+  /** @brief Returns true if all loading has been completed
    *
    * See notes in: set_loading_is_complete()
    */
@@ -143,35 +156,34 @@ class data_store_conduit {
    * but part of the set may be spilled to disk if memory is
    * insufficient. Local cache mode is activated via the cmd line
    * flag: --data_store_cache
-   */ 
+   */
   bool is_local_cache() const { return m_is_local_cache; }
 
-  /** @brief Turn preloading on or off */ 
+  /** @brief Turn preloading on or off */
   void set_is_preloading(bool flag);
 
-  /** @brief Turn on explicit loading */ 
+  /** @brief Turn on explicit loading */
   void set_is_explicitly_loading(bool flag);
 
   /** @brief Marks the data_store as fully loaded
    *
    * Fully loaded means that each rank has all the data that it
    * is intended to own. When not running in local cache mode, this
-   * occurs (1) at the conclusion of preloading, prior to the beginning of 
-   * the first epoch, or (2) at the conclusion of the first epoch, if 
-   * explicitly loading. When running in local cache mode, this occurs 
-   * (1) at the conclusion of preload_local_cache(), which is called prior 
+   * occurs (1) at the conclusion of preloading, prior to the beginning of
+   * the first epoch, or (2) at the conclusion of the first epoch, if
+   * explicitly loading. When running in local cache mode, this occurs
+   * (1) at the conclusion of preload_local_cache(), which is called prior
    * to the first epoch, or (2) at the conclusion of exchange_local_caches(),
    * at th conclusion of the first epoch, if explicitly loading.
    */
-  void set_loading_is_complete(); 
-
+  void set_loading_is_complete();
 
   /** @brief turns local cache mode on of off */
   void set_is_local_cache(bool flag) { m_is_local_cache = flag; }
 
   /** @brief Check that explicit loading, preloading, and fully loaded flags are consistent */
   void check_query_flags() const;
-   
+
   //=================================================================
   // END methods for setting and querying the data store's mode
   //=================================================================
@@ -183,15 +195,23 @@ class data_store_conduit {
   void build_preloaded_owner_map(const std::vector<int>& per_rank_list_sizes);
 
   /// fills in m_owner, which maps index -> owning processor
-  void set_preloaded_owner_map(const std::unordered_map<int,int> &owner) { m_owner = owner; }
+  void set_preloaded_owner_map(const std::unordered_map<int,int> &owner) {
+    // TODO: needs slab extension
+    // m_owner = owner;
+    LBANN_ERROR("Slab-extension missing");
+  }
 
   /** @brief Special hanling for ras_lipid_conduit_data_reader; may go away in the future */
   void clear_owner_map();
 
-  void set_owner_map(const std::unordered_map<int, int> &m) { m_owner = m; }
+  void set_owner_map(const std::unordered_map<int, int> &m) {
+    // TODO: needs slab extension
+    // m_owner = m;
+    LBANN_ERROR("Slab-extension missing");
+  }
 
   /** @brief Special handling for ras_lipid_conduit_data_reader; may go away in the future */
-  void add_owner(int data_id, int owner) { m_owner[data_id] = owner; }
+  void add_owner(int data_id, int owner) { m_owner[std::make_pair(data_id, m_offset_in_partition)] = owner; }
 
   /** @brief Special handling for ras_lipid_conduit_data_reader; may go away in the future */
   void set_finished_building_map() { m_owner_maps_were_exchanged = true; }
@@ -212,7 +232,7 @@ class data_store_conduit {
    */
   void preload_local_cache();
 
-  void exchange_mini_batch_data(size_t current_pos, size_t mb_size); 
+  void exchange_mini_batch_data(size_t current_pos, size_t mb_size);
 
   void set_node_sizes_vary() { m_node_sizes_vary = true; }
 
@@ -234,17 +254,17 @@ class data_store_conduit {
    *
    * Debug logging is enabled on all ranks via the cmd line flag: --data_store_debug
    */
-  void flush_debug_file(); 
+  void flush_debug_file();
 
   /** @brief Closes then reopens the profile logging file
    *
    * Profile logging is enabled on P_0 via the cmd line flag: --data_store_profile
    */
-  void flush_profile_file() const; 
+  void flush_profile_file() const;
 
   /** @brief Writes object's state to file */
   void write_checkpoint(std::string dir_name);
-  
+
   /** @brief Loads object's state from file */
   void load_checkpoint(std::string dir_name, generic_data_reader *reader = nullptr);
 
@@ -259,7 +279,7 @@ class data_store_conduit {
    * @param n is the maximum number of samples to test; set to -1 to test all
    * @return true, if all samples read from file match those constructed from
    *               the local shared memory segment (aka, cache)
-   */ 
+   */
   bool test_local_cache_imagenet(int n);
 
   void test_imagenet_node(int sample_id, bool dereference = true);
@@ -295,7 +315,7 @@ private :
   /** @brief Used to form the directory path for spilling conduit nodes */
   int m_cur_spill_dir_integer = -1;
 
-  /** @brief @brief Current directory for spilling (writing to file) conduit nodes 
+  /** @brief @brief Current directory for spilling (writing to file) conduit nodes
    *
    * m_cur_spill_dir = m_spill_dir_base/<m_cur_spill_dir_integer>
    */
@@ -357,14 +377,14 @@ private :
   double m_rebuild_time = 0;
 
   // total time for exchange_mini_batch_data
-  double m_exchange_time = 0; 
+  double m_exchange_time = 0;
 
-  // sanity check: 
+  // sanity check:
   //   m_start_snd_rcv_time + m_wait_all_time + m_rebuild_time
   // should be only slightly less than m_exchange_time;
   // Note that, for imagenet, the first call to exchange_data_by_sample
   // involves additional communication for exchanging sample sizes
- 
+
   //===========================================================
   // END: timers for profiling exchange_data
   //===========================================================
@@ -377,7 +397,7 @@ private :
   /** @brief True, if we are in preload mode */
   bool m_preloading = false;
 
-  /** @brief True, if we are in explicit loading mode 
+  /** @brief True, if we are in explicit loading mode
    *
    * There is some redundancy here: m_preloading and m_explicitly_loading
    * can not both be true, but both may be false. When m_loading_is_complete
@@ -409,22 +429,35 @@ private :
   bool m_world_master;
   bool m_trainer_master;
   int  m_rank_in_trainer;
-  int  m_rank_in_world = -1; // -1 for debugging 
-  int  m_np_in_trainer;
+  int  m_rank_in_world = -1; // -1 for debugging
+  int  m_partition_in_trainer;
+  int  m_offset_in_partition;
 
-  /** @brief Maps an index to the processor that owns the associated data */ 
-  map_ii_t m_owner;
+  /// number of procs in the trainer; convenience handle
+  int  m_np_in_trainer;
+  int  m_num_partitions_in_trainer;
+
+  /** @brief Maps an index to the processor that owns the associated data
+   * First value of index is the sample ID and second value is the partiton ID
+   *
+   * Must be mutable since rhs.m_owner may be modified in copy_members,
+   * in which rhs is const.
+   */
+  mutable map_pssi_t m_owner;
 
   /// convenience handle
   const std::vector<int> *m_shuffled_indices;
 
   /** @brief Contains the conduit nodes that are "owned" by this rank
    *
-   * Maps data_id -> conduit::Node.
-   */ 
-  std::unordered_map<int, conduit::Node> m_data;
+   * Map data_id -> conduit::Node.
+   * Must be mutable since rhs.m_owner may be modified in copy_members,
+   * in which rhs is const.
+   */
+  mutable std::unordered_map<int, conduit::Node> m_data;
 
-  /** @brief Contains the conduit nodes that are "owned" by this rank
+  /** @brief Contains a cache of the conduit nodes that are
+   * "owned" by this rank
    *
    * This differs from m_data in that this holds temporarily,
    * during the first epoch, if we're running in local cache mode
@@ -449,11 +482,11 @@ private :
   std::vector<size_t> m_outgoing_msg_sizes;
   std::vector<size_t> m_incoming_msg_sizes;
 
-  /** @brief Maps a data_id to its image size 
+  /** @brief Maps a data_id to its image size
    *
    * Used when conduit Nodes have non-uniform size, e.g, imagenet;
    * see: set_node_sizes_vary()
-   */ 
+   */
   map_is_t m_sample_sizes;
 
   /** @brief Maps a data_id to the image location in a shared memory segment */
@@ -469,7 +502,7 @@ private :
   std::vector<std::unordered_set<int>> m_indices_to_recv;
 
   //=========================================================================
-  // methods follow 
+  // methods follow
   //=========================================================================
 
   void exchange_data_by_sample(size_t current_pos, size_t mb_size);
@@ -512,29 +545,27 @@ private :
   void compute_image_offsets(map_is_t &image_sizes, std::vector<std::vector<int>> &indices);
 
   /// for use in local cache mode
-  void exchange_images(std::vector<char> &work, map_is_t &image_sizes, std::vector<std::vector<int>> &indices); 
+  void exchange_images(std::vector<char> &work, map_is_t &image_sizes, std::vector<std::vector<int>> &indices);
 
-  /// for use in local cache mode
   void build_conduit_nodes(map_is_t &sizes);
-
 
   /// for use in local cache mode
   void fillin_shared_images(char* images, size_t size, size_t offset);
 
   /** @brief For testing during development
    *
-   * At the beginning of the 2nd epoch, calls write_checkpoint(), 
-   * clears some variables, calls load_checkpoint then continues. 
+   * At the beginning of the 2nd epoch, calls write_checkpoint(),
+   * clears some variables, calls load_checkpoint then continues.
    * To activate this test use cmd flag: --data_store_test_checkpoint=
-   */ 
+   */
   void test_checkpoint(const std::string&);
 
   /** @brief Called by test_checkpoint */
   void print_variables();
 
-  /** @brief Called by test_checkpoint 
+  /** @brief Called by test_checkpoint
    *
-   * For testing and development. Prints the first 'n' entries from 
+   * For testing and development. Prints the first 'n' entries from
    * the owner map * (which maps sample_id -> owning rank) to std::cout
    */
   void print_partial_owner_map(int n);
@@ -544,7 +575,7 @@ private :
   std::string get_metadata_fn() const;
 
   /** @brief Creates the directory if it does not already exist */
-  void make_dir_if_it_doesnt_exist(const std::string &dir); 
+  void make_dir_if_it_doesnt_exist(const std::string &dir);
 
   /** @brief Writes conduit node to file */
   void spill_conduit_node(const conduit::Node &node, int data_id);
@@ -554,8 +585,8 @@ private :
 
   /** @brief Creates directory structure, opens metadata file for output, etc
    *
-   * This method is called for both --data_store_spill and 
-   * --data_store_test_checkpoint 
+   * This method is called for both --data_store_spill and
+   * --data_store_test_checkpoint
    */
   void setup_spill(std::string dir);
 
@@ -572,7 +603,7 @@ private :
    * files are opened if the cmd flag --data_store_debug is passed.
    * A profiling file is opened only be <world_master, data reader role>
    * pairs; files are opened if the cmd flag --data_store_profile is passed.
-   */ 
+   */
   void open_informational_files();
 
   /** @brief Creates a directory for spilling conduit nodes */
@@ -591,11 +622,11 @@ private :
   // functions and templates for optional profiling and debug files follow
   //=========================================================================
 
-  void PROFILE() const { 
+  void PROFILE() const {
     if (!m_profile) {
       return;
     }
-    (*m_profile) << std::endl; 
+    (*m_profile) << std::endl;
     flush_profile_file();
   }
 
@@ -612,11 +643,11 @@ private :
     flush_profile_file();
   }
 
-  void DEBUG_DS() { 
+  void DEBUG_DS() {
     if (!m_debug) {
       return;
     }
-    (*m_debug) << std::endl; 
+    (*m_debug) << std::endl;
     flush_debug_file();
   }
 

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -136,6 +136,9 @@
 #include "lbann/data_readers/data_reader_pilot2_molecular.hpp"
 #include "lbann/data_readers/data_reader_mesh.hpp"
 #include "lbann/data_readers/data_reader_python.hpp"
+#ifdef LBANN_HAS_DISTCONV
+#include "lbann/data_readers/data_reader_hdf5.hpp"
+#endif // LBANN_HAS_DISTCONV
 
 /// Data stores
 #include "lbann/data_store/data_store_conduit.hpp"

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -20,5 +20,10 @@ set_full_path(THIS_DIR_SOURCES
   data_reader_npz_ras_lipid.cpp
   )
 
+if (LBANN_HAS_DISTCONV)
+  list(APPEND THIS_DIR_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/data_reader_hdf5.cpp")
+endif ()
+
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -1,0 +1,335 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+/////////////////////////////////////////////////////////////////////////////////
+#include "lbann/data_readers/data_reader_hdf5.hpp"
+#include "lbann/utils/profiling.hpp"
+#include "lbann/utils/distconv.hpp"
+#include "conduit/conduit_relay.hpp"
+#include "conduit/conduit_relay_io_hdf5.hpp"
+
+#include <cstdio>
+#include <string>
+#include <fstream>
+#include <unordered_set>
+#include <iostream>
+#include <cstring>
+
+namespace {
+inline hid_t check_hdf5(hid_t hid, const char *file, int line) {
+  if (hid < 0) {
+    std::cerr << "HDF5 error" << std::endl;
+    std::cerr << "Error at " << file << ":" << line << std::endl;
+    MPI_Abort(MPI_COMM_WORLD, 1);
+  }
+  return hid;
+}
+} // namespace
+
+#define CHECK_HDF5(call) check_hdf5(call, __FILE__, __LINE__)
+
+namespace lbann {
+
+const std::string hdf5_reader::HDF5_KEY_DATA = "full";
+const std::string hdf5_reader::HDF5_KEY_RESPONSES = "unitPar";
+
+hdf5_reader::hdf5_reader(const bool shuffle)
+    : generic_data_reader(shuffle),
+      m_use_data_store(options::get()->get_bool("use_data_store")) {
+}
+
+hdf5_reader::hdf5_reader(const hdf5_reader& rhs)  : generic_data_reader(rhs) {
+  copy_members(rhs);
+}
+
+hdf5_reader& hdf5_reader::operator=(const hdf5_reader& rhs) {
+  // check for self-assignment
+  if (this == &rhs) {
+    return (*this);
+  }
+  generic_data_reader::operator=(rhs);
+  copy_members(rhs);
+  return (*this);
+}
+
+void hdf5_reader::copy_members(const hdf5_reader &rhs) {
+  if(rhs.m_data_store != nullptr) {
+    m_data_store = new data_store_conduit(rhs.get_data_store());
+  }
+  m_data_store->set_data_reader_ptr(this);
+
+  m_has_labels = rhs.m_has_labels;
+  m_has_responses = rhs.m_has_responses;
+  m_num_features = rhs.m_num_features;
+  m_data_dims = rhs.m_data_dims;
+  m_hyperslab_dims = rhs.m_hyperslab_dims;
+  m_comm = rhs.m_comm;
+  m_file_paths = rhs.m_file_paths;
+  m_use_data_store = rhs.m_use_data_store;
+
+  for(size_t i = 0; i < m_num_response_features; i++) {
+    m_all_responses[i] = rhs.m_all_responses[i];
+  }
+}
+
+void hdf5_reader::read_hdf5_hyperslab(hsize_t h_data, hsize_t filespace,
+                                      int rank, short *sample) {
+  prof_region_begin("read_hdf5_hyperslab", prof_colors[0], false);
+  // this is the splits, right now it is hard coded to split along the
+  // z axis
+  int num_io_parts = dc::get_number_of_io_partitions();
+
+  // how many times the pattern should repeat in the hyperslab
+  hsize_t count[4] = {1,1,1,1};
+
+  // necessary for the hdf5 lib
+  hid_t memspace = H5Screate_simple(4, m_hyperslab_dims.data(), NULL);
+  int spatial_offset = rank % num_io_parts;
+  hsize_t offset[4] = {0, m_hyperslab_dims[1] * spatial_offset, 0, 0};
+
+  // from an explanation of the hdf5 select_hyperslab:
+  // start -> a starting location for the hyperslab
+  // stride -> the number of elements to separate each element or block to be selected
+  // count -> the number of elemenets or blocks to select along each dimension
+  // block -> the size of the block selected from the dataspace
+  //hsize_t status;
+
+  CHECK_HDF5(H5Sselect_hyperslab(filespace, H5S_SELECT_SET,
+                                 offset, NULL, count,
+                                 m_hyperslab_dims.data()));
+
+  CHECK_HDF5(H5Dread(h_data, H5T_NATIVE_SHORT, memspace,
+                     filespace, m_dxpl, sample));
+  prof_region_end("read_hdf5_hyperslab", false);
+}
+
+void hdf5_reader::read_hdf5_sample(int data_id, short *sample) {
+  int world_rank = get_comm()->get_rank_in_trainer();
+  auto file = m_file_paths[data_id];
+  hid_t h_file = CHECK_HDF5(H5Fopen(file.c_str(), H5F_ACC_RDONLY, m_fapl));
+
+  // load in dataset
+  hid_t h_data = CHECK_HDF5(
+      H5Dopen(h_file, HDF5_KEY_DATA.c_str(), H5P_DEFAULT));
+  hid_t filespace = CHECK_HDF5(H5Dget_space(h_data));
+  //get the number of dimesnionse from the dataset
+  int rank1 = H5Sget_simple_extent_ndims(filespace);
+  hsize_t dims[rank1];
+  // read in what the dimensions are
+  CHECK_HDF5(H5Sget_simple_extent_dims(filespace, dims, NULL));
+
+  read_hdf5_hyperslab(h_data, filespace, world_rank, sample);
+  //close data set
+  CHECK_HDF5(H5Dclose(h_data));
+
+  if (m_has_responses) {
+    h_data = CHECK_HDF5(H5Dopen(h_file, HDF5_KEY_RESPONSES.c_str(), H5P_DEFAULT));
+    CHECK_HDF5(H5Dread(h_data, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, m_all_responses));
+    CHECK_HDF5(H5Dclose(h_data));
+  }
+  CHECK_HDF5(H5Fclose(h_file));
+  return;
+}
+
+void hdf5_reader::load() {
+  lbann_comm* l_comm = get_comm();
+  MPI_Comm mpi_comm = l_comm->get_trainer_comm().GetMPIComm();
+  int world_rank = l_comm->get_rank_in_trainer();
+  int color = world_rank / dc::get_number_of_io_partitions();
+  MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
+  m_shuffled_indices.clear();
+  m_shuffled_indices.resize(m_file_paths.size());
+  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+  int nprocs;
+  MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+  if ((nprocs % dc::get_number_of_io_partitions()) !=0) {
+    LBANN_ERROR("nprocs should be divisible by num of io partitions otherwise this wont work");
+  }
+
+  // Read the dimension size of the first sample,
+  // assuming that all of the samples have the same dimension size
+  if (m_file_paths.size() > 0) {
+    const hid_t h_file = CHECK_HDF5(H5Fopen(m_file_paths[0].c_str(),
+                                            H5F_ACC_RDONLY, H5P_DEFAULT));
+    const hid_t h_data = CHECK_HDF5(H5Dopen(h_file, HDF5_KEY_DATA.c_str(),
+                                            H5P_DEFAULT));
+    const hid_t h_space = CHECK_HDF5(H5Dget_space(h_data));
+    if (CHECK_HDF5(H5Sget_simple_extent_ndims(h_space)) != 4) {
+      LBANN_ERROR("The number of dimensions of HDF5 data samples should be 4");
+    }
+    hsize_t dims[4];
+    CHECK_HDF5(H5Sget_simple_extent_dims(h_space, dims, NULL));
+    CHECK_HDF5(H5Dclose(h_data));
+    m_data_dims = std::vector<int>(dims, dims+4);
+  } else {
+    LBANN_ERROR("The number of HDF5 samples should not be zero");
+  }
+
+  m_num_features = std::accumulate(m_data_dims.begin(),
+                                   m_data_dims.end(),
+                                   (size_t) 1,
+                                   std::multiplies<size_t>());
+
+
+  for (auto i: m_data_dims) {
+    m_hyperslab_dims.push_back(i);
+  }
+  // Partition the z dimension
+  m_hyperslab_dims[1] /= dc::get_number_of_io_partitions();
+
+#define DATA_READER_HDF5_USE_MPI_IO
+#ifdef DATA_READER_HDF5_USE_MPI_IO
+  m_fapl = CHECK_HDF5(H5Pcreate(H5P_FILE_ACCESS));
+  CHECK_HDF5(H5Pset_fapl_mpio(m_fapl, m_comm, MPI_INFO_NULL));
+  m_dxpl = CHECK_HDF5(H5Pcreate(H5P_DATASET_XFER));
+  CHECK_HDF5(H5Pset_dxpl_mpio(m_dxpl, H5FD_MPIO_INDEPENDENT));  // H5FD_MPIO_COLLECTIVE
+#else
+  m_fapl = H5P_DEFAULT;
+  m_dxpl = H5P_DEFAULT;
+#endif
+  std::vector<int> local_list_sizes;
+  options *opts = options::get();
+  if (opts->get_bool("preload_data_store")) {
+    LBANN_ERROR("preload_data_store not supported on HDF5 data reader");
+  }
+  if (m_use_data_store) {
+    instantiate_data_store();
+  }
+
+  select_subset_of_data();
+  MPI_Comm_dup(dc::get_mpi_comm(), &m_response_gather_comm);
+}
+
+bool hdf5_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
+  return true;
+}
+
+bool hdf5_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
+  prof_region_begin("fetch_datum", prof_colors[0], false);
+
+  // In the Cosmoflow case, each minibatch should have only one
+  // sample per rank.
+  assert_eq(X.Width(), 1);
+  assert_eq(X.Height(),
+            m_num_features / dc::get_number_of_io_partitions()
+            / (sizeof(DataType) / sizeof(short)));
+
+  if (m_use_data_store) {
+    fetch_datum_conduit(X, data_id);
+  } else {
+    read_hdf5_sample(data_id, (short*)X.Buffer());
+  }
+  prof_region_end("fetch_datum", false);
+  return true;
+}
+
+void hdf5_reader::fetch_datum_conduit(Mat& X, int data_id) {
+  const std::string conduit_key = LBANN_DATA_ID_STR(data_id);
+  // Create a node to hold all of the data
+  conduit::Node node;
+  if (data_store_active()) {
+    prof_region_begin("get_conduit_node", prof_colors[0], false);
+    const conduit::Node& ds_node = m_data_store->get_conduit_node(data_id);
+    node.set_external(ds_node);
+    prof_region_end("get_conduit_node", false);
+  } else {
+    auto &conduit_obj = node[conduit_key + "/slab"];
+    conduit_obj.set(conduit::DataType::int16(
+        m_num_features / dc::get_number_of_io_partitions()));
+    short *sample_buf = conduit_obj.value();
+    read_hdf5_sample(data_id, sample_buf);
+    node[conduit_key + "/responses"].set(m_all_responses, 4);
+    if (priming_data_store()) {
+      // Once the node has been populated save it in the data store
+      m_data_store->set_conduit_node(data_id, node);
+    }
+  }
+  prof_region_begin("set_external", prof_colors[0], false);
+  conduit::Node slab;
+  slab.set_external(node[conduit_key + "/slab"]);
+  prof_region_end("set_external", false);
+  short *data = slab.value();
+  prof_region_begin("copy_to_buffer", prof_colors[0], false);
+  std::memcpy(X.Buffer(), data, slab.dtype().number_of_elements()*slab.dtype().element_bytes());
+  prof_region_end("copy_to_buffer", false);
+}
+
+//get from a cached response
+bool hdf5_reader::fetch_response(Mat& Y, int data_id, int mb_idx) {
+  prof_region_begin("fetch_response", prof_colors[0], false);
+  assert_eq(Y.Height(), m_num_response_features);
+  float *buf = nullptr;
+  if (data_store_active()) {
+    conduit::Node node;
+    const conduit::Node& ds_node = m_data_store->get_conduit_node(data_id);
+    node.set_external(ds_node);
+    const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
+    buf = node[conduit_obj+"/responses"].value();
+  }else {
+    buf = m_all_responses;
+  }
+  std::memcpy(Y.Buffer(), buf,
+              m_num_response_features*sizeof(DataType));
+  gather_responses(Y.Buffer());
+  prof_region_end("fetch_response", false);
+  return true;
+}
+
+// Gather scattered responses to the first N ranks, where N is the
+// mini-batch size. This is not necessary when the rank reordering
+// is used.
+void hdf5_reader::gather_responses(float *responses) {
+  float recv_buf[m_num_response_features];
+  const int rank = dc::get_mpi_rank();
+  const int num_part = dc::get_number_of_io_partitions();
+  const int mini_batch_size = this->get_loaded_mini_batch_size();
+  const int src_rank = rank * num_part;
+  const int dst_rank = rank / num_part;
+  const int tag = 0;
+  int req_idx = 0;
+  MPI_Request req[2];
+
+  // send
+  if (rank % num_part == 0) {
+    MPI_Isend(responses, m_num_response_features, MPI_FLOAT, dst_rank,
+              tag, m_response_gather_comm, &req[req_idx]);
+    ++req_idx;
+  }
+
+  // recv
+  if (rank < mini_batch_size) {
+    MPI_Irecv(recv_buf, m_num_response_features, MPI_FLOAT, src_rank, tag,
+              m_response_gather_comm, &req[req_idx]);
+    ++req_idx;
+  }
+
+  if (req_idx > 0) {
+    MPI_Waitall(req_idx, req, MPI_STATUS_IGNORE);
+  }
+
+  std::memcpy(responses, recv_buf, sizeof(float) * m_num_response_features);
+}
+
+} // namespace lbann

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -32,6 +32,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/options.hpp"
 #include "lbann/utils/timer.hpp"
+#include "lbann/utils/distconv.hpp"
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/commify.hpp"
 #include <unordered_set>
@@ -61,11 +62,20 @@ data_store_conduit::data_store_conduit(
     LBANN_ERROR("m_comm is nullptr");
   }
 
+#ifdef LBANN_HAS_DISTCONV
+  int num_io_parts = dc::get_number_of_io_partitions();
+#else
+  int num_io_parts = 1;
+#endif // LBANN_HAS_DISTCONV
+
   m_world_master = m_comm->am_world_master();
   m_trainer_master = m_comm->am_trainer_master();
   m_rank_in_trainer = m_comm->get_rank_in_trainer();
   m_rank_in_world = m_comm->get_rank_in_world();
+  m_partition_in_trainer = m_rank_in_trainer/num_io_parts; // needs a better name  which group you are in
+  m_offset_in_partition = m_rank_in_trainer%num_io_parts;
   m_np_in_trainer = m_comm->get_procs_per_trainer();
+  m_num_partitions_in_trainer = m_np_in_trainer/num_io_parts; // rename this m_num_io_groups_in_trainer
 
   open_informational_files();
 
@@ -79,10 +89,10 @@ data_store_conduit::data_store_conduit(
   if (opts->has_string("data_store_test_checkpoint")
       && opts->has_string("data_store_spill")) {
     LBANN_ERROR("you passed both --data_store_test_checkpoint and --data_store_spill; please use one or the other or none, but not both");
-  }  
+  }
   if (opts->has_string("data_store_test_checkpoint")) {
     setup_checkpoint_test();
-  }  
+  }
   if (opts->has_string("data_store_spill")) {
     setup_spill(opts->get_string("data_store_spill"));
   }
@@ -90,7 +100,7 @@ data_store_conduit::data_store_conduit(
   set_is_local_cache(opts->get_bool("data_store_cache"));
   set_is_preloading(opts->get_bool("preload_data_store"));
   set_is_explicitly_loading(! is_preloading());
-  
+
   if (is_local_cache()) {
     PROFILE("data_store_conduit is running in local_cache mode");
   } else {
@@ -128,7 +138,7 @@ void data_store_conduit::setup_checkpoint_test() {
   std::string c = options::get()->get_string("data_store_test_checkpoint");
   if (c == "1") {
     LBANN_ERROR("--data_store_test_checkpoint=1; you probably forgot to specify the spill directory; you must specify --data_store_test_checkpoint=<string>'");
-  } 
+  }
   if (c == "lassen") {
      c = get_lassen_spill_dir();
   }
@@ -161,8 +171,8 @@ data_store_conduit& data_store_conduit::operator=(const data_store_conduit& rhs)
   return (*this);
 }
 
-void data_store_conduit::set_data_reader_ptr(generic_data_reader *reader) { 
-  m_reader = reader; 
+void data_store_conduit::set_data_reader_ptr(generic_data_reader *reader) {
+  m_reader = reader;
   m_debug = 0;
   m_profile = 0;
   open_informational_files();
@@ -244,7 +254,7 @@ void data_store_conduit::setup_data_store_buffers() {
 void data_store_conduit::spill_preloaded_conduit_node(int data_id, const conduit::Node &node) {
   // note: at this point m_data[data_id] = node
   conduit::Node n3 = node;
-  { 
+  {
     std::lock_guard<std::mutex> lock(m_mutex);
     build_node_for_sending(node, n3);
   }
@@ -271,17 +281,16 @@ void data_store_conduit::set_preloaded_conduit_node(int data_id, const conduit::
   }
 
   if (is_local_cache()) {
-    m_data[data_id] = node; 
+    m_data[data_id] = node;
     return;
   }
-
 
   if (m_spill) {
     spill_preloaded_conduit_node(data_id, node);
     return;
   }
 
-  { 
+  {
     conduit::Node n2 = node;
     std::lock_guard<std::mutex> lock(m_mutex);
     build_node_for_sending(n2, m_data[data_id]);
@@ -374,7 +383,8 @@ void data_store_conduit::set_conduit_node(int data_id, const conduit::Node &node
       {
     //    std::lock_guard<std::mutex> lock(m_mutex);
         LBANN_ERROR("NOT YET IMPLEMENTED");
-        m_owner[data_id] = m_rank_in_trainer;
+        auto key = std::make_pair(data_id, m_offset_in_partition);
+        m_owner[key] = m_rank_in_trainer;
         m_sample_sizes[data_id] = n2.total_bytes_compact();
         spill_conduit_node(node, data_id);
         m_spilled_nodes[data_id] = m_cur_spill_dir_integer;
@@ -382,14 +392,15 @@ void data_store_conduit::set_conduit_node(int data_id, const conduit::Node &node
     }
 
     else {
-      {
-      //  std::lock_guard<std::mutex> lock(m_mutex);
-        m_owner[data_id] = m_rank_in_trainer;
-        build_node_for_sending(node, m_data[data_id]);
-        m_sample_sizes[data_id] = m_data[data_id].total_bytes_compact();
-      }  
+      //      m_mutex.lock();
+      DEBUG_DS("set_conduit_node : rank_in_trainer=", m_rank_in_trainer, " and partition_in_trainer=", m_partition_in_trainer, " offset in partition=", m_offset_in_partition, " with num_partitions=", m_num_partitions_in_trainer);
+      auto key = std::make_pair(data_id, m_offset_in_partition);
+      m_owner[key] = m_rank_in_trainer;
+      build_node_for_sending(node, m_data[data_id]);
       error_check_compacted_node(m_data[data_id], data_id);
-    }  
+      m_sample_sizes[data_id] = m_data[data_id].total_bytes_compact();
+      //      m_mutex.unlock();
+    }
   }
 }
 
@@ -609,8 +620,14 @@ int data_store_conduit::build_indices_i_will_recv(int current_pos, int mb_size) 
   int k = 0;
   for (int i=current_pos; i< current_pos + mb_size; ++i) {
     auto index = (*m_shuffled_indices)[i];
-    if ((i % m_owner_map_mb_size) % m_np_in_trainer == m_rank_in_trainer) {
-      int owner = m_owner[index];
+#ifdef LBANN_HAS_DISTCONV
+    int num_ranks_in_partition = dc::get_number_of_io_partitions();
+#else
+    int num_ranks_in_partition = 1;
+#endif // LBANN_HAS_DISTCONV
+    if ((((i % m_owner_map_mb_size) % m_num_partitions_in_trainer) * num_ranks_in_partition + m_offset_in_partition) == m_rank_in_trainer) {
+      auto key = std::make_pair(index, m_offset_in_partition);
+      int owner = m_owner[key];
       m_indices_to_recv[owner].insert(index);
       k++;
     }
@@ -633,11 +650,17 @@ int data_store_conduit::build_indices_i_will_send(int current_pos, int mb_size) 
       is_mine = true;
     }
     if (is_mine) {
-      m_indices_to_send[(i % m_owner_map_mb_size) % m_np_in_trainer].insert(index);
+#ifdef LBANN_HAS_DISTCONV
+      int num_ranks_in_partition = dc::get_number_of_io_partitions();
+#else
+      int num_ranks_in_partition = 1;
+#endif // LBANN_HAS_DISTCONV
+      m_indices_to_send[(((i % m_owner_map_mb_size) % m_num_partitions_in_trainer) * num_ranks_in_partition + m_offset_in_partition)].insert(index);
 
       // Sanity check
-      if (m_owner[index] != m_rank_in_trainer) {
-        LBANN_ERROR( "error for i: ", i, " index: ", index, " m_owner: ", m_owner[index], " me: ", m_rank_in_trainer);
+      auto key = std::make_pair(index, m_offset_in_partition);
+      if (m_owner[key] != m_rank_in_trainer) {
+        LBANN_ERROR( "error for i: ", i, " index: ", index, " m_owner: ", m_owner[key], " me: ", m_rank_in_trainer);
       }
       k++;
     }
@@ -656,7 +679,8 @@ void data_store_conduit::build_preloaded_owner_map(const std::vector<int>& per_r
       ++owning_rank;
       per_rank_list_range_start += per_rank_list_size;
     }
-    m_owner[(*m_shuffled_indices)[i]] = owning_rank;
+    auto key = std::make_pair((*m_shuffled_indices)[i], m_offset_in_partition);
+    m_owner[key] = owning_rank;
   }
 PROFILE("build_preloaded_owner_map; m_owner_maps_were_exchanged = true");
   m_owner_maps_were_exchanged = true;
@@ -703,10 +727,11 @@ void data_store_conduit::compact_nodes() {
 }
 
 int data_store_conduit::get_index_owner(int idx) {
-  if (m_owner.find(idx) == m_owner.end()) {
+  auto key = std::make_pair(idx, m_offset_in_partition);
+  if (m_owner.find(key) == m_owner.end()) {
     LBANN_ERROR(" idx: ", idx, " was not found in the m_owner map; map size: ", m_owner.size());
   }
-  return m_owner[idx];
+  return m_owner[key];
 }
 
 void data_store_conduit::check_mem_capacity(lbann_comm *comm, const std::string sample_list_file, size_t stride, size_t offset) {
@@ -935,7 +960,7 @@ void data_store_conduit::set_loading_is_complete() {
   }
 }
 
-bool data_store_conduit::is_fully_loaded() const { 
+bool data_store_conduit::is_fully_loaded() const {
   if (m_loading_is_complete) {
     return true;
   }
@@ -966,7 +991,7 @@ void data_store_conduit::get_image_sizes(map_is_t &file_sizes, std::vector<std::
       my_image_sizes.push_back(t.second[LBANN_DATA_ID_STR(data_id) + "/buffer_size"].value());
     }
   }
-  
+
   else {
     // get sizes of files for which I'm responsible
     for (size_t h=m_rank_in_trainer; h<m_shuffled_indices->size(); h += m_np_in_trainer) {
@@ -1125,7 +1150,7 @@ void data_store_conduit::exchange_local_caches() {
   PROFILE("  is_local_cache(): ", is_local_cache());
   PROFILE("  is_fully_loaded: ", is_fully_loaded());
 
-  // indices[j] will contain the indices 
+  // indices[j] will contain the indices
   // that P_j will read from disk, and subsequently bcast to all others
   std::vector<std::vector<int>> indices;
 
@@ -1195,7 +1220,7 @@ void data_store_conduit::build_conduit_nodes(map_is_t &sizes) {
   const std::vector<image_data_reader::sample_t> &image_list = image_reader->get_image_list();
   for (auto t : sizes) {
     int data_id = t.first;
-    int label = image_list[data_id].second; 
+    int label = image_list[data_id].second;
     if (m_image_offsets.find(data_id) == m_image_offsets.end()) {
       LBANN_ERROR("m_image_offsets.find(data_id) == m_image_offsets.end() for data_id: ", data_id);
     }
@@ -1317,31 +1342,52 @@ void data_store_conduit::exchange_owner_maps() {
   m_comm->all_gather(&my_count, 1, all_counts.data(), 1,  m_comm->get_trainer_comm());
 
   std::vector<size_t> my_sizes(m_my_num_indices);
+  std::vector<std::pair<size_t,size_t>> nodes_i_own(m_owner.size());
   size_t j = 0;
   for (auto t : m_owner) {
-    my_sizes[j++] = t.first;
+    auto slab_id = std::make_pair(t.first.first, t.first.second);
+    nodes_i_own[j++] = slab_id;
+    DEBUG_DS("I am building the size vector from the owner map for ", t.first.first, ".", t.first.second, " and ", t.second);
   }
 
-  std::vector<size_t> others;
+  std::vector<std::pair<size_t,size_t>> other_ranks_nodes;
   for (int k=0; k<m_np_in_trainer; k++) {
-    others.resize(all_counts[k]);
+    other_ranks_nodes.resize(all_counts[k]);
     if (m_rank_in_trainer == k) {
-      m_comm->broadcast<size_t>(k, my_sizes.data(), all_counts[k],  m_comm->get_trainer_comm());
+      m_comm->broadcast<std::pair<size_t,size_t>>(k, nodes_i_own.data(), all_counts[k],  m_comm->get_trainer_comm());
+      if(m_debug) {
+        int c = 0;
+        for(auto i : nodes_i_own) {
+          DEBUG_DS("k=", k,  ": nodes_i_own[", c, "]=", i.first, ".", i.second);
+          c++;
+        }
+      }
     } else {
-      m_comm->broadcast<size_t>(k, others.data(), all_counts[k],  m_comm->get_trainer_comm());
-      for (size_t i=0; i<others.size(); ++i) {
-        if (m_owner.find(others[i]) != m_owner.end()) {
+      m_comm->broadcast<std::pair<size_t,size_t>>(k, other_ranks_nodes.data(), all_counts[k],  m_comm->get_trainer_comm());
+      if(m_debug) {
+        int c = 0;
+        for(auto i : other_ranks_nodes) {
+          DEBUG_DS("k=", k,  ": other_ranks_nodes[", c, "]=", i.first, ".", i.second);
+          c++;
+        }
+      }
+      for (size_t i=0; i<other_ranks_nodes.size(); ++i) {
+        auto key = other_ranks_nodes[i];
+        // Check to make sure that I don't own this
+        if (m_owner.find(key) != m_owner.end()) {
 
           if (m_debug) {
-            DEBUG_DS("data_store_conduit::exchange_owner_maps, duplicate data_id: ", others[i], "; k= ", k, "\nmy current m_owner map: ");
-            for (auto t : m_owner) DEBUG_DS("data_id: ", t.first, " owner: ", t.second);
-            DEBUG_DS("\nowner map (partial or whole) from P_", k);
-            for (auto t : others) DEBUG_DS(t, " ");
+            auto slab_id = other_ranks_nodes[i];
+            DEBUG_DS("data_store_conduit::exchange_owner_maps, duplicate data_id: ", slab_id.first, ".", slab_id.second, "; k= ", k, "\nm_owner:\n");
+            for (auto t : m_owner) DEBUG_DS("data_id: ", t.first.first, " / ", t.first.second, " owner: ", t.second);
+            DEBUG_DS("\nother_ranks_nodes[k]: ");
+            for (auto t : other_ranks_nodes) DEBUG_DS(t.first, ".", t.second, " ");
           }
 
-          LBANN_ERROR("duplicate data_id: ", others[i], " role: ", m_reader->get_role(), "; m_owner[", others[i],"] = ", m_owner[others[i]], " for role: ", m_reader->get_role(), " m_owner.size: ", m_owner.size(), " m_data.size(): ", m_data.size());
+          LBANN_ERROR("duplicate data_id: ", other_ranks_nodes[i].first, ".",
+                      other_ranks_nodes[i].second, " role: ", m_reader->get_role(), "; m_owner[",other_ranks_nodes[i].first, ".", other_ranks_nodes[i].second,"] = ", m_owner[key]);
         }
-        m_owner[others[i]] = k;
+        m_owner[key] = k;
       }
     }
 
@@ -1429,7 +1475,7 @@ void data_store_conduit::exchange_mini_batch_data(size_t current_pos, size_t mb_
     PROFILE("  is_fully_loaded: ", is_fully_loaded());
     if (! is_local_cache()) {
       profile_timing();
-    }  
+    }
   }
 
   double tm1 = get_time();
@@ -1439,11 +1485,11 @@ void data_store_conduit::exchange_mini_batch_data(size_t current_pos, size_t mb_
     PROFILE("calling exchange_owner_maps");
     if (!m_owner_maps_were_exchanged) {
       exchange_owner_maps();
-    } 
+    }
 
-    else {  
+    else {
       PROFILE("  owner_maps were already exchanged; returning");
-    }  
+    }
     m_owner_maps_were_exchanged = true;
 PROFILE("exchange_mini_batch_data; m_owner_maps_were_exchanged = true");
     /*
@@ -1452,7 +1498,7 @@ PROFILE("exchange_mini_batch_data; m_owner_maps_were_exchanged = true");
       m_is_spilled = true;
       m_metadata.close();
       save_state();
-    }  
+    }
     */
   }
 
@@ -1512,7 +1558,7 @@ void data_store_conduit::test_checkpoint(const std::string &checkpoint_dir) {
   }
 
   if (m_world_master) {
-    std::cerr << "Cleared the owner map; m_owner.size(): " << m_owner.size() 
+    std::cerr << "Cleared the owner map; m_owner.size(): " << m_owner.size()
               << std::endl
               << "Calling load_checkpoint" << std::endl;
   }
@@ -1527,9 +1573,9 @@ void data_store_conduit::test_checkpoint(const std::string &checkpoint_dir) {
   //check that the owner map was correctly loaded
   for (auto t : m_owner) {
     if (sanity.find(t.first) == sanity.end()) {
-      LBANN_ERROR("sanity.find(t.first) == sanity.end() for t.first= ", t.first);
+      LBANN_ERROR("sanity.find(t.first) == sanity.end() for t.first= ", t.first.first, ":", t.first.second);
     } else if (sanity[t.first] != m_owner[t.first]) {
-      LBANN_ERROR("sanity[t.first] != m_owner[t.first] for t.first= ", t.first, " and m_owner[t.first]= ", m_owner[t.first]);
+      LBANN_ERROR("sanity[t.first] != m_owner[t.first] for t.first= ", t.first.first, ":", t.first.second, " and m_owner[t.first]= ", m_owner[t.first]);
     }
   }
 
@@ -1566,7 +1612,7 @@ void data_store_conduit::setup_spill(std::string base_dir) {
   // open metadata file; this will contains the file pathnames of spilled
   // conduit nodes
   const std::string fnn = get_metadata_fn();
-  m_metadata.open(fnn.c_str()); 
+  m_metadata.open(fnn.c_str());
   if (!m_metadata) {
     LBANN_ERROR("failed to open ", fnn, " for writing");
   }
@@ -1609,15 +1655,15 @@ void data_store_conduit::save_state() {
   {
   cereal::XMLOutputArchive archive(os);
     archive(CEREAL_NVP(m_my_num_indices),
-            CEREAL_NVP(m_owner_maps_were_exchanged), 
+            CEREAL_NVP(m_owner_maps_were_exchanged),
             CEREAL_NVP(m_is_setup),
-            CEREAL_NVP(m_preloading), 
-            CEREAL_NVP(m_loading_is_complete), 
+            CEREAL_NVP(m_preloading),
+            CEREAL_NVP(m_loading_is_complete),
             CEREAL_NVP(m_explicitly_loading),
-            CEREAL_NVP(m_owner_map_mb_size), 
-            CEREAL_NVP(m_compacted_sample_size), 
+            CEREAL_NVP(m_owner_map_mb_size),
+            CEREAL_NVP(m_compacted_sample_size),
             CEREAL_NVP(m_is_local_cache),
-            CEREAL_NVP(m_node_sizes_vary), 
+            CEREAL_NVP(m_node_sizes_vary),
             CEREAL_NVP(m_have_sample_sizes),
             CEREAL_NVP(m_owner),
             CEREAL_NVP(m_sample_sizes));
@@ -1665,7 +1711,7 @@ void data_store_conduit::load_checkpoint(std::string dir_name, generic_data_read
     m_rank_in_trainer = m_comm->get_rank_in_trainer();
     m_rank_in_world = m_comm->get_rank_in_world();
     m_np_in_trainer = m_comm->get_procs_per_trainer();
-  }  
+  }
 
   // Open metadata filename; this is in index re, checkpointed conduit filenames
   const std::string metadata_fn = get_metadata_fn();
@@ -1715,7 +1761,7 @@ std::string data_store_conduit::get_conduit_dir() const {
 }
 
 std::string data_store_conduit::get_cereal_fn() const {
-  return m_spill_dir_base + '/' + m_cereal_fn + "_" + m_reader->get_role() + "_" + std::to_string(m_rank_in_world) + ".xml"; 
+  return m_spill_dir_base + '/' + m_cereal_fn + "_" + m_reader->get_role() + "_" + std::to_string(m_rank_in_world) + ".xml";
 }
 
 std::string data_store_conduit::get_metadata_fn() const {
@@ -1799,13 +1845,13 @@ void data_store_conduit::open_informational_files() {
 
 void data_store_conduit::print_partial_owner_map(int n) {
    std::cerr << "\nHere is part of the owner map; m_owner.size(): " << m_owner.size() << std::endl;
-  std::map<int,int> m;
+   std::map<std::pair<size_t,size_t>, int> m;
   for (auto t : m_owner) {
     m[t.first] = t.second;
   }
   int j = 0;
   for (auto t : m) {
-    std::cerr << "  sample_id: " << t.first << " owner: " << t.second << std::endl;
+    std::cerr << "  sample_id: " << t.first.first << ":" << t.first.second << " owner: " << t.second << std::endl;
     if (j++ >= 10) break;
   }
 }
@@ -1846,7 +1892,7 @@ void data_store_conduit::test_imagenet_node(int index, bool dereference) {
     std::cerr << "; (>= INT_MAX)\n";
   } else {
     std::cerr << std::endl;
-  }  
+  }
   conduit::Node nd1;
   image_reader->load_conduit_node_from_file(data_id, nd1);
   char *buf1 = nd1[LBANN_DATA_ID_STR(data_id) + "/buffer"].value();
@@ -1865,7 +1911,7 @@ void data_store_conduit::test_imagenet_node(int index, bool dereference) {
       const conduit::Schema &s = nd2.schema();
       s.print();
       nd2.print();
-    }  
+    }
 
 
 
@@ -1935,13 +1981,13 @@ void data_store_conduit::check_query_flags() const {
   }
 }
 
-void data_store_conduit::clear_owner_map() { 
+void data_store_conduit::clear_owner_map() {
     m_owner_maps_were_exchanged = false;
-    m_owner.clear(); 
+    m_owner.clear();
 }
 
 void data_store_conduit::verify_sample_size() {
-  // Note: m_compacted_sample_size is set during calls to set_conduit_node() or 
+  // Note: m_compacted_sample_size is set during calls to set_conduit_node() or
   //  set_preloaded_conduit_node(). Hence, if these are not called (i.e, the
   //  rank does not own any data), m_compacted_sample_size will be zero.
   //  This method ensures that all ranks know the sample size, whether or not
@@ -1957,4 +2003,3 @@ void data_store_conduit::verify_sample_size() {
 }
 
 }  // namespace lbann
-

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -178,6 +178,17 @@ void init_data_readers(
       reader_numpy_npz->set_has_responses(!readme.disable_responses());
       reader_numpy_npz->set_scaling_factor_int16(readme.scaling_factor_int16());
       reader = reader_numpy_npz;
+#ifdef LBANN_HAS_DISTCONV
+    } else if (name=="cosmoflow_hdf5") {
+      auto* reader_cosmo_hdf5 = new hdf5_reader(shuffle);
+      auto filedir = readme.data_filedir();
+      if(!endsWith(filedir, "/")) {
+        filedir = filedir + "/";
+      }
+      const auto paths = glob(filedir +readme.data_file_pattern());
+      reader_cosmo_hdf5->set_hdf5_paths(paths);
+      reader = reader_cosmo_hdf5;
+#endif // LBANN_HAS_DISTCONV
     } else if (name == "pilot2_molecular_reader") {
       pilot2_molecular_reader* reader_pilot2_molecular = new pilot2_molecular_reader(readme.num_neighbors(), readme.max_neighborhood(), shuffle);
       reader = reader_pilot2_molecular;


### PR DESCRIPTION
This PR merges distconv extensions for HDF5 data reader and slab-based reading.

This PR needs much more robust design but is intended to show what's been working for Cosmoflow. There are a lot of ad-hoc changes scattered around data store, data reader and io buffer. The fundamental reason of these changes is that in the baseline LBANN a data reader is assumed to return full samples, which is no longer the case with slab reading.

Another thing needed here is to determine how each sample should be partitioned. Currently, it is assumed to be partitioned in the depth dimension, and the number of partitions is provided by an environment variable, which can be queried with `dc::get_number_of_io_partitions()`. I think that the parallel strategy of `input_layer` should be propagated here, and the use of the environment variable should be replaced.
