### PR TITLE
randomize samples in smiles reader

### DIFF
--- a/include/lbann/data_readers/data_reader_smiles.hpp
+++ b/include/lbann/data_readers/data_reader_smiles.hpp
@@ -67,9 +67,6 @@ public:
   void set_sequence_length(int n) { m_linearized_data_size = n; }
   int get_sequence_length() { return get_linearized_data_size(); }
 
-  void set_num_samples(int n) { m_num_samples = n; }
-  int get_num_samples() { return m_num_samples; }
-
 private:
 
   /// used for sanity checking in load() and do_preload();
@@ -100,13 +97,6 @@ private:
   int get_smiles_string_length(const std::string &line, int line_number);
 
   //==== end hack to make it work fast ====
-
-  // Number of samples the user has requested
-  int m_num_samples = -1;
-
-  // The total number of samples in the file; will be 
-  // computed from the input file
-  int m_total_samples;
 
   int m_linearized_data_size = 0;
   int m_linearized_label_size = 0;

--- a/include/lbann/data_readers/data_reader_smiles.hpp
+++ b/include/lbann/data_readers/data_reader_smiles.hpp
@@ -72,6 +72,11 @@ public:
 
 private:
 
+  /// used for sanity checking in load() and do_preload();
+  /// may eventually go away
+  int m_min_index = INT_MAX;
+  int m_max_index = 0;
+
   //==== start hack to make it work fast ====
   
   // maps: sample_id to <sample offset, wrt m_data[0], sample_size>

--- a/src/data_readers/data_reader_smiles.cpp
+++ b/src/data_readers/data_reader_smiles.cpp
@@ -135,7 +135,9 @@ void smiles_data_reader::load() {
   //  std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
   //
   if (! opts->get_bool("smiles_random_off")) {
-    LBANN_WARNING("starting to generate some random numbers ... theoretically this could run forever, esp. if you set --num_samples too high.");
+    if (is_master()) {
+      std::cout << "starting to generate some random numbers ... theoretically this could run forever, esp. if you set --num_samples too high." << std::endl;
+    }  
     int seed = opts->get_int("smiles_srand", time(NULL));
     srand(seed);
     std::set<int> useme_indices;
@@ -147,7 +149,9 @@ void smiles_data_reader::load() {
       m_shuffled_indices[jj++] = idx;
     }
   } else {
-    LBANN_WARNING("pulling all samples from top of file");
+    if (is_master()) {
+      std::cout << "pulling all samples from top of file" << std::endl;
+    }
   }
 
   resize_shuffled_indices();

--- a/src/data_readers/data_reader_smiles.cpp
+++ b/src/data_readers/data_reader_smiles.cpp
@@ -172,6 +172,9 @@ void smiles_data_reader::load() {
     }
   } 
 
+  instantiate_data_store();
+  select_subset_of_data();
+
   // get values for ad-hoc sanity checking; see: do_preload()
   m_min_index = INT_MAX;
   m_max_index = 0;
@@ -179,9 +182,6 @@ void smiles_data_reader::load() {
     if (idx < m_min_index) m_min_index = idx;
     if (idx > m_max_index) m_max_index = idx;
   }
-
-  instantiate_data_store();
-  select_subset_of_data();
 
   get_delimiter();
 


### PR DESCRIPTION
Modified so that, when --num_samples is requested, the indices are randomly pulled from all possible indices.
