### PR TITLE
Add option to shuffle data in Python data reader

### DIFF
--- a/applications/graph/main.py
+++ b/applications/graph/main.py
@@ -108,6 +108,7 @@ reader = lbann.reader_pb2.DataReader()
 _reader = reader.reader.add()
 _reader.name = 'python'
 _reader.role = 'train'
+_reader.shuffle = True
 _reader.percent_of_data_to_use = 1.0
 _reader.python.module = 'dataset'
 _reader.python.module_dir = os.path.dirname(os.path.realpath(__file__))

--- a/applications/nlp/rnn/main.py
+++ b/applications/nlp/rnn/main.py
@@ -90,6 +90,7 @@ reader = lbann.reader_pb2.DataReader()
 _reader = reader.reader.add()
 _reader.name = 'python'
 _reader.role = 'train'
+_reader.shuffle = True
 _reader.percent_of_data_to_use = 1.0
 _reader.python.module = 'dataset'
 _reader.python.module_dir = current_dir

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -851,6 +851,7 @@ def create_python_data_reader(lbann,
     reader = lbann.reader_pb2.Reader()
     reader.name = 'python'
     reader.role = execution_mode
+    reader.shuffle = False
     reader.percent_of_data_to_use = 1.0
     reader.python.module = module_name
     reader.python.module_dir = dir_name

--- a/bamboo/unit_tests/test_unit_datastore_imagenet.py
+++ b/bamboo/unit_tests/test_unit_datastore_imagenet.py
@@ -91,6 +91,7 @@ def construct_data_reader(lbann):
     # Configure data reader
     reader.name = 'imagenet'
     reader.role = 'train'
+    reader.shuffle = False
     reader.data_filedir = lbann.contrib.lc.paths.imagenet_dir(data_set='train')
     reader.data_filename = lbann.contrib.lc.paths.imagenet_labels(data_set='train')
     reader.percent_of_data_to_use = imagenet_fraction

--- a/include/lbann/data_readers/data_reader_python.hpp
+++ b/include/lbann/data_readers/data_reader_python.hpp
@@ -39,7 +39,8 @@ public:
                 std::string module_dir,
                 std::string sample_function,
                 std::string num_samples_function,
-                std::string sample_dims_function);
+                std::string sample_dims_function,
+                bool shuffle);
   python_reader(const python_reader&) = default;
   python_reader& operator=(const python_reader&) = default;
   ~python_reader() override;

--- a/src/data_readers/data_reader_python.cpp
+++ b/src/data_readers/data_reader_python.cpp
@@ -39,8 +39,9 @@ python_reader::python_reader(std::string module,
                              std::string module_dir,
                              std::string sample_function,
                              std::string num_samples_function,
-                             std::string sample_dims_function)
-  : generic_data_reader(true) {
+                             std::string sample_dims_function,
+                             bool shuffle)
+  : generic_data_reader(shuffle) {
 
   // Make sure Python is running and acquire GIL
   python::global_interpreter_lock gil;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -303,7 +303,8 @@ void init_data_readers(
                                  params.module_dir(),
                                  params.sample_function(),
                                  params.num_samples_function(),
-                                 params.sample_dims_function());
+                                 params.sample_dims_function(),
+                                 shuffle);
 #else
       LBANN_ERROR("attempted to construct Python data reader, "
                   "but LBANN is not built with Python/C API");
@@ -460,7 +461,8 @@ void init_data_readers(
                                               params.module_dir(),
                                               params.sample_function(),
                                               params.num_samples_function(),
-                                              params.sample_dims_function());
+                                              params.sample_dims_function(),
+                                              shuffle);
         (*(python_reader *)reader_validation) = (*(python_reader *)reader);
 #else
         LBANN_ERROR("attempted to construct Python data reader, "


### PR DESCRIPTION
Previously, the Python data reader always shuffled its data. However, I've found it helpful to disable shuffling in some of the unit tests so I can precisely control the computation (see the unit test in https://github.com/LLNL/lbann/pull/1529). There was already an option for shuffling in the data reader Protobuf message, so this was a straightforward change.

[Bamboo build](https://lc.llnl.gov/bamboo/browse/LBANN-TIM282-1).