### PR TITLE
Updated distconv adaptors to use new optimizer methods

### DIFF
--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1280,13 +1280,14 @@ void base_convolution_adapter<TensorDataType, Device>::setup_bp_tensors() {
 
   m_kernel_gradient = make_unique<TensorDevType>(kernel_shape, loc, shared_dist);
   // Gradient buffer is needed for auto-tuning the bp filter algorithm
+  auto* kernel_optimizer = static_cast<data_type_optimizer<TensorDataType>*>(l.get_weights(0).get_optimizer());
   assert0(dc::tensor::View(
             *m_kernel_gradient,
-            l.get_weights(0).get_optimizer()->get_gradient().Buffer()));
+            kernel_optimizer->get_gradient().Buffer()));
 
   // Bias tensor. Shared by all procs
   if (l.m_bias_scaling_factor != TensorDataType(0)) {
-    auto* bias_optimizer = l.get_weights(1).get_optimizer();
+    auto* bias_optimizer = static_cast<data_type_optimizer<TensorDataType>*>(l.get_weights(1).get_optimizer());
     if (bias_optimizer != nullptr) {
       dc::Shape bias_shape(dc::get_num_dims(l), 1);
       bias_shape[dc::get_channel_dim()] = l.get_output_dims()[0];
@@ -1295,7 +1296,7 @@ void base_convolution_adapter<TensorDataType, Device>::setup_bp_tensors() {
       // which is set when its view is set.
       assert0(dc::tensor::View(
                 *m_bias_gradient,
-                l.get_weights(1).get_optimizer()->get_gradient().Buffer()));
+                bias_optimizer->get_gradient().Buffer()));
     }
   }
 }

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -360,9 +360,9 @@ void batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::fp_com
   const bool is_training =
       l.m_model->get_execution_context().get_execution_mode() == execution_mode::training;
   auto& local_running_mean =
-    ValuesGetter::mutable_values(this->get_weights(2)).Matrix();
+    ValuesGetter::mutable_values(l.get_weights(2)).Matrix();
   auto& local_running_var =
-    ValuesGetter::mutable_values(this->get_weights(3)).Matrix();
+    ValuesGetter::mutable_values(l.get_weights(3)).Matrix();
 
   assert0(dc::tensor::View(
       m_scale, l.weights_values(0).LockedMatrix().LockedBuffer()));


### PR DESCRIPTION
also fixed bug in how weights were being accessed.