### PR TITLE
Optimize GPU performance of slice and concat layers

### DIFF
--- a/src/layers/transform/concatenate.cu
+++ b/src/layers/transform/concatenate.cu
@@ -37,7 +37,7 @@ using dim4 = cuda::array<size_t, 4>;
 /**
  *  Block dimensions: bsize x 1 x 1
  *
- *  Grid dimensions: (max_input_size / bsize) x num_inputs x 1
+ *  Grid dimensions: (max_input_dims[3] / bsize) x max_input_dims[2] x max_input_dims[1]
  */
 template <typename T>
 __global__ void concat4d_kernel(
@@ -52,42 +52,37 @@ __global__ void concat4d_kernel(
   // Indices
   const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
   const size_t nthreadsx = gridDim.x * blockDim.x;
   const size_t nthreadsy = gridDim.y * blockDim.y;
+  const size_t nthreadsz = gridDim.z * blockDim.z;
 
-  for (size_t j=gidy; j<num_inputs; j+=nthreadsy) {
+  for (size_t j=0; j<num_inputs; ++j) {
 
-    // Objects for current input tensor
+    // Current input tensor
     const auto& input_buffer = input_buffer_list[j];
     const auto& input_dims = input_dims_list[j];
     const auto& input_strides = input_strides_list[j];
     const auto& output_offset = output_offset_list[j];
-    const auto& input_size = (input_dims[0] * input_dims[1]
-                              * input_dims[2] * input_dims[3]);
 
-    for (size_t i=gidx; i<input_size; i+=nthreadsx) {
-
-      // Get position in input tensor
-      dim4 pos;
-      size_t pos_flat = i;
-      #pragma unroll
-      for (int d=3; d>=0; --d) {
-        pos[d] = pos_flat % input_dims[d];
-        pos_flat = pos_flat / input_dims[d];
+    // Copy from input tensor to output tensor
+    for (size_t i0=0; i0<input_dims[0]; ++i0) {
+      for (size_t i1=gidz; i1<input_dims[1]; i1+=nthreadsz) {
+        for (size_t i2=gidy; i2<input_dims[2]; i2+=nthreadsy) {
+          for (size_t i3=gidx; i3<input_dims[3]; i3+=nthreadsx) {
+            const auto& x = input_buffer[i0 * input_strides[0]
+                                         + i1 * input_strides[1]
+                                         + i2 * input_strides[2]
+                                         + i3 * input_strides[3]];
+            auto& y = output_buffer[output_offset
+                                    + i0 * output_strides[0]
+                                    + i1 * output_strides[1]
+                                    + i2 * output_strides[2]
+                                    + i3 * output_strides[3]];
+            y = x;
+          }
+        }
       }
-
-      // Copy value to output tensor
-      const auto& x = input_buffer[pos[0] * input_strides[0]
-                                   + pos[1] * input_strides[1]
-                                   + pos[2] * input_strides[2]
-                                   + pos[3] * input_strides[3]];
-      auto& y = output_buffer[output_offset
-                              + pos[0] * output_strides[0]
-                              + pos[1] * output_strides[1]
-                              + pos[2] * output_strides[2]
-                              + pos[3] * output_strides[3]];
-      y = x;
-
     }
 
   }
@@ -97,7 +92,8 @@ __global__ void concat4d_kernel(
 /**
  *  Block dimensions: bsize x 1 x 1
  *
- *  Grid dimensions: (max_input_size / bsize) x num_inputs x 1
+ *  Grid dimensions: (max_output_dims[3] / bsize) x max_output_dims[2] x max_output_dims[1]
+ *
  */
 template <typename T>
 __global__ void slice4d_kernel(
@@ -112,42 +108,37 @@ __global__ void slice4d_kernel(
   // Indices
   const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
   const size_t nthreadsx = gridDim.x * blockDim.x;
   const size_t nthreadsy = gridDim.y * blockDim.y;
+  const size_t nthreadsz = gridDim.z * blockDim.z;
 
-  for (size_t j=gidy; j<num_outputs; j+=nthreadsy) {
+  for (size_t j=0; j<num_outputs; ++j) {
 
-    // Objects for current output tensor
+    // Current output tensor
     const auto& input_offset = input_offset_list[j];
     auto& output_buffer = output_buffer_list[j];
     const auto& output_dims = output_dims_list[j];
     const auto& output_strides = output_strides_list[j];
-    const auto& output_size = (output_dims[0] * output_dims[1]
-                              * output_dims[2] * output_dims[3]);
 
-    for (size_t i=gidx; i<output_size; i+=nthreadsx) {
-
-      // Get position in output tensor
-      dim4 pos;
-      size_t pos_flat = i;
-      #pragma unroll
-      for (int d=3; d>=0; --d) {
-        pos[d] = pos_flat % output_dims[d];
-        pos_flat = pos_flat / output_dims[d];
+    // Copy from input tensor to output tensor
+    for (size_t i0=0; i0<output_dims[0]; ++i0) {
+      for (size_t i1=gidz; i1<output_dims[1]; i1+=nthreadsz) {
+        for (size_t i2=gidy; i2<output_dims[2]; i2+=nthreadsy) {
+          for (size_t i3=gidx; i3<output_dims[3]; i3+=nthreadsx) {
+            const auto& x = input_buffer[input_offset
+                                         + i0 * input_strides[0]
+                                         + i1 * input_strides[1]
+                                         + i2 * input_strides[2]
+                                         + i3 * input_strides[3]];
+            auto& y = output_buffer[i0 * output_strides[0]
+                                    + i1 * output_strides[1]
+                                    + i2 * output_strides[2]
+                                    + i3 * output_strides[3]];
+            y = x;
+          }
+        }
       }
-
-      // Copy value to input tensor
-      const auto& x = input_buffer[input_offset
-                                   + pos[0] * input_strides[0]
-                                   + pos[1] * input_strides[1]
-                                   + pos[2] * input_strides[2]
-                                   + pos[3] * input_strides[3]];
-      auto& y = output_buffer[pos[0] * output_strides[0]
-                              + pos[1] * output_strides[1]
-                              + pos[2] * output_strides[2]
-                              + pos[3] * output_strides[3]];
-      y = x;
-
     }
 
   }
@@ -210,7 +201,7 @@ void fp_compute_impl(
   const size_t num_inputs = l.get_num_parents();
   std::vector<const TensorDataType*> input_buffer_list;
   std::vector<dim4> input_dims_list, input_strides_list;
-  size_t max_input_size = 0;
+  dim4 max_input_dims{0,0,0,0};
   for (size_t j=0; j<num_inputs; ++j) {
     const auto& input = l.get_prev_activations(j);
     const auto& input_dims = l.get_input_dims(j);
@@ -233,8 +224,9 @@ void fp_compute_impl(
     input_dims_list.push_back({rdims[3], rdims[2], rdims[1], rdims[0]});
     input_strides_list.push_back(
       {rstrides[3], rstrides[2], rstrides[1], rstrides[0]});
-    max_input_size = std::max(max_input_size,
-                              rdims[3]*rdims[2]*rdims[1]*rdims[0]);
+    for (size_t i=0; i<4; ++i) {
+      max_input_dims[i] = std::max(max_input_dims[i], rdims[3-i]);
+    }
   }
 
   // Get strides for output tensor
@@ -316,12 +308,15 @@ void fp_compute_impl(
   pos += sizeof(size_t) * output_offset_list.size();
 
   // Launch CUDA kernel
+  const auto& max_input_size = (max_input_dims[0] * max_input_dims[1]
+                                * max_input_dims[2] * max_input_dims[3]);
   if (max_input_size > 0) {
-    constexpr size_t block_size = 256;
+    constexpr size_t block_size = 64;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
-    grid_dims.x = (max_input_size + block_size - 1) / block_size;
-    grid_dims.y = num_inputs;
+    grid_dims.x = (max_input_dims[3] + block_size - 1) / block_size;
+    grid_dims.y = max_input_dims[2];
+    grid_dims.z = max_input_dims[1];
     concat4d_kernel<<<grid_dims, block_dims, 0, stream>>>(
       num_inputs,
       device_input_buffer_list,
@@ -359,7 +354,7 @@ void bp_compute_impl(
   const size_t num_inputs = l.get_num_parents();
   std::vector<TensorDataType*> input_grad_buffer_list;
   std::vector<dim4> input_grad_dims_list, input_grad_strides_list;
-  size_t max_input_grad_size = 0;
+  dim4 max_input_grad_dims{0,0,0,0};
   for (size_t j=0; j<num_inputs; ++j) {
     auto& input_grad = l.get_error_signals(j);
     const auto& input_grad_dims = l.get_input_dims(j);
@@ -382,8 +377,9 @@ void bp_compute_impl(
     input_grad_dims_list.push_back({rdims[3], rdims[2], rdims[1], rdims[0]});
     input_grad_strides_list.push_back(
       {rstrides[3], rstrides[2], rstrides[1], rstrides[0]});
-    max_input_grad_size = std::max(max_input_grad_size,
-                                   rdims[3]*rdims[2]*rdims[1]*rdims[0]);
+    for (size_t i=0; i<4; ++i) {
+      max_input_grad_dims[i] = std::max(max_input_grad_dims[i], rdims[3-i]);
+    }
   }
 
   // Get strides for output gradient tensor
@@ -465,12 +461,17 @@ void bp_compute_impl(
   pos += sizeof(dim4) * input_grad_strides_list.size();
 
   // Launch CUDA kernel
+  const auto& max_input_grad_size = (max_input_grad_dims[0]
+                                     * max_input_grad_dims[1]
+                                     * max_input_grad_dims[2]
+                                     * max_input_grad_dims[3]);
   if (max_input_grad_size > 0) {
-    constexpr size_t block_size = 256;
+    constexpr size_t block_size = 64;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
-    grid_dims.x = (max_input_grad_size + block_size - 1) / block_size;
-    grid_dims.y = num_inputs;
+    grid_dims.x = (max_input_grad_dims[3] + block_size - 1) / block_size;
+    grid_dims.y = max_input_grad_dims[2];
+    grid_dims.z = max_input_grad_dims[1];
     slice4d_kernel<<<grid_dims, block_dims, 0, stream>>>(
       num_inputs,
       local_output_grad.LockedBuffer(),

--- a/src/layers/transform/slice.cu
+++ b/src/layers/transform/slice.cu
@@ -37,7 +37,7 @@ using dim4 = cuda::array<size_t, 4>;
 /**
  *  Block dimensions: bsize x 1 x 1
  *
- *  Grid dimensions: (max_input_size / bsize) x num_inputs x 1
+ *  Grid dimensions: (max_input_dims[3] / bsize) x max_input_dims[2] x max_input_dims[1]
  */
 template <typename T>
 __global__ void concat4d_kernel(
@@ -52,42 +52,37 @@ __global__ void concat4d_kernel(
   // Indices
   const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
   const size_t nthreadsx = gridDim.x * blockDim.x;
   const size_t nthreadsy = gridDim.y * blockDim.y;
+  const size_t nthreadsz = gridDim.z * blockDim.z;
 
-  for (size_t j=gidy; j<num_inputs; j+=nthreadsy) {
+  for (size_t j=0; j<num_inputs; ++j) {
 
-    // Objects for current input tensor
+    // Current input tensor
     const auto& input_buffer = input_buffer_list[j];
     const auto& input_dims = input_dims_list[j];
     const auto& input_strides = input_strides_list[j];
     const auto& output_offset = output_offset_list[j];
-    const auto& input_size = (input_dims[0] * input_dims[1]
-                              * input_dims[2] * input_dims[3]);
 
-    for (size_t i=gidx; i<input_size; i+=nthreadsx) {
-
-      // Get position in input tensor
-      dim4 pos;
-      size_t pos_flat = i;
-      #pragma unroll
-      for (int d=3; d>=0; --d) {
-        pos[d] = pos_flat % input_dims[d];
-        pos_flat = pos_flat / input_dims[d];
+    // Copy from input tensor to output tensor
+    for (size_t i0=0; i0<input_dims[0]; ++i0) {
+      for (size_t i1=gidz; i1<input_dims[1]; i1+=nthreadsz) {
+        for (size_t i2=gidy; i2<input_dims[2]; i2+=nthreadsy) {
+          for (size_t i3=gidx; i3<input_dims[3]; i3+=nthreadsx) {
+            const auto& x = input_buffer[i0 * input_strides[0]
+                                         + i1 * input_strides[1]
+                                         + i2 * input_strides[2]
+                                         + i3 * input_strides[3]];
+            auto& y = output_buffer[output_offset
+                                    + i0 * output_strides[0]
+                                    + i1 * output_strides[1]
+                                    + i2 * output_strides[2]
+                                    + i3 * output_strides[3]];
+            y = x;
+          }
+        }
       }
-
-      // Copy value to output tensor
-      const auto& x = input_buffer[pos[0] * input_strides[0]
-                                   + pos[1] * input_strides[1]
-                                   + pos[2] * input_strides[2]
-                                   + pos[3] * input_strides[3]];
-      auto& y = output_buffer[output_offset
-                              + pos[0] * output_strides[0]
-                              + pos[1] * output_strides[1]
-                              + pos[2] * output_strides[2]
-                              + pos[3] * output_strides[3]];
-      y = x;
-
     }
 
   }
@@ -97,7 +92,8 @@ __global__ void concat4d_kernel(
 /**
  *  Block dimensions: bsize x 1 x 1
  *
- *  Grid dimensions: (max_input_size / bsize) x num_inputs x 1
+ *  Grid dimensions: (max_output_dims[3] / bsize) x max_output_dims[2] x max_output_dims[1]
+ *
  */
 template <typename T>
 __global__ void slice4d_kernel(
@@ -112,42 +108,37 @@ __global__ void slice4d_kernel(
   // Indices
   const size_t gidx = threadIdx.x + blockIdx.x * blockDim.x;
   const size_t gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const size_t gidz = threadIdx.z + blockIdx.z * blockDim.z;
   const size_t nthreadsx = gridDim.x * blockDim.x;
   const size_t nthreadsy = gridDim.y * blockDim.y;
+  const size_t nthreadsz = gridDim.z * blockDim.z;
 
-  for (size_t j=gidy; j<num_outputs; j+=nthreadsy) {
+  for (size_t j=0; j<num_outputs; ++j) {
 
-    // Objects for current output tensor
+    // Current output tensor
     const auto& input_offset = input_offset_list[j];
     auto& output_buffer = output_buffer_list[j];
     const auto& output_dims = output_dims_list[j];
     const auto& output_strides = output_strides_list[j];
-    const auto& output_size = (output_dims[0] * output_dims[1]
-                              * output_dims[2] * output_dims[3]);
 
-    for (size_t i=gidx; i<output_size; i+=nthreadsx) {
-
-      // Get position in output tensor
-      dim4 pos;
-      size_t pos_flat = i;
-      #pragma unroll
-      for (int d=3; d>=0; --d) {
-        pos[d] = pos_flat % output_dims[d];
-        pos_flat = pos_flat / output_dims[d];
+    // Copy from input tensor to output tensor
+    for (size_t i0=0; i0<output_dims[0]; ++i0) {
+      for (size_t i1=gidz; i1<output_dims[1]; i1+=nthreadsz) {
+        for (size_t i2=gidy; i2<output_dims[2]; i2+=nthreadsy) {
+          for (size_t i3=gidx; i3<output_dims[3]; i3+=nthreadsx) {
+            const auto& x = input_buffer[input_offset
+                                         + i0 * input_strides[0]
+                                         + i1 * input_strides[1]
+                                         + i2 * input_strides[2]
+                                         + i3 * input_strides[3]];
+            auto& y = output_buffer[i0 * output_strides[0]
+                                    + i1 * output_strides[1]
+                                    + i2 * output_strides[2]
+                                    + i3 * output_strides[3]];
+            y = x;
+          }
+        }
       }
-
-      // Copy value to input tensor
-      const auto& x = input_buffer[input_offset
-                                   + pos[0] * input_strides[0]
-                                   + pos[1] * input_strides[1]
-                                   + pos[2] * input_strides[2]
-                                   + pos[3] * input_strides[3]];
-      auto& y = output_buffer[pos[0] * output_strides[0]
-                              + pos[1] * output_strides[1]
-                              + pos[2] * output_strides[2]
-                              + pos[3] * output_strides[3]];
-      y = x;
-
     }
 
   }
@@ -207,7 +198,7 @@ void fp_compute_impl(
   const size_t num_outputs = l.get_num_children();
   std::vector<TensorDataType*> output_buffer_list;
   std::vector<dim4> output_dims_list, output_strides_list;
-  size_t max_output_size = 0;
+  dim4 max_output_dims{0,0,0,0};
   for (size_t j=0; j<num_outputs; ++j) {
     auto& output = l.get_activations(j);
     const auto& output_dims = l.get_output_dims(j);
@@ -230,8 +221,9 @@ void fp_compute_impl(
     output_dims_list.push_back({rdims[3], rdims[2], rdims[1], rdims[0]});
     output_strides_list.push_back(
       {rstrides[3], rstrides[2], rstrides[1], rstrides[0]});
-    max_output_size = std::max(max_output_size,
-                               rdims[3]*rdims[2]*rdims[1]*rdims[0]);
+    for (size_t i=0; i<4; ++i) {
+      max_output_dims[i] = std::max(max_output_dims[i], rdims[3-i]);
+    }
   }
 
   // Get strides for input tensor
@@ -309,12 +301,15 @@ void fp_compute_impl(
   pos += sizeof(dim4) * output_strides_list.size();
 
   // Launch CUDA kernel
+  const auto& max_output_size = (max_output_dims[0] * max_output_dims[1]
+                                 * max_output_dims[2] * max_output_dims[3]);
   if (max_output_size > 0) {
-    constexpr size_t block_size = 256;
+    constexpr size_t block_size = 64;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
-    grid_dims.x = (max_output_size + block_size - 1) / block_size;
-    grid_dims.y = num_outputs;
+    grid_dims.x = (max_output_dims[3] + block_size - 1) / block_size;
+    grid_dims.y = max_output_dims[2];
+    grid_dims.z = max_output_dims[1];
     slice4d_kernel<<<grid_dims, block_dims, 0, stream>>>(
       num_outputs,
       local_input.LockedBuffer(),
@@ -352,7 +347,7 @@ void bp_compute_impl(
   const size_t num_outputs = l.get_num_children();
   std::vector<const TensorDataType*> output_grad_buffer_list;
   std::vector<dim4> output_grad_dims_list, output_grad_strides_list;
-  size_t max_output_grad_size = 0;
+  dim4 max_output_grad_dims{0,0,0,0};
   for (size_t j=0; j<num_outputs; ++j) {
     const auto& output_grad = l.get_prev_error_signals(j);
     const auto& output_grad_dims = l.get_output_dims(j);
@@ -375,8 +370,9 @@ void bp_compute_impl(
     output_grad_dims_list.push_back({rdims[3], rdims[2], rdims[1], rdims[0]});
     output_grad_strides_list.push_back(
       {rstrides[3], rstrides[2], rstrides[1], rstrides[0]});
-    max_output_grad_size = std::max(max_output_grad_size,
-                                    rdims[3]*rdims[2]*rdims[1]*rdims[0]);
+    for (size_t i=0; i<4; ++i) {
+      max_output_grad_dims[i] = std::max(max_output_grad_dims[i], rdims[3-i]);
+    }
   }
 
   // Get strides for input gradient tensor
@@ -454,12 +450,17 @@ void bp_compute_impl(
   pos += sizeof(size_t) * input_grad_offset_list.size();
 
   // Launch CUDA kernel
+  const auto& max_output_grad_size = (max_output_grad_dims[0]
+                                      * max_output_grad_dims[1]
+                                      * max_output_grad_dims[2]
+                                      * max_output_grad_dims[3]);
   if (max_output_grad_size > 0) {
-    constexpr size_t block_size = 256;
+    constexpr size_t block_size = 64;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
-    grid_dims.x = (max_output_grad_size + block_size - 1) / block_size;
-    grid_dims.y = num_outputs;
+    grid_dims.x = (max_output_grad_dims[3] + block_size - 1) / block_size;
+    grid_dims.y = max_output_grad_dims[2];
+    grid_dims.z = max_output_grad_dims[1];
     concat4d_kernel<<<grid_dims, block_dims, 0, stream>>>(
       num_outputs,
       device_output_grad_buffer_list,


### PR DESCRIPTION
This PR makes two changes to the slice and concatenation layers:

- Use Hydrogen `simple_buffer`s for GPU workspaces rather than Thrust `device_vector`s. Thrust synchronizes the CUDA stream whenever it creates a `device_vector`, hurting kernel pipelining.
- CUDA kernels use nested loops to iterate through tensors. Previously we had a single loop and computed tensor positions with divides and moduli, but the kernel runtime was dominated by integer arithmetic. The new approach is optimized for the slice layers in multi-head attention, although it may be susceptible to bad performance with certain tensor shapes (if there are many children/parents, if an NCHW tensor is dominated by the N dimension, if the children/parent tensors have a wide range of sizes).

Timings with a toy model with repeated slices and concats (1 proc on Pascal):

| Commit | Mini-batch time |
|----|----|
| 9a9e31c (develop) | 0.0284 s |
| 14e00c4 | 0.0281 s |
| df70e84 | 0.0128 s |

Timings with Transformer (1 Pascal node):

| Commit | Mini-batch time |
|----|----|
| 9a9e31c (develop) | 0.276 s |
| 14e00c4 | 0.286 s |
| df70e84 | 0.259 s |

[Bamboo](https://lc.llnl.gov/bamboo/browse/LBANN-TIM284-1) doesn't show any new failures.

Notes for future optimizations:
- We map the CUDA kernel grid to the C, H, and W dimensions of an NCHW tensor. Is it worthwhile coming up with a separate implementation if N is large?
- We don't get full occupancy on the SMs because the kernel requires too many registers per thread (48 on Pascal). I tried staging some of the values in shared memory, but that ended up increasing the number of required registers.
- The kernel runtime is still dominated by integer arithmetic.
- In a toy model with repeated slices and concats, kernel pipelining is perfect.