### PR TITLE
Add support for distributed embedding layer with double datatype

### DIFF
--- a/src/layers/misc/dist_embedding.cu
+++ b/src/layers/misc/dist_embedding.cu
@@ -696,6 +696,8 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::apply_sparse_sgd_step(
 /// @todo fp16
 template class dist_embedding_layer<
   float, data_layout::DATA_PARALLEL, El::Device::GPU>;
+template class dist_embedding_layer<
+  double, data_layout::DATA_PARALLEL, El::Device::GPU>;
 
 } // namespace lbann
 #endif // LBANN_HAS_NVSHMEM


### PR DESCRIPTION
This adds `double` support to the distributed embedding layer. The layer input is cast from a floating-point number to an integer, so the `float` implementation supports up to 2^24=17M embeddings and the `double` implementation supports up to 2^53=9.0e15 embeddings.