### PR TITLE
GRU layer

### DIFF
--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -57,6 +57,8 @@ class MolVAE(lbann.modules.Module):
         :return: float, recon component of loss
         """
 
+        x = lbann.Slice(x, slice_points=str_list([0, self.input_feature_dims]))
+        x = lbann.Identity(x)
         x_emb = lbann.Embedding(
             x,
             num_embeddings=self.dictionary_size,
@@ -86,7 +88,10 @@ class MolVAE(lbann.modules.Module):
         :return: float, kl term component of loss
         """
 
-        h = lbann.Constant(value=0.0, num_neurons='256')
+        h = lbann.Constant(
+            value=0.0,
+            num_neurons='256',
+        )
         h = lbann.GRU(
             x_emb, h,
             hidden_size=256,

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -122,11 +122,11 @@ class MolVAE(lbann.modules.Module):
         fc = lbann.modules.FullyConnectedModule
         gru = GRUModule
         #Encoder
-        self.encoder_rnn = gru(hidden_size=256, name=self.name+'_encoder_rnn', datatype=lbann.DataType.FP16, weights_datatype=lbann.DataType.FLOAT)
+        self.encoder_rnn = gru(hidden_size=256, name=self.name+'_encoder_rnn')
         self.q_mu = fc(128,name=self.name+'_qmu')
         self.q_logvar = fc(128,name=self.name+'_qlogvar')
         #Decoder
-        self.decoder_rnn = gru(hidden_size=512, num_layers=3, name=self.name+'_decoder_rnn', datatype=lbann.DataType.FP16, weights_datatype=lbann.DataType.FLOAT)
+        self.decoder_rnn = gru(hidden_size=512, num_layers=3, name=self.name+'_decoder_rnn')
         self.decoder_lat = fc(512,name=self.name+'_decoder_lat')
         #shared encoder/decodeer weights
         self.emb_weights = lbann.Weights(initializer=lbann.NormalInitializer(mean=0, standard_deviation=1),

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -216,8 +216,7 @@ class MolVAE(lbann.modules.Module):
         in_stack = {l : True for l in stack}
         while stack:
             l = stack.pop()
-            if (isinstance(l, lbann.FullyConnected)
-                or isinstance(l, lbann.ChannelwiseFullyConnected)):
+            if type(l) not in (lbann.Slice, lbann.Reshape, lbann.Tessellate):
                 l.datatype = self.datatype
             for parent in l.parents:
                 if parent not in in_stack and parent is not x_emb:
@@ -278,8 +277,7 @@ class MolVAE(lbann.modules.Module):
         in_stack = {l : True for l in stack}
         while stack:
             l = stack.pop()
-            if (isinstance(l, lbann.FullyConnected)
-                or isinstance(l, lbann.ChannelwiseFullyConnected)):
+            if type(l) not in (lbann.Slice, lbann.Reshape, lbann.Tessellate):
                 l.datatype = self.datatype
             for parent in l.parents:
                 if parent not in in_stack and parent not in (x_emb, z):

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -40,18 +40,11 @@ class MolVAE(lbann.modules.Module):
         self.label_to_ignore = ignore_label
 
         fc = lbann.modules.FullyConnectedModule
-        gru = lbann.modules.GRU
         #Encoder
-        winit = lbann.GlorotNormalInitializer()
-        self.encoder_rnn = gru(size=256, name=self.name+'_encoder_rnn')
         self.q_mu = fc(128,name=self.name+'_qmu')
         self.q_logvar = fc(128,name=self.name+'_qlogvar')
         #Decoder
-        self.decoder_rnn0 = gru(size=512, name=self.name+'_decoder_rnn0')
-        self.decoder_rnn1 = gru(size=512, name=self.name+'_decoder_rnn1')
-        self.decoder_rnn2 = gru(size=512, name=self.name+'_decoder_rnn2')
         self.decoder_lat = fc(512,name=self.name+'_decoder_lat')
-        self.decoder_fc = fc(dictionary_size,name=self.name+'_decoder_fc')
         #shared encoder/decodeer weights
         self.emb_weights = lbann.Weights(initializer=lbann.NormalInitializer(mean=0, standard_deviation=1),
                                    name='emb_matrix')
@@ -64,37 +57,44 @@ class MolVAE(lbann.modules.Module):
         :return: float, recon component of loss
         """
 
-        emb = lbann.Embedding(x,
-                              num_embeddings=self.dictionary_size,
-                              embedding_dim=self.embedding_size,
-                              name='emb',
-                              weights=self.emb_weights)
-        emb_slice = lbann.Slice(emb,
-                                axis=0,
-                                slice_points=str_list(range(self.input_feature_dims+1)),
-                                name='emb_slice')
-        emb_list = [lbann.Reshape(emb_slice, dims='-1', name='emb'+str(i))
-                    for i in range(self.input_feature_dims)]
+        x_emb = lbann.Embedding(
+            x,
+            num_embeddings=self.dictionary_size,
+            embedding_dim=self.embedding_size,
+            name='emb',
+            weights=self.emb_weights
+        )
 
         # Encoder: x -> z, kl_loss
-        z, kl_loss = self.forward_encoder(emb_list)
+        z, kl_loss = self.forward_encoder(x_emb)
 
         # Decoder: x, z -> recon_loss
-        recon_loss, arg_max = self.forward_decoder(x, emb_list, z)
+        pred, arg_max = self.forward_decoder(x_emb, z)
+        recon_loss = self.compute_loss(x, pred)
 
         return kl_loss, recon_loss, arg_max
 
-    def forward_encoder(self, emb_list):
+    def forward_encoder(self, x_emb):
         """Encoder step, emulating z ~ E(x) = q_E(z|x)
 
-        :param embed_list: list of tensors of floats, input sentence emb_list
+        :param x_emb: (n_batch, len(x), d_z) of floats, embeddings for input sentence x
         :return: (n_batch, d_z) of floats, sample of latent vector z
         :return: float, kl term component of loss
         """
 
         h = lbann.Constant(value=0.0, num_neurons='256')
-        for i in range(self.input_feature_dims):
-            _, h = self.encoder_rnn(emb_list[i], h)
+        h = lbann.GRU(
+            x_emb, h,
+            hidden_size=256,
+            name=f'{self.name}_encoder_rnn',
+        )
+        h = lbann.Slice(
+            h,
+            slice_points=str_list([self.input_feature_dims-1,
+                                   self.input_feature_dims]),
+            axis=0,
+        )
+        h = lbann.Identity(h)
 
         mu, logvar = self.q_mu(h), self.q_logvar(h)
 
@@ -115,50 +115,103 @@ class MolVAE(lbann.modules.Module):
 
         return z, kl_loss
 
-    def forward_decoder(self, x, emb_list, z):
+    def forward_decoder(self, x_emb, z):
         """Decoder step, emulating x ~ G(z)
 
-        :param x: list of tensors of longs, input sentence x
-        :param emb_list: embeddings of x
+        :param x_emb: (n_batch, len(x), d_z) of floats, embeddings for input sentence x
         :param z: (n_batch, d_z) of floats, latent vector z
         :return: float, recon component of loss
+        :return: list of ints, reconstructed sentence
         """
 
+        # z_0 = z.unsqueeze(1).repeat(1, x_emb.size(1), 1)
+        # x_input = torch.cat([x_emb, z_0], dim=-1)
+        z_0 = lbann.Tessellate(
+            lbann.Reshape(z, dims=str_list([1, 128])),
+            dims=str_list([self.input_feature_dims, 128]),
+        )
+        x_input = lbann.Concatenation(x_emb, z_0, axis=1)
+
+        h_0 = self.decoder_lat(z)
+
+        # output, _ = self.decoder_rnn(x_input, h_0)
+        h_1 = lbann.GRU(
+            x_emb, h_0,
+            hidden_size=512,
+            name=f'{self.name}_decoder_rnn0',
+        )
+        h_2 = lbann.GRU(
+            h_1, h_0,
+            hidden_size=512,
+            name=f'{self.name}_decoder_rnn1',
+        )
+        output = lbann.GRU(
+            h_2, h_0,
+            hidden_size=512,
+            name=f'{self.name}_decoder_rnn2',
+        )
+
+        # y = self.decoder_fc(output)
+        y = lbann.ChannelwiseFullyConnected(
+            output,
+            output_channel_dims=self.dictionary_size,
+            bias=True,
+            name=f'{self.name}_decoder_fc',
+        )
+
+        # Find argmax
+        y_slice = lbann.Slice(
+            y,
+            axis=0,
+            slice_points=str_list(range(self.input_feature_dims+1)),
+        )
+        y_slice = [lbann.Reshape(y_slice, dims='-1') for _ in range(self.input_feature_dims)]
+        arg_max = [lbann.Argmax(yi, device='CPU') for yi in y_slice]
+
+        return y, arg_max
+
+    def compute_loss(self, x, y):
+
+        # y[:, :-1]
+        y = lbann.Slice(
+            y,
+            axis=0,
+            slice_points=str_list([0, self.input_feature_dims-1]),
+        )
+        y = lbann.Identity(y)
+
         # x[:, 1:]
-        xshift = lbann.Slice(x, slice_points=str_list([1, self.input_feature_dims]))
-        xshift = lbann.Identity(xshift)
-        xshift_slice = lbann.Slice(xshift, slice_points=str_list(range(self.input_feature_dims)))
-        xshift_list = [lbann.Identity(xshift_slice) for i in range(self.input_feature_dims-1)]
+        x = lbann.Slice(
+            x,
+            slice_points=str_list([1, self.input_feature_dims]),
+        )
+        x = lbann.Identity(x)
 
-        # Unroll RNN
-        h = [self.decoder_lat(z)] * 3
-        recon_loss = []
-        arg_max = []
-        for i in range(self.input_feature_dims-1):
-
-            # RNN stack
-            x_input = lbann.Concatenation(emb_list[i], z)
-            _, h[0] = self.decoder_rnn0(x_input, h[0])
-            _, h[1] = self.decoder_rnn1(h[0], h[1])
-            _, h[2] = self.decoder_rnn2(h[1], h[2])
-            output = h[2]
-            #output = h[0]
-            y = self.decoder_fc(output)
-            arg_max.append(lbann.Argmax(y,device='CPU'))
-
-            # Cross entropy loss
-            y = lbann.Softmax(y)
-            xshift_onehot = lbann.OneHot(xshift_list[i], size=self.dictionary_size)
-            recon_loss.append(lbann.CrossEntropy(y, xshift_onehot))
-
-        # Average cross entropy over sequence length
-        pad_mask = lbann.NotEqual(xshift,
-                                  lbann.Constant(value=self.label_to_ignore, hint_layer=xshift))
-        length = lbann.Reduction(pad_mask, mode='sum')
+        # Set ignored labels to -1
+        ignore_mask = lbann.Equal(
+            x,
+            lbann.Constant(value=self.label_to_ignore, hint_layer=x),
+        )
+        keep_mask = lbann.LogicalNot(ignore_mask)
+        length = lbann.Reduction(keep_mask, mode='sum')
         length = lbann.Max(length, lbann.Constant(value=1, num_neurons="1"))
-        recon_loss = lbann.Concatenation(recon_loss)
-        recon_loss = lbann.Multiply(recon_loss, pad_mask)
-        recon_loss = lbann.Reduction(recon_loss, mode='sum')
+        x = lbann.Add(
+            lbann.Multiply(keep_mask, x),
+            lbann.Multiply(ignore_mask, lbann.Constant(value=-1, hint_layer=x)),
+        )
+
+        # recon_loss = F.cross_entropy(
+        #     y[:, :-1].contiguous().view(-1, y.size(-1)),
+        #     x[:, 1:].contiguous().view(-1),
+        #     ignore_index=self.pad
+        # )
+        y = lbann.ChannelwiseSoftmax(y)
+        x = lbann.Slice(x, slice_points=str_list(range(self.input_feature_dims)))
+        x = [lbann.Identity(x) for _ in range(self.input_feature_dims-1)]
+        x = [lbann.OneHot(xi, size=self.dictionary_size) for xi in x]
+        x = [lbann.Reshape(xi, dims=str_list([1, self.dictionary_size])) for xi in x]
+        x = lbann.Concatenation(x, axis=0)
+        recon_loss = lbann.CrossEntropy(y, x)
         recon_loss = lbann.Divide(recon_loss, length)
 
-        return recon_loss, arg_max
+        return recon_loss

--- a/applications/ATOM/train_atom_vae.py
+++ b/applications/ATOM/train_atom_vae.py
@@ -106,16 +106,14 @@ def construct_model(run_args):
     assert embedding_size is not None
     assert dictionary_size is not None
 
-    kl, recon, arg_max = molvae.MolVAE(input_feature_dims,
-                                       dictionary_size,
-                                       embedding_size,
-                                       pad_index)(input_)
+    kl, recon = molvae.MolVAE(input_feature_dims,
+                              dictionary_size,
+                              embedding_size,
+                              pad_index)(input_)
 
     vae_loss.append(kl)
     vae_loss.append(recon)
     print("LEN vae loss ", len(vae_loss))
-    #metric layers
-    pred_tensor = lbann.Concatenation(arg_max[:-1], name='pred_tensor')
 
     layers = list(lbann.traverse_layer_graph(input_))
     # Setup objective function

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -131,15 +131,19 @@ def construct_model(lbann):
     ih_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
     hh_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
     ih_matrix_weights = lbann.Weights(
+        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(ih_matrix, order='F'))))
     hh_matrix_weights = lbann.Weights(
+        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(hh_matrix, order='F'))))
     ih_bias_weights = lbann.Weights(
+        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(ih_bias))))
     hh_bias_weights = lbann.Weights(
+        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(hh_bias))))
 
@@ -178,8 +182,7 @@ def construct_model(lbann):
     # Gradient checking
     # ------------------------------------------
 
-    ### @todo Restore
-    # callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
 
     # ------------------------------------------
     # Construct model

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -232,5 +232,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__):
-    globals()[test.__name__] = test
+# for test in tools.create_tests(setup_experiment, __file__):
+#     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -63,7 +63,7 @@ def numpy_gru(x, h, ih_matrix, hh_matrix, ih_bias, hh_bias):
     y = []
     for t in range(sequence_length):
         ih = np.matmul(ih_matrix, x[t]) + ih_bias
-        hh = np.matmul(hh_matrix, h) + ih_bias
+        hh = np.matmul(hh_matrix, h) + hh_bias
         r = scipy.special.expit(ih[:hidden_size] + hh[:hidden_size])
         z = scipy.special.expit(ih[hidden_size:2*hidden_size] + hh[hidden_size:2*hidden_size])
         n = np.tanh(ih[2*hidden_size:] + r*hh[2*hidden_size:])
@@ -131,19 +131,15 @@ def construct_model(lbann):
     ih_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
     hh_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
     ih_matrix_weights = lbann.Weights(
-        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(ih_matrix, order='F'))))
     hh_matrix_weights = lbann.Weights(
-        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(hh_matrix, order='F'))))
     ih_bias_weights = lbann.Weights(
-        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(ih_bias))))
     hh_bias_weights = lbann.Weights(
-        optimizer=lbann.NoOptimizer(), ### @todo Remove
         initializer=lbann.ValueInitializer(
             values=tools.str_list(np.nditer(hh_bias))))
 

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -1,0 +1,237 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+import scipy.special
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20200909)
+_num_samples = 15
+_sequence_length = 5
+_input_size = 13
+_hidden_size = 7
+_sample_size = _sequence_length*_input_size + _hidden_size
+_samples = np.random.normal(size=(_num_samples,_sample_size)).astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:]
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# NumPy implementation
+# ==============================================
+
+def numpy_gru(x, h, ih_matrix, hh_matrix, ih_bias, hh_bias):
+
+    # Cast inputs to float64
+    if x.dtype is not np.float64:
+        x = x.astype(np.float64)
+    if h.dtype is not np.float64:
+        h = h.astype(np.float64)
+    if ih_matrix.dtype is not np.float64:
+        ih_matrix = ih_matrix.astype(np.float64)
+    if hh_matrix.dtype is not np.float64:
+        hh_matrix = hh_matrix.astype(np.float64)
+    if ih_bias.dtype is not np.float64:
+        ih_bias = ih_bias.astype(np.float64)
+    if hh_bias.dtype is not np.float64:
+        hh_bias = hh_bias.astype(np.float64)
+
+    # Dimensions
+    sequence_length, input_size = x.shape
+    hidden_size = h.shape[0]
+
+    # Unroll GRU
+    y = []
+    for t in range(sequence_length):
+        ih = np.matmul(ih_matrix, x[t]) + ih_bias
+        hh = np.matmul(hh_matrix, h) + ih_bias
+        r = scipy.special.expit(ih[:hidden_size] + hh[:hidden_size])
+        z = scipy.special.expit(ih[hidden_size:2*hidden_size] + hh[hidden_size:2*hidden_size])
+        n = np.tanh(ih[2*hidden_size:] + r*hh[2*hidden_size:])
+        h = (1-z)*n + z*h
+        y.append(h)
+    return np.stack(y)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples() // 2
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.SGD()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Sum with a weights layer so that gradient checking will
+    # verify that error signals are correct.
+    x_weights = lbann.Weights(initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input')
+    h_weights = lbann.Weights(initializer=lbann.ConstantInitializer(value=0.0),
+                              name='inital_hidden')
+    input_ = lbann.Identity(lbann.Input())
+    input_slice = lbann.Slice(
+        input_,
+        slice_points=tools.str_list([0, _sequence_length*_input_size, _sample_size]),
+    )
+    x = lbann.Reshape(input_slice, dims=tools.str_list([_sequence_length,_input_size]))
+    x = lbann.Sum(x, lbann.WeightsLayer(weights=x_weights, hint_layer=x))
+    h = lbann.Reshape(input_slice, dims=tools.str_list([_hidden_size]),)
+    h = lbann.Sum(h, lbann.WeightsLayer(weights=h_weights, hint_layer=h))
+    x_lbann = x
+    h_lbann = h
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # 1-layer, uni-directional GRU
+    # ------------------------------------------
+
+    # Weights
+    ih_matrix = np.random.normal(size=(3*_hidden_size,_input_size)).astype(np.float32)
+    hh_matrix = np.random.normal(size=(3*_hidden_size,_hidden_size)).astype(np.float32)
+    ih_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
+    hh_bias = np.random.normal(size=(3*_hidden_size,)).astype(np.float32)
+    ih_matrix_weights = lbann.Weights(
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(ih_matrix, order='F'))))
+    hh_matrix_weights = lbann.Weights(
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(hh_matrix, order='F'))))
+    ih_bias_weights = lbann.Weights(
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(ih_bias))))
+    hh_bias_weights = lbann.Weights(
+        initializer=lbann.ValueInitializer(
+            values=tools.str_list(np.nditer(hh_bias))))
+
+    # LBANN implementation
+    x = x_lbann
+    h = h_lbann
+    y = lbann.GRU(
+        x,
+        h,
+        hidden_size=_hidden_size,
+        weights=[ih_matrix_weights,hh_matrix_weights,ih_bias_weights,hh_bias_weights],
+    )
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='1-layer, unidirectional'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        input_ = get_sample(i).astype(np.float64)
+        x = input_[:_sequence_length*_input_size].reshape((_sequence_length,_input_size))
+        h = input_[_sequence_length*_input_size:]
+        y = numpy_gru(x, h, ih_matrix, hh_matrix, ih_bias, hh_bias)
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    ### @todo Restore
+    # callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/include/lbann/layers/learning/CMakeLists.txt
+++ b/include/lbann/layers/learning/CMakeLists.txt
@@ -9,6 +9,7 @@ set_full_path(THIS_DIR_HEADERS
   entrywise_scale_bias.hpp
   fully_connected.hpp
   fully_connected_cuda.hpp
+  gru.hpp
   learning.hpp
   )
 

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -78,7 +78,7 @@ private:
   cudnn::TensorDescriptor m_input_cudnn_desc;
   cudnn::TensorDescriptor m_output_cudnn_desc;
   cudnn::TensorDescriptor m_hidden_cudnn_desc;
-  cudnn::FilterDescriptor m_weights_cudnn_desc;
+  cudnn::FilterDescriptor m_packed_weights_cudnn_desc;
   ByteBuffer m_cudnn_reserve_space;
 #endif // LBANN_HAS_CUDNN
 

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -34,6 +34,27 @@
 
 namespace lbann {
 
+/** @brief Gated recurrent unit
+ *
+ *  Expects two inputs: a 2D input sequence (
+ *  @f$ \text{sequence\_length}\times\text{input\_size} @f$ )
+ *  and a 1D initial hidden state ( @f$ \text{hidden\_size} @f$ ).
+ *
+ *  Uses four weights: "ih\_matrix" (
+ *  @f$ 3 \text{hidden\_size}\times\text{input\_size} @f$ ),
+ *  "hh\_matrix" (
+ *  @f$ 3 \text{hidden\_size}\times\text{hidden\_size} @f$ ),
+ *  "ih_bias" ( @f$ 3 \text{hidden\_size} @f$ ),
+ *  "hh_bias" ( @f$ 3 \text{hidden\_size} @f$ ).
+ *
+ *  @todo Support CPU
+ *  @todo Support bidirectional RNNs
+ *  @todo Support stacked RNNs
+ *
+ *  @warning cuDNN 8 exposes a new RNN API and deprecates the old one.
+ *  Consider reimplementing this layer once cuDNN 8 is the minimum
+ *  version.
+ */
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 class gru_layer
   : public data_type_layer<TensorDataType> {

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -66,7 +66,7 @@ protected:
 #endif // LBANN_HAS_CUDNN
 
   void fp_compute() override;
-  // void bp_compute() override; /// @todo Implement
+  void bp_compute() override;
 
 private:
 
@@ -84,10 +84,8 @@ private:
 
   template <typename T>
   friend void fp_compute_impl(gru_layer<T,Layout,Device>&);
-#ifdef LBANN_HAS_GPU
   template <typename T>
   friend void bp_compute_impl(gru_layer<T,Layout,Device>&);
-#endif // LBANN_HAS_GPU
 
 };
 

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -1,0 +1,111 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_LEARNING_GRU_HPP_INCLUDED
+#define LBANN_LAYERS_LEARNING_GRU_HPP_INCLUDED
+
+#include "lbann/layers/data_type_layer.hpp"
+#ifdef LBANN_HAS_CUDNN
+#include "lbann/utils/cudnn.hpp"
+#endif // LBANN_HAS_CUDNN
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+class gru_layer
+  : public data_type_layer<TensorDataType> {
+
+  static_assert(Layout == data_layout::DATA_PARALLEL,
+                "GRU layer only supports data parallel layout");
+
+public:
+
+  gru_layer(
+    lbann_comm* comm,
+    size_t hidden_size);
+
+  gru_layer(const gru_layer& other);
+  gru_layer& operator=(const gru_layer& other);
+  ~gru_layer() = default;
+
+  gru_layer* copy() const override;
+  std::string get_type() const override;
+  data_layout get_data_layout() const override;
+  El::Device get_device_allocation() const override;
+  description get_description() const override;
+
+protected:
+
+  void setup_dims(DataReaderMetaData& dr_metadata) override;
+  void setup_data(size_t max_mini_batch_size) override;
+#ifdef LBANN_HAS_CUDNN
+  void setup_gpu() override;
+#endif // LBANN_HAS_CUDNN
+
+  void fp_compute() override;
+  // void bp_compute() override; /// @todo Implement
+
+private:
+
+  size_t m_hidden_size;
+
+#ifdef LBANN_HAS_CUDNN
+  using ByteBuffer = hydrogen::simple_buffer<El::byte, Device>;
+  cudnn::RNNDescriptor m_rnn_cudnn_desc;
+  cudnn::TensorDescriptor m_input_cudnn_desc;
+  cudnn::TensorDescriptor m_output_cudnn_desc;
+  cudnn::TensorDescriptor m_hidden_cudnn_desc;
+  cudnn::FilterDescriptor m_weights_cudnn_desc;
+  ByteBuffer m_cudnn_reserve_space;
+#endif // LBANN_HAS_CUDNN
+
+  template <typename T>
+  friend void fp_compute_impl(gru_layer<T,Layout,Device>&);
+#ifdef LBANN_HAS_GPU
+  template <typename T>
+  friend void bp_compute_impl(gru_layer<T,Layout,Device>&);
+#endif // LBANN_HAS_GPU
+
+};
+
+// Builder function
+LBANN_DEFINE_LAYER_BUILDER(gru);
+
+// Explicit template instantiation
+#ifdef LBANN_HAS_CUDNN
+#ifndef LBANN_GRU_LAYER_INSTANTIATE
+#define PROTO(T)                                                        \
+  extern template class gru_layer<                                             \
+    T, data_layout::DATA_PARALLEL, El::Device::GPU>;
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+#endif // LBANN_GRU_LAYER_INSTANTIATE
+#endif // LBANN_HAS_CUDNN
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_LEARNING_GRU_HPP_INCLUDED

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -54,6 +54,7 @@
 #include "lbann/layers/learning/embedding.hpp"
 #include "lbann/layers/learning/channelwise_scale_bias.hpp"
 #include "lbann/layers/learning/entrywise_scale_bias.hpp"
+#include "lbann/layers/learning/gru.hpp"
 
 /// Loss layers
 #include "lbann/layers/loss/categorical_accuracy.hpp"

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -144,6 +144,229 @@ void copy_activation_desc(const cudnnActivationDescriptor_t& src,
                           cudnnActivationDescriptor_t& dst);
 
 ////////////////////////////////////////////////////////////
+// Wrapper classes for cuDNN types
+////////////////////////////////////////////////////////////
+
+/** @brief Wrapper around @c cudnnTensorDescriptor_t */
+class TensorDescriptor {
+
+public:
+
+  TensorDescriptor(cudnnTensorDescriptor_t desc=nullptr);
+  template <typename... ArgTs>
+  TensorDescriptor(ArgTs... args) {
+    set(args...);
+  }
+
+  ~TensorDescriptor();
+
+  // Copy-and-swap idiom
+  TensorDescriptor(const TensorDescriptor&);
+  TensorDescriptor(TensorDescriptor&&);
+  TensorDescriptor& operator=(TensorDescriptor);
+  friend void swap(TensorDescriptor& first, TensorDescriptor& second);
+
+  /** @brief Take ownership of cuDNN object */
+  void reset(cudnnTensorDescriptor_t desc=nullptr);
+  /** @brief Return cuDNN object and release ownership */
+  cudnnTensorDescriptor_t release();
+  /** @brief Return cuDNN object without releasing ownership */
+  cudnnTensorDescriptor_t get() const noexcept;
+  /** @brief Return cuDNN object without releasing ownership */
+  operator cudnnTensorDescriptor_t() const noexcept;
+
+  /** @brief Create cuDNN object
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** @brief Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  void set(
+    cudnnDataType_t data_type,
+    const std::vector<int>& dims,
+    std::vector<int> strides = {});
+  /** @brief Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  template <typename... IntTs>
+  void set(
+    cudnnDataType_t data_type,
+    IntTs... dims) {
+    set(data_type, {static_cast<int>(dims)...});
+  }
+
+private:
+
+  cudnnTensorDescriptor_t desc_{nullptr};
+
+};
+
+/** Wrapper around @c cudnnFilterDescriptor_t */
+class FilterDescriptor {
+
+public:
+
+  FilterDescriptor(cudnnFilterDescriptor_t desc=nullptr);
+  template <typename... ArgTs>
+  FilterDescriptor(ArgTs... args) {
+    set(args...);
+  }
+
+  ~FilterDescriptor();
+
+  // Copy-and-swap idiom
+  FilterDescriptor(const FilterDescriptor&);
+  FilterDescriptor(FilterDescriptor&&);
+  FilterDescriptor& operator=(FilterDescriptor);
+  friend void swap(FilterDescriptor& first, FilterDescriptor& second);
+
+  /** @brief Take ownership of cuDNN object */
+  void reset(cudnnFilterDescriptor_t desc=nullptr);
+  /** @brief Return cuDNN object and release ownership */
+  cudnnFilterDescriptor_t release();
+  /** @brief Return cuDNN object without releasing ownership */
+  cudnnFilterDescriptor_t get() const noexcept;
+  /** @brief Return cuDNN object without releasing ownership */
+  operator cudnnFilterDescriptor_t() const noexcept;
+
+  /** Create cuDNN object
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  void set(
+    cudnnDataType_t data_type,
+    cudnnTensorFormat_t format,
+    const std::vector<int>& dims);
+  /** Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  template <typename... IntTs>
+  void set(
+    cudnnDataType_t data_type,
+    cudnnTensorFormat_t format,
+    IntTs... dims) {
+    set(data_type, format, {static_cast<int>(dims)...});
+  }
+
+private:
+
+  cudnnFilterDescriptor_t desc_{nullptr};
+
+};
+
+/** Wrapper around @c cudnnDropoutDescriptor_t */
+class DropoutDescriptor {
+
+public:
+
+  DropoutDescriptor(cudnnDropoutDescriptor_t desc=nullptr);
+  template <typename... ArgTs>
+  DropoutDescriptor(ArgTs... args) {
+    set(args...);
+  }
+
+  ~DropoutDescriptor();
+
+  // Copy-and-swap idiom
+  DropoutDescriptor(const DropoutDescriptor&);
+  DropoutDescriptor(DropoutDescriptor&&);
+  DropoutDescriptor& operator=(DropoutDescriptor);
+  friend void swap(DropoutDescriptor& first, DropoutDescriptor& second);
+
+  /** @brief Take ownership of cuDNN object */
+  void reset(cudnnDropoutDescriptor_t desc=nullptr);
+  /** @brief Return cuDNN object and release ownership */
+  cudnnDropoutDescriptor_t release();
+  /** @brief Return cuDNN object without releasing ownership */
+  cudnnDropoutDescriptor_t get() const noexcept;
+  /** @brief Return cuDNN object without releasing ownership */
+  operator cudnnDropoutDescriptor_t() const noexcept;
+
+  /** Create cuDNN object
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  void set(
+    float dropout,
+    void* states,
+    size_t states_size,
+    unsigned long long seed);
+
+private:
+
+  cudnnDropoutDescriptor_t desc_{nullptr};
+
+};
+
+/** Wrapper around @c cudnnRNNDescriptor_t */
+class RNNDescriptor {
+
+public:
+
+  RNNDescriptor(cudnnRNNDescriptor_t desc=nullptr);
+  template <typename... ArgTs>
+  RNNDescriptor(ArgTs... args) {
+    set(args...);
+  }
+
+  ~RNNDescriptor();
+
+  // Copy-and-swap idiom
+  RNNDescriptor(const RNNDescriptor&);
+  RNNDescriptor(RNNDescriptor&&);
+  RNNDescriptor& operator=(RNNDescriptor);
+  friend void swap(RNNDescriptor& first, RNNDescriptor& second);
+
+  /** @brief Take ownership of cuDNN object */
+  void reset(cudnnRNNDescriptor_t desc=nullptr);
+  /** @brief Return cuDNN object and release ownership */
+  cudnnRNNDescriptor_t release();
+  /** @brief Return cuDNN object without releasing ownership */
+  cudnnRNNDescriptor_t get() const noexcept;
+  /** @brief Return cuDNN object without releasing ownership */
+  operator cudnnRNNDescriptor_t() const noexcept;
+
+  /** Create cuDNN object
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** Configure cuDNN object
+   *
+   *  Creates cuDNN object if needed.
+   */
+  void set(
+    size_t hidden_size,
+    size_t num_layers,
+    cudnnDropoutDescriptor_t dropout_desc,
+    cudnnRNNInputMode_t input_mode,
+    cudnnDirectionMode_t direction,
+    cudnnRNNMode_t mode,
+    cudnnRNNAlgo_t algo,
+    cudnnDataType_t math_precision);
+
+private:
+
+  cudnnRNNDescriptor_t desc_{nullptr};
+
+};
+
+////////////////////////////////////////////////////////////
 // cuDNN tensor managers
 ////////////////////////////////////////////////////////////
 

--- a/python/lbann/modules/rnn.py
+++ b/python/lbann/modules/rnn.py
@@ -213,6 +213,13 @@ class GRU(Module):
             data_layout=self.data_layout
         )
 
+        self.ones = lbann.Constant(
+            value=1.0,
+            num_neurons=str(size),
+            data_layout=self.data_layout,
+            name=self.name+'_ones',
+        )
+
     def forward(self, x, prev_state):
         """Apply GRU step.
 
@@ -285,7 +292,7 @@ class GRU(Module):
             lbann.Add(
                 lbann.Multiply(
                     lbann.WeightedSum(
-                        lbann.Constant(value=1.0, hint_layer=zt, data_layout=self.data_layout),
+                        self.ones,
                         zt,
                         scaling_factors='1 -1', data_layout=self.data_layout
                     ),

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -515,8 +515,9 @@ void ltfb::on_batch_begin(model *m) {
   // Choose tournament winner
   // Note: restore local model data if it got a better score.
   El::Int tournament_winner = partner_trainer;
-  if ((m_low_score_wins && local_score <= partner_score) ||
-      (!m_low_score_wins && local_score >= partner_score)) {
+  if ((m_low_score_wins && local_score <= partner_score)
+      || (!m_low_score_wins && local_score >= partner_score)
+      || (!std::isnan(local_score) && std::isnan(partner_score))) {
     tournament_winner = local_trainer;
     switch (m_comm_algo) {
     case communication_algorithm::sendrecv_weights:

--- a/src/layers/learning/CMakeLists.txt
+++ b/src/layers/learning/CMakeLists.txt
@@ -10,6 +10,7 @@ set_full_path(THIS_DIR_SOURCES
   embedding.cpp
   embedding_builder.cpp
   fully_connected.cpp
+  gru.cpp
   )
 
 if (LBANN_HAS_CUDA)

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -1,0 +1,605 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_GRU_LAYER_INSTANTIATE
+#include "lbann/layers/learning/gru.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/weights/initializer.hpp"
+#include "lbann/proto/proto_common.hpp"
+#include <layers.pb.h>
+
+namespace lbann {
+
+// ---------------------------------------------
+// Life cycle
+// ---------------------------------------------
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+gru_layer<TensorDataType, Layout, Device>::gru_layer(lbann_comm* comm, size_t hidden_size)
+  : data_type_layer<TensorDataType>(comm),
+    m_hidden_size{hidden_size} {
+  this->m_expected_num_parent_layers = 2;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+gru_layer<TensorDataType, Layout, Device>::gru_layer(const gru_layer& other)
+  : data_type_layer<TensorDataType>(other),
+    m_hidden_size{other.m_hidden_size}
+#ifdef LBANN_HAS_CUDNN
+  , m_rnn_cudnn_desc{other.m_rnn_cudnn_desc},
+    m_input_cudnn_desc{other.m_input_cudnn_desc},
+    m_output_cudnn_desc{other.m_output_cudnn_desc},
+    m_hidden_cudnn_desc{other.m_hidden_cudnn_desc},
+    m_weights_cudnn_desc{other.m_weights_cudnn_desc}
+#endif // LBANN_HAS_CUDNN
+{
+#ifdef LBANN_HAS_CUDNN
+  /// @todo Copy m_cudnn_reserve_space?
+#endif // LBANN_HAS_CUDNN
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+gru_layer<TensorDataType, Layout, Device>& gru_layer<TensorDataType, Layout, Device>
+::operator=(const gru_layer& other) {
+  data_type_layer<TensorDataType>::operator=(other);
+  m_hidden_size = other.m_hidden_size;
+#ifdef LBANN_HAS_CUDNN
+  m_rnn_cudnn_desc = other.m_rnn_cudnn_desc;
+  m_input_cudnn_desc = other.m_input_cudnn_desc;
+  m_output_cudnn_desc = other.m_output_cudnn_desc;
+  m_hidden_cudnn_desc = other.m_hidden_cudnn_desc;
+  m_weights_cudnn_desc = other.m_weights_cudnn_desc;
+  /// @todo Copy m_cudnn_reserve_space?
+#endif // LBANN_HAS_CUDNN
+  return *this;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+gru_layer<TensorDataType,Layout,Device>*
+gru_layer<TensorDataType,Layout,Device>
+::copy() const
+{
+  return new gru_layer(*this);
+}
+
+// ---------------------------------------------
+// Query functions
+// ---------------------------------------------
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+std::string
+gru_layer<TensorDataType,Layout,Device>
+::get_type() const
+{
+  return "GRU";
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+data_layout
+gru_layer<TensorDataType,Layout,Device>
+::get_data_layout() const
+{
+  return Layout;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+El::Device
+gru_layer<TensorDataType,Layout,Device>
+::get_device_allocation() const
+{
+  return Device;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+description
+gru_layer<TensorDataType,Layout,Device>
+::get_description() const
+{
+  auto desc = data_type_layer<TensorDataType>::get_description();
+  desc.add("Hidden size", m_hidden_size);
+  return desc;
+}
+
+// ---------------------------------------------
+// Setup
+// ---------------------------------------------
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void gru_layer<TensorDataType, Layout, Device>::setup_dims(DataReaderMetaData& dr_metadata) {
+  data_type_layer<TensorDataType>::setup_dims(dr_metadata);
+  const int sequence_length = this->get_input_dims()[0];
+  if (static_cast<size_t>(this->get_input_size(1)) != m_hidden_size) {
+    LBANN_ERROR(
+      this->get_type()," layer \"",this->get_name(),"\" ",
+      "has an invalid input tensor for the initial hidden state");
+  }
+  const std::vector<int> output_dims = {sequence_length, static_cast<int>(m_hidden_size)};
+  this->set_output_dims(output_dims);
+}
+
+namespace {
+
+std::string get_gru_weight_name(size_t index) {
+  switch (index) {
+  case 0:
+    return "ih_matrix";
+  case 1:
+    return "hh_matrix";
+  case 2:
+    return "ih_bias";
+  case 3:
+    return "hh_bias";
+  default:
+    LBANN_ERROR("unknown index for GRU weight (",index,")");
+  }
+}
+
+} // namespace <anon>
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void gru_layer<TensorDataType, Layout, Device>
+::setup_data(size_t max_mini_batch_size) {
+  data_type_layer<TensorDataType>::setup_data(max_mini_batch_size);
+
+  const size_t sequence_length = this->get_input_dims()[0];
+  const size_t input_size = this->get_input_size(0) / sequence_length;
+
+  // Construct default weights if needed
+  if (!this->has_weights()) {
+    const auto scale = El::To<TensorDataType>(1./std::sqrt(m_hidden_size));
+    for (size_t i=0; i<4; ++i) {
+      auto w = make_unique<data_type_weights<TensorDataType>>(this->get_comm());
+      auto init = make_unique<uniform_initializer<TensorDataType>>(-scale, scale);
+      auto opt = this->m_model->template create_optimizer<TensorDataType>();
+      w->set_name(this->get_name() + "_" + get_gru_weight_name(i));
+      w->set_initializer(std::move(init));
+      w->set_optimizer(std::move(opt));
+      this->set_weights(i, w.get());
+      this->m_model->add_weights(std::move(w));
+    }
+  }
+  if (this->num_weights() != 4) {
+    LBANN_ERROR(
+      "attempted to setup ",
+      this->get_type()," layer \"",this->get_name(),"\" ",
+      "with an invalid number of weights ",
+      "(expected 4, found ",this->num_weights(),")");
+  }
+
+  // Setup weight dimensions and distribution
+  auto& ih_matrix = this->get_weights(0);
+  auto& hh_matrix = this->get_weights(1);
+  auto& ih_bias = this->get_weights(2);
+  auto& hh_bias = this->get_weights(3);
+  ih_matrix.set_dims({static_cast<int>(3*m_hidden_size)}, {static_cast<int>(input_size)});
+  hh_matrix.set_dims({static_cast<int>(3*m_hidden_size)}, {static_cast<int>(m_hidden_size)});
+  ih_bias.set_dims({static_cast<int>(3*m_hidden_size)});
+  hh_bias.set_dims({static_cast<int>(3*m_hidden_size)});
+  auto dist = this->get_prev_activations().DistData();
+  dist.colDist = El::STAR;
+  dist.rowDist = El::STAR;
+  ih_matrix.set_matrix_distribution(dist);
+  hh_matrix.set_matrix_distribution(dist);
+  ih_bias.set_matrix_distribution(dist);
+  hh_bias.set_matrix_distribution(dist);
+
+}
+
+#ifdef LBANN_HAS_CUDNN
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void gru_layer<TensorDataType, Layout, Device>::setup_gpu() {
+
+  // Dimensions
+  const size_t sequence_length = this->get_input_dims(0)[0];
+  const size_t input_size = this->get_input_size(0) / sequence_length;
+
+  // GPU objects
+  auto&& handle = cudnn::get_handle();
+  auto data_type = cudnn::get_data_type<TensorDataType>();
+
+  // RNN descriptor
+  size_t dropout_state_size;
+  CHECK_CUDNN(cudnnDropoutGetStatesSize(handle, &dropout_state_size));
+  cudnn::DropoutDescriptor dropout_desc(0.f, nullptr, dropout_state_size, 0);
+  m_rnn_cudnn_desc.set(
+    m_hidden_size,
+    1,  // num_layers
+    dropout_desc,
+    CUDNN_LINEAR_INPUT,
+    CUDNN_UNIDIRECTIONAL,
+    CUDNN_GRU,
+    CUDNN_RNN_ALGO_STANDARD,
+    data_type);
+
+  // Input and output tensor descriptors
+  m_input_cudnn_desc.set(data_type, 1, input_size, 1);
+  m_output_cudnn_desc.set(data_type, 1, m_hidden_size, 1);
+  m_hidden_cudnn_desc.set(data_type, 1, 1, m_hidden_size);
+
+  // Packed weights descriptor
+  size_t weights_size;
+  CHECK_CUDNN(
+    cudnnGetRNNParamsSize(
+      handle,
+      m_rnn_cudnn_desc,
+      m_input_cudnn_desc,
+      &weights_size,
+      data_type));
+  m_weights_cudnn_desc.set(
+    data_type,
+    CUDNN_TENSOR_NCHW,
+    weights_size / sizeof(TensorDataType),
+    1,
+    1);
+
+}
+#endif // LBANN_HAS_CUDNN
+
+// ---------------------------------------------
+// Forward prop
+// ---------------------------------------------
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void gru_layer<TensorDataType, Layout, Device>::fp_compute() {
+  fp_compute_impl(*this);
+}
+
+#ifdef LBANN_HAS_CUDNN
+template <typename TensorDataType>
+hydrogen::simple_buffer<El::byte, El::Device::GPU> pack_cudnn_rnn_weights(
+  const cudnnHandle_t& handle,
+  const cudnn::RNNDescriptor& rnn_desc,
+  const cudnn::TensorDescriptor& input_desc,
+  const cudnn::FilterDescriptor& weights_desc,
+  const El::SyncInfo<El::Device::GPU>& sync_info,
+  size_t input_size,
+  size_t hidden_size,
+  const El::Matrix<TensorDataType,El::Device::GPU>& ih_matrix,
+  const El::Matrix<TensorDataType,El::Device::GPU>& hh_matrix,
+  const El::Matrix<TensorDataType,El::Device::GPU>& ih_bias,
+  const El::Matrix<TensorDataType,El::Device::GPU>& hh_bias) {
+
+  // Allocate buffer for packed weights
+  size_t packed_weights_size;
+  CHECK_CUDNN(
+    cudnnGetRNNParamsSize(
+      handle,
+      rnn_desc,
+      input_desc,
+      &packed_weights_size,
+      cudnn::get_data_type<TensorDataType>()));
+  hydrogen::simple_buffer<El::byte, El::Device::GPU> packed_weights(packed_weights_size, sync_info);
+
+  // Construct objects
+  static cudnn::FilterDescriptor result_weights_desc;
+  result_weights_desc.create();
+  TensorDataType* packed_weights_ptr;
+  El::Matrix<TensorDataType,El::Device::GPU> packed_weights_view;
+  packed_weights_view.SetSyncInfo(sync_info);
+
+  // Copy values from ih_matrix
+  for (auto i : {0, 1, 2}) {
+    CHECK_CUDNN(
+      cudnnGetRNNLinLayerMatrixParams(
+        handle,
+        rnn_desc,
+        0, // pseudoLayer
+        input_desc,
+        weights_desc,
+        packed_weights.data(),
+        i, // linLayerID
+        result_weights_desc,
+        reinterpret_cast<void**>(&packed_weights_ptr)));
+    packed_weights_view.Attach(input_size, hidden_size, packed_weights_ptr, input_size);
+    El::Transpose(
+      ih_matrix(El::IR(i*hidden_size, (i+1)*hidden_size), El::ALL),
+      packed_weights_view,
+      false);
+  }
+
+  // Copy values from hh_matrix
+  for (auto i : {0, 1, 2}) {
+    CHECK_CUDNN(
+      cudnnGetRNNLinLayerMatrixParams(
+        handle,
+        rnn_desc,
+        0, // pseudoLayer
+        input_desc,
+        weights_desc,
+        packed_weights.data(),
+        3+i, // linLayerID
+        result_weights_desc,
+        reinterpret_cast<void**>(&packed_weights_ptr)));
+    packed_weights_view.Attach(hidden_size, hidden_size, packed_weights_ptr, hidden_size);
+    El::Transpose(
+      hh_matrix(El::IR(i*hidden_size, (i+1)*hidden_size), El::ALL),
+      packed_weights_view,
+      false);
+  }
+
+  // Copy values from ih_bias
+  for (auto i : {0, 1, 2}) {
+    CHECK_CUDNN(
+      cudnnGetRNNLinLayerBiasParams(
+        handle,
+        rnn_desc,
+        0, // pseudoLayer
+        input_desc,
+        weights_desc,
+        packed_weights.data(),
+        i, // linLayerID
+        result_weights_desc,
+        reinterpret_cast<void**>(&packed_weights_ptr)));
+    packed_weights_view.Attach(hidden_size, 1, packed_weights_ptr, hidden_size);
+    El::Copy(
+      ih_bias(El::IR(i*hidden_size, (i+1)*hidden_size), El::ALL),
+      packed_weights_view);
+  }
+
+  // Copy values from hh_bias
+  for (auto i : {0, 1, 2}) {
+    CHECK_CUDNN(
+      cudnnGetRNNLinLayerBiasParams(
+        handle,
+        rnn_desc,
+        0, // pseudoLayer
+        input_desc,
+        weights_desc,
+        packed_weights.data(),
+        3+i, // linLayerID
+        result_weights_desc,
+        reinterpret_cast<void**>(&packed_weights_ptr)));
+    packed_weights_view.Attach(hidden_size, 1, packed_weights_ptr, hidden_size);
+    El::Copy(
+      ih_bias(El::IR(i*hidden_size, (i+1)*hidden_size), El::ALL),
+      packed_weights_view);
+  }
+
+  return packed_weights;
+}
+#endif // LBANN_HAS_CUDNN
+
+#ifdef LBANN_HAS_CUDNN
+template <typename TensorDataType>
+void fp_compute_impl(
+  gru_layer<TensorDataType,data_layout::DATA_PARALLEL,El::Device::GPU>& l) {
+
+  // Matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::GPU>;
+  const auto& local_input_sequence
+    = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(0));
+  const auto& local_init_hidden
+    = dynamic_cast<const LocalMat&>(l.get_local_prev_activations(1));
+  auto& local_output_sequence
+    = dynamic_cast<LocalMat&>(l.get_local_activations());
+  const auto& ih_matrix
+    = dynamic_cast<const LocalMat&>(l.weights_values(0).LockedMatrix());
+  const auto& hh_matrix
+    = dynamic_cast<const LocalMat&>(l.weights_values(1).LockedMatrix());
+  const auto& ih_bias
+    = dynamic_cast<const LocalMat&>(l.weights_values(2).LockedMatrix());
+  const auto& hh_bias
+    = dynamic_cast<const LocalMat&>(l.weights_values(3).LockedMatrix());
+
+  // Dimensions
+  const size_t sequence_length = l.get_input_dims(0)[0];
+  const size_t mini_batch_size = local_input_sequence.Width();
+  const size_t input_size = l.get_input_size(0) / sequence_length;
+  const size_t hidden_size = l.m_hidden_size;
+
+  // Return immediately if there is no work to be done
+  if (mini_batch_size <= 0) {
+    return;
+  }
+
+  // GPU objects
+  auto&& sync_info = local_input_sequence.GetSyncInfo();
+  auto&& handle = cudnn::get_handle();
+  const auto data_type = cudnn::get_data_type<TensorDataType>();
+
+  // Configure input and output tensor descriptors
+  auto& input_desc = l.m_input_cudnn_desc;
+  auto& output_desc = l.m_output_cudnn_desc;
+  auto& hidden_desc = l.m_hidden_cudnn_desc;
+  input_desc.set(data_type, mini_batch_size, input_size, 1);
+  output_desc.set(data_type, mini_batch_size, hidden_size, 1);
+  hidden_desc.set(data_type, 1, mini_batch_size, hidden_size);
+  std::vector<cudnnTensorDescriptor_t> input_desc_list(sequence_length, input_desc);
+  std::vector<cudnnTensorDescriptor_t> output_desc_list(sequence_length, output_desc);
+
+  // Reorder input tensor dims
+  // Note: cuDNN uses sequence_length x mini_batch_size x hidden_size
+  /// @todo Consider custom kernel
+  LocalMat input_sequence_workspace, output_sequence_workspace;
+  input_sequence_workspace.SetSyncInfo(sync_info);
+  output_sequence_workspace.SetSyncInfo(sync_info);
+  input_sequence_workspace.Resize(mini_batch_size*input_size, sequence_length);
+  output_sequence_workspace.Resize(mini_batch_size*hidden_size, sequence_length);
+  for (size_t i=0; i<sequence_length; ++i) {
+    const auto input_sequence_view
+      = local_input_sequence(El::IR(i*input_size, (i+1)*input_size), El::ALL);
+    LocalMat input_sequence_workspace_view(
+      input_size,
+      mini_batch_size,
+      input_sequence_workspace.Buffer(0, i),
+      input_size);
+    input_sequence_workspace_view.SetSyncInfo(sync_info);
+    El::Copy(input_sequence_view, input_sequence_workspace_view);
+  }
+
+  // Pack weights into workspace buffer
+  auto weights_workspace = pack_cudnn_rnn_weights(
+    handle,
+    l.m_rnn_cudnn_desc,
+    input_desc,
+    l.m_weights_cudnn_desc,
+    sync_info,
+    input_size,
+    hidden_size,
+    ih_matrix,
+    hh_matrix,
+    ih_bias,
+    hh_bias);
+
+  // Allocate cuDNN workspace buffers
+  /// @todo Handle synchronization for m_cudnn_reserve_space
+  size_t cudnn_workspace_size, cudnn_reserve_space_size;
+  CHECK_CUDNN(
+    cudnnGetRNNWorkspaceSize(
+      handle,
+      l.m_rnn_cudnn_desc,
+      sequence_length,
+      input_desc_list.data(),
+      &cudnn_workspace_size));
+  CHECK_CUDNN(
+    cudnnGetRNNTrainingReserveSize(
+      handle,
+      l.m_rnn_cudnn_desc,
+      sequence_length,
+      input_desc_list.data(),
+      &cudnn_reserve_space_size));
+  using ByteBuffer = hydrogen::simple_buffer<El::byte, El::Device::GPU>;
+  ByteBuffer cudnn_workspace(cudnn_workspace_size, sync_info);
+  l.m_cudnn_reserve_space.allocate(cudnn_reserve_space_size);
+
+  // Launch cuDNN GRU
+  CHECK_CUDNN(
+    cudnnRNNForwardTraining(
+      handle,
+      l.m_rnn_cudnn_desc,
+      sequence_length,
+      input_desc_list.data(),
+      input_sequence_workspace.LockedBuffer(),
+      hidden_desc,
+      local_init_hidden.LockedBuffer(),
+      hidden_desc,  // cxDesc
+      nullptr,      // cx
+      l.m_weights_cudnn_desc,
+      weights_workspace.data(),
+      output_desc_list.data(),
+      output_sequence_workspace.Buffer(),
+      hidden_desc,  // hyDesc
+      nullptr,      // hy
+      hidden_desc,  // cyDesc
+      nullptr,      // cy
+      cudnn_workspace.data(),
+      cudnn_workspace.size(),
+      l.m_cudnn_reserve_space.data(),
+      l.m_cudnn_reserve_space.size()));
+
+  // Reorder output tensor dims
+  // Note: cuDNN uses sequence_length x mini_batch_size x hidden_size
+  /// @todo Consider custom kernel
+  for (size_t i=0; i<sequence_length; ++i) {
+    LocalMat output_sequence_workspace_view(
+      hidden_size,
+      mini_batch_size,
+      output_sequence_workspace.LockedBuffer(0, i),
+      hidden_size);
+    output_sequence_workspace_view.SetSyncInfo(sync_info);
+    auto output_sequence_view
+      = local_output_sequence(El::IR(i*hidden_size, (i+1)*hidden_size), El::ALL);
+    El::Copy(output_sequence_workspace_view, output_sequence_view);
+  }
+
+}
+#endif // LBANN_HAS_CUDNN
+
+// ---------------------------------------------
+// Back prop
+// ---------------------------------------------
+
+/// @todo Implement
+
+// ---------------------------------------------
+// Builder
+// ---------------------------------------------
+
+namespace
+{
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+struct Builder
+{
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&...)
+  {
+    LBANN_ERROR(
+      "Attempted to construct gru_layer with invalid parameters ",
+      "(TensorDataType=",TypeName<TensorDataType>(),", ",
+      "Layout=",to_string(Layout),", ",
+      "Device=",to_string(Device),")");
+    return nullptr;
+  }
+};
+
+#ifdef LBANN_HAS_CUDNN
+template <typename TensorDataType>
+struct Builder<TensorDataType,data_layout::DATA_PARALLEL,El::Device::GPU>
+{
+  template <typename... Args>
+  static std::unique_ptr<Layer> Build(Args&&... args)
+  {
+    constexpr auto Layout = data_layout::DATA_PARALLEL;
+    constexpr auto Device = El::Device::GPU;
+    using LayerType = gru_layer<TensorDataType,Layout,Device>;
+    return make_unique<LayerType>(std::forward<Args>(args)...);
+  }
+};
+#endif // LBANN_HAS_CUDNN
+
+} // namespace <anon>
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+std::unique_ptr<Layer> build_gru_layer_from_pbuf(
+  lbann_comm* comm, lbann_data::Layer const& proto_layer)
+{
+  using BuilderType = Builder<TensorDataType, Layout, Device>;
+  LBANN_ASSERT_MSG_HAS_FIELD(proto_layer, gru);
+  const auto& params = proto_layer.gru();
+  return BuilderType::Build(comm, params.hidden_size());
+}
+
+// ---------------------------------------------
+// Explicit template instantiation
+// ---------------------------------------------
+
+/// @todo CPU implementation
+#ifdef LBANN_HAS_CUDNN
+#define PROTO(T)                                                        \
+  template class gru_layer<                                             \
+    T, data_layout::DATA_PARALLEL, El::Device::GPU>;
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+#endif // LBANN_HAS_CUDNN
+
+#define PROTO_DEVICE(T, Device)                 \
+  LBANN_LAYER_BUILDER_ETI(gru, T, Device)
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+
+} // namespace lbann

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -130,7 +130,7 @@ gru_layer<TensorDataType,Layout,Device>
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void gru_layer<TensorDataType, Layout, Device>::setup_dims(DataReaderMetaData& dr_metadata) {
   data_type_layer<TensorDataType>::setup_dims(dr_metadata);
-  const int sequence_length = this->get_input_dims()[0];
+  const int sequence_length = this->get_input_dims(0)[0];
   if (static_cast<size_t>(this->get_input_size(1)) != m_hidden_size) {
     LBANN_ERROR(
       this->get_type()," layer \"",this->get_name(),"\" ",
@@ -169,6 +169,7 @@ void gru_layer<TensorDataType, Layout, Device>
 
   // Construct default weights if needed
   if (!this->has_weights()) {
+    this->set_num_weights(4);
     const auto scale = El::To<TensorDataType>(1./std::sqrt(m_hidden_size));
     for (size_t i=0; i<4; ++i) {
       auto w = make_unique<data_type_weights<TensorDataType>>(this->get_comm());

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -48,6 +48,7 @@
 #include "lbann/layers/learning/embedding.hpp"
 #include "lbann/layers/learning/entrywise_scale_bias.hpp"
 #include "lbann/layers/learning/fully_connected.hpp"
+#include "lbann/layers/learning/gru.hpp"
 #include "lbann/layers/learning/learning.hpp"
 #include "lbann/layers/loss/categorical_accuracy.hpp"
 #include "lbann/layers/loss/cross_entropy.hpp"
@@ -167,6 +168,7 @@ private:
     LBANN_REGISTER_BUILDER(Embedding, embedding);
     LBANN_REGISTER_BUILDER(EntrywiseScaleBias, entrywise_scale_bias);
     LBANN_REGISTER_BUILDER(FullyConnected, fully_connected);
+    LBANN_REGISTER_BUILDER(GRU, gru);
 
     // Math layers
     LBANN_REGISTER_DEFAULT_BUILDER(Abs, abs);

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -103,6 +103,7 @@ message Layer {
     ChannelwiseScaleBias channelwise_scale_bias = 329;
     EntrywiseScaleBias entrywise_scale_bias = 330;
     ChannelwiseFullyConnected channelwise_fully_connected = 331;
+    GRU gru = 333;
 
     // Loss layers
     CrossEntropy cross_entropy = 60;
@@ -660,6 +661,10 @@ message Layer {
      *  @details Default: false
      */
     google.protobuf.BoolValue transpose = 3;
+  }
+
+  message GRU {
+    uint64 hidden_size = 1;
   }
 
   //////////////////

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -663,7 +663,25 @@ message Layer {
     google.protobuf.BoolValue transpose = 3;
   }
 
+  /** @brief Gated recurrent unit
+   *
+   *  Expects two inputs: a 2D input sequence (
+   *  @f$ \text{sequence\_length}\times\text{input\_size} @f$ )
+   *  and a 1D initial hidden state ( @f$ \text{hidden\_size} @f$ ).
+   *
+   *  Uses four weights: "ih\_matrix" (
+   *  @f$ 3 \text{hidden\_size}\times\text{input\_size} @f$ ),
+   *  "hh\_matrix" (
+   *  @f$ 3 \text{hidden\_size}\times\text{hidden\_size} @f$ ),
+   *  "ih_bias" ( @f$ 3 \text{hidden\_size} @f$ ),
+   *  "hh_bias" ( @f$ 3 \text{hidden\_size} @f$ ).
+   *
+   *  @todo Support CPU
+   *  @todo Support bidirectional RNNs
+   *  @todo Support stacked RNNs
+   */
   message GRU {
+    /// Size of each hidden state and output vector
     uint64 hidden_size = 1;
   }
 

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -577,6 +577,20 @@ RNNDescriptor::RNNDescriptor(const RNNDescriptor& other) {
     cudnnRNNMode_t mode;
     cudnnRNNAlgo_t algo;
     cudnnDataType_t math_precision;
+#if CUDNN_VERSION >= 8000
+    CHECK_CUDNN(
+      cudnnGetRNNDescriptor_v6(
+        get_handle(),
+        other.desc_,
+        &hidden_size,
+        &num_layers,
+        &dropout_desc,
+        &input_mode,
+        &direction,
+        &mode,
+        &algo,
+        &math_precision));
+#else // CUDNN_VERSION < 8000
     CHECK_CUDNN(
       cudnnGetRNNDescriptor(
         get_handle(),
@@ -589,6 +603,7 @@ RNNDescriptor::RNNDescriptor(const RNNDescriptor& other) {
         &mode,
         &algo,
         &math_precision));
+#endif // CUDNN_VERSION >= 8000
     set(
       hidden_size,
       num_layers,
@@ -653,7 +668,7 @@ void RNNDescriptor::set(
   cudnnDataType_t math_precision) {
   create();
   CHECK_CUDNN(
-    cudnnSetRNNDescriptor(
+    cudnnSetRNNDescriptor_v6(
       get_handle(),
       desc_,
       hidden_size,

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -242,6 +242,431 @@ void copy_activation_desc(const cudnnActivationDescriptor_t& src,
 }
 
 ////////////////////////////////////////////////////////////
+// Wrapper classes for cuDNN types
+////////////////////////////////////////////////////////////
+
+// -----------------------------
+// TensorDescriptor
+// -----------------------------
+
+TensorDescriptor::TensorDescriptor(cudnnTensorDescriptor_t desc)
+  : desc_{desc}
+{}
+
+TensorDescriptor::~TensorDescriptor() {
+  if (desc_) {
+    // Don't check status to avoid exceptions
+    cudnnDestroyTensorDescriptor(desc_);
+  }
+}
+
+TensorDescriptor::TensorDescriptor(const TensorDescriptor& other) {
+  if (other.desc_) {
+    cudnnDataType_t data_type;
+    int num_dims;
+    CHECK_CUDNN(
+      cudnnGetTensorNdDescriptor(
+        other.desc_,
+        0,          // nbDimsRequested
+        &data_type,
+        &num_dims,
+        nullptr,    // dimA
+        nullptr));  // strideA
+    std::vector<int> dims(num_dims), strides(num_dims);
+    CHECK_CUDNN(
+      cudnnGetTensorNdDescriptor(
+        other.desc_,
+        num_dims,
+        &data_type,
+        &num_dims,
+        dims.data(),
+        strides.data()));
+    set(data_type, dims, strides);
+  }
+}
+
+TensorDescriptor::TensorDescriptor(TensorDescriptor&& other)
+  : desc_{other.desc_} {
+  other.desc_ = nullptr;
+}
+
+TensorDescriptor& TensorDescriptor::operator=(TensorDescriptor other) {
+  swap(other, *this);
+  return *this;
+}
+
+void swap(TensorDescriptor& first, TensorDescriptor& second) {
+  std::swap(first.desc_, second.desc_);
+}
+
+void TensorDescriptor::reset(cudnnTensorDescriptor_t desc) {
+  if (desc_) {
+    CHECK_CUDNN(cudnnDestroyTensorDescriptor(desc_));
+  }
+  desc_ = desc;
+}
+
+cudnnTensorDescriptor_t TensorDescriptor::release() {
+  auto old_desc = desc_;
+  desc_ = nullptr;
+  return old_desc;
+}
+
+cudnnTensorDescriptor_t TensorDescriptor::get() const noexcept {
+  return desc_;
+}
+
+TensorDescriptor::operator cudnnTensorDescriptor_t() const noexcept {
+  return get();
+}
+
+void TensorDescriptor::create() {
+  if (!desc_) {
+    CHECK_CUDNN(cudnnCreateTensorDescriptor(&desc_));
+  }
+}
+
+void TensorDescriptor::set(
+  cudnnDataType_t data_type,
+  const std::vector<int>& dims,
+  std::vector<int> strides) {
+
+  // Check that arguments are valid
+  if (dims.empty()) {
+    LBANN_ERROR("attempted to set cuDNN tensor descriptor with no dimensions");
+  }
+  if (dims.size() < 3) {
+    // As of cuDNN 7.65, cuDNN does not support tensors with <3 dims
+    LBANN_ERROR(
+      "attempted to set cuDNN tensor descriptor with fewer than 3 dimensions");
+  }
+  if (!strides.empty() && dims.size() != strides.size()) {
+    LBANN_ERROR(
+      "attempted to set cuDNN tensor descriptor ",
+      "with mismatched dimensions (",dims.size(),") ",
+      "and strides (",strides.size(),")");
+  }
+
+  // Assume data is contiguous if no strides are provided
+  if (strides.empty()) {
+    strides.resize(dims.size(), 1);
+    for (int i=strides.size()-1; i>0; --i) {
+      strides[i-1] = strides[i] * dims[i];
+    }
+  }
+
+  // Set cuDNN object
+  create();
+  CHECK_CUDNN(
+    cudnnSetTensorNdDescriptor(
+      desc_,
+      data_type,
+      dims.size(),
+      dims.data(),
+      strides.data()));
+
+}
+
+// -----------------------------
+// FilterDescriptor
+// -----------------------------
+
+FilterDescriptor::FilterDescriptor(cudnnFilterDescriptor_t desc)
+  : desc_{desc}
+{}
+
+FilterDescriptor::~FilterDescriptor() {
+  if (desc_) {
+    // Don't check status to avoid exceptions
+    cudnnDestroyFilterDescriptor(desc_);
+  }
+}
+
+FilterDescriptor::FilterDescriptor(const FilterDescriptor& other) {
+  if (other.desc_) {
+    int num_dims;
+    cudnnDataType_t data_type;
+    cudnnTensorFormat_t format;
+    CHECK_CUDNN(
+      cudnnGetFilterNdDescriptor(
+        other.desc_,
+        0,          // nbDimsRequested
+        &data_type,
+        &format,
+        &num_dims,
+        nullptr));  // filterDimA
+    std::vector<int> dims(num_dims);
+    CHECK_CUDNN(
+      cudnnGetFilterNdDescriptor(
+        other.desc_,
+        num_dims,
+        &data_type,
+        &format,
+        &num_dims,
+        dims.data()));
+    set(data_type, format, dims);
+  }
+}
+
+FilterDescriptor::FilterDescriptor(FilterDescriptor&& other)
+  : desc_{other.desc_} {
+  other.desc_ = nullptr;
+}
+
+FilterDescriptor& FilterDescriptor::operator=(FilterDescriptor other) {
+  swap(other, *this);
+  return *this;
+}
+
+void swap(FilterDescriptor& first, FilterDescriptor& second) {
+  std::swap(first.desc_, second.desc_);
+}
+
+void FilterDescriptor::reset(cudnnFilterDescriptor_t desc) {
+  if (desc_) {
+    CHECK_CUDNN(cudnnDestroyFilterDescriptor(desc_));
+  }
+  desc_ = desc;
+}
+
+cudnnFilterDescriptor_t FilterDescriptor::release() {
+  auto old_desc = desc_;
+  desc_ = nullptr;
+  return old_desc;
+}
+
+cudnnFilterDescriptor_t FilterDescriptor::get() const noexcept {
+  return desc_;
+}
+
+FilterDescriptor::operator cudnnFilterDescriptor_t() const noexcept {
+  return get();
+}
+
+void FilterDescriptor::create() {
+  if (!desc_) {
+    CHECK_CUDNN(cudnnCreateFilterDescriptor(&desc_));
+  }
+}
+
+void FilterDescriptor::set(
+  cudnnDataType_t data_type,
+  cudnnTensorFormat_t format,
+  const std::vector<int>& dims) {
+  create();
+  CHECK_CUDNN(
+    cudnnSetFilterNdDescriptor(
+      desc_,
+      data_type,
+      format,
+      dims.size(),
+      dims.data()));
+}
+
+// -----------------------------
+// DropoutDescriptor
+// -----------------------------
+
+DropoutDescriptor::DropoutDescriptor(cudnnDropoutDescriptor_t desc)
+  : desc_{desc}
+{}
+
+DropoutDescriptor::~DropoutDescriptor() {
+  if (desc_) {
+    // Don't check status to avoid exceptions
+    cudnnDestroyDropoutDescriptor(desc_);
+  }
+}
+
+DropoutDescriptor::DropoutDescriptor(const DropoutDescriptor& other) {
+  if (other.desc_) {
+    float dropout;
+    void* states;
+    size_t states_size;
+    unsigned long long seed;
+    CHECK_CUDNN(cudnnDropoutGetStatesSize(get_handle(), &states_size));
+    CHECK_CUDNN(
+      cudnnGetDropoutDescriptor(
+        other.desc_,
+        get_handle(),
+        &dropout,
+        &states,
+        &seed));
+    set(dropout, states, states_size, seed);
+  }
+}
+
+DropoutDescriptor::DropoutDescriptor(DropoutDescriptor&& other)
+  : desc_{other.desc_} {
+  other.desc_ = nullptr;
+}
+
+DropoutDescriptor& DropoutDescriptor::operator=(DropoutDescriptor other) {
+  swap(other, *this);
+  return *this;
+}
+
+void swap(DropoutDescriptor& first, DropoutDescriptor& second) {
+  std::swap(first.desc_, second.desc_);
+}
+
+void DropoutDescriptor::reset(cudnnDropoutDescriptor_t desc) {
+  if (desc_) {
+    CHECK_CUDNN(cudnnDestroyDropoutDescriptor(desc_));
+  }
+  desc_ = desc;
+}
+
+cudnnDropoutDescriptor_t DropoutDescriptor::release() {
+  auto old_desc = desc_;
+  desc_ = nullptr;
+  return old_desc;
+}
+
+cudnnDropoutDescriptor_t DropoutDescriptor::get() const noexcept {
+  return desc_;
+}
+
+DropoutDescriptor::operator cudnnDropoutDescriptor_t() const noexcept {
+  return get();
+}
+
+void DropoutDescriptor::create() {
+  if (!desc_) {
+    CHECK_CUDNN(cudnnCreateDropoutDescriptor(&desc_));
+  }
+}
+
+void DropoutDescriptor::set(
+  float dropout,
+  void* states,
+  size_t states_size,
+  unsigned long long seed) {
+  create();
+  CHECK_CUDNN(
+    cudnnSetDropoutDescriptor(
+      desc_,
+      get_handle(),
+      dropout,
+      states,
+      states_size,
+      seed));
+}
+
+// -----------------------------
+// RNNDescriptor
+// -----------------------------
+
+RNNDescriptor::RNNDescriptor(cudnnRNNDescriptor_t desc)
+  : desc_{desc}
+{}
+
+RNNDescriptor::~RNNDescriptor() {
+  if (desc_) {
+    // Don't check status to avoid exceptions
+    cudnnDestroyRNNDescriptor(desc_);
+  }
+}
+
+RNNDescriptor::RNNDescriptor(const RNNDescriptor& other) {
+  if (other.desc_) {
+    int hidden_size, num_layers;
+    cudnnDropoutDescriptor_t dropout_desc;
+    cudnnRNNInputMode_t input_mode;
+    cudnnDirectionMode_t direction;
+    cudnnRNNMode_t mode;
+    cudnnRNNAlgo_t algo;
+    cudnnDataType_t math_precision;
+    CHECK_CUDNN(
+      cudnnGetRNNDescriptor(
+        get_handle(),
+        other.desc_,
+        &hidden_size,
+        &num_layers,
+        &dropout_desc,
+        &input_mode,
+        &direction,
+        &mode,
+        &algo,
+        &math_precision));
+    set(
+      hidden_size,
+      num_layers,
+      dropout_desc,
+      input_mode,
+      direction,
+      mode,
+      algo,
+      math_precision);
+  }
+}
+
+RNNDescriptor::RNNDescriptor(RNNDescriptor&& other)
+  : desc_{other.desc_} {
+  other.desc_ = nullptr;
+}
+
+RNNDescriptor& RNNDescriptor::operator=(RNNDescriptor other) {
+  swap(other, *this);
+  return *this;
+}
+
+void swap(RNNDescriptor& first, RNNDescriptor& second) {
+  std::swap(first.desc_, second.desc_);
+}
+
+void RNNDescriptor::reset(cudnnRNNDescriptor_t desc) {
+  if (desc_) {
+    CHECK_CUDNN(cudnnDestroyRNNDescriptor(desc_));
+  }
+  desc_ = desc;
+}
+
+cudnnRNNDescriptor_t RNNDescriptor::release() {
+  auto old_desc = desc_;
+  desc_ = nullptr;
+  return old_desc;
+}
+
+cudnnRNNDescriptor_t RNNDescriptor::get() const noexcept {
+  return desc_;
+}
+
+RNNDescriptor::operator cudnnRNNDescriptor_t() const noexcept {
+  return get();
+}
+
+void RNNDescriptor::create() {
+  if (!desc_) {
+    CHECK_CUDNN(cudnnCreateRNNDescriptor(&desc_));
+  }
+}
+
+void RNNDescriptor::set(
+  size_t hidden_size,
+  size_t num_layers,
+  cudnnDropoutDescriptor_t dropout_desc,
+  cudnnRNNInputMode_t input_mode,
+  cudnnDirectionMode_t direction,
+  cudnnRNNMode_t mode,
+  cudnnRNNAlgo_t algo,
+  cudnnDataType_t math_precision) {
+  create();
+  CHECK_CUDNN(
+    cudnnSetRNNDescriptor(
+      get_handle(),
+      desc_,
+      hidden_size,
+      num_layers,
+      dropout_desc,
+      input_mode,
+      direction,
+      mode,
+      algo,
+      math_precision));
+}
+
+////////////////////////////////////////////////////////////
 // Base cuDNN tensor manager
 ////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Our current implementation of GRU is a layer module in the Python frontend. It operates on each time step sequentially, so it requires that input sequences are sliced into time steps and its GPU performance tends to be dominated by the kernel launch overheads from many small kernels.

To improve performance, I've implemented a dedicated GRU layer that calls into cuDNN on GPU. Its API is different from the Python frontend module since it operates on the entire sequence at a time. This helps avoid fine-grained slicing and concatenating. Currently it only supports single-layer, unidirectional GRUs and it has no CPU implementation.  

In addition to the layer, I've added some wrapper classes to the cuDNN header. I found that they made dealing with cuDNN objects much nicer. @mrwyattii might be interested in looking in `include/lbann/utils/cudnn.hpp`/`src/utils/cudnn.cpp` when he starts working on a cuDNN/MIOpen abstraction layer. I've also updated the ATOM VAE model to use the new layer.

The GRU layer passes metric checking and gradient checking on Pascal and Lassen. In some rough experiments with the ATOM VAE model on Pascal, the mini-batch time dropped from 0.26 sec to 0.09 sec. It's not ready to be merged into `develop` yet, but I think we can use this work for some experiments.