### PR TITLE
Fix LBANN inference

### DIFF
--- a/include/lbann/callbacks/load_model.hpp
+++ b/include/lbann/callbacks/load_model.hpp
@@ -55,7 +55,8 @@ class load_model : public callback_base {
   load_model(std::vector<std::string> dirs,
              std::string extension="prototext") :
     callback_base(), m_dirs(std::move(dirs)),
-    m_extension(std::move(extension))
+    m_extension(std::move(extension)),
+    m_loaded(false)
   {}
   load_model(const load_model&) = default;
   load_model& operator=(
@@ -69,6 +70,9 @@ class load_model : public callback_base {
   }
 
   void on_train_begin(model *m) override;
+
+  void on_test_begin(model *m) override;
+
   /* ckptdir_is_fullpath flag if true
  * allow user to specify full path to model weights to load
  * and allow system to ignore appending trainer id, num of epochs/steps
@@ -89,6 +93,8 @@ class load_model : public callback_base {
   /// Disables the normal behavior of saving when training is complete
   std::string m_extension; //file extension
 
+  /// Flag to indicate if the model has already been loaded
+  bool m_loaded;
 };
 
 // Builder function

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -83,25 +83,9 @@ int main(int argc, char *argv[]) {
                                    training_dr_linearized_data_size));
     }
 
-    // Load layer weights from checkpoint if checkpoint directory given
-    if(opts->has_string("ckpt_dir")){
-      for(auto&& m : models) {
-        auto&& dirs = parse_list<std::string>(opts->get_string("ckpt_dir"));
-        for(auto&& d : dirs) { //load file from each (space limited) directory
-          bool loaded = callback::load_model::load_model_weights(d,
-              "sgd",
-               m.get(),
-               opts->get_bool("ckptdir_is_fullpath"));
-           if(!loaded)  LBANN_ERROR("Unable to reload model");
-        }
-      }
-    }else {
-      LBANN_ERROR("Unable to reload model");
-    }
-
     /// Interleave the inference between the models so that they can use a shared data reader
     /// Enable shared testing data readers on the command line via --share_testing_data_readers=1
-    El::Int num_samples = models[0]->get_num_iterations_per_epoch(execution_mode::testing);
+    El::Int num_samples = trainer->get_data_coordinator().get_data_reader(execution_mode::testing)->get_num_iterations_per_epoch();
     for(El::Int s = 0; s < num_samples; s++) {
       for(auto&& m : models) {
         trainer->evaluate(m.get(), execution_mode::testing, 1);

--- a/src/callbacks/load_model.cpp
+++ b/src/callbacks/load_model.cpp
@@ -46,9 +46,20 @@ namespace callback {
 
 
 void load_model::on_train_begin(model *m) {
-  for (const auto& d : m_dirs) {
-    bool loaded = load_model_weights(d, "", m, true);
-    if(!loaded)  LBANN_ERROR("Unable to reload model");
+  if(!m_loaded) {
+    for (const auto& d : m_dirs) {
+      m_loaded = load_model_weights(d, "", m, true);
+      if(!m_loaded)  LBANN_ERROR("Unable to reload model on train begin");
+    }
+  }
+}
+
+void load_model::on_test_begin(model *m) {
+  if(!m_loaded) {
+    for (const auto& d : m_dirs) {
+      m_loaded = load_model_weights(d, "", m, true);
+      if(!m_loaded)  LBANN_ERROR("Unable to reload model on test begin");
+    }
   }
 }
 

--- a/src/training_algorithms/sgd_training_algorithm.cpp
+++ b/src/training_algorithms/sgd_training_algorithm.cpp
@@ -150,6 +150,10 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
                                       data_coordinator& dc,
                                       execution_mode mode,
                                       size_t num_batches) {
+  model.reset_epoch_statistics(mode);
+  model.reset_mode(c, mode);
+  // Ensure that the data coordinator has the right execution context
+  dc.reset_mode(c);
   // Return early if execution mode is invalid
   if (!model.is_execution_mode_valid(mode)) return;
   if (mode != execution_mode::validation
@@ -161,9 +165,6 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
   }
 
   // Evaluate on all mini-batches
-  model.reset_epoch_statistics(mode);
-  model.reset_mode(c, mode);
-  dc.reset_mode(c);
   do_evaluate_begin_cbs(model, mode);
   if (num_batches > 0) {
     for (size_t i = 0; i < num_batches; i++) { evaluate_mini_batch(c, model, dc, mode); }


### PR DESCRIPTION
Updated the load_model callback so that it works on inference only
runs.  Updated the lbann_inf front end so that it uses the
lbann_library support for the load_model callback, rather than an
explicit call to a static function.  Changed how the evaluate function
sets up the model and data coordinator so that it has the execution
context and mode at the start of the function. This fixes a bug where
a model is called in inference only.