### PR TITLE
Update FindPython.cmake

### DIFF
--- a/cmake/modules/FindPython.cmake
+++ b/cmake/modules/FindPython.cmake
@@ -83,7 +83,7 @@ include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
   Python
   REQUIRED_VARS Python_EXECUTABLE Python_INCLUDE_DIRS Python_LIBRARIES
-  Python_VERSION_MAJOR Python_VERSION_MINOR Python_VERSION_PATCH
+  Python_VERSION
   VERSION_VAR Python_VERSION)
 
 # Build the imported target


### PR DESCRIPTION
If `VERSION_MINOR` or `VERSION_PATCH` is `0`, then the `find_package_handle_standard_args` function will fail (the 0 will be interpreted as `FALSE`). So just use the whole version in that function.