### PR TITLE
Allow dump weights to be used with LTFB

### DIFF
--- a/include/lbann/callbacks/dump_weights.hpp
+++ b/include/lbann/callbacks/dump_weights.hpp
@@ -48,8 +48,8 @@ class dump_weights : public callback_base {
   /**
    * @param basename The basename for writing files.
    */
-  dump_weights(std::string basename, El::Int epoch_interval=1) :
-    callback_base(), m_basename(std::move(basename)),
+  dump_weights(std::string dir, El::Int epoch_interval=1) :
+    callback_base(), m_directory(std::move(dir)),
     m_epoch_interval(std::max(El::Int(1),epoch_interval)) {}
   dump_weights(const dump_weights&) = default;
   dump_weights& operator=(
@@ -60,15 +60,15 @@ class dump_weights : public callback_base {
   void on_train_begin(model *m) override;
   void on_epoch_end(model *m) override;
   std::string name() const override { return "dump weights"; }
-  void set_target_dir(const std::string& basename) { m_basename = basename; }
-  const std::string& get_target_dir() { return m_basename; }
+  void set_target_dir(const std::string& dir) { m_directory = dir; }
+  const std::string& get_target_dir() { return m_directory; }
  private:
   /** Basename for writing files. */
-  std::string m_basename;
+  std::string m_directory;
   /** Interval at which to dump weights */
   El::Int m_epoch_interval;
   /// Dump weights from learning layers.
-  void do_dump_weights(model *m, std::string s = "");
+  void do_dump_weights(const model& m, std::string s = "");
 };
 
 // Builder function

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -29,6 +29,8 @@
 #include "lbann/callbacks/dump_weights.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/weights/data_type_weights.hpp"
+//#include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/trainer_file_utils.hpp"
 
 #include <callbacks.pb.h>
 
@@ -38,30 +40,28 @@ namespace lbann {
 namespace callback {
 
 void dump_weights::on_train_begin(model *m) {
-  do_dump_weights(m, "initial");
+  do_dump_weights(*m, "initial");
 }
 
 void dump_weights::on_epoch_end(model *m) {
-  do_dump_weights(m);
+  do_dump_weights(*m);
 }
 
-void dump_weights::do_dump_weights(model *m, std::string s) {
-  const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
+void dump_weights::do_dump_weights(const model& m, std::string s) {
+  const auto& c = static_cast<const sgd_execution_context&>(m.get_execution_context());
 
   if(c.get_epoch() % m_epoch_interval != 0)  return;
 
-  makedir(m_basename.c_str());
-  for (weights *w : m->get_weights()) {
-    std::string epoch = "-epoch" + std::to_string(c.get_epoch()-1);
-    if(s != "") {
-      epoch = "-" + s;
-    }
-    const std::string file
-      = (m_basename
-         + "/" + m->get_name()
-         + epoch
-         + "-" + w->get_name()
-         + "-Weights");
+  // Create directory
+  const std::string root_file_path = get_multi_trainer_model_path(m, m_directory);
+  file::trainer_master_make_directory(root_file_path, m.get_comm());
+
+  //  makedir(m_directory.c_str());
+  for (weights *w : m.get_weights()) {
+    const std::string file = (root_file_path
+                              + c.get_state_string()
+                              + "-" + w->get_name()
+                              + "-Weights");
     const auto* dtw = dynamic_cast<const data_type_weights<DataType>*>(w);
     El::Write(dtw->get_values(), file, El::ASCII);
   }

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -72,7 +72,7 @@ build_dump_weights_callback_from_pbuf(
   const google::protobuf::Message& proto_msg, const std::shared_ptr<lbann_summary>&) {
   const auto& params =
     dynamic_cast<const lbann_data::Callback::CallbackDumpWeights&>(proto_msg);
-  return make_unique<dump_weights>(params.basename(), params.epoch_interval());
+  return make_unique<dump_weights>(params.directory(), params.epoch_interval());
 }
 
 } // namespace callback

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -131,7 +131,7 @@ message Callback {
   }
 
   message CallbackDumpWeights {
-    string basename = 1;
+    string directory = 1;
     int64  epoch_interval = 2;
   }
 


### PR DESCRIPTION
Updated the dump weights callback to properly handly output from 
multiple models and trainers so that they don't clobber each other.