### PR TITLE
Bugfix trainer specific callback outputs

### DIFF
--- a/include/lbann/callbacks/callback.hpp
+++ b/include/lbann/callbacks/callback.hpp
@@ -187,6 +187,38 @@ public:
 
   ///@}
 
+  /** @brief Build a standard directory hierachy including trainer,
+   * execution context, and model information (in that order).
+   */
+  inline std::string get_multi_trainer_ec_model_path(const model& m,
+                                                     const std::string& root_dir) {
+    std::string dir = root_dir;
+    if (dir.empty()) { dir = "./"; }
+    if (dir.back() != '/') { dir += "/"; }
+
+    const auto& c = static_cast<const sgd_execution_context&>(m.get_execution_context());
+    return build_string(dir,
+                        c.get_trainer().get_name(), '/',
+                        c.get_state_string(), '/',
+                        m.get_name(), '/');
+  }
+
+  /** @brief Build a standard directory hierachy including trainer,
+   * model information in that order.
+   */
+  inline std::string get_multi_trainer_model_path(const model& m,
+                                                  const std::string& root_dir) {
+    std::string dir = root_dir;
+    if (dir.empty()) { dir = "./"; }
+    if (dir.back() != '/') { dir += "/"; }
+
+    const auto& c = static_cast<const sgd_execution_context&>(m.get_execution_context());
+    return build_string(dir,
+                        c.get_trainer().get_name(), '/',
+                        m.get_name(), '/');
+  }
+
+
 protected:
 
   /** @brief Copy-assignment operator.

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -66,6 +66,12 @@ public:
        CEREAL_NVP(m_step));
   }
 
+  /** @brief Return the state of the execution context as a string */
+  virtual std::string get_state_string() const noexcept {
+    return build_string("ec.", to_string(get_execution_mode()),
+                        ".step.", get_step());
+  }
+
   /** @brief Current step in the training algorithm
     *  @details Step counts the number of iterations in the training
     *  algorithm's internal state

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -68,6 +68,12 @@ public:
        CEREAL_NVP(m_effective_mini_batch_size));
   }
 
+  /** @brief Return the state of the execution context as a string */
+  std::string get_state_string() const noexcept override {
+    return build_string("sgd.", to_string(get_execution_mode()),
+                        ".epoch.", get_epoch(), ".step.", get_step());
+  }
+
   /** Number of times the training set has been traversed. */
   inline size_t get_epoch() const noexcept { return m_epoch; }
 

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ set_full_path(THIS_DIR_HEADERS
   summary.hpp
   summary_impl.hpp
   timer.hpp
+  trainer_file_utils.hpp
   type_erased_matrix.hpp
   typename.hpp
   )

--- a/include/lbann/utils/trainer_file_utils.hpp
+++ b/include/lbann/utils/trainer_file_utils.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+/// @todo Rename this file to file.hpp
+
+#ifndef LBANN_TRAINER_UTILS_FILE_HPP_INCLUDED
+#define LBANN_TRAINER_UTILS_FILE_HPP_INCLUDED
+
+#include "lbann/comm.hpp"
+
+namespace lbann {
+
+namespace file {
+
+/** @brief Trainer master creates directory if needed.
+ *
+ *  Coordinate efforts to allow the trainer master to make a directory
+ *  if needed and synchronizes all other trainer ranks to ensure they
+ *  see a consistent state of the file system.
+ */
+  void trainer_master_make_directory(const std::string& path, lbann_comm* comm);
+
+} // namespace file
+
+} // namespace lbann
+
+#endif // LBANN_TRAINER_UTILS_FILE_HPP_INCLUDED

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -27,6 +27,7 @@ set_full_path(THIS_DIR_SOURCES
   lbann_library.cpp
   jag_common.cpp
   commify.cpp
+  trainer_file_utils.cpp
 )
 
 if (LBANN_HAS_HALF)

--- a/src/utils/trainer_file_utils.cpp
+++ b/src/utils/trainer_file_utils.cpp
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/trainer_file_utils.hpp"
+#include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+namespace file {
+
+void trainer_master_make_directory(const std::string& path, lbann_comm* comm) {
+  if (comm == nullptr) {
+    LBANN_ERROR("Invalid communicator pointer");
+    return;
+  }
+
+  if (path.empty() || path == "." || path == "/") {
+    return;
+  }
+
+  if (comm->am_trainer_master()) {
+    // only master checks to see if the directory exists and creates if not.
+    make_directory(path);
+  }
+  comm->trainer_barrier();
+
+}
+
+} // namespace file
+
+} // namespace lbann


### PR DESCRIPTION
Ensure that dump outputs places output files in a multi-trainer aware directory hierarchy.  Also added support for a trainer master aware make directory function that is inspired by PR #1459 but places the code in a separate utility file that requires access to the comm object.  Additionally, added helper functions to the callback and execution context classes to get a multi-trainer aware directory hierarchy.