### PR TITLE
Fix a bug related to some recent changes in Hydrogen

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -85,9 +85,6 @@ struct request {
   mpi_req_type mpi_req = mpi_null_req;
   nccl_req_type nccl_req = nccl_null_req;
   mpicuda_req_type mpicuda_req = mpicuda_null_req;
-#ifdef LBANN_HAS_GPU
-  El::SyncInfo<El::Device::GPU> req_syncinfo_;
-#endif // LBANN_HAS_GPU
 };
 
 } // namespace Al

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -85,6 +85,9 @@ struct request {
   mpi_req_type mpi_req = mpi_null_req;
   nccl_req_type nccl_req = nccl_null_req;
   mpicuda_req_type mpicuda_req = mpicuda_null_req;
+#ifdef LBANN_HAS_GPU
+  El::SyncInfo<El::Device::GPU> req_syncinfo_;
+#endif // LBANN_HAS_GPU
 };
 
 } // namespace Al

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -230,11 +230,13 @@ void nb_allreduce_aluminum(El::Matrix<T, El::Device::GPU>& m,
                            typename BackendT::allreduce_algo_type algo
                            = BackendT::allreduce_algo_type::automatic) {
   const auto local_size = m.Height() * m.Width();
+  const auto& syncinfo = El::SyncInfoFromMatrix(m);
+  req.req_syncinfo_ = syncinfo;
   ::Al::NonblockingAllreduce<BackendT>(
     m.Buffer(),
     local_size,
     mpi_op_to_al_op(op),
-    c.template GetComm<BackendT>(El::SyncInfoFromMatrix(m)),
+    c.template GetComm<BackendT>(syncinfo),
     GetRequest(req, tag),
     algo);
 }
@@ -380,12 +382,17 @@ void lbann_comm::wait(Al::request& req) {
   if (req.nccl_req != Al::nccl_null_req) {
     // Note this does not block the host.
     ::Al::Wait<::Al::NCCLBackend>(req.nccl_req);
+    // Need the internal stream to wait for the backend stream
+    CHECK_CUDA(cudaStreamWaitEvent(
+                 req.req_syncinfo_.stream_, req.nccl_req->op_event, 0));
   }
 #endif // AL_HAS_NCCL
 #ifdef AL_HAS_MPI_CUDA
   if (req.mpicuda_req != Al::mpicuda_null_req) {
     // Note this does not block the host.
     ::Al::Wait<::Al::MPICUDABackend>(req.mpicuda_req);
+    CHECK_CUDA(cudaStreamWaitEvent(
+                 req.req_syncinfo_.stream_, req.mpicuda_req->op_event, 0));
   }
 #endif  // AL_HAS_MPI_CUDA
 #endif // LBANN_HAS_ALUMINUM


### PR DESCRIPTION
Recent changes in Hydrogen introduced a new stream on which Aluminum communications would be run. This was supposed to be an implementation detail, but it does not elegantly handle the nonblocking case.

I've discussed this with @ndryden and we've hypothesized that the NCCL backend should have its own stream as an implementation detail of Aluminum, which would hide this better. This patch should hold LBANN over until we get that in.