### PR TITLE
Fix bug in utility function that generates uniform random floats

### DIFF
--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -130,7 +130,8 @@ struct random_uniform_impl<Generator, float> {
     // float has a 24-bit significand, including an implicit bit. See
     // section on converting uint64_ts to doubles in
     // http://xoshiro.di.unimi.it/
-    const uint32_t r = g();
+    constexpr uint64_t mask32 = 0xFFFFFFFFull;
+    const uint64_t r = uint64_t(g()) & mask32;
     return (r >> 8) * (1.0f / 16777216.0f);
   }
 };


### PR DESCRIPTION
The unit test in #1544 can fail to compile because of an overflow error when the RNG produces 64 random bits.