### PR TITLE
Quick refactor of weights layer

### DIFF
--- a/include/lbann/layers/transform/weights.hpp
+++ b/include/lbann/layers/transform/weights.hpp
@@ -79,31 +79,12 @@ public:
   weights_layer(const weights_layer& other)
     : transform_layer<TensorDataType>(other),
       m_gradient(other.m_gradient ? other.m_gradient->Copy() : nullptr) {
-    if (other.m_workspace) {
-      switch (other.m_workspace->GetDevice()) {
-      case El::Device::CPU: m_workspace.reset(new CPUMatType); break;
-#ifdef LBANN_HAS_GPU
-      case El::Device::GPU: m_workspace.reset(new GPUMatType); break;
-#endif // LBANN_HAS_GPU
-      default: LBANN_ERROR("unknown device type");
-      }
-      m_workspace->SetMemoryMode(other.m_workspace->MemoryMode());
-    }
+    m_workspace.SetMemoryMode(other.m_workspace.MemoryMode());
   }
   weights_layer& operator=(const weights_layer& other){
     transform_layer<TensorDataType>::operator=(other);
     m_gradient.reset(other.m_gradient ? other.m_gradient->Copy() : nullptr);
-    m_workspace.reset();
-    if (other.m_workspace) {
-      switch (other.m_workspace->GetDevice()) {
-      case El::Device::CPU: m_workspace.reset(new CPUMatType); break;
-#ifdef LBANN_HAS_GPU
-      case El::Device::GPU: m_workspace.reset(new GPUMatType); break;
-#endif // LBANN_HAS_GPU
-      default: LBANN_ERROR("unknown device type");
-      }
-      m_workspace->SetMemoryMode(other.m_workspace->MemoryMode());
-    }
+    m_workspace.SetMemoryMode(other.m_workspace.MemoryMode());
     return *this;
   }
   weights_layer* copy() const override { return new weights_layer(*this); }
@@ -122,19 +103,10 @@ public:
     m_gradient.reset(AbsDistMatrixType::Instantiate(dist));
 
     // Initialize workspace
-    switch (Dev) {
-    case El::Device::CPU: m_workspace.reset(new CPUMatType); break;
-#ifdef LBANN_HAS_GPU
-    case El::Device::GPU:
-      m_workspace.reset(new GPUMatType);
-#ifdef HYDROGEN_HAVE_CUB
-      m_workspace->SetMemoryMode(1); // Use CUB GPU memory pool if possible
-#endif // HYDROGEN_HAVE_CUB
-      break;
-#endif // LBANN_HAS_GPU
-    default: LBANN_ERROR("unknown device type");
-    }
-
+#if defined HYDROGEN_HAVE_CUB
+    if (Dev == El::Device::GPU)
+      m_workspace.SetMemoryMode(1); // Use CUB GPU memory pool if possible
+#endif // defined HYDROGEN_HAVE_CUB
   }
 
   void setup_data(size_t max_mini_batch_size) override {
@@ -180,18 +152,18 @@ public:
   void fp_compute() override {
 
     // Matrices
-    const auto& local_weights = this->get_data_type_weights(0).get_values().LockedMatrix();
+    const auto& local_weights =
+      this->get_data_type_weights(0).get_values().LockedMatrix();
     auto& local_output = this->get_local_activations();
-    m_workspace->Resize(local_output.Width(), 1);
-    El::Fill(*m_workspace, El::TypeTraits<TensorDataType>::One());
+    El::Ones(m_workspace, local_output.Width(), 1);
 
     // Duplicate weights across matrix columns
     El::Gemm(El::NORMAL, El::TRANSPOSE,
-             El::TypeTraits<TensorDataType>::One(), local_weights, *m_workspace,
+             El::TypeTraits<TensorDataType>::One(), local_weights, m_workspace,
              El::TypeTraits<TensorDataType>::Zero(), local_output);
 
     // Clean up
-    m_workspace->Empty();
+    m_workspace.Empty();
 
   }
 
@@ -204,16 +176,20 @@ public:
 
     // Matrices
     const auto& local_gradient_wrt_output = this->get_local_prev_error_signals();
-    m_workspace->Resize(local_gradient_wrt_output.Width(), 1);
-    El::Fill(*m_workspace, El::TypeTraits<TensorDataType>::One());
+    El::Ones(m_workspace, local_gradient_wrt_output.Width(), 1);
 
     El::Gemv(El::NORMAL,
-             El::TypeTraits<TensorDataType>::One(), local_gradient_wrt_output, *m_workspace,
-             El::TypeTraits<TensorDataType>::Zero(), m_gradient->Matrix());
-    opt->add_to_gradient(*m_gradient, El::TypeTraits<TensorDataType>::One(), true);
+             El::TypeTraits<TensorDataType>::One(),
+             local_gradient_wrt_output, m_workspace,
+             El::TypeTraits<TensorDataType>::Zero(),
+             m_gradient->Matrix());
+
+    opt->add_to_gradient(*m_gradient,
+                         El::TypeTraits<TensorDataType>::One(),
+                         true);
 
     // Clean up
-    m_workspace->Empty();
+    m_workspace.Empty();
 
   }
 
@@ -222,8 +198,7 @@ public:
   /** Weights gradient. */
   std::unique_ptr<AbsDistMatrixType> m_gradient;
   /** Workspace. */
-  std::unique_ptr<AbsMatrixType> m_workspace;
-
+  El::Matrix<TensorDataType, Dev> m_workspace;
 };
 
 LBANN_DEFINE_LAYER_BUILDER(weights);


### PR DESCRIPTION
We have more static type knowledge that is easy to exploit in this layer.

I doubt that it will be significant in terms of performance, but I did this whilst debugging something else. It didn't fit with the rest of that PR, but I didn't want it to go to waste. In the interest of smaller and easier PRs, I've split it off into this very little PR.