### PR TITLE
Feature ds return random data on fail

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -12,8 +12,15 @@ Performance optimizations:
 Model portability & usability:
 
 Internal features:
+ - Refactored standard command line arguments into independent
+   compilation unit
 
 I/O & data readers:
+ - Enabled the data store to substitute missing data samples with
+   valid samples already existing in the data store.
+ - New command line argument --ds_fail_on_missing_samples and paired
+   environment variable LBANN_DS_FAIL_ON_MISSING_SAMPLES that forces
+   LBANN to fail, rather than substitute, on missing samples.
 
 Build system:
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -17,10 +17,23 @@ Internal features:
 
 I/O & data readers:
  - Enabled the data store to substitute missing data samples with
-   valid samples already existing in the data store.
+   valid samples already existing in the data store.  This feature
+   applies to both the JAG Conduit and SMILES data readers.  Should
+   generalize to others when they leverage the data store.
  - New command line argument --ds_fail_on_missing_samples and paired
    environment variable LBANN_DS_FAIL_ON_MISSING_SAMPLES that forces
    LBANN to fail, rather than substitute, on missing samples.
+ - New command line argument --sl_fail_on_missing_files" and paired
+   environment variable LBANN_SL_FAIL_ON_MISSING_FILES Force the
+   sample list to fail on a missing file rather than skipping it
+   and working with a smaller data set or allowing the data store
+    to substitute random samples later.
+ - New command line argument --sl_fail_on_unreadable_files and paired
+   environment variable LBANN_SL_FAIL_ON_UNDREADABLE_FILES force the
+   sample list to fail on a files that cannot be opened rather than
+   skipping it and working with a smaller data set or allowing the
+   data store to substitute random samples later.
+
 
 Build system:
 

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -1,3 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef __SAMPLE_LIST_HPP__
 #define __SAMPLE_LIST_HPP__
 

--- a/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
+++ b/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
@@ -1,3 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef __SAMPLE_LIST_CONDUIT_IO_HANDLE_HPP__
 #define __SAMPLE_LIST_CONDUIT_IO_HANDLE_HPP__
 

--- a/include/lbann/data_readers/sample_list_hdf5.hpp
+++ b/include/lbann/data_readers/sample_list_hdf5.hpp
@@ -1,3 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef __SAMPLE_LIST_HDF5_HPP__
 #define __SAMPLE_LIST_HDF5_HPP__
 
@@ -35,7 +61,7 @@ class sample_list_hdf5 : public sample_list_open_files<sample_name_t, hid_t> {
 
 template <typename sample_name_t>
 inline sample_list_hdf5<sample_name_t>::sample_list_hdf5()
-: sample_list_open_files<sample_name_t, hid_t>() {} 
+: sample_list_open_files<sample_name_t, hid_t>() {}
 
 template <typename sample_name_t>
 inline sample_list_hdf5<sample_name_t>::~sample_list_hdf5() {

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -1,3 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -420,7 +446,7 @@ inline void sample_list<sample_name_t>
     gathered_archive[p].resize(packed_sizes[p]);
     if (me == p) {
       gathered_archive[p] = archive;
-    } 
+    }
     int sz = packed_sizes[p];
     char *data = const_cast<char*>(gathered_archive[p].data());
     comm.trainer_broadcast<char>(p, data, sz);

--- a/include/lbann/data_readers/sample_list_open_files.hpp
+++ b/include/lbann/data_readers/sample_list_open_files.hpp
@@ -1,7 +1,35 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
 #ifndef __SAMPLE_LIST_OPEN_FILES_HPP__
 #define __SAMPLE_LIST_OPEN_FILES_HPP__
 
 #include "sample_list.hpp"
+#include "lbann/utils/std_options.hpp"
+#include "lbann/utils/argument_parser.hpp"
 
 /// Number of system and other files that may be open during execution
 #define LBANN_MAX_OPEN_FILE_MARGIN 128

--- a/include/lbann/data_readers/sample_list_open_files.hpp
+++ b/include/lbann/data_readers/sample_list_open_files.hpp
@@ -33,7 +33,7 @@
 
 /// Number of system and other files that may be open during execution
 #define LBANN_MAX_OPEN_FILE_MARGIN 128
-#define LBANN_MAX_OPEN_FILE_RETRY 3
+#define LBANN_MAX_OPEN_FILE_RETRY 1
 
 namespace lbann {
 

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -34,6 +34,7 @@
 #include "lbann/comm.hpp"
 #include "lbann/utils/exception.hpp"
 #include "conduit/conduit_node.hpp"
+#include "conduit/conduit.hpp"
 #include <unordered_map>
 #include <unordered_set>
 #include <mutex>
@@ -115,6 +116,8 @@ class data_store_conduit {
   void set_preloaded_conduit_node(int data_id, const conduit::Node &node);
 
   void spill_preloaded_conduit_node(int data_id, const conduit::Node &node);
+
+  const conduit::Node & get_random_data(int data_id, int& rand_data_id) const;
 
   const conduit::Node & get_random_node() const;
 
@@ -458,6 +461,8 @@ private :
    * in which rhs is const.
    */
   mutable std::unordered_map<int, conduit::Node> m_data;
+
+  mutable std::unordered_map<int, conduit::Node> m_surrogate_data_cache;
 
   /** @brief Contains a cache of the conduit nodes that are
    * "owned" by this rank

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -36,6 +36,7 @@ set_full_path(THIS_DIR_HEADERS
   random_number_generators.hpp
   serialization.hpp
   statistics.hpp
+  std_options.hpp
   summary.hpp
   summary_impl.hpp
   timer.hpp

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -59,6 +59,25 @@
               << std::endl;                                     \
   } while (0)
 
+// Macro to print a warning to standard error stream.
+#define LBANN_WARN_ERROR_ON_FLAG(flag, ...)                     \
+  do {                                                          \
+    const int rank_LBANN_WARNING = lbann::get_rank_in_world();  \
+    std::string type = "warning";                               \
+    if(flag) { type = "error"; }                                \
+    std::string msg = lbann::build_string(                      \
+      "LBANN ", flag,                                           \
+      (rank_LBANN_WARNING >= 0                                  \
+       ? " on rank " + std::to_string(rank_LBANN_WARNING)       \
+       : std::string()),                                        \
+      " (", __FILE__, ":", __LINE__, "): ", __VA_ARGS__);       \
+    if(flag) {                                                  \
+      throw lbann::exception(msg);                              \
+    }else {                                                     \
+      std::cerr << msg << std::endl;                            \
+    }                                                           \
+  } while (0)
+
 // Macro to print a message to standard cout stream.
 #define LBANN_MSG(...)                                          \
   do {                                                          \

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -34,11 +34,6 @@ namespace lbann {
 
 const int lbann_default_random_seed = 42;
 
-#define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
-#define NUM_IO_THREADS "Num. IO threads"
-
-void construct_std_options();
-
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                                            lbann_data::Trainer* pb_trainer,
                                            lbann_data::LbannPB &pb,

--- a/include/lbann/utils/std_options.hpp
+++ b/include/lbann/utils/std_options.hpp
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifndef LBANN_STD_OPTIONS_HPP
+#define LBANN_STD_OPTIONS_HPP
+
+namespace lbann {
+
+#define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
+#define NUM_IO_THREADS "Num. IO threads"
+#define DATA_STORE_FAIL_ON_MISSING_SAMPLES "Data store fail on missing samples"
+
+void construct_std_options();
+
+} // namespace lbann
+
+#endif // LBANN_STD_OPTIONS_HPP

--- a/include/lbann/utils/std_options.hpp
+++ b/include/lbann/utils/std_options.hpp
@@ -33,6 +33,8 @@ namespace lbann {
 #define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
 #define NUM_IO_THREADS "Num. IO threads"
 #define DATA_STORE_FAIL_ON_MISSING_SAMPLES "Data store fail on missing samples"
+#define SAMPLE_LIST_FAIL_ON_MISSING_FILES "Sample list fail on missing files"
+#define SAMPLE_LIST_FAIL_ON_UNREADABLE_FILES "Sample list fail on unreadable files"
 
 void construct_std_options();
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -30,6 +30,7 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #ifdef LBANN_HAS_CUDNN
 #include "lbann/utils/cudnn.hpp"

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>

--- a/model_zoo/lbann_help.cpp
+++ b/model_zoo/lbann_help.cpp
@@ -27,6 +27,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <lbann/proto/proto_common.hpp>
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/lbann_library.hpp"
 

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -29,6 +29,7 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf_utils.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -921,8 +921,6 @@ void data_reader_jag_conduit::do_preload_data_store() {
       LBANN_WARN_ERROR_ON_FLAG(fail_on_unreadable_files,
                                " :: trying to load the node ", index,
                                " and failed to read the file", err_msg);
-                               // " with key ", key + " and got " + e.what(),
-                               // ": replacing with data from ", rand_data_id);
     }
     m_data_store->set_preloaded_conduit_node(index, node);
   }

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -765,7 +765,9 @@ const conduit::Node & data_store_conduit::get_random_node() const {
   }
 
   if (m_compacted_sample_size == 0) {
-    LBANN_ERROR("can't return random node since we have no valid size for data (set_conduit_node has never been called)");
+    LBANN_ERROR("can't return random node since we have no valid size for data ",
+                "(set_conduit_node has never been called): m_data.size()=",
+                m_data.size());
   }
   int retry_count = 0, MAX_RNG_SAMPLE_SELECTIONS = 10;
   do {

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -733,7 +733,6 @@ const conduit::Node & data_store_conduit::get_random_data(int data_id, int& rand
       conduit::NodeIterator data_itr = cld.children();
       std::string data_id_str = LBANN_DATA_ID_STR(data_id);
       while(data_itr.has_next()) {
-        //        conduit::Node &datum = data_itr.next();
         data_itr.next(); // Advanced the iterator
         std::string datum_name = data_itr.name();
         if(rand_data_id_str != "") {

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -32,6 +32,7 @@
 #include "lbann/proto/init_image_data_readers.hpp"
 #include "lbann/proto/factories.hpp"
 #include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -23,6 +23,7 @@ set_full_path(THIS_DIR_SOURCES
   stack_profiler.cpp
   stack_trace.cpp
   statistics.cpp
+  std_options.cpp
   summary.cpp
   system_info.cpp
   lbann_library.cpp

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -34,28 +34,13 @@
 #include "lbann/callbacks/dump_weights.hpp"
 #include "lbann/callbacks/save_model.hpp"
 #include "lbann/callbacks/load_model.hpp"
+#include "lbann/utils/std_options.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
 #include <lbann.pb.h>
 #include <model.pb.h>
 
 namespace lbann {
-
-void construct_std_options() {
-  auto& arg_parser = global_argument_parser();
-  arg_parser.add_option(MAX_RNG_SEEDS_DISPLAY,
-                        {"--rng_seeds_per_trainer_to_display"},
-                        utils::ENV("LBANN_RNG_SEEDS_PER_TRAINER_TO_DISPLAY"),
-                        "Limit how many random seeds LBANN should display "
-                        "from each trainer",
-                        2);
-  arg_parser.add_option(NUM_IO_THREADS,
-                        {"--num_io_threads"},
-                        utils::ENV("LBANN_NUM_IO_THREADS"),
-                        "Number of threads available to both I/O and "
-                        "initial data transformations for each rank.",
-                        64);
-}
 
 /// Construct a trainer that contains a lbann comm object and threadpool
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,

--- a/src/utils/std_options.cpp
+++ b/src/utils/std_options.cpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/std_options.hpp"
+#include "lbann/utils/argument_parser.hpp"
+
+namespace lbann {
+
+void construct_std_options() {
+  auto& arg_parser = global_argument_parser();
+  arg_parser.add_option(MAX_RNG_SEEDS_DISPLAY,
+                        {"--rng_seeds_per_trainer_to_display"},
+                        utils::ENV("LBANN_RNG_SEEDS_PER_TRAINER_TO_DISPLAY"),
+                        "Limit how many random seeds LBANN should display "
+                        "from each trainer",
+                        2);
+  arg_parser.add_option(NUM_IO_THREADS,
+                        {"--num_io_threads"},
+                        utils::ENV("LBANN_NUM_IO_THREADS"),
+                        "Number of threads available to both I/O and "
+                        "initial data transformations for each rank.",
+                        64);
+  arg_parser.add_flag(DATA_STORE_FAIL_ON_MISSING_SAMPLES,
+                      {"--ds_fail_on_missing_samples"},
+                      utils::ENV("LBANN_DS_FAIL_ON_MISSING_SAMPLES"),
+                      "Force the data store to fail on a missing sample "
+                      "rather than substituting it with a random sample.");
+}
+
+} // namespace lbann

--- a/src/utils/std_options.cpp
+++ b/src/utils/std_options.cpp
@@ -48,6 +48,21 @@ void construct_std_options() {
                       utils::ENV("LBANN_DS_FAIL_ON_MISSING_SAMPLES"),
                       "Force the data store to fail on a missing sample "
                       "rather than substituting it with a random sample.");
+  arg_parser.add_flag(SAMPLE_LIST_FAIL_ON_MISSING_FILES,
+                      {"--sl_fail_on_missing_files"},
+                      utils::ENV("LBANN_SL_FAIL_ON_MISSING_FILES"),
+                      "Force the sample list to fail on a missing file "
+                      "rather than skipping it and working with a smaller "
+                      "data set or allowing the data store to substitute "
+                      "random samples later.");
+  arg_parser.add_flag(SAMPLE_LIST_FAIL_ON_UNREADABLE_FILES,
+                      {"--sl_fail_on_unreadable_files"},
+                      utils::ENV("LBANN_SL_FAIL_ON_UNDREADABLE_FILES"),
+                      "Force the sample list to fail on a files that cannot "
+                      "be opened rather than skipping it and working with a "
+                      "smaller data set or allowing the data store to "
+                      "substitute random samples later.");
+
 }
 
 } // namespace lbann


### PR DESCRIPTION
This PR allows the data store to to substitute missing data samples with valid samples already existing in the data store.  On the smiles data reader this has been tested to show that if you never exchange data, the training can still continue.  I will work on adding support for JAG failing to find a file as well.