### PR TITLE
Set LD_LIBRARY_PATH in Python frontend contrib launchers

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -46,6 +46,9 @@ def make_batch_script(
         if key not in environment:
             environment[key] = os.getenv(key, default)
 
+    # Set environment for shared libraries
+    set_environment('LD_LIBRARY_PATH', os.environ['LD_LIBRARY_PATH'])
+
     # Setup GPU bindings
     # Note: Each Hydrogen process is assigned to the GPU index that
     # matches its node communicator rank. This is not compatible with

--- a/python/lbann/contrib/nersc/launcher.py
+++ b/python/lbann/contrib/nersc/launcher.py
@@ -32,6 +32,9 @@ def make_batch_script(
         if key not in environment:
             environment[key] = os.getenv(key, default)
 
+    # Set environment for shared libraries
+    set_environment('LD_LIBRARY_PATH', os.environ['LD_LIBRARY_PATH'])
+
     # Optimizations for Cori GPU nodes
     if system == 'cgpu':
         cores_per_proc = cores_per_node(system) // procs_per_node


### PR DESCRIPTION
When I build LBANN with Spack and launch a job with the Python frontend, I encounter an error where it can't find shared libraries. The problem is that Spack installs all of LBANN's dependencies in arbitrary places and then manipulates `LD_LIBRARY_PATH` to make them discoverable. The quick fix is to just forward the user's `LD_LIBRARY_PATH` to the LBANN executable.

While we're thinking about this, should we forward any other environment variables? First one off the top of my head is `OMP_NUM_THREADS`.