### PR TITLE
Cleanup and consolidate initialization of the RNGs

### DIFF
--- a/bamboo/integration_tests/test_integration_alexnet.py
+++ b/bamboo/integration_tests/test_integration_alexnet.py
@@ -149,7 +149,7 @@ def augment_test_func(test_func):
                 match = re.search('training epoch [0-9]+ top-5 accuracy : ([0-9.]+)%', line)
                 if match:
                     train_accuracy = float(match.group(1))
-                match = re.search('validation top-5 accuracy : ([0-9.]+)%', line)
+                match = re.search('test top-5 accuracy : ([0-9.]+)%', line)
                 if match:
                     test_accuracy = float(match.group(1))
                 match = re.search('training epoch [0-9]+ mini-batch time statistics : ([0-9.]+)s mean', line)

--- a/bamboo/integration_tests/test_integration_alexnet.py
+++ b/bamboo/integration_tests/test_integration_alexnet.py
@@ -53,6 +53,8 @@ def setup_experiment(lbann):
     data_reader = data.imagenet.make_data_reader(lbann, num_classes=1000)
     # We train on a subset of ImageNet
     data_reader.reader[0].percent_of_data_to_use = imagenet_fraction
+    # Only evaluate on ImageNet validation set at end of training
+    data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
     return trainer, model, data_reader, optimizer

--- a/bamboo/integration_tests/test_integration_lenet.py
+++ b/bamboo/integration_tests/test_integration_lenet.py
@@ -29,10 +29,11 @@ expected_train_accuracy_range = (98.75, 99.25)
 expected_test_accuracy_range = (98, 99)
 
 # Average mini-batch time (in sec) for each LC system
+# Note that run times are with LBANN_DETERMINISTIC set
 expected_mini_batch_times = {
     'pascal':   0.0013,
     'catalyst': 0.0055,
-    'lassen':   0.0020,
+    'lassen':   0.0022,
     'ray':      0.0025,
     'corona':   0.0075,
 }

--- a/bamboo/integration_tests/test_integration_lenet.py
+++ b/bamboo/integration_tests/test_integration_lenet.py
@@ -30,7 +30,7 @@ expected_test_accuracy_range = (98, 99)
 
 # Average mini-batch time (in sec) for each LC system
 expected_mini_batch_times = {
-    'pascal':   0.0012,
+    'pascal':   0.0013,
     'catalyst': 0.0055,
     'lassen':   0.0020,
     'ray':      0.0025,

--- a/bamboo/integration_tests/test_integration_resnet50.py
+++ b/bamboo/integration_tests/test_integration_resnet50.py
@@ -149,7 +149,7 @@ def augment_test_func(test_func):
                 match = re.search('training epoch [0-9]+ top-5 accuracy : ([0-9.]+)%', line)
                 if match:
                     train_accuracy = float(match.group(1))
-                match = re.search('validation top-5 accuracy : ([0-9.]+)%', line)
+                match = re.search('test top-5 accuracy : ([0-9.]+)%', line)
                 if match:
                     test_accuracy = float(match.group(1))
                 match = re.search('training epoch [0-9]+ mini-batch time statistics : ([0-9.]+)s mean', line)

--- a/bamboo/integration_tests/test_integration_resnet50.py
+++ b/bamboo/integration_tests/test_integration_resnet50.py
@@ -53,6 +53,8 @@ def setup_experiment(lbann):
     data_reader = data.imagenet.make_data_reader(lbann, num_classes=1000)
     # We train on a subset of ImageNet
     data_reader.reader[0].percent_of_data_to_use = imagenet_fraction
+    # Only evaluate on ImageNet validation set at end of training
+    data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.1, momentum=0.9)
     return trainer, model, data_reader, optimizer

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -74,7 +74,7 @@ using world_comm_ptr =
  *  @param seed RNG seed.
  *  @return     LBANN communicator corresponding to MPI_COMM_WORLD.
  */
-world_comm_ptr initialize(int& argc, char**& argv, int seed = -1);
+world_comm_ptr initialize(int& argc, char**& argv);
 
 /** Destroy LBANN communicator.
  *

--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -170,6 +170,14 @@ class lbann_comm {
   inline int get_world_rank(int trainer, int rank) const {
     return procs_per_trainer * trainer + rank;
   }
+  /** Return the "rank" of the trainer that this rank is in */
+  inline int map_world_rank_to_trainer_rank(int world_rank) const {
+    return (world_rank / procs_per_trainer);
+  }
+  /** Return the "rank" within the trainer that this rank is in */
+  inline int map_world_rank_to_rank_in_trainer(int world_rank) const {
+    return (world_rank % procs_per_trainer);
+  }
   /** Return the rank of the master process in this trainer. */
   inline int get_trainer_master() const {
     return 0;
@@ -416,6 +424,14 @@ class lbann_comm {
   void all_gather(T &src, std::vector<T> &data, const El::mpi::Comm& c) {
     El::mpi::AllGather(&src, 1, data.data(), 1, c,
                        El::SyncInfo<El::Device::CPU>{});
+  }
+  /**
+   * Allgather for a single element over the world communicator;
+   * std::vector<T> &data must be correctly sized prior to entry.
+   */
+  template <typename T>
+  void world_all_gather(T &src, std::vector<T> &data) {
+    all_gather(src, data, get_world_comm());
   }
   /**
    * Allgather for a single element over the trainer communicator;

--- a/include/lbann/data_coordinator/data_coordinator.hpp
+++ b/include/lbann/data_coordinator/data_coordinator.hpp
@@ -48,25 +48,11 @@ class data_coordinator {
   using io_buffer_map_t = std::map<execution_mode, std::atomic<int>>;
 
  public:
-  data_coordinator(trainer& trainer, lbann_comm *comm, std::map<execution_mode, generic_data_reader *> data_readers) :
+  data_coordinator(trainer& trainer, lbann_comm *comm) :
     m_trainer(&trainer),
     m_comm(comm),
-    m_data_readers(data_readers),
     m_data_set_processed(false),
-    m_execution_context(nullptr) {
-
-    if(m_data_readers[execution_mode::training] != nullptr) {
-      this->m_training_dataset.total_samples() = m_data_readers[execution_mode::training]->get_num_data();
-    }
-
-    if(m_data_readers[execution_mode::validation] != nullptr) {
-      this->m_validation_dataset.total_samples() = m_data_readers[execution_mode::validation]->get_num_data();
-    }
-
-    if(m_data_readers[execution_mode::testing] != nullptr) {
-      this->m_testing_dataset.total_samples() = m_data_readers[execution_mode::testing]->get_num_data();
-    }
-  }
+    m_execution_context(nullptr) {}
 
   ~data_coordinator() {
     // Data coordinator always frees data readers.
@@ -105,7 +91,7 @@ class data_coordinator {
        CEREAL_NVP(m_data_set_processed)*/);
   }
 
-  void setup(int max_mini_batch_size);
+  void setup(int max_mini_batch_size, std::map<execution_mode, generic_data_reader *> data_readers);
 
   /** Check to see if there is a valid training context for the data coordinator */
   bool has_valid_execution_context() const {

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -31,7 +31,7 @@
 
 #include "lbann/base.hpp"
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/io/file_io.hpp"

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -34,7 +34,6 @@
 #include "lbann/weights/variance_scaling_initializers.hpp"
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/exception.hpp"
-#include "lbann/utils/random.hpp"
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/im2col.hpp"
 #include "lbann/utils/distconv.hpp"

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/regularizers/regularizer.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/cudnn.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 
 namespace lbann {
 

--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -63,7 +63,6 @@ namespace proto {
 
 /** Construct a trainer specified with a prototext. */
 std::unique_ptr<trainer> construct_trainer(lbann_comm* comm,
-                                           const std::map<execution_mode, generic_data_reader*>& data_readers,
                                            const lbann_data::Trainer& proto_trainer);
 
 /** Construct a model specified with a prototext. */

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -79,7 +79,7 @@ void set_num_parallel_readers(const lbann_comm& comm, ::lbann_data::LbannPB& p);
 void get_cmdline_overrides(const lbann_comm& comm, ::lbann_data::LbannPB& p);
 
 /** @brief print various params (learn_rate, etc) to cout */
-void print_parameters(const lbann_comm& comm, ::lbann_data::LbannPB& p);
+void print_parameters(const lbann_comm& comm, ::lbann_data::LbannPB& p, int random_seed, int data_seq_random_seed);
 
 /** @brief prints usage information */
 void print_help(const lbann_comm& comm);

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -79,7 +79,11 @@ void set_num_parallel_readers(const lbann_comm& comm, ::lbann_data::LbannPB& p);
 void get_cmdline_overrides(const lbann_comm& comm, ::lbann_data::LbannPB& p);
 
 /** @brief print various params (learn_rate, etc) to cout */
-void print_parameters(const lbann_comm& comm, ::lbann_data::LbannPB& p, int random_seed, int data_seq_random_seed);
+void print_parameters(const lbann_comm& comm,
+                      ::lbann_data::LbannPB& p,
+                      std::vector<int>& root_random_seeds,
+                      std::vector<int>& random_seeds,
+                      std::vector<int>& data_seq_random_seeds);
 
 /** @brief prints usage information */
 void print_help(const lbann_comm& comm);

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -66,7 +66,9 @@ public:
   /** Archive for checkpoint and restart */
   template <class Archive> void serialize(Archive & ar) {
     ar(CEREAL_NVP(m_persist),
-       CEREAL_NVP(m_max_mini_batch_size));
+       CEREAL_NVP(m_max_mini_batch_size),
+       CEREAL_NVP(m_random_seed),
+       CEREAL_NVP(m_data_seq_random_seed));
   }
 
   /** Set the trainer's name; this is an arbitrary string
@@ -85,6 +87,15 @@ public:
 
   /** Human-readable description. */
   description get_description() const;
+
+  /** Set the random seeds used for the trainer */
+  void set_random_seeds(int random_seed, int data_seq_random_seed) {
+    m_random_seed = random_seed;
+    m_data_seq_random_seed = data_seq_random_seed;
+  }
+
+  int get_random_seed() const { return m_random_seed; }
+  int get_data_seq_random_seed() const { return m_data_seq_random_seed; }
 
   /** @brief Get the list of callbacks for the trainer. */
   std::vector<observer_ptr<callback_base>> get_callbacks() {
@@ -199,6 +210,11 @@ private:
    *  local to the particular, instance of the training context..
    */
   size_t m_max_mini_batch_size;
+
+  // Random seed used for the general RNGs
+  int m_random_seed;
+  // Random seed used for the RNG used to fetch data
+  int m_data_seq_random_seed;
 
   /** Threads available for I/O */
   std::unique_ptr<thread_pool> m_io_thread_pool;

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -66,6 +66,7 @@ public:
   template <class Archive> void serialize(Archive & ar) {
     ar(CEREAL_NVP(m_persist),
        CEREAL_NVP(m_max_mini_batch_size),
+       CEREAL_NVP(m_root_random_seed),
        CEREAL_NVP(m_random_seed),
        CEREAL_NVP(m_data_seq_random_seed));
   }
@@ -88,7 +89,8 @@ public:
   description get_description() const;
 
   /** Set the random seeds used for the trainer */
-  void set_random_seeds(int random_seed, int data_seq_random_seed) {
+  void set_random_seeds(int root_random_seed, int random_seed, int data_seq_random_seed) {
+    m_root_random_seed = root_random_seed;
     m_random_seed = random_seed;
     m_data_seq_random_seed = data_seq_random_seed;
   }
@@ -210,6 +212,8 @@ private:
    */
   size_t m_max_mini_batch_size;
 
+  // Root of the random seed tree: either default or user supplied
+  int m_root_random_seed;
   // Random seed used for the general RNGs
   int m_random_seed;
   // Random seed used for the RNG used to fetch data

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -53,8 +53,7 @@ public:
 
   /** Constructor. */
   trainer(lbann_comm *comm,
-          size_t mini_batch_size,
-          std::map<execution_mode, generic_data_reader *> data_readers);
+          size_t mini_batch_size);
 
   /** Copy constructor. */
   trainer(const trainer& other);
@@ -119,7 +118,7 @@ public:
   }
 
   /** Set up the trainer. */
-  void setup(std::unique_ptr<thread_pool> io_thread_pool);
+  void setup(std::unique_ptr<thread_pool> io_thread_pool, std::map<execution_mode, generic_data_reader *> data_readers);
 
   using execution_context_key_pair_t = typename std::pair<observer_ptr<model>, execution_mode>;
 

--- a/include/lbann/transforms/transform.hpp
+++ b/include/lbann/transforms/transform.hpp
@@ -38,7 +38,7 @@ namespace transform {
 
 /**
  * Abstract base class for transforms on data.
- * 
+ *
  * A transform takes a CPUMat and modifies it in-place. Transforms should
  * be thread-safe, as one instance of a transform may be called concurrently
  * within multiple threads.

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -32,6 +32,7 @@ set_full_path(THIS_DIR_HEADERS
   prototext.hpp
   python.hpp
   random.hpp
+  random_number_generators.hpp
   serialization.hpp
   statistics.hpp
   summary.hpp

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -34,6 +34,10 @@ namespace lbann {
 
 const int lbann_default_random_seed = 42;
 
+#define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
+
+void construct_std_options();
+
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                                            lbann_data::Trainer* pb_trainer,
                                            lbann_data::LbannPB &pb,

--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -24,56 +24,19 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_UTILS_RNG_HPP
-#define LBANN_UTILS_RNG_HPP
+#ifndef LBANN_UTILS_RANDOM_HPP
+#define LBANN_UTILS_RANDOM_HPP
 
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/utils/exception.hpp"
-#include <random>
+#include "lbann/utils/random_number_generators.hpp"
 
 namespace lbann {
 
 /** Probability distributions. */
 enum class probability_distribution {invalid, gaussian, bernoulli, uniform};
-
-using rng_gen = std::mt19937;  // Mersenne Twister
-using fast_rng_gen = std::minstd_rand;  // Minimum standard, LC
-
-/**
- * Return a reference to the global LBANN random number generator.
- * @note If compiling with OpenMP, this is stored in a threadprivate variable.
- */
-rng_gen& get_generator();
-
-/**
- * Return a reference to a possibly-faster global LBANN random number generator.
- * Compared to get_generator, this should be slightly faster.
- * @note If compiling with OpenMP, this is stored in a threadprivate variable.
- */
-fast_rng_gen& get_fast_generator();
-
-/**
- * Return a reference to the global LBANN random number generator used
- * for shuffling the data samples within each mini-batch
- * @note This is stored in a thread_local variable.
- */
-rng_gen& get_data_seq_generator();
-
-/**
- * Return a reference to the global LBANN random number generator used
- * for shuffling the data samples within each mini-batch
- * @note This is stored in a thread_local variable.
- */
-rng_gen& get_io_generator();
-
-/**
- * Return a reference to the fast global LBANN random number generator used
- * for the I/O threads
- * @note This is stored in a thread_local variable.
- */
-fast_rng_gen& get_fast_io_generator();
 
 /**
  * Return random integers uniformly distributed in [0, max).
@@ -154,33 +117,6 @@ template <typename T, typename Generator>
 inline T random_uniform(Generator& g) {
   return details::random_uniform_impl<Generator, T>::generate(g);
 }
-
-/** @brief Initialize the random number generator (with optional seed).
- *
- *  @param seed Seed value for the random number generator
- *  @param comm If present, mixes the process's rank within the model
- *              into the seed; if not, uses the MPI world rank.
- *
- */
-void init_random(int seed = -1, lbann_comm *comm = nullptr);
-
-/**
- * Initialize a random number generator (with optional seed) that is
- * specifically used for sequencing the training / testing data
- * samples.  Using a separate RNG for the data sequences helps provide
- * a stable training result that does not vary with how much I/O
- * parallelism is applied.
- */
-void init_data_seq_random(int seed = -1);
-
-/**
- * Initialize a random number generator (with optional seed) that is
- * specifically used by the I/O threads for tasks such as data
- * preprocessing, etc.
- *
- * Called from init_random
- */
-void init_io_random(int seed = -1);
 
 /**
  * Make mat into an m x n matrix where each entry is independently drawn from
@@ -291,4 +227,4 @@ void rng_bernoulli(const float p, DistMat *m) {
 #endif // LBANN_RANDOM_INSTANTIATE
 
 }// end namespace
-#endif // LBANN_UTILS_RNG_HPP
+#endif // LBANN_UTILS_RANDOM_HPP

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -96,7 +96,6 @@ void init_data_seq_random(int seed = -1);
  */
 void init_io_random(int seed = -1);
 
-
 } // namespace lbann
 
 #endif // LBANN_UTILS_RNG_HPP

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_RNG_HPP
+#define LBANN_UTILS_RNG_HPP
+
+#include "lbann/comm.hpp"
+#include <random>
+
+namespace lbann {
+
+using rng_gen = std::mt19937;  // Mersenne Twister
+using fast_rng_gen = std::minstd_rand;  // Minimum standard, LC
+
+/**
+ * Return a reference to the global LBANN random number generator.
+ * @note If compiling with OpenMP, this is stored in a threadprivate variable.
+ */
+rng_gen& get_generator();
+
+/**
+ * Return a reference to a possibly-faster global LBANN random number generator.
+ * Compared to get_generator, this should be slightly faster.
+ * @note If compiling with OpenMP, this is stored in a threadprivate variable.
+ */
+fast_rng_gen& get_fast_generator();
+
+/**
+ * Return a reference to the global LBANN random number generator used
+ * for shuffling the data samples within each mini-batch
+ * @note This is stored in a thread_local variable.
+ */
+rng_gen& get_data_seq_generator();
+
+/**
+ * Return a reference to the global LBANN random number generator used
+ * for shuffling the data samples within each mini-batch
+ * @note This is stored in a thread_local variable.
+ */
+rng_gen& get_io_generator();
+
+/**
+ * Return a reference to the fast global LBANN random number generator used
+ * for the I/O threads
+ * @note This is stored in a thread_local variable.
+ */
+fast_rng_gen& get_fast_io_generator();
+
+/** @brief Initialize the random number generator (with optional seed).
+ *
+ *  @param seed Seed value for the random number generator
+ *  @param comm If present, mixes the process's rank within the model
+ *              into the seed; if not, uses the MPI world rank.
+ *
+ */
+void init_random(int seed = -1, lbann_comm *comm = nullptr);
+
+/**
+ * Initialize a random number generator (with optional seed) that is
+ * specifically used for sequencing the training / testing data
+ * samples.  Using a separate RNG for the data sequences helps provide
+ * a stable training result that does not vary with how much I/O
+ * parallelism is applied.
+ */
+void init_data_seq_random(int seed = -1);
+
+/**
+ * Initialize a random number generator (with optional seed) that is
+ * specifically used by the I/O threads for tasks such as data
+ * preprocessing, etc.
+ *
+ * Called from init_random
+ */
+void init_io_random(int seed = -1);
+
+
+} // namespace lbann
+
+#endif // LBANN_UTILS_RNG_HPP

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -97,8 +97,7 @@ int main(int argc, char *argv[]) {
     std::terminate();
   }
 
-  int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 
   if (master) {

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -70,6 +70,7 @@ int guess_global_rank() noexcept
 
 int main(int argc, char *argv[]) {
   auto& arg_parser = global_argument_parser();
+  construct_std_options();
   auto use_cudnn_tensor_ops =
     arg_parser.add_flag("use cudnn tensor ops",
                         {"--use-cudnn-tensor-ops"},
@@ -82,7 +83,6 @@ int main(int argc, char *argv[]) {
                         utils::ENV("LBANN_USE_CUBLAS_TENSOR_OPS"),
                         "Set the default cuBLAS math mode to use "
                         "Tensor Core operations when available.");
-
   try {
     arg_parser.parse(argc, argv);
   }

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -38,8 +38,7 @@
 using namespace lbann;
 
 int main(int argc, char *argv[]) {
-  int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 
   try {

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -37,7 +38,47 @@
 
 using namespace lbann;
 
+namespace {
+int guess_global_rank() noexcept
+{
+  int have_mpi;
+  MPI_Initialized(&have_mpi);
+  if (have_mpi) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    return rank;
+  }
+  else {
+    if (char const* slurm_flag = std::getenv("SLURM_PROCID"))
+      return std::stoi(slurm_flag);
+    if (char const* open_mpi_flag = std::getenv("OMPI_WORLD_COMM_RANK"))
+      return std::stoi(open_mpi_flag);
+    else if (char const* mv2_flag = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"))
+      return std::stoi(mv2_flag);
+    else
+      return -1;
+  }
+}
+}// namespace <anon>
+
 int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  construct_std_options();
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    auto guessed_rank = guess_global_rank();
+    if (guessed_rank <= 0)
+      // Cannot call `El::ReportException` because MPI hasn't been
+      // initialized yet.
+      std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+                << e.what() << "\n\nProcess terminating."
+                << std::endl;
+    std::terminate();
+  }
+
   world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -38,8 +38,7 @@
 using namespace lbann;
 
 int main(int argc, char *argv[]) {
-  int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 
   if (master) {

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -37,7 +38,47 @@
 
 using namespace lbann;
 
+namespace {
+int guess_global_rank() noexcept
+{
+  int have_mpi;
+  MPI_Initialized(&have_mpi);
+  if (have_mpi) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    return rank;
+  }
+  else {
+    if (char const* slurm_flag = std::getenv("SLURM_PROCID"))
+      return std::stoi(slurm_flag);
+    if (char const* open_mpi_flag = std::getenv("OMPI_WORLD_COMM_RANK"))
+      return std::stoi(open_mpi_flag);
+    else if (char const* mv2_flag = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"))
+      return std::stoi(mv2_flag);
+    else
+      return -1;
+  }
+}
+}// namespace <anon>
+
 int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  construct_std_options();
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    auto guessed_rank = guess_global_rank();
+    if (guessed_rank <= 0)
+      // Cannot call `El::ReportException` because MPI hasn't been
+      // initialized yet.
+      std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+                << e.what() << "\n\nProcess terminating."
+                << std::endl;
+    std::terminate();
+  }
+
   world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -38,8 +38,7 @@
 using namespace lbann;
 
 int main(int argc, char *argv[]) {
-  int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 
   try {

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -37,7 +38,47 @@
 
 using namespace lbann;
 
+namespace {
+int guess_global_rank() noexcept
+{
+  int have_mpi;
+  MPI_Initialized(&have_mpi);
+  if (have_mpi) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    return rank;
+  }
+  else {
+    if (char const* slurm_flag = std::getenv("SLURM_PROCID"))
+      return std::stoi(slurm_flag);
+    if (char const* open_mpi_flag = std::getenv("OMPI_WORLD_COMM_RANK"))
+      return std::stoi(open_mpi_flag);
+    else if (char const* mv2_flag = std::getenv("MV2_COMM_WORLD_LOCAL_RANK"))
+      return std::stoi(mv2_flag);
+    else
+      return -1;
+  }
+}
+}// namespace <anon>
+
 int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  construct_std_options();
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    auto guessed_rank = guess_global_rank();
+    if (guessed_rank <= 0)
+      // Cannot call `El::ReportException` because MPI hasn't been
+      // initialized yet.
+      std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+                << e.what() << "\n\nProcess terminating."
+                << std::endl;
+    std::terminate();
+  }
+
   world_comm_ptr comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 

--- a/model_zoo/lbann_help.cpp
+++ b/model_zoo/lbann_help.cpp
@@ -27,12 +27,26 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <lbann/proto/proto_common.hpp>
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/lbann_library.hpp"
 
 #include <iostream>
 
 using namespace lbann;
 
-int main(int, char **) {
+int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  construct_std_options();
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+              << e.what() << "\n\nProcess terminating."
+              << std::endl;
+    std::terminate();
+  }
   print_help(std::cerr);
   return EXIT_SUCCESS;
 }

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
@@ -40,6 +41,18 @@
 using namespace lbann;
 
 int main(int argc, char *argv[]) {
+  auto& arg_parser = global_argument_parser();
+  construct_std_options();
+
+  try {
+    arg_parser.parse(argc, argv);
+  }
+  catch (std::exception const& e) {
+    std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
+              << e.what() << "\n\nProcess terminating."
+              << std::endl;
+    std::terminate();
+  }
   auto comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -40,8 +40,7 @@
 using namespace lbann;
 
 int main(int argc, char *argv[]) {
-  int random_seed = lbann_default_random_seed;
-  auto comm = initialize(argc, argv, random_seed);
+  auto comm = initialize(argc, argv);
   const bool master = comm->am_world_master();
 
   try {

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -63,7 +63,7 @@ namespace lbann {
 
 MPI_Errhandler err_handle;
 
-world_comm_ptr initialize(int& argc, char**& argv, int seed) {
+world_comm_ptr initialize(int& argc, char**& argv) {
   // Initialize Elemental.
   El::Initialize(argc, argv);
   // Create a new comm object.
@@ -99,10 +99,6 @@ world_comm_ptr initialize(int& argc, char**& argv, int seed) {
   }
   hwloc_topology_destroy(topo);
 #endif
-
-  // Initialize local random number generators.
-  init_random(seed);
-  init_data_seq_random(seed);
 
 #ifdef LBANN_HAS_NVSHMEM
   // Initialize NVSHMEM

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -38,7 +38,6 @@
 
 #include "lbann/comm.hpp"
 #include "lbann/utils/exception.hpp"
-#include "lbann/utils/random.hpp"
 #include "lbann/utils/omp_diagnostics.hpp"
 #include "lbann/utils/stack_trace.hpp"
 

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/callbacks/ltfb.hpp"
 #include "lbann/callbacks/imcomm.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 #include "lbann/optimizers/sgd.hpp"
 #include "lbann/optimizers/adam.hpp"
 #include "lbann/proto/proto_common.hpp"

--- a/src/callbacks/perturb_adam.cpp
+++ b/src/callbacks/perturb_adam.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/callbacks/perturb_adam.hpp"
 #include "lbann/proto/proto_common.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 
 #include <callbacks.pb.h>
 

--- a/src/callbacks/perturb_dropout.cpp
+++ b/src/callbacks/perturb_dropout.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/callbacks/perturb_dropout.hpp"
 #include "lbann/proto/proto_common.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 
 #include <callbacks.pb.h>
 

--- a/src/data_coordinator/data_coordinator.cpp
+++ b/src/data_coordinator/data_coordinator.cpp
@@ -29,7 +29,20 @@
 
 namespace lbann {
 
-void data_coordinator::setup(int max_mini_batch_size) {
+void data_coordinator::setup(int max_mini_batch_size, std::map<execution_mode, generic_data_reader *> data_readers) {
+  m_data_readers = data_readers;
+
+  if(m_data_readers[execution_mode::training] != nullptr) {
+    this->m_training_dataset.total_samples() = m_data_readers[execution_mode::training]->get_num_data();
+  }
+
+  if(m_data_readers[execution_mode::validation] != nullptr) {
+    this->m_validation_dataset.total_samples() = m_data_readers[execution_mode::validation]->get_num_data();
+  }
+
+  if(m_data_readers[execution_mode::testing] != nullptr) {
+    this->m_testing_dataset.total_samples() = m_data_readers[execution_mode::testing]->get_num_data();
+  }
 
   /// @todo BVE FIXME the list of execution modes should not include
   // ones will null data readers.  Fix this in next PR.

--- a/src/data_readers/data_reader_synthetic.cpp
+++ b/src/data_readers/data_reader_synthetic.cpp
@@ -27,7 +27,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/data_readers/data_reader_synthetic.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 #include <cstdio>
 #include <string>
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -35,7 +35,6 @@
 #include "lbann/layers/transform/evaluation.hpp"
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/metrics/layer_metric.hpp"
-#include "lbann/utils/random.hpp"
 #include "lbann/utils/omp_diagnostics.hpp"
 #include "lbann/utils/description.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"

--- a/src/proto/factories/trainer_factory.cpp
+++ b/src/proto/factories/trainer_factory.cpp
@@ -34,18 +34,13 @@ namespace lbann {
 namespace proto {
 
 std::unique_ptr<trainer> construct_trainer(lbann_comm* comm,
-                                           const std::map<execution_mode, generic_data_reader*>& data_readers,
                                            const lbann_data::Trainer& proto_trainer) {
 
   // Instantiate trainer
-  auto t = make_unique<trainer>(comm, proto_trainer.mini_batch_size(), data_readers);
+  auto t = make_unique<trainer>(comm, proto_trainer.mini_batch_size());
   const auto& name = proto_trainer.name();
   if (!name.empty()) {
     t->set_name(name);
-  }
-
-  for (auto d : data_readers) {
-    d.second->set_trainer(t.get());
   }
 
   // Construct callbacks

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -776,7 +776,7 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
 
 }
 
-void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p)
+void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p, int random_seed, int data_seq_random_seed)
 {
   if (!comm.am_world_master()) {
     return;
@@ -801,18 +801,19 @@ void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p)
   std::cout << std::endl
             << "Running with these parameters:\n"
             << " General:\n"
-            << "  datatype size:           " << sizeof(DataType) << std::endl
-            << "  mini_batch_size:         " << t.mini_batch_size() << std::endl
-            << "  num_epochs:              " << m.num_epochs()  << std::endl
-            << "  hydrogen_block_size:     " << t.hydrogen_block_size()  << std::endl
-            << "  procs_per_trainer:       " << t.procs_per_trainer()  << std::endl
-            << "  num_parallel_readers:    " << t.num_parallel_readers()  << std::endl
-            << "  serialize_io:            " << m.serialize_io()  << std::endl
-            << "  cuda:                    " << (disable_cuda ? "disabled" : "enabled") << std::endl
-            << "  cudnn:                   " << (disable_cudnn ? "disabled" : "enabled") << std::endl
-            << "  random_seed:             " << t.random_seed() << std::endl
-            << "  deterministic_exec:      " << (enable_determinism ? "enabled" : "disabled") << std::endl
-            << "  data_layout:             " << m.data_layout()  << std::endl
+            << "  datatype size:             " << sizeof(DataType) << std::endl
+            << "  mini_batch_size:           " << t.mini_batch_size() << std::endl
+            << "  num_epochs:                " << m.num_epochs()  << std::endl
+            << "  hydrogen_block_size:       " << t.hydrogen_block_size()  << std::endl
+            << "  procs_per_trainer:         " << t.procs_per_trainer()  << std::endl
+            << "  num_parallel_readers:      " << t.num_parallel_readers()  << std::endl
+            << "  serialize_io:              " << m.serialize_io()  << std::endl
+            << "  cuda:                      " << (disable_cuda ? "disabled" : "enabled") << std::endl
+            << "  cudnn:                     " << (disable_cudnn ? "disabled" : "enabled") << std::endl
+            << "  random_seed:               " << random_seed << std::endl
+            << "  data sequence random_seed: " << data_seq_random_seed << std::endl
+            << "  deterministic_exec:        " << (enable_determinism ? "enabled" : "disabled") << std::endl
+            << "  data_layout:               " << m.data_layout()  << std::endl
             << "     (only used for metrics)\n";
 }
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -32,6 +32,7 @@
 #include "lbann/proto/init_image_data_readers.hpp"
 #include "lbann/proto/factories.hpp"
 #include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <reader.pb.h>
@@ -776,7 +777,11 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
 
 }
 
-void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p, int random_seed, int data_seq_random_seed)
+void print_parameters(const lbann_comm& comm,
+                      lbann_data::LbannPB& p,
+                      std::vector<int>& root_random_seeds,
+                      std::vector<int>& random_seeds,
+                      std::vector<int>& data_seq_random_seeds)
 {
   if (!comm.am_world_master()) {
     return;
@@ -801,19 +806,37 @@ void print_parameters(const lbann_comm& comm, lbann_data::LbannPB& p, int random
   std::cout << std::endl
             << "Running with these parameters:\n"
             << " General:\n"
-            << "  datatype size:             " << sizeof(DataType) << std::endl
-            << "  mini_batch_size:           " << t.mini_batch_size() << std::endl
-            << "  num_epochs:                " << m.num_epochs()  << std::endl
-            << "  hydrogen_block_size:       " << t.hydrogen_block_size()  << std::endl
-            << "  procs_per_trainer:         " << t.procs_per_trainer()  << std::endl
-            << "  num_parallel_readers:      " << t.num_parallel_readers()  << std::endl
-            << "  serialize_io:              " << m.serialize_io()  << std::endl
-            << "  cuda:                      " << (disable_cuda ? "disabled" : "enabled") << std::endl
-            << "  cudnn:                     " << (disable_cudnn ? "disabled" : "enabled") << std::endl
-            << "  random_seed:               " << random_seed << std::endl
-            << "  data sequence random_seed: " << data_seq_random_seed << std::endl
-            << "  deterministic_exec:        " << (enable_determinism ? "enabled" : "disabled") << std::endl
-            << "  data_layout:               " << m.data_layout()  << std::endl
+            << "  datatype size:              " << sizeof(DataType) << std::endl
+            << "  mini_batch_size:            " << t.mini_batch_size() << std::endl
+            << "  num_epochs:                 " << m.num_epochs()  << std::endl
+            << "  hydrogen_block_size:        " << t.hydrogen_block_size()  << std::endl
+            << "  procs_per_trainer:          " << t.procs_per_trainer()  << std::endl
+            << "  num_parallel_readers:       " << t.num_parallel_readers()  << std::endl
+            << "  serialize_io:               " << m.serialize_io()  << std::endl
+            << "  cuda:                       " << (disable_cuda ? "disabled" : "enabled") << std::endl
+            << "  cudnn:                      " << (disable_cudnn ? "disabled" : "enabled") << std::endl;
+  auto& arg_parser = global_argument_parser();
+  std::stringstream root_rng, rng, data_seq_rng;
+  for(size_t i = 0; i < random_seeds.size(); i++) {
+    int trainer_rank = comm.map_world_rank_to_trainer_rank(i);
+    int rank_in_trainer = comm.map_world_rank_to_rank_in_trainer(i);
+    if(rank_in_trainer < arg_parser.get<int>(MAX_RNG_SEEDS_DISPLAY)) {
+      std::stringstream id;
+      id << "[" << trainer_rank << "][" << rank_in_trainer << "]";
+      root_rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(root_random_seeds[i]) << " " ;
+      rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(random_seeds[i]) << " " ;
+      data_seq_rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(data_seq_random_seeds[i]) << " " ;
+    }else {
+      root_rng << "... ";
+      rng << "... ";
+      data_seq_rng << "... ";
+    }
+  }
+  std::cout << "  root_random_seed[t][r]:     " << root_rng.str() << std::endl;
+  std::cout << "  random_seed[t][r]:          " << rng.str() << std::endl;
+  std::cout << "  data_seq_random_seed[t][r]: " << data_seq_rng.str() << std::endl;
+  std::cout << "  deterministic_exec:         " << (enable_determinism ? "enabled" : "disabled") << std::endl
+            << "  data_layout:                " << m.data_layout()  << std::endl
             << "     (only used for metrics)\n";
 }
 

--- a/src/transforms/vision/color_jitter.cpp
+++ b/src/transforms/vision/color_jitter.cpp
@@ -28,7 +28,7 @@
 #include "lbann/transforms/vision/adjust_brightness.hpp"
 #include "lbann/transforms/vision/adjust_contrast.hpp"
 #include "lbann/transforms/vision/adjust_saturation.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -19,6 +19,7 @@ set_full_path(THIS_DIR_SOURCES
   protobuf_utils.cpp
   python.cpp
   random.cpp
+  random_number_generators.cpp
   stack_profiler.cpp
   stack_trace.cpp
   statistics.cpp

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -67,7 +67,7 @@ bool io_generator_seed_inited = false;
 thread_local lbann::fast_rng_gen fast_io_generator;
 thread_local bool fast_io_generator_inited = false;
 int fast_io_generator_seed_base = 0;
-bol fast_io_generator_seed_inited = false;
+bool fast_io_generator_seed_inited = false;
 }
 
 namespace lbann {

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -31,85 +31,8 @@
 #include "lbann/utils/hash.hpp"
 #include <thread>
 
-namespace {
-#ifdef __ICC
-lbann::rng_gen generator;
-#pragma omp threadprivate(generator)
-
-lbann::fast_rng_gen fast_generator;
-#pragma omp threadprivate(fast_generator)
-#else
-// Random number generator, file-visible only.
-// Defined like this to work around a GCC problem with threadprivate objects:
-// https://stackoverflow.com/questions/23552077/how-to-define-a-object-or-struct-as-threadprivate-in-openmp/
-extern lbann::rng_gen generator;
-#pragma omp threadprivate(generator)
-lbann::rng_gen generator;
-
-extern lbann::fast_rng_gen fast_generator;
-#pragma omp threadprivate(fast_generator)
-lbann::fast_rng_gen fast_generator;
-#endif
-
-bool generator_inited = false;
-bool fast_generator_inited = false;
-
-thread_local lbann::rng_gen data_seq_generator;
-thread_local bool data_seq_generator_inited = false;
-int data_seq_generator_seed_base = 0;
-bool data_seq_generator_seed_inited = false;
-
-thread_local lbann::rng_gen io_generator;
-thread_local bool io_generator_inited = false;
-int io_generator_seed_base = 0;
-bool io_generator_seed_inited = false;
-
-thread_local lbann::fast_rng_gen fast_io_generator;
-thread_local bool fast_io_generator_inited = false;
-int fast_io_generator_seed_base = 0;
-bool fast_io_generator_seed_inited = false;
-}
 
 namespace lbann {
-
-rng_gen& get_generator() {
-  if (!::generator_inited) { LBANN_ERROR("RNG seed not set"); }
-  return ::generator;
-}
-
-fast_rng_gen& get_fast_generator() {
-  if (!::fast_generator_inited) { LBANN_ERROR("Fast RNG seed not set"); }
-  return ::fast_generator;
-}
-
-rng_gen& get_data_seq_generator() {
-  if (!::data_seq_generator_inited) {
-    if (!::data_seq_generator_seed_inited) { LBANN_ERROR("data sequence RNG seed not set"); }
-    ::data_seq_generator.seed(::data_seq_generator_seed_base);
-    ::data_seq_generator_inited = true;
-  }
-  return ::data_seq_generator;
-}
-
-rng_gen& get_io_generator() {
-  if (!::io_generator_inited) {
-    if (!::io_generator_seed_inited) { LBANN_ERROR("I/O RNG seed not set"); }
-    ::io_generator.seed(hash_combine(::io_generator_seed_base,
-                                     std::this_thread::get_id()));
-    ::io_generator_inited = true;
-  }
-  return ::io_generator;
-}
-
-fast_rng_gen& get_fast_io_generator() {
-  if (!::fast_io_generator_inited) {
-    if (!::fast_io_generator_seed_inited) { LBANN_ERROR("Fast I/O RNG seed not set"); }
-    ::fast_io_generator.seed(hash_combine(::fast_io_generator_seed_base,
-                                          std::this_thread::get_id()));
-    ::fast_io_generator_inited = true;
-  }
-  return ::fast_io_generator;
-}
 
 bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
   std::string dirname = std::string(p.m_checkpoint_dir) + "/rng_state";
@@ -132,7 +55,7 @@ bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
     rng_name = dirname + "/rng_seq_generator";
     std::ofstream rng_seq(rng_name);
     if(!rng_seq) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng_seq << ::data_seq_generator;
+    rng_seq << get_data_seq_generator();
     rng_seq.close();
 
 #ifdef LBANN_SET_EL_RNG
@@ -148,14 +71,14 @@ bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
   rng_name = dirname + "/rng_io_generator_" + rank_in_trainer;
   std::ofstream rng_io(rng_name);
   if(!rng_io) { LBANN_ERROR("Failed to open ", rng_name); }
-  rng_io << ::io_generator;
+  rng_io << get_io_generator();
   rng_io.close();
 
   /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_fast_io_generator_" + rank_in_trainer;
   std::ofstream rng_fast_io(rng_name);
   if(!rng_fast_io) { LBANN_ERROR("Failed to open ", rng_name); }
-  rng_fast_io << ::fast_io_generator;
+  rng_fast_io << get_fast_io_generator();
   rng_fast_io.close();
 
 #ifdef _OPENMP
@@ -165,27 +88,27 @@ bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
              + std::to_string(omp_get_thread_num());
     std::ofstream rng(rng_name);
     if(!rng) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng << ::generator;
+    rng << get_generator();
     rng.close();
 
     rng_name = dirname + "/rng_fast_generator_" + rank_in_trainer + "_"
              + std::to_string(omp_get_thread_num());
     std::ofstream rng_fast(rng_name);
     if(!rng_fast) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng_fast << ::fast_generator;
+    rng_fast << get_fast_generator();
     rng_fast.close();
   }
 #else
     rng_name = dirname + "/rng_generator_" + rank_in_trainer;
     std::ofstream rng(rng_name);
     if(!rng) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng << ::generator;
+    rng << get_generator();
     rng.close();
 
     rng_name = dirname + "/rng_fast_generator_" + rank_in_trainer;
     std::ofstream rng_fast(rng_name);
     if(!rng_fast) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng_fast << ::fast_generator;
+    rng_fast << get_fast_generator();
     rng_fast.close();
 #endif
 
@@ -209,7 +132,7 @@ bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm) {
   rng_name = dirname + "/rng_seq_generator";
   std::ifstream rng_seq(rng_name);
   if(!rng_seq) { LBANN_ERROR("Failed to open ", rng_name); }
-  rng_seq >> ::data_seq_generator;
+  rng_seq >> get_data_seq_generator();
 
 #ifdef LBANN_SET_EL_RNG
   rng_name = dirname + "/EL_generator";
@@ -229,13 +152,13 @@ bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm) {
   rng_name = dirname + "/rng_io_generator_" + rank_in_trainer;
   std::ifstream rng_io(rng_name);
   if(!rng_io) { LBANN_ERROR("Failed to open ", rng_name); }
-  rng_io >> ::io_generator;
+  rng_io >> get_io_generator();
 
   /// @todo - Note that the RNG with thread local data is not correct
   rng_name = dirname + "/rng_fast_io_generator_" + rank_in_trainer;
   std::ifstream rng_fast_io(rng_name);
   if(!rng_fast_io) { LBANN_ERROR("Failed to open ", rng_name); }
-  rng_fast_io >> ::fast_io_generator;
+  rng_fast_io >> get_fast_io_generator();
 
 #ifdef _OPENMP
   #pragma omp parallel private(rng_name)
@@ -244,114 +167,27 @@ bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm) {
              + std::to_string(omp_get_thread_num());
     std::ifstream rng(rng_name);
     if(!rng) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng >> ::generator;
+    rng >> get_generator();
 
     rng_name = dirname + "/rng_fast_generator_" + rank_in_trainer + "_"
              + std::to_string(omp_get_thread_num());
     std::ifstream rng_fast(rng_name);
     if(!rng_fast) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng_fast >> ::fast_generator;
+    rng_fast >> get_fast_generator();
    }
 #else
     rng_name = dirname + "/rng_generator_" + rank_in_trainer;
     std::ifstream rng(rng_name);
     if(!rng) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng >> ::generator;
+    rng >> get_generator();
 
     rng_name = dirname + "/rng_fast_generator_" + rank_in_trainer;
     std::ifstream rng_fast(rng_name);
     if(!rng_fast) { LBANN_ERROR("Failed to open ", rng_name); }
-    rng_fast >> ::fast_generator;
+    rng_fast >> get_fast_generator();
    }
 #endif
   return true;
-}
-
-void init_random(int seed, lbann_comm *comm) {
-  generator_inited = true;
-  fast_generator_inited = true;
-  if (seed != -1) {
-    // Seed every OpenMP thread, if present.
-    // Note: Threadprivate OMP variables don't work with dynamic threads.
-#ifdef _OPENMP
-    #pragma omp parallel
-    {
-      get_generator().seed(hash_combine(seed, omp_get_thread_num()));
-      get_fast_generator().seed(hash_combine(seed, omp_get_thread_num()));
-    }
-#else
-    get_generator().seed(seed);
-    get_fast_generator().seed(seed);
-#endif
-
-#ifdef LBANN_SET_EL_RNG
-    // Set Elemental's RNG seed
-    auto elemental_seed = hash_combine(seed, 104729); // 10000th prime
-    int mpi_initialized = 0;
-    MPI_Initialized(&mpi_initialized);
-    if(mpi_initialized) {
-      // If MPI is initialized mix in the rank to ensure that Hydrogen
-      // has good RNGs.  Note that under some configurations LBANN
-      // will not do this, so it is good to ensure that Hydrogen is
-      // well seeded.
-      elemental_seed = (comm == nullptr
-                        ? hash_combine(elemental_seed, El::mpi::Rank(El::mpi::COMM_WORLD))
-                        : hash_combine(elemental_seed, comm->get_rank_in_trainer()));
-    }
-    El::Generator().seed(elemental_seed);
-#endif
-
-  } else {
-    // Seed with a random value.
-    std::random_device rd;
-    unsigned rand_val = rd();
-#ifdef _OPENMP
-    #pragma omp parallel
-    {
-      get_generator().seed(hash_combine(rand_val, omp_get_thread_num()));
-      get_fast_generator().seed(hash_combine(rand_val, omp_get_thread_num()));
-    }
-#else
-    get_generator().seed(rand_val);
-    get_fast_generator().seed(rand_val);
-#endif
-#ifdef LBANN_SET_EL_RNG
-    El::Generator().seed(rand_val);
-#endif
-  }
-
-  init_io_random(seed);
-}
-
-void init_data_seq_random(int seed) {
-  if (seed == -1) {
-    // Seed with a random value.
-    std::random_device rd;
-    seed = rd();
-  }
-
-  ::data_seq_generator_seed_base = seed;
-  ::data_seq_generator_seed_inited = true;
-  /// Reset the init flag so that generator will reinitialize
-  ::data_seq_generator_inited = false;
-}
-
-void init_io_random(int seed) {
-  if (seed == -1) {
-    // Seed with a random value.
-    std::random_device rd;
-    seed = rd();
-  }
-
-  ::io_generator_seed_base = seed;
-  ::io_generator_seed_inited = true;
-  /// Reset the init flag so that generator will reinitialize
-  ::io_generator_inited = false;
-
-  ::fast_io_generator_seed_base = seed;
-  ::fast_io_generator_seed_inited = true;
-  /// Reset the init flag so that generator will reinitialize
-  ::fast_io_generator_inited = false;
 }
 
 template <typename TensorDataType>

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -1,0 +1,199 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <omp.h>
+#include "lbann/utils/random_number_generators.hpp"
+#include "lbann/utils/hash.hpp"
+#include "lbann/utils/exception.hpp"
+#include <thread>
+
+namespace {
+#ifdef __ICC
+lbann::rng_gen generator;
+#pragma omp threadprivate(generator)
+
+lbann::fast_rng_gen fast_generator;
+#pragma omp threadprivate(fast_generator)
+#else
+// Random number generator, file-visible only.
+// Defined like this to work around a GCC problem with threadprivate objects:
+// https://stackoverflow.com/questions/23552077/how-to-define-a-object-or-struct-as-threadprivate-in-openmp/
+extern lbann::rng_gen generator;
+#pragma omp threadprivate(generator)
+lbann::rng_gen generator;
+
+extern lbann::fast_rng_gen fast_generator;
+#pragma omp threadprivate(fast_generator)
+lbann::fast_rng_gen fast_generator;
+#endif
+
+bool generator_inited = false;
+bool fast_generator_inited = false;
+
+thread_local lbann::rng_gen data_seq_generator;
+thread_local bool data_seq_generator_inited = false;
+int data_seq_generator_seed_base = 0;
+bool data_seq_generator_seed_inited = false;
+
+thread_local lbann::rng_gen io_generator;
+thread_local bool io_generator_inited = false;
+int io_generator_seed_base = 0;
+bool io_generator_seed_inited = false;
+
+thread_local lbann::fast_rng_gen fast_io_generator;
+thread_local bool fast_io_generator_inited = false;
+int fast_io_generator_seed_base = 0;
+bool fast_io_generator_seed_inited = false;
+}
+
+namespace lbann {
+
+rng_gen& get_generator() {
+  if (!::generator_inited) { LBANN_ERROR("RNG seed not set"); }
+  return ::generator;
+}
+
+fast_rng_gen& get_fast_generator() {
+  if (!::fast_generator_inited) { LBANN_ERROR("Fast RNG seed not set"); }
+  return ::fast_generator;
+}
+
+rng_gen& get_data_seq_generator() {
+  if (!::data_seq_generator_inited) {
+    if (!::data_seq_generator_seed_inited) { LBANN_ERROR("data sequence RNG seed not set"); }
+    ::data_seq_generator.seed(::data_seq_generator_seed_base);
+    ::data_seq_generator_inited = true;
+  }
+  return ::data_seq_generator;
+}
+
+rng_gen& get_io_generator() {
+  if (!::io_generator_inited) {
+    if (!::io_generator_seed_inited) { LBANN_ERROR("I/O RNG seed not set"); }
+    ::io_generator.seed(hash_combine(::io_generator_seed_base,
+                                     std::this_thread::get_id()));
+    ::io_generator_inited = true;
+  }
+  return ::io_generator;
+}
+
+fast_rng_gen& get_fast_io_generator() {
+  if (!::fast_io_generator_inited) {
+    if (!::fast_io_generator_seed_inited) { LBANN_ERROR("Fast I/O RNG seed not set"); }
+    ::fast_io_generator.seed(hash_combine(::fast_io_generator_seed_base,
+                                          std::this_thread::get_id()));
+    ::fast_io_generator_inited = true;
+  }
+  return ::fast_io_generator;
+}
+void init_random(int seed, lbann_comm *comm) {
+  generator_inited = true;
+  fast_generator_inited = true;
+  if (seed != -1) {
+    // Seed every OpenMP thread, if present.
+    // Note: Threadprivate OMP variables don't work with dynamic threads.
+#ifdef _OPENMP
+    #pragma omp parallel
+    {
+      get_generator().seed(hash_combine(seed, omp_get_thread_num()));
+      get_fast_generator().seed(hash_combine(seed, omp_get_thread_num()));
+    }
+#else
+    get_generator().seed(seed);
+    get_fast_generator().seed(seed);
+#endif
+
+#ifdef LBANN_SET_EL_RNG
+    // Set Elemental's RNG seed
+    auto elemental_seed = hash_combine(seed, 104729); // 10000th prime
+    int mpi_initialized = 0;
+    MPI_Initialized(&mpi_initialized);
+    if(mpi_initialized) {
+      // If MPI is initialized mix in the rank to ensure that Hydrogen
+      // has good RNGs.  Note that under some configurations LBANN
+      // will not do this, so it is good to ensure that Hydrogen is
+      // well seeded.
+      elemental_seed = (comm == nullptr
+                        ? hash_combine(elemental_seed, El::mpi::Rank(El::mpi::COMM_WORLD))
+                        : hash_combine(elemental_seed, comm->get_rank_in_trainer()));
+    }
+    El::Generator().seed(elemental_seed);
+#endif
+
+  } else {
+    // Seed with a random value.
+    std::random_device rd;
+    unsigned rand_val = rd();
+#ifdef _OPENMP
+    #pragma omp parallel
+    {
+      get_generator().seed(hash_combine(rand_val, omp_get_thread_num()));
+      get_fast_generator().seed(hash_combine(rand_val, omp_get_thread_num()));
+    }
+#else
+    get_generator().seed(rand_val);
+    get_fast_generator().seed(rand_val);
+#endif
+#ifdef LBANN_SET_EL_RNG
+    El::Generator().seed(rand_val);
+#endif
+  }
+
+  init_io_random(seed);
+}
+
+void init_data_seq_random(int seed) {
+  if (seed == -1) {
+    // Seed with a random value.
+    std::random_device rd;
+    seed = rd();
+  }
+
+  ::data_seq_generator_seed_base = seed;
+  ::data_seq_generator_seed_inited = true;
+  /// Reset the init flag so that generator will reinitialize
+  ::data_seq_generator_inited = false;
+}
+
+void init_io_random(int seed) {
+  if (seed == -1) {
+    // Seed with a random value.
+    std::random_device rd;
+    seed = rd();
+  }
+
+  ::io_generator_seed_base = seed;
+  ::io_generator_seed_inited = true;
+  /// Reset the init flag so that generator will reinitialize
+  ::io_generator_inited = false;
+
+  ::fast_io_generator_seed_base = seed;
+  ::fast_io_generator_seed_inited = true;
+  /// Reset the init flag so that generator will reinitialize
+  ::fast_io_generator_inited = false;
+}
+
+}  // namespace lbann

--- a/tests/test_mpi_err_handling.cpp
+++ b/tests/test_mpi_err_handling.cpp
@@ -35,8 +35,7 @@ const int Buf_size = 10000;
 const int Trainer = 0;
 
 int main(int argc, char *argv[]) {
-  int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  world_comm_ptr comm = initialize(argc, argv);
 
   try {
     const int size = comm->get_procs_in_world();
@@ -52,7 +51,7 @@ int main(int argc, char *argv[]) {
 
     else {
       std::vector<int> buf;
-      comm->recv(buf.data(), 0, Trainer, 0); 
+      comm->recv(buf.data(), 0, Trainer, 0);
     }
 
 
@@ -63,4 +62,3 @@ int main(int argc, char *argv[]) {
 
   return EXIT_SUCCESS;
 }
-

--- a/tests/test_shuffled_indices.cpp
+++ b/tests/test_shuffled_indices.cpp
@@ -41,8 +41,11 @@ int mini_batch_size = 128;
 void test_is_shuffled(const generic_data_reader &reader, bool is_shuffled, const char *msg = nullptr);
 
 int main(int argc, char *argv[]) {
+  world_comm_ptr comm = initialize(argc, argv);
+  // Initialize the general RNGs and the data sequence RNGs
   int random_seed = lbann_default_random_seed;
-  world_comm_ptr comm = initialize(argc, argv, random_seed);
+  init_random(random_seed);
+  init_data_seq_random(random_seed);
   const bool master = comm->am_world_master();
 
   try {

--- a/unit_test/MPICatchMain.cpp
+++ b/unit_test/MPICatchMain.cpp
@@ -39,7 +39,7 @@ using namespace unit_test::utilities;
 int main(int argc, char* argv[])
 {
   // Set up the communication domain
-  auto world_comm = lbann::initialize(argc, argv, /*seed=*/13);
+  auto world_comm = lbann::initialize(argc, argv);
   expert::register_world_comm(*world_comm);
 
   // Initialize Catch2

--- a/unit_test/SequentialCatchMain.cpp
+++ b/unit_test/SequentialCatchMain.cpp
@@ -1,2 +1,39 @@
-#define CATCH_CONFIG_MAIN
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+#include <lbann/utils/random.hpp>
+
+int main(int argc, char* argv[]) {
+  // Initialize the general RNGs and the data sequence RNGs
+  int random_seed = 42;
+  lbann::init_random(random_seed);
+  lbann::init_data_seq_random(random_seed);
+
+  int result = Catch::Session().run(argc, argv);
+  return result;
+}

--- a/unit_test/SequentialCatchMain.cpp
+++ b/unit_test/SequentialCatchMain.cpp
@@ -26,7 +26,7 @@
 
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
-#include <lbann/utils/random.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 
 int main(int argc, char* argv[]) {
   // Initialize the general RNGs and the data sequence RNGs


### PR DESCRIPTION
Cleaned up the initialization of the random seed in LBANN library and
associated front ends.  Since the seed can be set by the user for each
trainer, the random seed should be initialized by the construction of
the trainer.  Remove the multiple RNG initializations that occur in
the base.cpp initialize function and multiple times in the
lbann_library construct trainer function.  Now the random seeds are
set by the user (possibly) and then have the trainer and global IDs
mixed in appropriately.  Also fixed a bug where the trainer rank was
never actually properly mixed in with the hash_combine function.  This
also adds the reporting of the user specified parameters to the
contruct_trainer function and properly reports the random seed that is
used.