### PR TITLE
Add per-convolutional-layer support for cuDNN tensor operations

### DIFF
--- a/applications/vision/lenet.py
+++ b/applications/vision/lenet.py
@@ -26,6 +26,7 @@ images = lbann.Identity(input_)
 labels = lbann.Identity(input_)
 
 # LeNet
+tensor_ops_mode = lbann.ConvTensorOpsMode.DEFAULT_TENSOR_OPS
 x = lbann.Convolution(images,
                       num_dims = 2,
                       num_output_channels = 6,
@@ -33,7 +34,8 @@ x = lbann.Convolution(images,
                       conv_dims_i = 5,
                       conv_strides_i = 1,
                       conv_dilations_i = 1,
-                      has_bias = True)
+                      has_bias = True,
+                      conv_tensor_op_mode=tensor_ops_mode)
 x = lbann.Relu(x)
 x = lbann.Pooling(x,
                   num_dims = 2,
@@ -47,7 +49,8 @@ x = lbann.Convolution(x,
                       conv_dims_i = 5,
                       conv_strides_i = 1,
                       conv_dilations_i = 1,
-                      has_bias = True)
+                      has_bias = True,
+                      conv_tensor_op_mode=tensor_ops_mode)
 x = lbann.Relu(x)
 x = lbann.Pooling(x,
                   num_dims = 2,

--- a/applications/vision/lenet.py
+++ b/applications/vision/lenet.py
@@ -26,7 +26,6 @@ images = lbann.Identity(input_)
 labels = lbann.Identity(input_)
 
 # LeNet
-tensor_ops_mode = lbann.ConvTensorOpsMode.DEFAULT_TENSOR_OPS
 x = lbann.Convolution(images,
                       num_dims = 2,
                       num_output_channels = 6,
@@ -34,8 +33,7 @@ x = lbann.Convolution(images,
                       conv_dims_i = 5,
                       conv_strides_i = 1,
                       conv_dilations_i = 1,
-                      has_bias = True,
-                      conv_tensor_op_mode=tensor_ops_mode)
+                      has_bias = True)
 x = lbann.Relu(x)
 x = lbann.Pooling(x,
                   num_dims = 2,
@@ -49,8 +47,7 @@ x = lbann.Convolution(x,
                       conv_dims_i = 5,
                       conv_strides_i = 1,
                       conv_dilations_i = 1,
-                      has_bias = True,
-                      conv_tensor_op_mode=tensor_ops_mode)
+                      has_bias = True)
 x = lbann.Relu(x)
 x = lbann.Pooling(x,
                   num_dims = 2,

--- a/applications/vision/resnet.py
+++ b/applications/vision/resnet.py
@@ -111,6 +111,12 @@ top1 = lbann.CategoricalAccuracy(probs, labels)
 top5 = lbann.TopKCategoricalAccuracy(probs, labels, k=5)
 layers = list(lbann.traverse_layer_graph(input_))
 
+# Setup tensor core operations (just to demonstrate enum usage)
+tensor_ops_mode = lbann.ConvTensorOpsMode.NO_TENSOR_OPS
+for l in layers:
+    if type(l) == lbann.Convolution:
+        l.conv_tensor_op_mode=tensor_ops_mode
+        
 # Setup objective function
 l2_reg_weights = set()
 for l in layers:

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -169,6 +169,7 @@ std::set<T> parse_set(std::string const& str) {
     return details::parse_set_impl<T>(trim_str);
   return {};
 }
+
 } // namespace lbann
 
 #endif // LBANN_PROTO_PROTO_COMMON_HPP_INCLUDED

--- a/include/lbann/utils/argument_parser.hpp
+++ b/include/lbann/utils/argument_parser.hpp
@@ -770,7 +770,8 @@ auto argument_parser<ErrorHandler>::add_flag_impl_(
 
 }// namespace utils
 
-using default_arg_parser_type = utils::argument_parser<utils::strict_parsing>;
+using default_arg_parser_type =
+         utils::argument_parser<utils::allow_extra_parameters>;
 
 default_arg_parser_type& global_argument_parser();
 

--- a/include/lbann/utils/cublas.hpp
+++ b/include/lbann/utils/cublas.hpp
@@ -177,6 +177,12 @@ void gemm_strided_batched(cublasHandle_t const& handle,
                           TensorDataType * C, int ldc,
                           long long int strideC,
                           int batchCount);
+
+/** @brief Set the default to use tensor core operations, allowing
+ *         FP32->FP16 conversions.
+ */
+void default_to_tensor_ops();
+
 } // namespace cublas
 } // namespace lbann
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -296,6 +296,17 @@ cudnnConvolutionBwdFilterAlgo_t get_bwd_filter_algorithm(
   size_t ws_size,
   void* ws);
 
+/** @brief Set the default to use tensor core operations, allowing
+ *         FP32->FP16 conversions.
+ */
+void default_to_tensor_ops() noexcept;
+
+/** @brief Get the default math type.
+ *
+ *  Will query the command-line args.
+ */
+cudnnMathType_t get_default_convolution_math_type() noexcept;
+
 } // namespace cudnn
 } // namespace lbann
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -30,6 +30,13 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#ifdef LBANN_HAS_CUDNN
+#include "lbann/utils/cudnn.hpp"
+#endif // LBANN_HAS_CUDNN
+#ifdef LBANN_HAS_CUDA
+#include "lbann/utils/cublas.hpp"
+#endif // LBANN_HAS_CUDA
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -38,13 +45,64 @@
 
 using namespace lbann;
 
+namespace {
+int guess_global_rank() noexcept
+{
+  int have_mpi;
+  MPI_Initialized(&have_mpi);
+  if (have_mpi) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    return rank;
+  }
+  else {
+    if (char const* slurm_flag = std::getenv("SLURM_PROCID"))
+      return std::stoi(slurm_flag);
+    if (char const* open_mpi_flag = std::getenv("OMPI_WORLD_COMM_RANK"))
+      return std::stoi(open_mpi_flag);
+    else if (char const* mv2_flag = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"))
+      return std::stoi(mv2_flag);
+    else
+      return -1;
+  }
+}
+}// namespace <anon>
+
 int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  auto use_cudnn_tensor_ops =
+    arg_parser.add_flag("use cudnn tensor ops",
+                        {"--use-cudnn-tensor-ops"},
+                        utils::ENV("LBANN_USE_CUDNN_TENSOR_OPS"),
+                        "Set the default cuDNN math mode to use "
+                        "Tensor Core operations when available.");
+  auto use_cublas_tensor_ops =
+    arg_parser.add_flag("use cublas tensor ops",
+                        {"--use-cublas-tensor-ops"},
+                        utils::ENV("LBANN_USE_CUBLAS_TENSOR_OPS"),
+                        "Set the default cuBLAS math mode to use "
+                        "Tensor Core operations when available.");
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    auto guessed_rank = guess_global_rank();
+    if (guessed_rank <= 0)
+      // Cannot call `El::ReportException` because MPI hasn't been
+      // initialized yet.
+      std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+                << e.what() << "\n\nProcess terminating."
+                << std::endl;
+    std::terminate();
+  }
+
   int random_seed = lbann_default_random_seed;
   world_comm_ptr comm = initialize(argc, argv, random_seed);
   const bool master = comm->am_world_master();
 
   if (master) {
-    std::cout << "\n\n==============================================================\n"
+    std::cout << "\n\n" << std::string(62,'=') << '\n'
               << "STARTING lbann with this command line:\n";
     for (int j=0; j<argc; j++) {
       std::cout << argv[j] << " ";
@@ -57,9 +115,29 @@ int main(int argc, char *argv[]) {
     options *opts = options::get();
     opts->init(argc, argv);
     if (opts->has_string("h") or opts->has_string("help") or argc == 1) {
+      if (master)
+        std::cout << arg_parser << std::endl;
       print_help(*comm);
       return EXIT_SUCCESS;
     }
+
+    // Setup cuDNN and cuBLAS defaults
+    if (master) {
+      std::cout << "Default tensor core settings:\n"
+                << "   cuDNN: " << (use_cudnn_tensor_ops ? "" : "NOT ")
+                << "using tensor core math." << "\n"
+                << "  cuBLAS: " << (use_cublas_tensor_ops ? "" : "NOT ")
+                << "using tensor core math." << "\n"
+                << std::endl;
+    }
+#ifdef LBANN_HAS_CUDNN
+    if (use_cudnn_tensor_ops)
+      cudnn::default_to_tensor_ops();
+#endif // LBANN_HAS_CUDNN
+#ifdef LBANN_HAS_CUDA
+    if (use_cublas_tensor_ops)
+      cublas::default_to_tensor_ops();
+#endif // LBANN_HAS_CUDA
 
     //this must be called after call to opts->init();
     if (!opts->get_bool("disable_signal_handler")) {

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -36,16 +36,16 @@ namespace lbann {
 namespace {
 
 #ifdef LBANN_HAS_CUDNN
-using ProtoTensorOpEnumType = decltype(lbann_data::Layer::DEFAULT_TENSOR_OPS);
+using ProtoTensorOpEnumType = decltype(lbann_data::DEFAULT_TENSOR_OPS);
 cudnnMathType_t convert_to_cudnn_math_type(ProtoTensorOpEnumType mt)
 {
   switch (mt)
   {
-  case lbann_data::Layer::DEFAULT_TENSOR_OPS:
+  case lbann_data::DEFAULT_TENSOR_OPS:
     return cudnn::get_default_convolution_math_type();
-  case lbann_data::Layer::NO_TENSOR_OPS:
+  case lbann_data::NO_TENSOR_OPS:
     return CUDNN_DEFAULT_MATH;
-  case lbann_data::Layer::USE_TENSOR_OPS:
+  case lbann_data::USE_TENSOR_OPS:
     return CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
   default:
     LBANN_ERROR("Bad math type value.");

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -286,16 +286,16 @@ factory_type const& get_layer_factory() noexcept
 // evils: protobuf and cudnn. I'd rather they never meet, but whatdya
 // gonna do.
 #ifdef LBANN_HAS_CUDNN
-using ProtoTensorOpEnumType = decltype(lbann_data::Layer::DEFAULT_TENSOR_OPS);
+using ProtoTensorOpEnumType = decltype(lbann_data::DEFAULT_TENSOR_OPS);
 cudnnMathType_t convert_to_cudnn_math_type(ProtoTensorOpEnumType mt)
 {
   switch (mt)
   {
-  case lbann_data::Layer::DEFAULT_TENSOR_OPS:
+  case lbann_data::DEFAULT_TENSOR_OPS:
     return cudnn::get_default_convolution_math_type();
-  case lbann_data::Layer::NO_TENSOR_OPS:
+  case lbann_data::NO_TENSOR_OPS:
     return CUDNN_DEFAULT_MATH;
-  case lbann_data::Layer::USE_TENSOR_OPS:
+  case lbann_data::USE_TENSOR_OPS:
     return CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
   default:
     LBANN_ERROR("Bad math type value.");

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -539,6 +539,17 @@ message Layer {
     bool transpose = 3;
   }
 
+  // Lives here because it's used by both Convolution and
+  // Deconvolution.
+  enum ConvTensorOpsMode {
+    // Use the global default.
+    DEFAULT_TENSOR_OPS = 0;
+    // Explicitly disable tensor ops.
+    NO_TENSOR_OPS = 1;
+    // Use tensor ops -- allows conversion FP32->FP16
+    USE_TENSOR_OPS = 2;
+  }
+
   message Convolution {
     int64 num_dims = 1;
     int64 num_output_channels = 4;
@@ -562,6 +573,9 @@ message Layer {
     bool has_bias = 10;                   //default: true
     double bias_initial_value = 11;       //default: 0
     double l2_regularization_factor = 12; //default: 0
+
+    // This field is ignored for non-GPU layers.
+    ConvTensorOpsMode conv_tensor_op_mode = 13;
   }
 
   message Deconvolution {
@@ -587,6 +601,9 @@ message Layer {
     bool has_bias = 10;                   //default: true
     double bias_initial_value = 11;       //default: 0
     double l2_regularization_factor = 12; //default: 0
+
+    // This field is ignored for non-GPU layers.
+    ConvTensorOpsMode conv_tensor_op_mode = 13;
   }
 
   /** @brief Lookup table to embedding vectors.

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -36,6 +36,17 @@ enum DataType {
   FP16 = 2;
 }
 
+// Lives here because it's used by both Convolution and
+// Deconvolution.
+enum ConvTensorOpsMode {
+  // Use the global default.
+  DEFAULT_TENSOR_OPS = 0;
+  // Explicitly disable tensor ops.
+  NO_TENSOR_OPS = 1;
+  // Use tensor ops -- allows conversion FP32->FP16
+  USE_TENSOR_OPS = 2;
+}
+
 message Layer {
   string name = 50;
   string parents = 151;
@@ -537,17 +548,6 @@ message Layer {
     bool has_bias = 2;
     // Whether to apply transpose of weights matrix
     bool transpose = 3;
-  }
-
-  // Lives here because it's used by both Convolution and
-  // Deconvolution.
-  enum ConvTensorOpsMode {
-    // Use the global default.
-    DEFAULT_TENSOR_OPS = 0;
-    // Explicitly disable tensor ops.
-    NO_TENSOR_OPS = 1;
-    // Use tensor ops -- allows conversion FP32->FP16
-    USE_TENSOR_OPS = 2;
   }
 
   message Convolution {

--- a/src/utils/argument_parser.cpp
+++ b/src/utils/argument_parser.cpp
@@ -78,12 +78,13 @@ void allow_extra_parameters::handle_error(
         && (err_text.substr(0, base_text.size()).compare(base_text) == 0))
     {
       auto const token = err_text.substr(base_text.size());
-      auto iter = std::find_if(newargv.begin(), newargv.end(),
+      auto iter = std::find_if(newargv.cbegin(), newargv.cend(),
                                [&token](char const* str)
                                {
                                  return token_match(token, str);
                                });
-      newargv.erase(newargv.cbegin() + 1, iter + 1);
+      newargv.erase(newargv.cbegin() + 1,
+                    (iter == newargv.cend() ? iter : iter + 1));
       parse_result = parser_.parse(clara::Args(newargv.size(), newargv.data()));
     }
     else

--- a/src/utils/cublas.cpp
+++ b/src/utils/cublas.cpp
@@ -284,6 +284,14 @@ void gemm_strided_batched(cublasHandle_t const& handle,
 #define LBANN_INSTANTIATE_GPU_HALF
 #include "lbann/macros/instantiate.hpp"
 
+void default_to_tensor_ops()
+{
+  CHECK_CUBLAS(
+        cublasSetMathMode(
+          hydrogen::cublas::GetLibraryHandle(),
+          CUBLAS_TENSOR_OP_MATH));
+}
+
 } // namespace cublas
 } // namespace lbann
 

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -883,6 +883,20 @@ cudnnConvolutionBwdFilterAlgo_t get_bwd_filter_algorithm(
   }
 }
 
+namespace {
+cudnnMathType_t default_tensor_ops_mode = CUDNN_DEFAULT_MATH;
+}
+
+void default_to_tensor_ops() noexcept
+{
+  default_tensor_ops_mode = CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
+}
+
+cudnnMathType_t get_default_convolution_math_type() noexcept
+{
+  return default_tensor_ops_mode;
+}
+
 #define PROTO(T)                                       \
   template cudnnDataType_t get_data_type<T>();                   \
   template void set_tensor_desc<T>(cudnnTensorDescriptor_t&, std::vector<int>, std::vector<int>); \

--- a/src/utils/unit_test/argument_parser_test.cpp
+++ b/src/utils/unit_test/argument_parser_test.cpp
@@ -509,7 +509,7 @@ TEMPLATE_TEST_CASE ("Testing the argument parser", "[parser][utilities]",
 }
 
 // Testing for cases of ignored arguments
-TEST_CASE("Partial argument parsing", "[tdd][parser][utilities]")
+TEST_CASE("Partial argument parsing", "[parser][utilities]")
 {
   lbann::utils::argument_parser<lbann::utils::allow_extra_parameters> parser;
   auto flag_v =
@@ -543,6 +543,21 @@ TEST_CASE("Partial argument parsing", "[tdd][parser][utilities]")
   {
     char const* argv[] = {"argument_parser_test.exe",
                           "-o", "-v", "-a", "-t", "2", "-p", "13"};
+    int const argc = sizeof(argv) / sizeof(argv[0]);
+
+    REQUIRE_NOTHROW(parser.parse(argc, argv));
+
+    CHECK(parser.template get<bool>("flag v"));
+    CHECK(flag_v);
+
+    CHECK(parser.template get<int>("parameter t") == 2);
+    CHECK(param_t == 2);
+  }
+
+  SECTION("Final argument is unknown flag is ok.")
+  {
+    char const* argv[] = {"argument_parser_test.exe",
+                          "-o", "-v", "-a", "-t", "2", "-p", "13", "-flag"};
     int const argc = sizeof(argv) / sizeof(argv[0]);
 
     REQUIRE_NOTHROW(parser.parse(argc, argv));


### PR DESCRIPTION
This is a redo of #1532 that controls access dynamically. It's ugly and hacky, but it's cuDNN-related so it's all getting ripped apart in other work anyway; don't read too much into it...

I've only updated `lbann.cpp`. The others will obviously default to no tensor cores.

`applications/vision/resnet.py` shows the enum being used.