### PR TITLE
Reset data coordinator after each LTFB round

### DIFF
--- a/include/lbann/io/data_buffers/generic_io_buffer.hpp
+++ b/include/lbann/io/data_buffers/generic_io_buffer.hpp
@@ -59,9 +59,9 @@ class fetch_data_functor {
       num_responses_fetched = data_reader->fetch_labels(responses);
     }
     if(num_samples_fetched != num_responses_fetched) {
-      std::string err = std::string("Number of samples: ") + std::to_string(num_samples_fetched)
-        + std::string(" does not match the number of responses: ") + std::to_string(num_responses_fetched);
-      throw lbann_exception(err);
+      LBANN_ERROR("Number of samples (",num_samples_fetched,") ",
+                  "does not match the ",
+                  "number of responses (",num_responses_fetched,")");
     }
     return num_samples_fetched;
   }

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -339,7 +339,8 @@ EvalType evaluate(model& m, const std::string& metric_name) {
   m.make_data_store_preloaded(execution_mode::validation);
 
   // Clean up and return metric value
-  c.set_execution_mode(original_mode);
+  m.reset_mode(c, original_mode);
+  c.get_trainer().get_data_coordinator().reset_mode(c);
   return metric_value;
 
 }


### PR DESCRIPTION
As discussed in #1597, the data coordinator doesn't properly switch from the validation set to the training set after an LTFB round finishes. I've adjusted the LTFB callback to match how we reset the execution mode in `sgd_training_algorithm`, e.g.:

https://github.com/LLNL/lbann/blob/9fcc5c315a079cf8a49781c22a859d915ea3d5fc/src/training_algorithms/sgd_training_algorithm.cpp#L109

This fixes #1597, but does not affect #1596. 