### PR TITLE
Pair RNG with I/O thread work

### DIFF
--- a/bamboo/integration_tests/test_integration_alexnet.py
+++ b/bamboo/integration_tests/test_integration_alexnet.py
@@ -30,8 +30,10 @@ expected_train_accuracy_range = (9, 15)
 expected_test_accuracy_range = (15, 24)
 
 # Average mini-batch time (in sec) for each LC system
+# Note that run times are with LBANN_DETERMINISTIC set
+# Commented out times are prior to thread safe RNGs
 expected_mini_batch_times = {
-    'pascal': 0.100,
+    'pascal': 0.154, # 0.100,
     'lassen': 0.050,
     'ray':    0.075,
 }

--- a/bamboo/integration_tests/test_integration_lenet.py
+++ b/bamboo/integration_tests/test_integration_lenet.py
@@ -30,12 +30,13 @@ expected_test_accuracy_range = (98, 99)
 
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
+# Commented out times are prior to thread safe RNGs
 expected_mini_batch_times = {
-    'pascal':   0.0013,
-    'catalyst': 0.0055,
+    'pascal':   0.0014, # 0.0013,
+    'catalyst': 0.0070, # 0.0055,
     'lassen':   0.0022,
     'ray':      0.0025,
-    'corona':   0.0075,
+    'corona':   0.0117, # 0.0075,
 }
 
 # ==============================================

--- a/bamboo/integration_tests/test_integration_lenet.py
+++ b/bamboo/integration_tests/test_integration_lenet.py
@@ -33,7 +33,7 @@ expected_test_accuracy_range = (98, 99)
 # Commented out times are prior to thread safe RNGs
 expected_mini_batch_times = {
     'pascal':   0.0014, # 0.0013,
-    'catalyst': 0.0070, # 0.0055,
+    'catalyst': 0.0073, # 0.0055,
     'lassen':   0.0022,
     'ray':      0.0025,
     'corona':   0.0117, # 0.0075,

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -37,7 +37,6 @@
 #include "lbann/io/file_io.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/utils/options.hpp"
-#include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/transforms/transform_pipeline.hpp"
 #include <cassert>
 #include <algorithm>
@@ -57,6 +56,7 @@
 namespace lbann {
 
 class data_store_conduit;
+class thread_pool;
 class trainer;
 
 /**

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -692,7 +692,7 @@ class generic_data_reader {
 
   lbann_comm *m_comm;
 
-  virtual bool fetch_data_block(CPUMat& X, El::Int thread_index, El::Int mb_size, El::Matrix<El::Int>& indices_fetched);
+  virtual bool fetch_data_block(CPUMat& X, El::Int block_offset, El::Int block_stride, El::Int mb_size, El::Matrix<El::Int>& indices_fetched);
 
   /**
    * Fetch a single sample into a matrix.

--- a/include/lbann/data_readers/data_reader_python.hpp
+++ b/include/lbann/data_readers/data_reader_python.hpp
@@ -60,7 +60,8 @@ public:
 
 protected:
   bool fetch_data_block(CPUMat& X,
-                        El::Int thread_id,
+                        El::Int block_offset,
+                        El::Int block_stride,
                         El::Int mb_size,
                         El::Matrix<El::Int>& indices_fetched) override;
   bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -214,7 +214,5 @@
 #include "lbann/utils/peek_map.hpp"
 #include "lbann/utils/stack_trace.hpp"
 #include "lbann/utils/stack_profiler.hpp"
-#include "lbann/utils/threads/thread_pool.hpp"
-#include "lbann/utils/threads/thread_utils.hpp"
 
 #endif // LBANN_LBANN_HPP_INCLUDED

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -35,6 +35,7 @@ namespace lbann {
 const int lbann_default_random_seed = 42;
 
 #define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
+#define NUM_IO_THREADS "Num. IO threads"
 
 void construct_std_options();
 

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -36,6 +36,7 @@ const int lbann_default_random_seed = 42;
 
 #define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
 #define NUM_IO_THREADS "Num. IO threads"
+#define STRICT_IO_THREAD_PINNING "Strict IO thread pinning"
 
 void construct_std_options();
 

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -36,7 +36,6 @@ const int lbann_default_random_seed = 42;
 
 #define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
 #define NUM_IO_THREADS "Num. IO threads"
-#define STRICT_IO_THREAD_PINNING "Strict IO thread pinning"
 
 void construct_std_options();
 

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -56,6 +56,11 @@ fast_rng_gen& get_fast_generator();
 rng_gen& get_data_seq_generator();
 
 /**
+ * Sets the local index for a thread to access the correct I/O RNGs.
+ */
+void set_io_generators_local_index(size_t idx);
+
+/**
  * Return a reference to the global LBANN random number generator used
  * for shuffling the data samples within each mini-batch
  * @note This is stored in a thread_local variable.
@@ -76,7 +81,7 @@ fast_rng_gen& get_fast_io_generator();
  *              into the seed; if not, uses the MPI world rank.
  *
  */
-void init_random(int seed = -1, lbann_comm *comm = nullptr);
+void init_random(int seed = -1, int num_io_RNGs = 1, lbann_comm *comm = nullptr);
 
 /**
  * Initialize a random number generator (with optional seed) that is
@@ -91,10 +96,11 @@ void init_data_seq_random(int seed = -1);
  * Initialize a random number generator (with optional seed) that is
  * specifically used by the I/O threads for tasks such as data
  * preprocessing, etc.
+ * Includes the number of I/O RNGs required.
  *
  * Called from init_random
  */
-void init_io_random(int seed = -1);
+void init_io_random(int seed = -1, int num_io_RNGs = 1);
 
 } // namespace lbann
 

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -55,9 +55,7 @@ fast_rng_gen& get_fast_generator();
  */
 rng_gen& get_data_seq_generator();
 
-/**
- * Sets the local index for a thread to access the correct I/O RNGs.
- */
+/** @brief Sets the local index for a thread to access the correct I/O RNGs. */
 void set_io_generators_local_index(size_t idx);
 
 /**

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -29,11 +29,20 @@
 
 #include "lbann/comm.hpp"
 #include <random>
+#include <mutex>
+#include <thread>
 
 namespace lbann {
 
 using rng_gen = std::mt19937;  // Mersenne Twister
 using fast_rng_gen = std::minstd_rand;  // Minimum standard, LC
+
+struct io_rng_t {
+  lbann::rng_gen io_generator;
+  lbann::fast_rng_gen fast_io_generator;
+  std::unique_ptr<std::mutex> io_mutex;
+  std::thread::id active_thread_id;
+};
 
 /**
  * Return a reference to the global LBANN random number generator.
@@ -56,7 +65,7 @@ fast_rng_gen& get_fast_generator();
 rng_gen& get_data_seq_generator();
 
 /** @brief Sets the local index for a thread to access the correct I/O RNGs. */
-void set_io_generators_local_index(size_t idx);
+io_rng_t& set_io_generators_local_index(size_t idx);
 
 /**
  * Return a reference to the global LBANN random number generator used

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -41,6 +41,8 @@ struct io_rng_t {
   lbann::rng_gen io_generator;
   lbann::fast_rng_gen fast_io_generator;
   std::unique_ptr<std::mutex> io_mutex;
+  // Track the owner so that it is easy to ensure the right thread is
+  // using this structure.
   std::thread::id active_thread_id;
 };
 
@@ -63,6 +65,9 @@ fast_rng_gen& get_fast_generator();
  * @note This is stored in a thread_local variable.
  */
 rng_gen& get_data_seq_generator();
+
+/** @brief Returns the number of provisioned I/O generators. */
+int get_num_io_generators();
 
 /** @brief Sets the local index for a thread to access the correct I/O RNGs. */
 io_rng_t& set_io_generators_local_index(size_t idx);

--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -38,9 +38,9 @@ using rng_gen = std::mt19937;  // Mersenne Twister
 using fast_rng_gen = std::minstd_rand;  // Minimum standard, LC
 
 struct io_rng_t {
-  lbann::rng_gen io_generator;
-  lbann::fast_rng_gen fast_io_generator;
-  std::unique_ptr<std::mutex> io_mutex;
+  lbann::rng_gen generator;
+  lbann::fast_rng_gen fast_generator;
+  std::unique_ptr<std::mutex> mutex;
   // Track the owner so that it is easy to ensure the right thread is
   // using this structure.
   std::thread::id active_thread_id;
@@ -51,7 +51,7 @@ struct locked_io_rng_ref {
   std::unique_lock<std::mutex> lock_;
   locked_io_rng_ref(io_rng_t& rng)
     : rng_(&rng),
-      lock_(*(rng.io_mutex.get()))
+      lock_(*(rng.mutex.get()))
   {
     rng_->active_thread_id = std::this_thread::get_id();
   }

--- a/include/lbann/utils/threads/CMakeLists.txt
+++ b/include/lbann/utils/threads/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_full_path(THIS_DIR_HEADERS
   thread_pool.hpp
   thread_safe_queues.hpp
+  thread_topology.hpp
   type_erased_function.hpp
   memory.hpp
   thread_utils.hpp

--- a/include/lbann/utils/threads/thread_pool.hpp
+++ b/include/lbann/utils/threads/thread_pool.hpp
@@ -7,6 +7,13 @@
 #include "type_erased_function.hpp"
 #include "lbann/utils/exception.hpp"
 
+#if defined(LBANN_TOPO_AWARE)
+#include <hwloc.h>
+#if defined(HWLOC_API_VERSION) && (HWLOC_API_VERSION < 0x00010b00)
+#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
+#endif
+#endif
+
 #include <sched.h>
 
 #include <future>
@@ -115,9 +122,9 @@ public:
 private:
   /** @brief The task executed by each thread */
   void do_thread_work_();
-#ifdef LBANN_HAS_PTHREAD_AFFINITY_SUPPORT
-  void do_thread_work_pinned_thread_(int tid, cpu_set_t cpu_set);
-#endif // LBANN_HAS_PTHREAD_AFFINITY_SUPPORT
+#if defined(LBANN_TOPO_AWARE)
+  void do_thread_work_pinned_thread_(int tid, hwloc_topology_t topo, hwloc_cpuset_t cpuset);
+#endif // LBANN_TOPO_AWARE
 private:
 
   /** @brief Container holding the threads */

--- a/include/lbann/utils/threads/thread_topology.hpp
+++ b/include/lbann/utils/threads/thread_topology.hpp
@@ -1,0 +1,64 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_HW_TOPOLOGY_HPP_INCLUDED
+#define LBANN_UTILS_HW_TOPOLOGY_HPP_INCLUDED
+
+// Defines, among other things, DataType.
+#include "lbann_config.hpp"
+
+#if defined(LBANN_TOPO_AWARE)
+#include <hwloc.h>
+#if defined(HWLOC_API_VERSION) && (HWLOC_API_VERSION < 0x00010b00)
+#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
+#endif
+#endif
+
+namespace lbann {
+  int get_num_numa_nodes();
+#if defined(LBANN_TOPO_AWARE)
+  void hwloc_print_topo();
+
+  int hwloc_bitmap_singlify_per_core(hwloc_topology_t topology, hwloc_bitmap_t cpuset, unsigned which);
+
+
+  hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo);
+
+  /** @brief Return the allocated cpuset for the current thread, masking out
+   *  PUs from spurious "unbound" cores.
+   *  Allocates a bitmap that must be freed by calling function */
+  hwloc_cpuset_t get_allocated_cpuset_for_current_thread(const hwloc_topology_t topo);
+
+  /** @brief Given two sets of CPU bitmaps return the common set of
+      cores */
+  void find_common_core_set_from_cpu_masks(hwloc_topology_t topo,
+                                           hwloc_bitmap_t core_set,
+                                           hwloc_bitmap_t primary_set,
+                                           hwloc_bitmap_t ht_set);
+#endif // LBANN_TOPO_AWAR
+}
+
+#endif // LBANN_UTILS_HW_TOPOLOGY_HPP_INCLUDED

--- a/include/lbann/utils/threads/thread_utils.hpp
+++ b/include/lbann/utils/threads/thread_utils.hpp
@@ -31,7 +31,6 @@
 
 namespace lbann {
 
-int num_available_cores_in_cpuset();
 int num_free_cores_per_process(const lbann_comm *comm);
 int free_core_offset(const lbann_comm *comm);
 

--- a/include/lbann/utils/threads/thread_utils.hpp
+++ b/include/lbann/utils/threads/thread_utils.hpp
@@ -31,6 +31,7 @@
 
 namespace lbann {
 
+int num_available_cores_in_cpuset();
 int num_free_cores_per_process(const lbann_comm *comm);
 int free_core_offset(const lbann_comm *comm);
 

--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -65,7 +65,8 @@ def make_batch_script(
         set_environment('AL_PROGRESS_RANKS_PER_NUMA_NODE', procs_per_node)
         set_environment('OMP_NUM_THREADS', cores_per_proc - 1)
         if scheduler == 'slurm':
-            masks = [2**cores_per_proc - 1]
+            # Include the hyperthreaded cores in the mask
+            masks = [2**cores_per_proc - 1 | ((2**cores_per_proc - 1) << 2*cores_per_socket)]
             while len(masks) < procs_per_node:
                 masks.append(masks[-1] << cores_per_proc)
             mask_str = ','.join([hex(mask) for mask in masks])

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -146,14 +146,25 @@ int lbann::generic_data_reader::fetch_data(CPUMat& X, El::Matrix<El::Int>& indic
     set_jag_variables(mb_size);
   }
 
+  // Fetch data is executed by the thread pool so it has to dispatch
+  // work to other threads in the thread pool and do some work locally
   for (int t = 0; t < static_cast<int>(m_io_thread_pool->get_num_threads()); t++) {
     // Queue up work into other threads and then finish off the
     // mini-batch in the active thread
-    m_io_thread_pool->submit_job_to_work_group(
-      std::bind(&generic_data_reader::fetch_data_block, this, std::ref(X), t,
-                m_io_thread_pool->get_num_threads(),
-                mb_size, std::ref(indices_fetched)));
+    if(t == m_io_thread_pool->get_local_thread_id()) {
+      continue;
+    }else {
+      m_io_thread_pool->submit_job_to_work_group(
+        std::bind(&generic_data_reader::fetch_data_block, this, std::ref(X), t,
+                  m_io_thread_pool->get_num_threads(),
+                  mb_size, std::ref(indices_fetched)));
+    }
   }
+  fetch_data_block(X,
+                   m_io_thread_pool->get_local_thread_id(),
+                   m_io_thread_pool->get_num_threads(),
+                   mb_size,
+                   indices_fetched);
 
   // Wait for all of the threads to finish
   m_io_thread_pool->finish_work_group();

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -92,6 +92,8 @@ bool lbann::generic_data_reader::fetch_data_block(CPUMat& X, El::Int block_offse
     }
     indices_fetched.Set(s, 0, index);
   }
+
+  io_rng.active_thread_id = std::thread::id();
   return true;
 }
 

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -79,7 +79,10 @@ void generic_data_reader::setup(int num_io_threads, observer_ptr<thread_pool> io
 
 
 bool lbann::generic_data_reader::fetch_data_block(CPUMat& X, El::Int block_offset, El::Int block_stride, El::Int mb_size, El::Matrix<El::Int>& indices_fetched) {
-  set_io_generators_local_index(block_offset);
+  io_rng_t& io_rng = set_io_generators_local_index(block_offset);
+  const std::lock_guard<std::mutex> lock(*(io_rng.io_mutex.get()));
+  io_rng.active_thread_id = std::this_thread::get_id();
+
   for (int s = block_offset; s < mb_size; s+=block_stride) {
     int n = m_current_pos + (s * m_sample_stride);
     int index = m_shuffled_indices[n];

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -29,6 +29,7 @@
 #include "lbann/data_readers/data_reader.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
 #include "lbann/utils/omp_pragma.hpp"
+#include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/trainers/trainer.hpp"
 #include <omp.h>
 #include <future>

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -79,9 +79,7 @@ void generic_data_reader::setup(int num_io_threads, observer_ptr<thread_pool> io
 
 
 bool lbann::generic_data_reader::fetch_data_block(CPUMat& X, El::Int block_offset, El::Int block_stride, El::Int mb_size, El::Matrix<El::Int>& indices_fetched) {
-  io_rng_t& io_rng = set_io_generators_local_index(block_offset);
-  const std::lock_guard<std::mutex> lock(*(io_rng.io_mutex.get()));
-  io_rng.active_thread_id = std::this_thread::get_id();
+  locked_io_rng_ref io_rng = set_io_generators_local_index(block_offset);
 
   for (int s = block_offset; s < mb_size; s+=block_stride) {
     int n = m_current_pos + (s * m_sample_stride);
@@ -93,7 +91,6 @@ bool lbann::generic_data_reader::fetch_data_block(CPUMat& X, El::Int block_offse
     indices_fetched.Set(s, 0, index);
   }
 
-  io_rng.active_thread_id = std::thread::id();
   return true;
 }
 

--- a/src/data_readers/data_reader_python.cpp
+++ b/src/data_readers/data_reader_python.cpp
@@ -106,13 +106,14 @@ int python_reader::get_linearized_label_size() const {
 }
 
 bool python_reader::fetch_data_block(CPUMat& X,
-                                     El::Int thread_id,
+                                     El::Int block_offset,
+                                     El::Int block_stride,
                                      El::Int mb_size,
                                      El::Matrix<El::Int>& indices_fetched) {
 
   // Acquire Python GIL on first IO thread
   // Note: Do nothing on other IO threads.
-  if (thread_id != 0) { return true; }
+  if (block_offset != 0) { return true; }
   python::global_interpreter_lock gil;
 
   // Check that shared memory array is large enough

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -871,8 +871,6 @@ void print_help(std::ostream& os)
        "  --hydrogen_block_size=<int>\n"
        "  --procs_per_trainer=<int>\n"
        "  --num_parallel_readers=<int>\n"
-       "  --num_io_threads=<int>\n"
-       "      # of threads used for I/O by the data readers\n"
        "  --serialize_io=<bool>\n"
        "      force data readers to use a single thread for I/O\n"
        "  --disable_background_io_activity=<bool>\n"

--- a/src/transforms/vision/unit_test/horizontal_flip_test.cpp
+++ b/src/transforms/vision/unit_test/horizontal_flip_test.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE("Testing horizontal flip preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     zeros(mat.template get<uint8_t>(), 3, 3, 1);

--- a/src/transforms/vision/unit_test/horizontal_flip_test.cpp
+++ b/src/transforms/vision/unit_test/horizontal_flip_test.cpp
@@ -3,12 +3,13 @@
 
 // File being tested
 #include <lbann/transforms/vision/horizontal_flip.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 TEST_CASE("Testing horizontal flip preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     zeros(mat.template get<uint8_t>(), 3, 3, 1);

--- a/src/transforms/vision/unit_test/random_affine_test.cpp
+++ b/src/transforms/vision/unit_test/random_affine_test.cpp
@@ -8,6 +8,8 @@
 // Note: This is *random* so we only do basic checks.
 TEST_CASE("Testing random affine preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
   // For simplicity, we'll only use a 3-channel matrix here.
   identity(mat.template get<uint8_t>(), 10, 10, 3);
   std::vector<size_t> dims = {3, 10, 10};

--- a/src/transforms/vision/unit_test/random_affine_test.cpp
+++ b/src/transforms/vision/unit_test/random_affine_test.cpp
@@ -3,13 +3,14 @@
 
 // File being tested
 #include <lbann/transforms/vision/random_affine.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 // Note: This is *random* so we only do basic checks.
 TEST_CASE("Testing random affine preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
   // For simplicity, we'll only use a 3-channel matrix here.
   identity(mat.template get<uint8_t>(), 10, 10, 3);
   std::vector<size_t> dims = {3, 10, 10};

--- a/src/transforms/vision/unit_test/random_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_crop_test.cpp
@@ -3,12 +3,13 @@
 
 // File being tested
 #include <lbann/transforms/vision/random_crop.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 TEST_CASE("Testing random crop preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/random_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_crop_test.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE("Testing random crop preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/random_resized_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_test.cpp
@@ -3,12 +3,13 @@
 
 // File being tested
 #include <lbann/transforms/vision/random_resized_crop.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 TEST_CASE("Testing random resized crop preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/random_resized_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_test.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE("Testing random resized crop preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
@@ -5,12 +5,13 @@
 #include <lbann/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.hpp>
 #include <lbann/transforms/vision/resize.hpp>
 #include <lbann/transforms/vision/random_crop.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 TEST_CASE("Testing random resized crop with fixed aspect ratio preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
@@ -9,6 +9,8 @@
 
 TEST_CASE("Testing random resized crop with fixed aspect ratio preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     ones(mat.template get<uint8_t>(), 5, 5, 1);

--- a/src/transforms/vision/unit_test/vertical_flip_test.cpp
+++ b/src/transforms/vision/unit_test/vertical_flip_test.cpp
@@ -3,12 +3,13 @@
 
 // File being tested
 #include <lbann/transforms/vision/vertical_flip.hpp>
+#include <lbann/utils/random_number_generators.hpp>
 #include "helper.hpp"
 
 TEST_CASE("Testing vertical flip preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
   // Grab the necessary I/O RNG and lock it
-  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
+  lbann::locked_io_rng_ref io_rng = lbann::set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     zeros(mat.template get<uint8_t>(), 3, 3, 1);

--- a/src/transforms/vision/unit_test/vertical_flip_test.cpp
+++ b/src/transforms/vision/unit_test/vertical_flip_test.cpp
@@ -7,6 +7,8 @@
 
 TEST_CASE("Testing vertical flip preprocessing", "[preproc]") {
   lbann::utils::type_erased_matrix mat = lbann::utils::type_erased_matrix(El::Matrix<uint8_t>());
+  // Grab the necessary I/O RNG and lock it
+  locked_io_rng_ref& io_rng = set_io_generators_local_index(0);
 
   SECTION("matrix with one channel") {
     zeros(mat.template get<uint8_t>(), 3, 3, 1);

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -55,11 +55,6 @@ void construct_std_options() {
                         "Number of threads available to both I/O and "
                         "initial data transformations for each rank.",
                         64);
-  arg_parser.add_flag(STRICT_IO_THREAD_PINNING,
-                      {"--strict_io_thread_pinning"},
-                      utils::ENV("LBANN_STRICT_IO_THREAD_PINNING"),
-                      "Restrict the Number of I/O threads to the number of "
-                      "available cores.");
 }
 
 /// Construct a trainer that contains a lbann comm object and threadpool

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -46,13 +46,20 @@ void construct_std_options() {
   arg_parser.add_option(MAX_RNG_SEEDS_DISPLAY,
                         {"--rng_seeds_per_trainer_to_display"},
                         utils::ENV("LBANN_RNG_SEEDS_PER_TRAINER_TO_DISPLAY"),
-                        "Limit how many random seeds LBANN should display from each trainer",
+                        "Limit how many random seeds LBANN should display "
+                        "from each trainer",
                         2);
   arg_parser.add_option(NUM_IO_THREADS,
                         {"--num_io_threads"},
                         utils::ENV("LBANN_NUM_IO_THREADS"),
-                        "Number of threads available to both I/O and initial data transformations for each rank.",
-                        24);
+                        "Number of threads available to both I/O and "
+                        "initial data transformations for each rank.",
+                        64);
+  arg_parser.add_flag(STRICT_IO_THREAD_PINNING,
+                      {"--strict_io_thread_pinning"},
+                      utils::ENV("LBANN_STRICT_IO_THREAD_PINNING"),
+                      "Restrict the Number of I/O threads to the number of "
+                      "available cores.");
 }
 
 /// Construct a trainer that contains a lbann comm object and threadpool

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -175,7 +175,7 @@ std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
 #endif
 
     // Initialize the general RNGs and the data sequence RNGs
-    init_random(random_seed);
+    init_random(random_seed, io_threads_per_process);
     init_data_seq_random(data_seq_random_seed);
     trainer->set_random_seeds(root_random_seed, random_seed, data_seq_random_seed);
 

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -77,12 +77,9 @@ bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
     std::ofstream rng_fast_io(rng_name);
     if(!rng_fast_io) { LBANN_ERROR("Failed to open ", rng_name); }
 
-    io_rng_t& io_rng = set_io_generators_local_index(i);
-    const std::lock_guard<std::mutex> lock(*(io_rng.io_mutex.get()));
-    io_rng.active_thread_id = std::this_thread::get_id();
+    locked_io_rng_ref io_rng = set_io_generators_local_index(i);
     rng_io << get_io_generator();
     rng_fast_io << get_fast_io_generator();
-    io_rng.active_thread_id = std::thread::id();
 
     rng_io.close();
     rng_fast_io.close();
@@ -165,12 +162,9 @@ bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm) {
     std::ifstream rng_fast_io(rng_name);
     if(!rng_fast_io) { LBANN_ERROR("Failed to open ", rng_name); }
 
-    io_rng_t& io_rng = set_io_generators_local_index(i);
-    const std::lock_guard<std::mutex> lock(*(io_rng.io_mutex.get()));
-    io_rng.active_thread_id = std::this_thread::get_id();
+    locked_io_rng_ref io_rng = set_io_generators_local_index(i);
     rng_io >> get_io_generator();
     rng_fast_io >> get_fast_io_generator();
-    io_rng.active_thread_id = std::thread::id();
   }
 
 

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -86,6 +86,10 @@ rng_gen& get_data_seq_generator() {
   return ::data_seq_generator;
 }
 
+int get_num_io_generators() {
+  return ::io_generators.size();
+}
+
 io_rng_t& set_io_generators_local_index(size_t idx) {
   ::local_io_generators_index = idx;
   if (!::io_generators_inited) { LBANN_ERROR("I/O RNG seed not set"); }

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -102,7 +102,7 @@ rng_gen& get_io_generator() {
   if (io_rng.active_thread_id != std::this_thread::get_id()) {
     LBANN_ERROR("I/O RNG illegal thread access");
   }
-  return io_rng.io_generator;
+  return io_rng.generator;
 }
 
 fast_rng_gen& get_fast_io_generator() {
@@ -111,7 +111,7 @@ fast_rng_gen& get_fast_io_generator() {
   if (io_rng.active_thread_id != std::this_thread::get_id()) {
     LBANN_ERROR("I/O RNG illegal thread access");
   }
-  return io_rng.fast_io_generator;
+  return io_rng.fast_generator;
 }
 
 void init_random(int seed, int num_io_RNGs, lbann_comm *comm) {
@@ -195,9 +195,9 @@ void init_io_random(int seed, int num_io_RNGs) {
   ::io_generators.resize(num_io_RNGs);
   for(int i = 0; i < num_io_RNGs; i++) {
     auto& io_rng = ::io_generators[i];
-    io_rng.io_generator.seed(hash_combine(seed_base, i));
-    io_rng.fast_io_generator.seed(hash_combine(seed_base, i));
-    io_rng.io_mutex = make_unique<std::mutex>();
+    io_rng.generator.seed(hash_combine(seed_base, i));
+    io_rng.fast_generator.seed(hash_combine(seed_base, i));
+    io_rng.mutex = make_unique<std::mutex>();
     io_rng.active_thread_id = std::thread::id();
   }
 }

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -191,7 +191,6 @@ void init_io_random(int seed, int num_io_RNGs) {
     seed_base = rd();
   }
 
-  ::io_generators_inited = true;
   ::io_generators.resize(num_io_RNGs);
   for(int i = 0; i < num_io_RNGs; i++) {
     auto& io_rng = ::io_generators[i];
@@ -200,6 +199,7 @@ void init_io_random(int seed, int num_io_RNGs) {
     io_rng.mutex = make_unique<std::mutex>();
     io_rng.active_thread_id = std::thread::id();
   }
+  ::io_generators_inited = true;
 }
 
 }  // namespace lbann

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -90,10 +90,10 @@ int get_num_io_generators() {
   return ::io_generators.size();
 }
 
-io_rng_t& set_io_generators_local_index(size_t idx) {
+locked_io_rng_ref set_io_generators_local_index(size_t idx) {
   ::local_io_generators_index = idx;
   if (!::io_generators_inited) { LBANN_ERROR("I/O RNG seed not set"); }
-  return ::io_generators[idx];
+  return locked_io_rng_ref(::io_generators[idx]);
 }
 
 rng_gen& get_io_generator() {

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -194,7 +194,7 @@ void init_io_random(int seed, int num_io_RNGs) {
     io_rng.io_generator.seed(hash_combine(seed_base, i));
     io_rng.fast_io_generator.seed(hash_combine(seed_base, i));
     io_rng.io_mutex = make_unique<std::mutex>();
-    io_rng.active_thread_id = std::this_thread::get_id();
+    io_rng.active_thread_id = std::thread::id();
   }
 }
 

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -95,7 +95,7 @@ rng_gen& get_data_seq_generator() {
 void set_io_generators_local_index(size_t idx) { ::local_io_generators_index = idx; }
 
 rng_gen& get_io_generator() {
-  size_t idx = ::local_io_generators_index;
+  const size_t idx = ::local_io_generators_index;
   if (!::io_generator_inited[idx]) {
     if (!::io_generator_seed_inited) { LBANN_ERROR("I/O RNG seed not set"); }
     ::io_generator[idx].seed(hash_combine(::io_generator_seed_base, idx));
@@ -105,7 +105,7 @@ rng_gen& get_io_generator() {
 }
 
 fast_rng_gen& get_fast_io_generator() {
-  size_t idx = ::local_io_generators_index;
+  const size_t idx = ::local_io_generators_index;
   if (!::fast_io_generator_inited[idx]) {
     if (!::fast_io_generator_seed_inited) { LBANN_ERROR("Fast I/O RNG seed not set"); }
     ::fast_io_generator[idx].seed(hash_combine(::fast_io_generator_seed_base, idx));

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -99,7 +99,7 @@ locked_io_rng_ref set_io_generators_local_index(size_t idx) {
 rng_gen& get_io_generator() {
   const size_t idx = ::local_io_generators_index;
   io_rng_t& io_rng = ::io_generators[idx];
-  if (io_rng.active_thread_id != std::this_thread::get_id()) {
+  if (io_rng.active_thread_id.load() != std::this_thread::get_id()) {
     LBANN_ERROR("I/O RNG illegal thread access");
   }
   return io_rng.generator;
@@ -108,7 +108,7 @@ rng_gen& get_io_generator() {
 fast_rng_gen& get_fast_io_generator() {
   const size_t idx = ::local_io_generators_index;
   io_rng_t& io_rng = ::io_generators[idx];
-  if (io_rng.active_thread_id != std::this_thread::get_id()) {
+  if (io_rng.active_thread_id.load() != std::this_thread::get_id()) {
     LBANN_ERROR("I/O RNG illegal thread access");
   }
   return io_rng.fast_generator;
@@ -196,8 +196,7 @@ void init_io_random(int seed, int num_io_RNGs) {
     auto& io_rng = ::io_generators[i];
     io_rng.generator.seed(hash_combine(seed_base, i));
     io_rng.fast_generator.seed(hash_combine(seed_base, i));
-    io_rng.mutex = make_unique<std::mutex>();
-    io_rng.active_thread_id = std::thread::id();
+    io_rng.active_thread_id.store(std::thread::id());
   }
   ::io_generators_inited = true;
 }

--- a/src/utils/threads/CMakeLists.txt
+++ b/src/utils/threads/CMakeLists.txt
@@ -32,6 +32,7 @@ endif ()
 set_full_path(THIS_DIR_SOURCES
   thread_pool.cpp
   thread_utils.cpp
+  thread_topology.cpp
 )
 
 # Propagate the files up the tree

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -3,11 +3,8 @@
 #include "lbann/utils/lbann_library.hpp"
 #include "lbann/utils/threads/thread_topology.hpp"
 
-#include <hydrogen/device/gpu/CUDA.hpp>
-
 #if defined(LBANN_TOPO_AWARE)
 #include <hwloc.h>
-#include <hwloc/cudart.h>
 #if defined(HWLOC_API_VERSION) && (HWLOC_API_VERSION < 0x00010b00)
 #define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
 #endif

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -67,7 +67,7 @@ void thread_pool::launch_pinned_threads(
                                       sizeof(cpu_set_t), &cpuset);
 
   if (error != 0) {
-    std::cerr << "error in pthread_getaffinity_np, error=" << error
+    std::cerr << "error in pthread_getaffinity_np, error=" << strerror(error)
               << std::endl;
   }
 
@@ -156,7 +156,7 @@ void thread_pool::do_thread_work_pinned_thread_(int tid, cpu_set_t cpu_set)
                                       sizeof(cpu_set_t), &cpu_set);
   if (error != 0) {
     std::cerr << "error in pthread_setaffinity_np, error="
-              << error << std::endl;
+              << strerror(error) << std::endl;
   }
 
   {

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -73,10 +73,10 @@ void thread_pool::launch_pinned_threads(
   int err;
   /* initialize a topology context */
   err = hwloc_topology_init(&topo);
-  if(!err) { LBANN_ERROR("hwloc_topology_init failed"); }
+  if(err) { LBANN_ERROR("hwloc_topology_init failed"); }
   /* build the topology created and configured above */
   err = hwloc_topology_load(topo);
-  if(!err) { LBANN_ERROR("hwloc_topology_load failed"); }
+  if(err) { LBANN_ERROR("hwloc_topology_load failed"); }
   // Get the number of PUs per core
   // hwloc_obj_t core = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0);
   m_threads_offset = PU_offset;
@@ -112,7 +112,7 @@ void thread_pool::launch_pinned_threads(
       hwloc_cpuset_t ht_cpuset = hwloc_bitmap_dup(iot_cpuset);
       hwloc_topology_t ht_topo;
       err = hwloc_topology_dup(&ht_topo, topo);
-      if(!err) { LBANN_ERROR("hwloc_topology_dup failed"); }
+      if(err) { LBANN_ERROR("hwloc_topology_dup failed"); }
       threads_.emplace_back(&thread_pool::do_thread_work_pinned_thread_,
                             this, cnt, ht_topo, ht_cpuset);
     }

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -1,7 +1,7 @@
 #include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/lbann_library.hpp"
-#include "lbann/utils/hw_topology.hpp"
+#include "lbann/utils/threads/thread_topology.hpp"
 
 #include <hydrogen/device/gpu/CUDA.hpp>
 
@@ -73,9 +73,10 @@ void thread_pool::launch_pinned_threads(
   int err;
   /* initialize a topology context */
   err = hwloc_topology_init(&topo);
-  assert(!err);
+  if(!err) { LBANN_ERROR("hwloc_topology_init failed"); }
   /* build the topology created and configured above */
   err = hwloc_topology_load(topo);
+  if(!err) { LBANN_ERROR("hwloc_topology_load failed"); }
   // Get the number of PUs per core
   // hwloc_obj_t core = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0);
   m_threads_offset = PU_offset;
@@ -111,7 +112,7 @@ void thread_pool::launch_pinned_threads(
       hwloc_cpuset_t ht_cpuset = hwloc_bitmap_dup(iot_cpuset);
       hwloc_topology_t ht_topo;
       err = hwloc_topology_dup(&ht_topo, topo);
-      assert(!err);
+      if(!err) { LBANN_ERROR("hwloc_topology_dup failed"); }
       threads_.emplace_back(&thread_pool::do_thread_work_pinned_thread_,
                             this, cnt, ht_topo, ht_cpuset);
     }

--- a/src/utils/threads/thread_topology.cpp
+++ b/src/utils/threads/thread_topology.cpp
@@ -168,7 +168,7 @@ hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo) {
 hwloc_cpuset_t get_allocated_cpuset_for_current_thread(hwloc_topology_t topo) {
   hwloc_cpuset_t current_cpuset = hwloc_bitmap_alloc();
   int err = hwloc_get_cpubind(topo, current_cpuset, 0);
-  if(!err) { LBANN_ERROR("Unable to execute hwloc_get_cpubind"); }
+  if(err) { LBANN_ERROR("Unable to execute hwloc_get_cpubind"); }
 
   hwloc_cpuset_t PU_core_set = hwloc_bitmap_alloc();
   // Primary core set
@@ -177,9 +177,9 @@ hwloc_cpuset_t get_allocated_cpuset_for_current_thread(hwloc_topology_t topo) {
   hwloc_cpuset_t ht_PU_core_set = hwloc_bitmap_dup(current_cpuset);
   // Get the list of available cores without hyperthreads
   err = hwloc_bitmap_singlify_per_core(topo, primary_PU_core_set, 0);
-  if(!err) { LBANN_ERROR("Unable to singlify the cpuset"); }
+  if(err) { LBANN_ERROR("Unable to singlify the cpuset"); }
   err = hwloc_bitmap_singlify_per_core(topo, ht_PU_core_set, 1);
-  if(!err) { LBANN_ERROR("Unable to singlify the cpuset"); }
+  if(err) { LBANN_ERROR("Unable to singlify the cpuset"); }
 
   if(!hwloc_bitmap_iszero(ht_PU_core_set)) {
     find_common_core_set_from_cpu_masks(topo, PU_core_set, primary_PU_core_set, ht_PU_core_set);

--- a/src/utils/threads/thread_topology.cpp
+++ b/src/utils/threads/thread_topology.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <lbann/utils/threads/thread_topology.hpp>
+#include <lbann/utils/exception.hpp>
 
 #if defined(LBANN_TOPO_AWARE)
 #include <hwloc.h>
@@ -167,7 +168,7 @@ hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo) {
 hwloc_cpuset_t get_allocated_cpuset_for_current_thread(hwloc_topology_t topo) {
   hwloc_cpuset_t current_cpuset = hwloc_bitmap_alloc();
   int err = hwloc_get_cpubind(topo, current_cpuset, 0);
-  assert(!err);
+  if(!err) { LBANN_ERROR("Unable to execute hwloc_get_cpubind"); }
 
   hwloc_cpuset_t PU_core_set = hwloc_bitmap_alloc();
   // Primary core set
@@ -176,9 +177,9 @@ hwloc_cpuset_t get_allocated_cpuset_for_current_thread(hwloc_topology_t topo) {
   hwloc_cpuset_t ht_PU_core_set = hwloc_bitmap_dup(current_cpuset);
   // Get the list of available cores without hyperthreads
   err = hwloc_bitmap_singlify_per_core(topo, primary_PU_core_set, 0);
-  assert(!err);
+  if(!err) { LBANN_ERROR("Unable to singlify the cpuset"); }
   err = hwloc_bitmap_singlify_per_core(topo, ht_PU_core_set, 1);
-  assert(!err);
+  if(!err) { LBANN_ERROR("Unable to singlify the cpuset"); }
 
   if(!hwloc_bitmap_iszero(ht_PU_core_set)) {
     find_common_core_set_from_cpu_masks(topo, PU_core_set, primary_PU_core_set, ht_PU_core_set);

--- a/src/utils/threads/thread_topology.cpp
+++ b/src/utils/threads/thread_topology.cpp
@@ -160,7 +160,7 @@ hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo) {
 #else
   hwloc_const_cpuset_t allowed_cpuset = hwloc_topology_get_allowed_cpuset(topo);
   local_cpuset = hwloc_bitmap_dup(allowed_cpuset);
-  hwloc_bitmap_free(allowed_cpuset);
+  //  hwloc_bitmap_free(allowed_cpuset);
 #endif // LBANN_HAS_GPU
   return local_cpuset;
 }

--- a/src/utils/threads/thread_topology.cpp
+++ b/src/utils/threads/thread_topology.cpp
@@ -1,0 +1,225 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include <lbann/utils/threads/thread_topology.hpp>
+
+#if defined(LBANN_TOPO_AWARE)
+#include <hwloc.h>
+#ifdef LBANN_HAS_GPU
+#include <hwloc/cudart.h>
+#endif // LBANN_HAS_GPU
+#if defined(HWLOC_API_VERSION) && (HWLOC_API_VERSION < 0x00010b00)
+#define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
+#endif
+#endif
+
+#ifdef LBANN_HAS_GPU
+#include <hydrogen/device/gpu/CUDA.hpp>
+#endif // LBANN_HAS_GPU
+
+#include <iostream>
+
+namespace lbann {
+
+int get_num_numa_nodes() {
+  int num_numa_nodes = 1;
+#if defined(LBANN_TOPO_AWARE)
+  // Determine the number of NUMA nodes present.
+  hwloc_topology_t topo;
+  hwloc_topology_init(&topo);
+  hwloc_topology_load(topo);
+  int numa_depth = hwloc_get_type_depth(topo, HWLOC_OBJ_NUMANODE);
+  // if (numa_depth == HWLOC_TYPE_DEPTH_UNKNOWN) {
+  //   LBANN_ERROR(comm->get_rank_in_world(),
+  //               ": cannot determine hwloc NUMA-node depth");
+  // }
+  num_numa_nodes = hwloc_get_nbobjs_by_depth(topo, numa_depth);
+  // Warn if there are more NUMA nodes than processes per node.
+  // It's probably fine if there are more processes than NUMA nodes for now.
+  // We can adjust that later when we better understand the threaded perf.
+  // ppn = comm->get_procs_per_node();
+  // if (num_numa_nodes > ppn) {
+  //   // if (comm->get_rank_in_node() == 0) {
+  //     std::cout << comm->get_rank_in_world() <<
+  //               ": WARNING: node has " << num_numa_nodes <<
+  //               " NUMA nodes but you have " << ppn << " processes per node" <<
+  //               std::endl;
+  //   // }
+  // }
+  hwloc_topology_destroy(topo);
+#endif // LBANN_TOPO_AWARE
+  return num_numa_nodes;
+}
+
+#if defined(LBANN_TOPO_AWARE)
+void hwloc_print_topo()
+{
+  hwloc_topology_t topo;
+  int err;
+  /* initialize a topology context */
+  err = hwloc_topology_init(&topo);
+  assert(!err);
+  /* build the topology created and configured above */
+  err = hwloc_topology_load(topo);
+
+  {
+    printf("%u cores\n",
+	   hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_CORE));
+  }
+
+  {
+    hwloc_obj_t core3, core7;
+    core3 = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 3);
+    core7 = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 7);
+    if (core3 && core7) {
+      hwloc_obj_t ancestor = hwloc_get_common_ancestor_obj(topo, core3, core7);
+      printf("ancestor type %s\n", hwloc_obj_type_string(ancestor->type));
+    }
+  }
+
+  {
+    hwloc_obj_t core0 = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0);
+    hwloc_obj_t parent = core0;
+    while (parent && !parent->memory.local_memory)
+      parent = parent->parent;
+    printf("%llu bytes\n", (unsigned long long) parent->memory.local_memory);
+  }
+
+  {
+    hwloc_obj_t pu = hwloc_get_obj_by_type(topo, HWLOC_OBJ_PU, 0);
+    while (pu) {
+      printf("%u\n", pu->os_index);
+      pu = pu->next_cousin;
+    }
+  }
+
+  /* terminate this topology context */
+  hwloc_topology_destroy(topo);
+  std::cout << err << std::endl;
+  return;
+}
+
+// This function is implemented in HWLOC 2.1
+int hwloc_bitmap_singlify_per_core(hwloc_topology_t topology, hwloc_bitmap_t cpuset, unsigned which)
+{
+  hwloc_obj_t core = NULL;
+  while ((core = hwloc_get_next_obj_covering_cpuset_by_type(topology, cpuset, HWLOC_OBJ_CORE, core)) != NULL) {
+    /* this core has some PUs in the cpuset, find the index-th one */
+    unsigned i = 0;
+    int pu = -1;
+    do {
+      pu = hwloc_bitmap_next(core->cpuset, pu);
+      if (pu == -1) {
+        /* no which-th PU in cpuset and core, remove the entire core */
+        hwloc_bitmap_andnot(cpuset, cpuset, core->cpuset);
+        break;
+      }
+      if (hwloc_bitmap_isset(cpuset, pu)) {
+        if (i == which) {
+          /* remove the entire core except that exact pu */
+          hwloc_bitmap_andnot(cpuset, cpuset, core->cpuset);
+          hwloc_bitmap_set(cpuset, pu);
+          break;
+        }
+        i++;
+      }
+    } while (1);
+  }
+  return 0;
+}
+
+hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo) {
+  hwloc_cpuset_t local_cpuset = hwloc_bitmap_alloc();
+#ifdef LBANN_HAS_GPU
+  // Find CPUs close to the GPU being used
+  hwloc_cudart_get_device_cpuset(topo, hydrogen::GPUManager::Device(), local_cpuset);
+#else
+  hwloc_const_cpuset_t allowed_cpuset = hwloc_topology_get_allowed_cpuset(topo);
+  local_cpuset = hwloc_bitmap_dup(allowed_cpuset);
+  hwloc_bitmap_free(allowed_cpuset);
+#endif // LBANN_HAS_GPU
+  return local_cpuset;
+}
+
+hwloc_cpuset_t get_allocated_cpuset_for_current_thread(hwloc_topology_t topo) {
+  hwloc_cpuset_t current_cpuset = hwloc_bitmap_alloc();
+  int err = hwloc_get_cpubind(topo, current_cpuset, 0);
+  assert(!err);
+
+  hwloc_cpuset_t PU_core_set = hwloc_bitmap_alloc();
+  // Primary core set
+  hwloc_cpuset_t primary_PU_core_set = hwloc_bitmap_dup(current_cpuset);
+  // Hyperthread core set
+  hwloc_cpuset_t ht_PU_core_set = hwloc_bitmap_dup(current_cpuset);
+  // Get the list of available cores without hyperthreads
+  err = hwloc_bitmap_singlify_per_core(topo, primary_PU_core_set, 0);
+  assert(!err);
+  err = hwloc_bitmap_singlify_per_core(topo, ht_PU_core_set, 1);
+  assert(!err);
+
+  if(!hwloc_bitmap_iszero(ht_PU_core_set)) {
+    find_common_core_set_from_cpu_masks(topo, PU_core_set, primary_PU_core_set, ht_PU_core_set);
+  }else {
+    PU_core_set = hwloc_bitmap_dup(primary_PU_core_set);
+  }
+
+  hwloc_bitmap_free(current_cpuset);
+  hwloc_bitmap_free(primary_PU_core_set);
+  hwloc_bitmap_free(ht_PU_core_set);
+
+  return PU_core_set;
+}
+
+
+void find_common_core_set_from_cpu_masks(hwloc_topology_t topo,
+                                         hwloc_bitmap_t core_set,
+                                         hwloc_bitmap_t primary_set,
+                                         hwloc_bitmap_t ht_set) {
+  hwloc_cpuset_t tmp_primary_set = hwloc_bitmap_alloc();
+  hwloc_cpuset_t tmp_ht_set = hwloc_bitmap_alloc();
+  // Find the set of cores in the mask of the primary set
+  {
+    hwloc_obj_t core = NULL;
+    while ((core = hwloc_get_next_obj_covering_cpuset_by_type(topo, primary_set, HWLOC_OBJ_CORE, core)) != NULL) {
+      hwloc_bitmap_or(tmp_primary_set, tmp_primary_set, core->cpuset);
+    }
+  }
+  // Find the set of cores in the mask for the secondary (hyperthread) set
+  {
+    hwloc_obj_t core = NULL;
+    while ((core = hwloc_get_next_obj_covering_cpuset_by_type(topo, ht_set, HWLOC_OBJ_CORE, core)) != NULL) {
+      hwloc_bitmap_or(tmp_ht_set, tmp_ht_set, core->cpuset);
+    }
+  }
+  // AND both sets together to find the actual cores in the CPU mask
+  hwloc_bitmap_and(core_set, tmp_primary_set, tmp_ht_set);
+
+  hwloc_bitmap_free(tmp_primary_set);
+  hwloc_bitmap_free(tmp_ht_set);
+}
+#endif // LBANN_TOPO_AWARE
+
+} // namespace lbann

--- a/src/utils/threads/thread_utils.cpp
+++ b/src/utils/threads/thread_utils.cpp
@@ -25,6 +25,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/utils/threads/thread_utils.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/lbann_library.hpp"
 #include <thread>
 #include <omp.h>
 
@@ -66,7 +68,12 @@ int num_free_cores_per_process(const lbann_comm *comm) {
 #endif // LBANN_HAS_ALUMINUM
 
   auto cores_in_cpuset = num_available_cores_in_cpuset();
-  auto max_cores_per_process = std::min(cores_in_cpuset, static_cast<int>(max_threads / processes_on_node));
+  auto max_cores_per_process = static_cast<int>(max_threads / processes_on_node);
+
+  auto& arg_parser = global_argument_parser();
+  if(arg_parser.get<bool>(STRICT_IO_THREAD_PINNING)) {
+    max_cores_per_process = std::min(cores_in_cpuset, max_cores_per_process);
+  }
   auto io_threads_per_process = std::max(1, (max_cores_per_process - omp_threads - aluminum_threads));
 
   return io_threads_per_process;

--- a/src/utils/threads/thread_utils.cpp
+++ b/src/utils/threads/thread_utils.cpp
@@ -30,6 +30,29 @@
 
 namespace lbann {
 
+int num_available_cores_in_cpuset() {
+  // Find the current thread affinity
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+
+  auto error = pthread_getaffinity_np(pthread_self(),
+                                      sizeof(cpu_set_t), &cpuset);
+
+  if (error != 0) {
+    std::cerr << "error in pthread_getaffinity_np, error=" << error
+              << std::endl;
+  }
+
+  int num_available_cores = 0;
+  for (int j = 0; j < CPU_SETSIZE; j++) {
+    if (CPU_ISSET(j, &cpuset)) {
+      num_available_cores++;
+    }
+  }
+
+  return num_available_cores;
+}
+
 int num_free_cores_per_process(const lbann_comm *comm) {
   auto hw_cc = std::thread::hardware_concurrency();
   auto max_threads = std::max(hw_cc,decltype(hw_cc){1});
@@ -42,7 +65,9 @@ int num_free_cores_per_process(const lbann_comm *comm) {
   aluminum_threads = 1;
 #endif // LBANN_HAS_ALUMINUM
 
-  auto io_threads_per_process = std::max(1, static_cast<int>((max_threads / processes_on_node) - omp_threads - aluminum_threads));
+  auto cores_in_cpuset = num_available_cores_in_cpuset();
+  auto max_cores_per_process = std::min(cores_in_cpuset, static_cast<int>(max_threads / processes_on_node));
+  auto io_threads_per_process = std::max(1, (max_cores_per_process - omp_threads - aluminum_threads));
 
   return io_threads_per_process;
 }
@@ -52,14 +77,14 @@ int free_core_offset(const lbann_comm *comm) {
   auto max_threads = std::max(hw_cc,decltype(hw_cc){1});
 
   auto omp_threads = omp_get_max_threads();
-  auto processes_on_node = comm->get_procs_per_node();
 
   auto aluminum_threads = 0;
 #ifdef LBANN_HAS_ALUMINUM
   aluminum_threads = 1;
 #endif // LBANN_HAS_ALUMINUM
 
-  auto io_threads_offset = ((omp_threads+aluminum_threads) * processes_on_node) % max_threads;
+  // Offset into the CPUMASK of each process
+  auto io_threads_offset = (omp_threads+aluminum_threads)% max_threads;
 
   return io_threads_offset;
 }

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -273,7 +273,7 @@ void data_type_weights<TensorDataType>::set_value(TensorDataType value, int inde
 
 #ifdef LBANN_DEBUG
   // Check that tensor position is valid
-  const auto& size = get_size();
+  const auto& size = weights::get_size();
   if (index < 0 || index >= size) {
     LBANN_ERROR("attempted to set value in "
                 "weights \"", this->get_name(), "\""


### PR DESCRIPTION
Fixed the data reader so that it will dispatch blocks of work to the
I/O thread pool.  The local executing thread no longer does a local
block of work.  The fetch_data_block function now properly renames the
parameter thread_id to block_offset to indicate that it marks which
block of work is being executed.  The fetch_data_block now sets a
thread local variable to index into the new vector of I/O random
number generators.  The I/O random number generators are no long
thread local variables, but there is a global vector of them that is
paired with each block of I/O and transformation work.  The number of
I/O RNGs is setup during initialization to have one per thread in the
I/O pool.