### PR TITLE
Add access to cuDNN tensor core functionality, controlled by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,9 @@ option(LBANN_WITH_CONDUIT "Enable Conduit library" ON)
 
 option(LBANN_WITH_CUDNN "Include Nvidia cuDNN" ON)
 
+option(LBANN_WITH_CUDNN_TENSOR_OPS
+  "Use cuDNN tensor operations when possible." OFF)
+
 option(LBANN_WITH_DIHYDROGEN "Build with DiHydrogen support" OFF)
 if (LBANN_WITH_DIHYDROGEN)
   message(WARNING "DiHydrogen support is currently expermimental. "
@@ -330,6 +333,7 @@ if (LBANN_HAS_CUDA)
   endif (LBANN_HAS_GPU_FP16)
 
   set(LBANN_HAS_CUDNN ${CUDNN_FOUND})
+  set(LBANN_HAS_CUDNN_TENSOR_OPS ${LBANN_WITH_CUDNN_TENSOR_OPS})
 
   if (LBANN_HAS_ALUMINUM AND AL_HAS_NCCL)
     set(LBANN_HAS_NCCL2 TRUE)

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -37,6 +37,7 @@
 
 #cmakedefine LBANN_HAS_CUDA
 #cmakedefine LBANN_HAS_CUDNN
+#cmakedefine LBANN_HAS_CUDNN_TENSOR_OPS
 #cmakedefine LBANN_HAS_NVSHMEM
 #ifndef LBANN_HAS_CUDA
 #undef LBANN_HAS_NVSHMEM

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -490,6 +490,12 @@ public:
 
     // Set convolution descriptor
     CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&m_convolution_cudnn_desc));
+#ifdef LBANN_HAS_CUDNN_TENSOR_OPS
+    CHECK_CUDNN(
+      cudnnSetConvolutionMathType(
+        m_convolution_cudnn_desc,
+        CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION));
+#endif // LBANN_HAS_CUDNN_TENSOR_OPS
     CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(m_convolution_cudnn_desc,
                                                 m_pads.size(),
                                                 m_pads.data(),
@@ -1154,6 +1160,14 @@ private:
       int num_groups;
       CHECK_CUDNN(cudnnGetConvolutionGroupCount(src,
                                                 &num_groups));
+
+#ifdef LBANN_HAS_CUDNN_TENSOR_OPS
+      // Assume the math type propagates with copy, too.
+      cudnnMathType_t mathtype;
+      CHECK_CUDNN(cudnnGetConvolutionMathType(src, &mathtype));
+      CHECK_CUDNN(cudnnSetConvolutionMathType(dst, mathtype));
+#endif // LBANN_HAS_CUDNN_TENSOR_OPS
+
       CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(dst,
                                                   num_dims,
                                                   pads.data(),

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -24,7 +24,6 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann_config.hpp"
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/number_theory.hpp"
 

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -24,6 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "lbann_config.hpp"
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/number_theory.hpp"
 


### PR DESCRIPTION
This is a fairly broad hammer for applying this functionality, and it will eventually be controlled on a layer-by-layer basis. For now, a CMake flag controls access and it's applied to all convolution layers.