### PR TITLE
Update superbuild to use Hydrogen 1.4.0 and Aluminum 0.4.0

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -330,7 +330,7 @@ fi
 # Load packages
 if [ ${USE_MODULES} -ne 0 ]; then
     module load git
-    module load cmake/3.14.5
+    module load cmake/3.16.8
 else
     use git
 fi
@@ -805,7 +805,6 @@ cmake \
 -D LBANN_SB_BUILD_PROTOBUF=ON \
 -D LBANN_SB_BUILD_CUB=${WITH_CUB} \
 -D LBANN_SB_BUILD_ALUMINUM=${WITH_ALUMINUM} \
--D ALUMINUM_TAG=v0.3.3 \
 -D ALUMINUM_ENABLE_MPI_CUDA=${ALUMINUM_WITH_MPI_CUDA} \
 -D ALUMINUM_ENABLE_NCCL=${ALUMINUM_WITH_NCCL} \
 -D LBANN_SB_BUILD_CONDUIT=${WITH_CONDUIT} \

--- a/superbuild/aluminum/CMakeLists.txt
+++ b/superbuild/aluminum/CMakeLists.txt
@@ -11,7 +11,7 @@ else ()
     CACHE STRING "The URL from which to clone Aluminum")
 endif ()
 
-set(ALUMINUM_TAG "v0.3.3"
+set(ALUMINUM_TAG "v0.4.0"
   CACHE STRING "The git tag to checkout for Aluminum")
 
 set(ALUMINUM_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"

--- a/superbuild/hydrogen/CMakeLists.txt
+++ b/superbuild/hydrogen/CMakeLists.txt
@@ -109,7 +109,7 @@ else ()
 endif ()
 
 # ... then the tag.
-set(HYDROGEN_TAG "v1.3.4"
+set(HYDROGEN_TAG "v1.4.0"
   CACHE STRING "The git tag or hash to checkout for Hydrogen")
 
 if (HYDROGEN_CUSTOM_SOURCE_DIR)


### PR DESCRIPTION
This makes changes so `build_lbann_lc.sh` works with the recent version bumps (#1588 and https://github.com/LLNL/Elemental/pull/102).

I'm trying to get LBANN built with Spack, but I'm running into trouble since the new versions are not available in the built-in Spack packages for Hydrogen and Aluminum. Would it be feasible to maintain our own Spack packages for LBANN, Hydrogen, and Aluminum inside of LBANN and copy them to the Spack repo whenever we make changes? That way we can rapidly modify the Spack packages without waiting for a PR to get approved by the Spack team.