### PR TITLE
Support large numbers of channels in GPU batchnorm layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_batch_normalization.py
+++ b/bamboo/unit_tests/test_unit_layer_batch_normalization.py
@@ -1,0 +1,179 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20200827)
+_num_samples = 29
+_sample_dims = (7,5,3)
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = np.random.normal(size=(_num_samples,_sample_size)).astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:]
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples() // 2
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: We want to use gradient checking to verify that error
+    # signals are correct. To do this, we zero-initialize a weights
+    # object, construct a zero-valued tensor, and add it to the
+    # input. To make sure that batchnorm is non-trivial, we multiply
+    # the zero-valued tensor by the mini-batch index.
+    x = lbann.Reshape(lbann.Input(), dims=tools.str_list(_sample_dims))
+    x_weights = lbann.Weights(optimizer=lbann.SGD(),
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x0 = lbann.WeightsLayer(weights=x_weights,
+                            dims=tools.str_list(_sample_dims))
+    x1 = lbann.Divide(lbann.MiniBatchIndex(), lbann.MiniBatchSize())
+    x1 = lbann.Tessellate(lbann.Reshape(x1, dims='1 1 1'), dims=tools.str_list(_sample_dims))
+    x = lbann.Sum(x, lbann.Multiply(x0, x1))
+    x_lbann = x
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Local statistics
+    # ------------------------------------------
+
+    # LBANN implementation
+    decay = 0.9
+    epsilon = 1e-5
+    x = x_lbann
+    y = lbann.BatchNormalization(x,
+                                 decay=decay,
+                                 epsilon=epsilon,
+                                 scale_init=1.5,
+                                 bias_init=0.25,
+                                 data_layout='data_parallel')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='local statistics'))
+
+    # ------------------------------------------
+    # Global statistics
+    # ------------------------------------------
+
+    # LBANN implementation
+    decay = 0.9
+    epsilon = 1e-5
+    x = x_lbann
+    y = lbann.BatchNormalization(x,
+                                 decay=decay,
+                                 epsilon=epsilon,
+                                 scale_init=0.8,
+                                 bias_init=-0.25,
+                                 statistics_group_size=-1,
+                                 data_layout='data_parallel')
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='global statistics'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 1
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -33,66 +33,89 @@ namespace lbann {
 
 namespace {
 
-/** CUDA kernel to compute channel sums.
- *  Sums and squares of sums are used to compute mean and variance.
+/** Functor for adding arrays. */
+template <typename T, size_t N>
+struct array_sum
+{
+  using ArrayType = cuda::array<T,N>;
+  __device__ __forceinline__
+  ArrayType operator()(const ArrayType& x, const ArrayType& y)
+  {
+    ArrayType sum;
+#pragma unroll
+    for (size_t i = 0; i < N; ++i) {
+      sum[i] = x[i] + y[i];
+    }
+    return sum;
+  }
+};
+
+/** Accumulate sums and sums of squares for each channel.
+ *
+ *  On input, sums and sqsums are assumed to be filled with zeros.
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (channel_size / bsize) x num_channels x 1
  */
-template <El::Int block_size, typename TensorDataType>
-__global__ void channel_sums_kernel(
-  El::Int channel_height,
-  El::Int width,
-  const TensorDataType * __restrict__ data, El::Int data_ldim,
+template <typename TensorDataType, int bdimx>
+__global__ void fp_sums_kernel(
+  int mini_batch_size,
+  int num_channels,
+  int channel_size,
+  const TensorDataType * __restrict__ data, int data_ldim,
         TensorDataType * __restrict__ sums,
         TensorDataType * __restrict__ sqsums) {
 
-  // Indices
-  const El::Int tid = threadIdx.x;
-  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int bidy = blockIdx.y;
+  // Indices and dimensions
+  constexpr int bdimy = 1;
+  constexpr int bdimz = 1;
+  const auto& tid = threadIdx.x;
+  const auto& gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& gidy = blockIdx.y;
+  const auto& nthreadsx = blockDim.x * gridDim.x;
+  const auto& nthreadsy = gridDim.y;
 
-  // Initialize shared memory
-  __shared__ TensorDataType shared_sums[block_size];
-  __shared__ TensorDataType shared_sqsums[block_size];
+  for (int channel = gidy; channel < num_channels; channel += nthreadsy) {
 
-  // Compute row sums in shared memory
-  TensorDataType private_sum = 0;
-  TensorDataType private_sqsum = 0;
-  if (gidx < channel_height) {
-    const auto& row = gidx + bidy * channel_height;
-    for (El::Int col = 0; col < width; ++col) {
-      const auto& x = data[row + col * data_ldim];
-      private_sum += x;
-      private_sqsum += x * x;
+    // Accumulate sums and perform block-wide reduction
+    using array_t = cuda::array<TensorDataType,2>;
+    using array_sum_t = array_sum<TensorDataType,2>;
+    array_t sum_sqsum;
+    sum_sqsum[0] = TensorDataType(0);
+    sum_sqsum[1] = TensorDataType(0);
+    for (int i = gidx; i < channel_size; i += nthreadsx) {
+      for (int j = 0; j < mini_batch_size; ++j) {
+        const auto& x = data[i + channel*channel_size + j*data_ldim];
+        sum_sqsum[0] += x;
+        sum_sqsum[1] += x * x;
+      }
     }
-  }
-  shared_sums[tid] = private_sum;
-  shared_sqsums[tid] = private_sqsum;
+    sum_sqsum = cuda::block_reduce<bdimx,bdimy,bdimz,array_t,array_sum_t>(sum_sqsum);
 
-  // Compute channel sum with shared memory reduction
-  /// @todo unroll loops
-  for (El::Int stride = block_size / 2; stride > 0; stride /= 2) {
-    __syncthreads();
-    if(tid < stride) {
-      shared_sums[tid] += shared_sums[tid + stride];
-      shared_sqsums[tid] += shared_sqsums[tid + stride];
+    // Output result to global memory
+    if (tid == 0) {
+      cuda::atomic_add(&sums[channel], sum_sqsum[0]);
+      cuda::atomic_add(&sqsums[channel], sum_sqsum[1]);
     }
-  }
 
-  // Output channel sum to global memory
-  if (tid == 0) {
-    cuda::atomic_add(&sums[bidy], shared_sums[0]);
-    cuda::atomic_add(&sqsums[bidy], shared_sqsums[0]);
   }
 
 }
 
-/** CUDA kernel to compute statistics.
+/** Compute statistics for each channel.
+ *
  *  On input, global_mean and global_var are assumed to contain sums
  *  and squares of sums, respectively.
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (num_channels / bsize) x 1 x 1
  */
 template <typename TensorDataType>
-__global__ void compute_statistics_kernel(
-  El::Int num_sums,
-  El::Int num_per_sum,
+__global__ void fp_statistics_kernel(
+  int num_sums,
+  int num_per_sum,
   TensorDataType epsilon,
   TensorDataType decay,
   TensorDataType * __restrict__ global_mean,
@@ -100,9 +123,9 @@ __global__ void compute_statistics_kernel(
   TensorDataType * __restrict__ global_running_mean,
   TensorDataType * __restrict__ global_running_var) {
 
-  const El::Int gid = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int num_threads = blockDim.x * gridDim.x;
-  for (El::Int i = gid; i < num_sums; i += num_threads) {
+  const auto& gid = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& num_threads = blockDim.x * gridDim.x;
+  for (auto i = gid; i < num_sums; i += num_threads) {
 
     TensorDataType num_per_sum_dt = TensorDataType(num_per_sum);
     // Compute mean and variance
@@ -123,54 +146,79 @@ __global__ void compute_statistics_kernel(
 
 }
 
-/** CUDA kernel to apply batch normalization. */
-template <El::Int block_size, typename TensorDataType>
-__global__ void batch_normalization_kernel(
-  El::Int channel_height,
-  El::Int width,
-  const TensorDataType * __restrict__ global_input, El::Int input_ldim,
+/** Compute outputs.
+ *
+ *  y_i = (x_i - mean) / sqrt(var + epsilon)
+ *
+ *  Block dimensions: bdimx x bdimy x bdimz
+ *
+ *  Grid dimensions: (channel_size / bdimx) x (mini_batch_size / bdimy) x (num_channels / bdimz)
+ *
+ */
+template <typename TensorDataType>
+__global__ void fp_output_kernel(
+  int mini_batch_size,
+  int num_channels,
+  int channel_size,
+  const TensorDataType * __restrict__ global_input, int input_ldim,
   const TensorDataType * __restrict__ global_mean,
   const TensorDataType * __restrict__ global_var,
   TensorDataType epsilon,
   const TensorDataType * __restrict__ global_scale,
   const TensorDataType * __restrict__ global_bias,
-        TensorDataType * __restrict__ global_output, El::Int output_ldim) {
+        TensorDataType * __restrict__ global_output, int output_ldim) {
 
-  // Indices
-  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int bidy = blockIdx.y;
+  // Indices and dimensions
+  const auto& gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const auto& gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const auto& nthreadsx = blockDim.x * gridDim.x;
+  const auto& nthreadsy = blockDim.y * gridDim.y;
+  const auto& nthreadsz = blockDim.z * gridDim.z;
 
-  // Copy batch normalization parameters to private memory
-  const auto& mean = global_mean[bidy];
-  const auto& var = global_var[bidy];
-  const auto& scale = global_scale[bidy];
-  const auto& bias = global_bias[bidy];
-
-  // Get reciprocal of standard deviation
-  const auto& inv_stdev = cuda::rsqrt(var + epsilon);
-
-  // Apply batch normalization
-  if (gidx < channel_height) {
-    const auto& row = gidx + bidy * channel_height;
-    for (El::Int col = 0; col < width; ++col) {
-      const auto& x = global_input[row + col * input_ldim];
-      const auto& xhat = (x - mean) * inv_stdev;
-      const auto& y = scale * xhat + bias;
-      global_output[row + col * output_ldim] = y;
+  for (auto k = gidz; k < num_channels; k += nthreadsz) {
+    const auto& mean = global_mean[k];
+    const auto& var = global_var[k];
+    const auto& inv_stdev = cuda::rsqrt(var + epsilon);
+    const auto& scale = global_scale[k];
+    const auto& bias = global_bias[k];
+    for (auto j = gidy; j < mini_batch_size; j += nthreadsy) {
+      for (auto i = gidx; i < channel_size; i += nthreadsx) {
+        const auto& x = global_input[i + k*channel_size + j*input_ldim];
+        const auto& xhat = (x - mean) * inv_stdev;
+        const auto& y = scale * xhat + bias;
+        global_output[i + k*channel_size + j*output_ldim] = y;
+      }
     }
   }
 
 }
 
-/** CUDA kernel to compute gradients w.r.t. batch norm parameters. */
-template <El::Int block_size, typename TensorDataType>
-__global__ void backprop1_kernel(
-  El::Int channel_height,
-  El::Int width,
+/** Compute gradients w.r.t. statistics and affine transform.
+ *
+ *  dL/dscale = sum(dL/dy_i * xhat_i)
+ *
+ *  dL/dbias = sum(dL/dy_i)
+ *
+ *  dL/dmean = - sum(dL/dy_i) / sqrt(var+epsilon)
+ *
+ *  dL/dvar = - sum(dL/dy_i * (x_i-mean)) * (var+epsilon)^(-3/2) / 2
+ *
+ *  On input, means_grad and vars_grad are filled with zeros.
+ *
+ *  Block dimensions: bsize x 1 x 1
+ *
+ *  Grid dimensions: (channel_size / bsize) x num_channels x 1
+ */
+template <typename TensorDataType, int bdimx>
+__global__ void bp_statistics_grad_kernel(
+  int mini_batch_size,
+  int num_channels,
+  int channel_size,
   const TensorDataType * __restrict__ global_input,
-  El::Int input_ldim,
+  int input_ldim,
   const TensorDataType * __restrict__ global_gradient_wrt_output,
-  El::Int gradient_wrt_output_ldim,
+  int gradient_wrt_output_ldim,
   const TensorDataType * __restrict__ global_mean,
   const TensorDataType * __restrict__ global_var,
   TensorDataType epsilon,
@@ -180,82 +228,82 @@ __global__ void backprop1_kernel(
         TensorDataType * __restrict__ global_dmean,
         TensorDataType * __restrict__ global_dvar) {
 
-  // Indices
-  const El::Int tid = threadIdx.x;
-  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int bidy = blockIdx.y;
+  // Indices and dimensions
+  constexpr int bdimy = 1;
+  constexpr int bdimz = 1;
+  const auto& tid = threadIdx.x;
+  const auto& gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& gidy = blockIdx.y;
+  const auto& nthreadsx = blockDim.x * gridDim.x;
+  const auto& nthreadsy = gridDim.y;
 
-  // Initialize shared memory
-  __shared__ TensorDataType shared_dscale[block_size];
-  __shared__ TensorDataType shared_dbias[block_size];
-  __shared__ TensorDataType shared_dmean[block_size];
-  __shared__ TensorDataType shared_dvar[block_size];
+  for (int channel = gidy; channel < num_channels; channel += nthreadsy) {
 
-  // Copy batch normalization parameters to private memory
-  const auto& mean = global_mean[bidy];
-  const auto& var = global_var[bidy];
-  const auto& scale = global_scale[bidy];
+    // Copy batch normalization parameters to private memory
+    const auto& mean = global_mean[channel];
+    const auto& var = global_var[channel];
+    const auto& scale = global_scale[channel];
 
-  // Compute useful constants
-  const TensorDataType zero = TensorDataType(0);
-  const auto& inv_stdev = cuda::rsqrt(var + epsilon);
-  const auto& dvar_factor = inv_stdev * inv_stdev * inv_stdev / TensorDataType(2);
+    // Compute useful constants
+    const auto& inv_stdev = cuda::rsqrt(var + epsilon);
+    const auto& dvar_factor = inv_stdev * inv_stdev * inv_stdev * TensorDataType(0.5);
 
-  // Compute row-wise gradient contributions in shared memory
-  auto dscale = zero;
-  auto dbias = zero;
-  auto dmean = zero;
-  auto dvar = zero;
-  if (gidx < channel_height) {
-    const auto& row = gidx + bidy * channel_height;
-    for(El::Int col = 0; col < width; ++col) {
-      const auto& x = global_input[row + col * input_ldim];
-      const auto& xhat = (x - mean) * inv_stdev;
-      const auto& dy = global_gradient_wrt_output[row + col * gradient_wrt_output_ldim];
-      dscale += dy * xhat;
-      dbias += dy;
-      const auto& dxhat = dy * scale;
-      dmean += - dxhat * inv_stdev;
-      dvar += - dxhat * (x - mean) * dvar_factor;
+    // Accumulate sums and perform block-wide reduction
+    using array_t = cuda::array<TensorDataType,4>;
+    using array_sum_t = array_sum<TensorDataType,4>;
+    array_t sums;
+    sums[0] = TensorDataType(0);
+    sums[1] = TensorDataType(0);
+    sums[2] = TensorDataType(0);
+    sums[3] = TensorDataType(0);
+    for (int i = gidx; i < channel_size; i += nthreadsx) {
+      for (int j = 0; j < mini_batch_size; ++j) {
+        const auto& x = global_input[i + channel*channel_size + j*input_ldim];
+        const auto& xhat = (x - mean) * inv_stdev;
+        const auto& dy = global_gradient_wrt_output[i
+                                                    + channel*channel_size
+                                                    + j*gradient_wrt_output_ldim];
+        sums[0] += dy * xhat;
+        sums[1] += dy;
+        const auto& dxhat = dy * scale;
+        sums[2] -= dxhat * inv_stdev;
+        sums[3] -= dxhat * (x - mean) * dvar_factor;
+      }
     }
-  }
-  shared_dscale[tid] = dscale;
-  shared_dbias[tid] = dbias;
-  shared_dmean[tid] = dmean;
-  shared_dvar[tid] = dvar;
+    sums = cuda::block_reduce<bdimx,bdimy,bdimz,array_t,array_sum_t>(sums);
 
-  // Compute gradients with shared memory reduction
-  // @todo unroll loops
-  for (El::Int stride = block_size / 2; stride > 0; stride /= 2) {
-    __syncthreads();
-    if (tid < stride) {
-      shared_dscale[tid] += shared_dscale[tid + stride];
-      shared_dbias[tid] += shared_dbias[tid + stride];
-      shared_dmean[tid] += shared_dmean[tid + stride];
-      shared_dvar[tid] += shared_dvar[tid + stride];
+    // Output result to global memory
+    if (tid == 0) {
+      cuda::atomic_add(&global_dscale[channel], sums[0]);
+      cuda::atomic_add(&global_dbias[channel], sums[1]);
+      cuda::atomic_add(&global_dmean[channel], sums[2]);
+      cuda::atomic_add(&global_dvar[channel], sums[3]);
     }
-  }
 
-  // Output channel sum to global memory
-  if (tid == 0) {
-    cuda::atomic_add(&global_dscale[bidy], shared_dscale[0]);
-    cuda::atomic_add(&global_dbias[bidy], shared_dbias[0]);
-    cuda::atomic_add(&global_dmean[bidy], shared_dmean[0]);
-    cuda::atomic_add(&global_dvar[bidy], shared_dvar[0]);
   }
 
 }
 
-/** CUDA kernel to compute gradients w.r.t. input. */
-template <El::Int block_size, typename TensorDataType>
-__global__ void backprop2_kernel(
-  El::Int channel_height,
-  El::Int local_width,
-  El::Int num_per_sum,
+/** Compute gradients w.r.t. input.
+ *
+ *  dL/dx_i = ( dL/dxhat_i / sqrt(var+epsilon)
+ *              + dL/dmean / n
+ *              + dL/dvar * (x_i - mean) * 2/(n-1) )
+ *
+ *  Block dimensions: bdimx x bdimy x bdimz
+ *
+ *  Grid dimensions: (channel_size / bdimx) x (mini_batch_size / bdimy) x (num_channels / bdimz)
+ */
+template <typename TensorDataType>
+__global__ void bp_input_grad_kernel(
+  int mini_batch_size,
+  int num_channels,
+  int channel_size,
+  int num_per_sum,
   const TensorDataType * __restrict__ global_input,
-  El::Int input_ldim,
+  int input_ldim,
   const TensorDataType * __restrict__ global_gradient_wrt_output,
-  El::Int gradient_wrt_output_ldim,
+  int gradient_wrt_output_ldim,
   const TensorDataType * __restrict__ global_mean,
   const TensorDataType * __restrict__ global_var,
   TensorDataType epsilon,
@@ -263,33 +311,33 @@ __global__ void backprop2_kernel(
   const TensorDataType * __restrict__ global_dmean,
   const TensorDataType * __restrict__ global_dvar,
         TensorDataType * __restrict__ global_gradient_wrt_input,
-  El::Int gradient_wrt_input_ldim) {
+  int gradient_wrt_input_ldim) {
 
-  // Indices
-  const El::Int gidx = threadIdx.x + blockIdx.x * blockDim.x;
-  const El::Int bidy = blockIdx.y;
+  // Indices and dimensions
+  const auto& gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const auto& gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const auto& nthreadsx = blockDim.x * gridDim.x;
+  const auto& nthreadsy = blockDim.y * gridDim.y;
+  const auto& nthreadsz = blockDim.z * gridDim.z;
 
-  // Copy batch normalization parameters to private memory
-  const auto& mean = global_mean[bidy];
-  const auto& var = global_var[bidy];
-  const auto& scale = global_scale[bidy];
-  const auto& dmean = global_dmean[bidy];
-  const auto& dvar = global_dvar[bidy];
-
-  // Compute useful constants
-  const auto& inv_stdev = cuda::rsqrt(var + epsilon);
-  const auto& dmean_term = dmean / TensorDataType(num_per_sum);
-  const auto& dvar_term = dvar * TensorDataType(2) / TensorDataType(num_per_sum - 1);
-
-  // Apply batch normalization
-  if (gidx < channel_height) {
-    const auto& row = gidx + bidy * channel_height;
-    for (El::Int col = 0; col < local_width; ++col) {
-      const auto& x = global_input[row + col * input_ldim];
-      const auto& dy = global_gradient_wrt_output[row + col * gradient_wrt_output_ldim];
-      const auto& dxhat = dy * scale;
-      auto& dx = global_gradient_wrt_input[row + col * gradient_wrt_input_ldim];
-      dx = dxhat * inv_stdev + dmean_term + dvar_term * (x - mean);
+  for (auto k = gidz; k < num_channels; k += nthreadsz) {
+    const auto& mean = global_mean[k];
+    const auto& var = global_var[k];
+    const auto& inv_stdev = cuda::rsqrt(var + epsilon);
+    const auto& scale = global_scale[k];
+    const auto& dmean = global_dmean[k];
+    const auto& dvar = global_dvar[k];
+    const auto& dmean_term = dmean / TensorDataType(num_per_sum);
+    const auto& dvar_term = dvar * TensorDataType(2) / TensorDataType(num_per_sum - 1);
+    for (auto j = gidy; j < mini_batch_size; j += nthreadsy) {
+      for (auto i = gidx; i < channel_size; i += nthreadsx) {
+        const auto& x = global_input[i + k*channel_size + j*input_ldim];
+        const auto& dy = global_gradient_wrt_output[i + k*channel_size + j*gradient_wrt_output_ldim];
+        const auto& dxhat = dy * scale;
+        auto& dx = global_gradient_wrt_input[i + k*channel_size + j*gradient_wrt_input_ldim];
+        dx = dxhat * inv_stdev + dmean_term + dvar_term * (x - mean);
+      }
     }
   }
 
@@ -436,18 +484,21 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute() {
     El::Zero(local_mean);
     El::Zero(local_var);
     if (!local_input.IsEmpty()) {
-      const El::Int block_size = 256;
+      constexpr int block_size = 256;
       dim3 block_dims, grid_dims;
       block_dims.x = block_size;
       grid_dims.x = (channel_size + block_size - 1) / block_size;
-      grid_dims.y = num_channels;
-      channel_sums_kernel<block_size>
+      grid_dims.y = El::Min(num_channels, 65535);
+      fp_sums_kernel<TensorDataType, block_size>
         <<<grid_dims, block_dims, 0, stream>>>(
-          channel_size, local_width,
+          local_width,
+          num_channels,
+          channel_size,
           local_input.LockedBuffer(), local_input.LDim(),
-          local_mean.Buffer(), local_var.Buffer());
+          local_mean.Buffer(),
+          local_var.Buffer());
     }
-    El::Int num_per_sum;
+    int num_per_sum;
     if (this->m_statistics_group_size == 0) {
       // Global statistics aggregation; allreduce on fused buffer.
       this->m_comm->allreduce(*this->m_mean_and_var, this->m_mean_and_var->RedundantComm(),
@@ -475,9 +526,10 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute() {
     if (num_per_sum <= 1) {
       El::Fill(local_var, TensorDataType(1.0));
     } else if (num_channels > 0) {
-      const El::Int block_dim = 256;
-      const El::Int grid_dim = (num_channels + block_dim - 1) / block_dim;
-      compute_statistics_kernel<<<grid_dim, block_dim, 0, stream>>>(
+      constexpr size_t block_dim = 256;
+      const size_t grid_dim = El::Min((num_channels + block_dim - 1) / block_dim,
+                                      65535);
+      fp_statistics_kernel<<<grid_dim, block_dim, 0, stream>>>(
           num_channels, num_per_sum, this->m_epsilon, this->m_decay,
           local_mean.Buffer(), local_var.Buffer(),
           local_running_mean.Buffer(), local_running_var.Buffer());
@@ -495,14 +547,15 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute() {
                            this->m_var_v->LockedMatrix() :
                            this->weights_values(3).LockedMatrix());
   if (!local_input.IsEmpty()) {
-    const El::Int block_size = 256;
+    constexpr int block_size = 256;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
     grid_dims.x = (channel_size + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    batch_normalization_kernel<block_size>
+    grid_dims.y = El::Min(local_width, 65535);
+    grid_dims.z = El::Min(num_channels, 65535);
+    fp_output_kernel
       <<<grid_dims, block_dims, 0, stream>>>(
-        channel_size, local_width,
+        local_width, num_channels, channel_size,
         local_input.LockedBuffer(), local_input.LDim(),
         local_mean.LockedBuffer(), local_var.LockedBuffer(), this->m_epsilon,
         local_scale.LockedBuffer(), local_bias.LockedBuffer(),
@@ -557,14 +610,14 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute() {
   El::Zero(local_mean_gradient);
   El::Zero(local_var_gradient);
   if (!local_input.IsEmpty()) {
-    const El::Int block_size = 256;
+    constexpr int block_size = 256;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
     grid_dims.x = (channel_size + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    backprop1_kernel<block_size>
+    grid_dims.y = El::Min(num_channels, 65535);
+    bp_statistics_grad_kernel<TensorDataType,block_size>
       <<<grid_dims, block_dims, 0, stream>>>(
-        channel_size, local_width,
+        local_width, num_channels, channel_size,
         local_input.LockedBuffer(), local_input.LDim(),
         local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
         local_mean.LockedBuffer(), local_var.LockedBuffer(), this->m_epsilon,
@@ -600,7 +653,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute() {
   }
 
   // Compute error signal
-  El::Int num_per_sum;
+  int num_per_sum;
   if (this->m_statistics_group_size == 0) {
     // Global statistics aggregation.
     num_per_sum = channel_size * width;
@@ -614,14 +667,15 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute() {
   if (num_per_sum <= 1) {
     El::Zero(local_gradient_wrt_input);
   } else if (!local_input.IsEmpty()) {
-    const El::Int block_size = 256;
+    constexpr int block_size = 256;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
     grid_dims.x = (channel_size + block_size - 1) / block_size;
-    grid_dims.y = num_channels;
-    backprop2_kernel<block_size>
+    grid_dims.y = El::Min(local_width, 65535);
+    grid_dims.z = El::Min(num_channels, 65535);
+    bp_input_grad_kernel
       <<<grid_dims, block_dims, 0, stream>>>(
-        channel_size, local_width, num_per_sum,
+        local_width, num_channels, channel_size, num_per_sum,
         local_input.LockedBuffer(), local_input.LDim(),
         local_gradient_wrt_output.LockedBuffer(), local_gradient_wrt_output.LDim(),
         local_mean.LockedBuffer(), local_var.LockedBuffer(), this->m_epsilon,


### PR DESCRIPTION
We recently encountered runtime errors in the batchnorm layer when operating on large, flattened data (see https://github.com/vmos1/lbann_cosmogan/pull/1). It happens because we launch CUDA kernels with the grid y-dimension equal to the number of channels, and the maximum grid y-dimension is 65K. I've modified the CUDA kernels so the grid y-dimension no longer needs to match the number of channels. I've also added a Bamboo test that does gradient checking on the batchnorm layer.

[The Bamboo build is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM300-1).

Pinging @vmos1.