### PR TITLE
Avoid char in hashing unit tests

### DIFF
--- a/src/utils/unit_test/hash_test.cpp
+++ b/src/utils/unit_test/hash_test.cpp
@@ -10,7 +10,7 @@ TEST_CASE ("Testing convenience functions for hashing", "[hash][utilities]") {
 
   SECTION ("hash_combine") {
     std::unordered_set<size_t> hashes;
-    for (size_t seed=0; seed<10; ++seed) {
+    for (size_t seed=0; seed<=16; seed+=2) {
       hashes.insert(seed);
     }
     for (size_t seed=0; seed<=16; seed+=2) {
@@ -27,21 +27,29 @@ TEST_CASE ("Testing convenience functions for hashing", "[hash][utilities]") {
     std::vector<Humor> enum_list = { Humor::MELANCHOLIC, Humor::SANGUINE,
                                      Humor::CHOLERIC, Humor::PHLEGMATIC };
     std::unordered_set<size_t> hashes;
-    for (size_t i=0; i<enum_list.size(); ++i) {
-      const auto hash = lbann::enum_hash<Humor>()(enum_list[i]);
+    for (const auto val : enum_list) {
+      const auto hash = lbann::enum_hash<Humor>()(val);
       CHECK_FALSE(hashes.count(hash));
       hashes.insert(hash);
     }
   }
 
   SECTION ("pair_hash") {
+    const std::vector<unsigned long> i_list = {1, 2, 1018, 1019,
+                                               11209, 543210, 4294967295};
+    const std::vector<float> j_list = {-12.34f, -8.76f, -4.56f,
+                                       0.f, 4.56f, 8.76f, 12.34f};
     std::unordered_set<size_t> hashes;
-    for (char i=-12; i<=12; i+=3) {
-      for (unsigned long j=0; j<=11209; j+=1019) {
-        std::pair<char,unsigned long> val(i,j);
-        const auto hash = lbann::pair_hash<char,unsigned long>()(val);
-        CHECK_FALSE(hashes.count(hash));
-        hashes.insert(hash);
+    for (const auto i : i_list) {
+      for (const auto j : j_list) {
+        std::pair<unsigned long,float> val1(i,j);
+        const auto hash1 = lbann::pair_hash<unsigned long,float>()(val1);
+        CHECK_FALSE(hashes.count(hash1));
+        hashes.insert(hash1);
+        std::pair<float,unsigned long> val2(j,i);
+        const auto hash2 = lbann::pair_hash<float,unsigned long>()(val2);
+        CHECK_FALSE(hashes.count(hash2));
+        hashes.insert(hash2);
       }
     }
   }


### PR DESCRIPTION
We've run into problems in the unit test for `lbann::pair_hash` because the signedness of `char` is implementation-specific. I've updated the unit test to use `float` instead. I've also expanded the test to test whether switching the order of the `pair` changes the hash. The unit test passes on Lassen.