### PR TITLE
Update superbuild to build Hydrogen 1.3.4

### DIFF
--- a/superbuild/hydrogen/CMakeLists.txt
+++ b/superbuild/hydrogen/CMakeLists.txt
@@ -109,7 +109,7 @@ else ()
 endif ()
 
 # ... then the tag.
-set(HYDROGEN_TAG "v1.3.3"
+set(HYDROGEN_TAG "v1.3.4"
   CACHE STRING "The git tag or hash to checkout for Hydrogen")
 
 if (HYDROGEN_CUSTOM_SOURCE_DIR)


### PR DESCRIPTION
### Description

@szaman19 has encountered a bug where GPU memory usage grows during training, eventually crashing the program. It is fixed by upgrading to Hydrogen 1.3.4, so I've bumped the Hydrogen version in the superbuild.

### Bug details

When running [a model with GCN](https://github.com/szaman19/lbann/tree/develop-gcn/applications/graph/GCN) on Ray, he observed GPU memory usage was growing by about 0.4 GB every epoch. I think I've narrowed it down to [the point in backprop where a layer passes error signals to its parents](https://github.com/LLNL/lbann/blob/8445dd96586719887c0a8e0c640f1b36cd2b853b/src/layers/data_type_layer.cpp#L715). This function passes around a `std::unique_ptr<El::BaseDistMat>` and it sometimes relies on the unique pointer to deallocate the matrix when it goes out of scope (usually when the layer and parent are on different devices). However, the destructor for `El::BaseDistMat` is non-virtual in Hydrogen 1.3.3, so the deallocation is not done correctly. The destructor was made virtual in https://github.com/LLNL/Elemental/commit/050db999bcec5ccf01e48e4d341a5035719db739 and I don't see the memory leak anymore when I build with Hydrogen 1.3.4.

There are some coincidental reasons why we hadn't seen this before (backprop usually terminates before reaching any CPU layers; we usually put identity layers as the children of the input layer, which uses a different code path to propagate error signals), so I'm not too worried about our existing models. However, it's important to fix this soon since perfectly sensible model designs can trigger the bug.