### PR TITLE
Remove reservation flag when Python frontend calls jsrun

### DIFF
--- a/python/lbann/launcher/lsf.py
+++ b/python/lbann/launcher/lsf.py
@@ -120,18 +120,14 @@ class LSFBatchScript(BatchScript):
         args = [launcher]
         args.extend(make_iterable(launcher_args))
         args.append(f'--chdir {work_dir}')
-        if reservation:
-            args.append(f'--use_reservation {reservation}')
-            args.append(f'--np {nodes * procs_per_node}')
-        else:
-            args.extend([
-                f'--nrs {nodes}',
-                '--rs_per_host 1',
-                f'--tasks_per_rs {procs_per_node}',
-                '--launch_distribution packed',
-                '--cpu_per_rs ALL_CPUS',
-                '--gpu_per_rs ALL_GPUS',
-            ])
+        args.extend([
+            f'--nrs {nodes}',
+            '--rs_per_host 1',
+            f'--tasks_per_rs {procs_per_node}',
+            '--launch_distribution packed',
+            '--cpu_per_rs ALL_CPUS',
+            '--gpu_per_rs ALL_GPUS',
+        ])
         args.extend(make_iterable(command))
         self.add_command(args)
 


### PR DESCRIPTION
We have run into errors when calling `jsrun` with the `--use_reservation` flag. This PR just removes it.

Now, the reservation option in `lbann.run` only has an effect if you run on an LSF system and submit as a batch job (`batch_job=True`). It is ignored in all other cases.