### PR TITLE
Fix bug when generating uniform random doubles

### DIFF
--- a/include/lbann/utils/beta.hpp
+++ b/include/lbann/utils/beta.hpp
@@ -142,7 +142,7 @@ private:
    * Generate Beta-distributed values using Johnk's algorithm.
    * This is a rejection-sampling algorithm that only needs a few
    * uniformly random values.
-   * 
+   *
    * See:
    *
    *     Johnk, H. D. "Erzeugung von betaverteilten und gammaverteilten
@@ -168,8 +168,8 @@ private:
   template <typename Generator>
   result_type generate_johnk(Generator& g, result_type a, result_type b) {
     while (true) {
-      const result_type U = fast_random_uniform<result_type>(g);
-      const result_type V = fast_random_uniform<result_type>(g);
+      const result_type U = random_uniform<result_type>(g);
+      const result_type V = random_uniform<result_type>(g);
       const result_type X = std::pow(U, result_type(1) / a);
       const result_type Y = std::pow(V, result_type(1) / b);
       const result_type XplusY = X + Y;

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -113,65 +113,44 @@ inline T fast_rand_int_pow2(Generator& g, T max) {
   return x & ((typename Generator::result_type) max);
 }
 
-// Methods for quickly generating uniformly random values in [0, 1).
+// Methods for generating uniformly random values in [0, 1).
 
 namespace details {
 
-// See section on converting uint64_ts to doubles in:
-// http://xoshiro.di.unimi.it/
-
-template <typename Generator>
-inline float random_float(Generator& g) {
-  const uint32_t r = uint32_t(g()) >> 9;  // Truncate if needed.
-  return r * (1.0f / 8388608.0f);
-}
-
-template <typename Generator>
-inline double random_double_32(Generator& g) {
-  const uint32_t r1 = g() >> 5;
-  const uint32_t r2 = g() >> 6;
-  return (r1 * 67108864.0 + r2) * (1.0 / 9007199254740992.0);
-}
-
-template <typename Generator>
-inline double random_double_64(Generator& g) {
-  const uint64_t r = g() >> 11;
-  return r * (1.0 / 9007199254740992.0);
-}
-
-template <typename Generator>
-inline double random_double(Generator& g) {
-  // TODO: Replace with if constexpr when possible.
-  if (sizeof(typename Generator::result_type) == 4) {
-    return random_double_32(g);
-  } else if (sizeof(typename Generator::result_type) == 8) {
-    return random_double_64(g);
-  } else {
-    LBANN_ERROR("Unsupported generator type");
-  }
-}
-
+/** Generates uniform random value in the range [0, 1). The generator
+ *  is assumed to produce at least 32 random bits.
+ */
 template <typename Generator, typename T>
 struct random_uniform_impl {
   static T generate(Generator&);
 };
 template <typename Generator>
 struct random_uniform_impl<Generator, float> {
-  static float generate(Generator& g) { return random_float(g); }
+  static float generate(Generator& g) {
+    // float has a 24-bit significand, including an implicit bit. See
+    // section on converting uint64_ts to doubles in
+    // http://xoshiro.di.unimi.it/
+    const uint32_t r = g();
+    return (r >> 8) * (1.0f / 16777216.0f);
+  }
 };
 template <typename Generator>
 struct random_uniform_impl<Generator, double> {
-  static float generate(Generator& g) { return random_double(g); }
+  static double generate(Generator& g) {
+    // double has a 53-bit significand, including an implicit bit. See
+    // section on converting uint64_ts to doubles in
+    // http://xoshiro.di.unimi.it/
+    constexpr uint64_t mask32 = 0xFFFFFFFFull;
+    const uint64_t r = (uint64_t(g()) << 32) | (uint64_t(g()) & mask32);
+    return (r >> 11) * (1.0 / 9007199254740992.0);
+  }
 };
 
-}  // namespace details
+} // namespace details
 
-/** Generate uniformly random values in the range [0, 1). */
+/** @brief Generate uniform random value in the range [0, 1). */
 template <typename T, typename Generator>
-inline T fast_random_uniform(Generator& g) {
-  static_assert(sizeof(typename Generator::result_type) == 4 ||
-                sizeof(typename Generator::result_type) == 8,
-                "Invalid generator result_type.");
+inline T random_uniform(Generator& g) {
   return details::random_uniform_impl<Generator, T>::generate(g);
 }
 

--- a/src/utils/unit_test/random_test.cpp
+++ b/src/utils/unit_test/random_test.cpp
@@ -4,43 +4,75 @@
 // File being tested
 #include <lbann/utils/random.hpp>
 
+#include <limits>
+
 constexpr size_t num_tests = 1000;
 
-TEST_CASE("Testing fast_random_uniform", "[random][utilities]") {
-  SECTION("32-bit generator") {
+TEST_CASE("Testing random_uniform", "[random][utilities]") {
+
+  SECTION("32-bit Mersenne Twister") {
     std::mt19937 gen;
     SECTION("floats") {
       for (size_t i = 0; i < num_tests; ++i) {
-        float val = lbann::fast_random_uniform<float>(gen);
+        const float val = lbann::random_uniform<float>(gen);
         REQUIRE(val >= 0.0f);
         REQUIRE(val < 1.0f);
       }
     }
-
     SECTION("doubles") {
       for (size_t i = 0; i < num_tests; ++i) {
-        double val = lbann::fast_random_uniform<double>(gen);
+        const double val = lbann::random_uniform<double>(gen);
         REQUIRE(val >= 0.0);
         REQUIRE(val < 1.0);
       }
     }
   }
-  SECTION("64-bit generator") {
+
+  SECTION("64-bit Mersenne Twister") {
     std::mt19937_64 gen;
     SECTION("floats") {
       for (size_t i = 0; i < num_tests; ++i) {
-        float val = lbann::fast_random_uniform<float>(gen);
+        const float val = lbann::random_uniform<float>(gen);
         REQUIRE(val >= 0.0f);
         REQUIRE(val < 1.0f);
       }
     }
-
     SECTION("doubles") {
       for (size_t i = 0; i < num_tests; ++i) {
-        double val = lbann::fast_random_uniform<double>(gen);
+        const double val = lbann::random_uniform<double>(gen);
         REQUIRE(val >= 0.0);
         REQUIRE(val < 1.0);
       }
     }
   }
+
+  SECTION("Bounds") {
+    SECTION("float") {
+      SECTION("Min") {
+        auto gen = []() -> uint64_t { return 0ull; };
+        const float val = lbann::random_uniform<float>(gen);
+        REQUIRE(val == 0.0f);
+      }
+      SECTION("Max") {
+        auto gen = []() -> uint64_t { return -1ull; };
+        const float val = lbann::random_uniform<float>(gen);
+        constexpr float eps = std::numeric_limits<float>::epsilon();
+        REQUIRE(val == 1.0f - eps/2);
+      }
+    }
+    SECTION("double") {
+      SECTION("Min") {
+        auto gen = []() -> uint64_t { return 0ull; };
+        const double val = lbann::random_uniform<double>(gen);
+        REQUIRE(val == 0.0);
+      }
+      SECTION("Max") {
+        auto gen = []() -> uint64_t { return -1ull; };
+        const double val = lbann::random_uniform<double>(gen);
+        constexpr double eps = std::numeric_limits<double>::epsilon();
+        REQUIRE(val == 1.0 - eps/2);
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
I've made three changes to the `fast_random_uniform` function in `utils/random.hpp`:
- I only got very small numbers when calling `fast_random_uniform<double>` on Lassen. On closer inspection, it happened because `std::mt19937` returned 32 random bits within a 64-bit data type. The function used the return type to distinguish between the 32-bit and 64-bit random generators (e.g. `std::mt19937` and `std::mt19937_64`), but it turns out that does not distinguish them. To avoid this error, I've hard-coded the function to always assume the generator outputs 32 bits of randomness.
- I've renamed the function to `random_uniform`. The `fast_` prefix implies that corners were cut for the sake of performance, but this function will exactly convert random bits to a uniform distribution in [0,1).
- I've added unit tests to check the lower and upper bounds of the generated numbers.

[Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM280-1).