### PR TITLE
Tighten up the timelimits on the job requests for the bamboo jobs.

### DIFF
--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -36,14 +36,12 @@ ALLOCATION_TIME_LIMIT_NIGHTLY=45
 ALLOCATION_TIME_LIMIT_WEEKLY=90
 
 if [ "${CLUSTER}" = 'lassen' ]; then
-#    ALLOCATION_TIME_LIMIT=600
     if [ ${WEEKLY} -ne 0 ]; then
         timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
         timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 2 -W ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
     fi
 elif [ "${CLUSTER}" = 'ray' ]; then
-#    ALLOCATION_TIME_LIMIT=240
     if [ ${WEEKLY} -ne 0 ]; then
         timeout -k 5 24h bsub -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
@@ -65,14 +63,12 @@ elif [ "${CLUSTER}" = 'corona' ]; then
         fi
     fi
 elif [ "${CLUSTER}" = 'pascal' ]; then
-#    ALLOCATION_TIME_LIMIT=960
     if [ ${WEEKLY} -ne 0 ]; then
         timeout -k 5 24h salloc -N4 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
-#        ALLOCATION_TIME_LIMIT=90 # Start with 1.5 hrs; may adjust for CPU clusters
         if [[ $(mjstat -c | awk 'match($1, "pbatch") && NF < 7 { print $5 }') -ne "0" ]];
         then
-            timeout -k 5 24h salloc -N2 --partition=pvis -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
+            timeout -k 5 24h salloc -N2 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
         else
             echo "Partition \"pbatch\" on cluster \"${CLUSTER}\" appears to be down."
         fi

--- a/bamboo/allocate_and_run.sh
+++ b/bamboo/allocate_and_run.sh
@@ -32,44 +32,60 @@ if [ "${CLUSTER}" = 'pascal' ]; then
     export MV2_USE_CUDA=1
 fi
 
+ALLOCATION_TIME_LIMIT_NIGHTLY=45
+ALLOCATION_TIME_LIMIT_WEEKLY=90
+
 if [ "${CLUSTER}" = 'lassen' ]; then
-    ALLOCATION_TIME_LIMIT=600
+#    ALLOCATION_TIME_LIMIT=600
     if [ ${WEEKLY} -ne 0 ]; then
-        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT} ./run.sh --weekly
+        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
-        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 2 -W ${ALLOCATION_TIME_LIMIT} ./run.sh
+        timeout -k 5 24h bsub -G guests -Is -q pbatch -nnodes 2 -W ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
     fi
 elif [ "${CLUSTER}" = 'ray' ]; then
-    ALLOCATION_TIME_LIMIT=240
+#    ALLOCATION_TIME_LIMIT=240
     if [ ${WEEKLY} -ne 0 ]; then
-        timeout -k 5 24h bsub -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT} ./run.sh --weekly
+        timeout -k 5 24h bsub -Is -q pbatch -nnodes 4 -W ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
-        timeout -k 5 24h bsub -Is -q pbatch -nnodes 2 -W ${ALLOCATION_TIME_LIMIT} ./run.sh
+        timeout -k 5 24h bsub -Is -q pbatch -nnodes 2 -W ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
     fi
 elif [ "${CLUSTER}" = 'corona' ]; then
-    ALLOCATION_TIME_LIMIT=960
     if [ ${WEEKLY} -ne 0 ]; then
-        timeout -k 5 24h salloc -N4 --partition=mi60 -t ${ALLOCATION_TIME_LIMIT} ./run.sh --weekly
+        ALLOCATION_TIME_LIMIT_WEEKLY=960
+        timeout -k 5 24h salloc -N4 --partition=mi60 -t ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
-        ALLOCATION_TIME_LIMIT=90 # Start with 1.5 hrs; may adjust for CPU clusters
+        ALLOCATION_TIME_LIMIT_NIGHTLY=90 # Start with 1.5 hrs; may adjust for CPU clusters
         if [[ $(mjstat -c | awk 'match($1, "mi60") && NF < 7 { print $5 }') -ne "0" ]];
         then
-            timeout -k 5 24h salloc -N2 --partition=mi60 -t ${ALLOCATION_TIME_LIMIT} ./run.sh
+            timeout -k 5 24h salloc -N2 --partition=mi60 -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
         else
             echo "Partition \"mi60\" on cluster \"${CLUSTER}\" appears to be down."
             echo "Trying \"mi25\"."
-               timeout -k 5 24h salloc -N2 --partition=mi25 -t ${ALLOCATION_TIME_LIMIT} ./run.sh
+               timeout -k 5 24h salloc -N2 --partition=mi25 -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
         fi
     fi
-elif [ "${CLUSTER}" = 'catalyst' ] || [ "${CLUSTER}" = 'pascal' ]; then
-    ALLOCATION_TIME_LIMIT=960
+elif [ "${CLUSTER}" = 'pascal' ]; then
+#    ALLOCATION_TIME_LIMIT=960
     if [ ${WEEKLY} -ne 0 ]; then
-        timeout -k 5 24h salloc -N4 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT} ./run.sh --weekly
+        timeout -k 5 24h salloc -N4 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
     else
-        ALLOCATION_TIME_LIMIT=90 # Start with 1.5 hrs; may adjust for CPU clusters
+#        ALLOCATION_TIME_LIMIT=90 # Start with 1.5 hrs; may adjust for CPU clusters
         if [[ $(mjstat -c | awk 'match($1, "pbatch") && NF < 7 { print $5 }') -ne "0" ]];
         then
-            timeout -k 5 24h salloc -N2 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT} ./run.sh
+            timeout -k 5 24h salloc -N2 --partition=pvis -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
+        else
+            echo "Partition \"pbatch\" on cluster \"${CLUSTER}\" appears to be down."
+        fi
+    fi
+elif [ "${CLUSTER}" = 'catalyst' ]; then
+    if [ ${WEEKLY} -ne 0 ]; then
+        ALLOCATION_TIME_LIMIT_WEEKLY=960
+        timeout -k 5 24h salloc -N4 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT_WEEKLY} ./run.sh --weekly
+    else
+        ALLOCATION_TIME_LIMIT_NIGHTLY=90 # Start with 1.5 hrs; may adjust for CPU clusters
+        if [[ $(mjstat -c | awk 'match($1, "pbatch") && NF < 7 { print $5 }') -ne "0" ]];
+        then
+            timeout -k 5 24h salloc -N2 --partition=pbatch -t ${ALLOCATION_TIME_LIMIT_NIGHTLY} ./run.sh
         else
             echo "Partition \"pbatch\" on cluster \"${CLUSTER}\" appears to be down."
         fi


### PR DESCRIPTION
This should allow us to take advantge of backfill on the systems.