### PR TITLE
Initialize thread-local RNGs used for I/O in a deterministic way

### DIFF
--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -69,6 +69,18 @@ rng_gen& get_io_generator();
  */
 fast_rng_gen& get_fast_io_generator();
 
+/**
+ * Allow each pinned I/O thread to initialize the global LBANN random
+ * number generator used for I/O in a deterministic way.
+ */
+void init_io_generator(const int local_thread_id);
+
+/**
+ * Allow each pinned I/O thread to initialize the fast global LBANN random
+ * number generator used for I/O in a deterministic way.
+ */
+void init_fast_io_generator(const int local_thread_id);
+
 /** @brief Initialize the random number generator (with optional seed).
  *
  *  @param seed Seed value for the random number generator

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -109,6 +109,19 @@ fast_rng_gen& get_fast_io_generator() {
   }
   return ::fast_io_generator;
 }
+
+void init_io_generator(const int local_thread_id) {
+  ::io_generator.seed(hash_combine(::io_generator_seed_base,
+                                   local_thread_id));
+  ::io_generator_inited = true;
+}
+
+void init_fast_io_generator(const int local_thread_id) {
+  ::fast_io_generator.seed(hash_combine(::fast_io_generator_seed_base,
+                                        local_thread_id));
+  ::fast_io_generator_inited = true;
+}
+
 void init_random(int seed, lbann_comm *comm) {
   generator_inited = true;
   fast_generator_inited = true;

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -1,4 +1,5 @@
 #include "lbann/utils/threads/thread_pool.hpp"
+#include "lbann/utils/random_number_generators.hpp"
 
 #include <algorithm>
 #include <iostream>
@@ -145,6 +146,9 @@ void thread_pool::do_thread_work_pinned_thread_(int tid, cpu_set_t cpu_set)
     std::thread::id this_id = std::this_thread::get_id();
     m_thread_id_to_local_id_map[this_id] = tid;
   }
+  init_io_generator(tid);
+  init_fast_io_generator(tid);
+
   while (not all_work_done_)
   {
     auto task = global_work_queue_.wait_and_pop();


### PR DESCRIPTION
Instead of using the thread id, which may change run-to-run, for seeding thread specific RNGs used for I/O, use the local index number assigned to the thread.