### PR TITLE
Fix bug in weights proxy when weights buffer is reallocated

### DIFF
--- a/include/lbann/weights/weights_proxy.hpp
+++ b/include/lbann/weights/weights_proxy.hpp
@@ -262,8 +262,14 @@ public:
    */
   void synchronize_with_master()
   {
-    if (!empty() && !values_->Viewing()) {
-      El::Copy(master_weights_->get_values(), *values_);
+    if (!empty()) {
+      const auto& master_values = master_weights_->get_values();
+      if (values_->Viewing()) {
+        El::LockedView(*values_, dynamic_cast<const ValuesType&>(master_values));
+      }
+      else {
+        El::Copy(master_values, *values_);
+      }
     }
   }
 


### PR DESCRIPTION
Closes #1596. The bug happens because LTFB calls the `weights` 's copy-assignment operator, which reallocates data buffers. However, the layers interact with `weights` via `weights_proxy` objects, which assume that the `weights` 's data buffer never changes. Thus, the layers receive junk when they try accessing weight values. Fortunately, the fix is easy: whenever the `weights_proxy` is synchronized with its corresponding `weights`, make sure to update the view into the data buffer. I no longer see the bad learning in LTFB.

[Bamboo build is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM297-1).

Pinging @samadejacobs.