### PR TITLE
CUDA kernel for tensor reordering in GRU layer

### DIFF
--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -314,6 +314,7 @@ class MolVAE(lbann.modules.Module):
         )
         keep_mask = lbann.LogicalNot(ignore_mask)
         length = lbann.Reduction(keep_mask, mode='sum')
+        length = lbann.Max(length, self.constant(1, [1]))
         x = lbann.Add(
             lbann.Multiply(keep_mask, x),
             lbann.Multiply(ignore_mask, self.constant(-1, hint_layer=x)),
@@ -354,7 +355,7 @@ class MolVAE(lbann.modules.Module):
         )
         recon_loss = lbann.Subtract(z, recon_loss)
         recon_loss = lbann.Reshape(recon_loss, dims=str_list([1]))
-        recon_loss = lbann.SafeDivide(recon_loss, length)
+        recon_loss = lbann.Divide(recon_loss, length)
 
         return recon_loss
 

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -217,7 +217,8 @@ class MolVAE(lbann.modules.Module):
         while stack:
             l = stack.pop()
             if type(l) not in (lbann.Slice, lbann.Reshape, lbann.Tessellate):
-                l.datatype = self.datatype
+                #l.datatype = self.datatype
+                l.datatype = lbann.DataType.FLOAT
             for parent in l.parents:
                 if parent not in in_stack and parent is not x_emb:
                     stack.append(parent)
@@ -230,13 +231,16 @@ class MolVAE(lbann.modules.Module):
         z = lbann.Add([mu, (lbann.Multiply([lbann.Exp(lbann.WeightedSum(logvar,scaling_factors='0.5')),eps]))])
 
         # kl_loss = 0.5 * (logvar.exp() + mu ** 2 - 1 - logvar).sum(1).mean()
-        kl_loss = lbann.Reduction(lbann.WeightedSum(
-                                        [lbann.Exp(logvar),
-                                        lbann.Square(mu),
-                                        lbann.Constant(value=1.0, hint_layer=mu),
-                                        logvar],
-                                        scaling_factors='0.5 0.5 -0.5 -0.5'),
-                                        mode='sum')
+        kl_loss = lbann.Reduction(
+            lbann.WeightedSum(
+                lbann.Exp(logvar),
+                lbann.Square(mu),
+                self.constant(1, hint_layer=mu),
+                logvar,
+                scaling_factors='0.5 0.5 -0.5 -0.5',
+            ),
+            mode='sum',
+        )
 
         return z, kl_loss
 
@@ -307,17 +311,13 @@ class MolVAE(lbann.modules.Module):
         # Note: Ignored indices result in zero vectors
         ignore_mask = lbann.Equal(
             x,
-            lbann.Constant(value=self.label_to_ignore, hint_layer=x),
+            self.constant(self.label_to_ignore, hint_layer=x),
         )
         keep_mask = lbann.LogicalNot(ignore_mask)
         length = lbann.Reduction(keep_mask, mode='sum')
-        length = lbann.Max(
-            length,
-            lbann.Constant(value=1, num_neurons=str_list([1])),
-        )
         x = lbann.Add(
             lbann.Multiply(keep_mask, x),
-            lbann.Multiply(ignore_mask, lbann.Constant(value=-1, hint_layer=x)),
+            lbann.Multiply(ignore_mask, self.constant(-1, hint_layer=x)),
         )
         x = lbann.Slice(x, slice_points=str_list(range(self.input_feature_dims)))
         x = [lbann.Identity(x) for _ in range(self.input_feature_dims-1)]
@@ -330,12 +330,18 @@ class MolVAE(lbann.modules.Module):
         #     x[:, 1:].contiguous().view(-1),
         #     ignore_index=self.pad
         # )
+        # Note: Ideally we'd shift y by y.max(-1) for numerical stability
+        shifts = lbann.MatMul(
+            lbann.Max(y, self.constant(0, hint_layer=y)),
+            self.constant(
+                1 / math.sqrt(self.dictionary_size),
+                [self.dictionary_size, self.dictionary_size],
+            ),
+        )
+        y = lbann.Subtract(y, shifts)
         z = lbann.MatMul(
             lbann.Exp(y),
-            lbann.Constant(
-                value=1,
-                num_neurons=str_list([self.dictionary_size, 1]),
-            ),
+            self.constant(1, [self.dictionary_size, 1]),
         )
         z = lbann.Log(z)
         z = lbann.MatMul(
@@ -343,12 +349,20 @@ class MolVAE(lbann.modules.Module):
             z,
         )
         recon_loss = lbann.MatMul(
-            lbann.Reshape(y, dims=str_list([-1, 1])),
-            lbann.Reshape(x, dims=str_list([-1, 1])),
-            transpose_a=True,
+            lbann.Reshape(y, dims=str_list([1, -1])),
+            lbann.Reshape(x, dims=str_list([1, -1])),
+            transpose_b=True,
         )
         recon_loss = lbann.Subtract(z, recon_loss)
         recon_loss = lbann.Reshape(recon_loss, dims=str_list([1]))
-        recon_loss = lbann.Divide(recon_loss, length)
+        recon_loss = lbann.SafeDivide(recon_loss, length)
 
         return recon_loss
+
+    def constant(self, value, dims=[], datatype=None, hint_layer=None):
+        return lbann.Constant(
+            value=value,
+            num_neurons=str_list(dims),
+            datatype=datatype,
+            hint_layer=hint_layer,
+        )

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -118,7 +118,7 @@ class MolVAE(lbann.modules.Module):
         self.embedding_size = embedding_size
         self.dictionary_size = dictionary_size
         self.label_to_ignore = ignore_label
-        self.datatype = lbann.DataType.FP16
+        self.datatype = lbann.DataType.FLOAT
         self.weights_datatype = lbann.DataType.FLOAT
 
         fc = lbann.modules.FullyConnectedModule
@@ -217,8 +217,7 @@ class MolVAE(lbann.modules.Module):
         while stack:
             l = stack.pop()
             if type(l) not in (lbann.Slice, lbann.Reshape, lbann.Tessellate):
-                #l.datatype = self.datatype
-                l.datatype = lbann.DataType.FLOAT
+                l.datatype = self.datatype
             for parent in l.parents:
                 if parent not in in_stack and parent is not x_emb:
                     stack.append(parent)

--- a/include/lbann/utils/cuda.hpp
+++ b/include/lbann/utils/cuda.hpp
@@ -225,8 +225,9 @@ private:
 };
 
 // -------------------------------------------------------------
-// Helper functions for entrywise operations
+// Helper functions for tensor operations
 // -------------------------------------------------------------
+
 #ifdef __CUDACC__
 
 /** Apply an entry-wise unary operator to GPU data.
@@ -269,6 +270,16 @@ void apply_entrywise_binary_operator(
   El::AbstractDistMatrix<TensorDataType>& output);
 
 #endif // __CUDACC__
+
+/** Copy entries between GPU tensors. */
+template <typename TensorDataType>
+void copy_tensor(
+  cudaStream_t stream,
+  const std::vector<size_t>& dims,
+  const TensorDataType* input,
+  const std::vector<size_t>& input_strides,
+  TensorDataType* output,
+  const std::vector<size_t>& output_strides);
 
 // -------------------------------------------------------------
 // Utilities for Thrust

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -31,9 +31,9 @@
 namespace lbann {
 namespace cuda {
 
-////////////////////////////////////////////////////////////
-// CUDA event wrapper
-////////////////////////////////////////////////////////////
+// -------------------------------------------------------------
+// Utilities for CUDA events
+// -------------------------------------------------------------
 
 event_wrapper::event_wrapper() : m_event(nullptr), m_stream(0) {
   CHECK_CUDA(cudaEventCreateWithFlags(&m_event, cudaEventDisableTiming));
@@ -76,6 +76,149 @@ void event_wrapper::synchronize() {
 }
 
 cudaEvent_t& event_wrapper::get_event() { return m_event; }
+
+// -------------------------------------------------------------
+// Helper functions for tensor operations
+// -------------------------------------------------------------
+
+namespace {
+
+using int4 = cuda::array<int, 4>;
+
+/**
+ *  Block dimensions: bdimx x bdimy x bdimz
+ *
+ *  Grid dimensions: (dim[3] / bdimx) x (dim[2] / bdimy) x (dim[1] / bdimx)
+ */
+template <typename TensorDataType>
+__global__ void copy_4d_kernel(
+  int4 dims,
+  const TensorDataType* __restrict__ input,
+  int4 input_strides,
+  TensorDataType* __restrict__ output,
+  int4 output_strides) {
+
+  // Indices
+  const auto& gidx = threadIdx.x + blockIdx.x * blockDim.x;
+  const auto& gidy = threadIdx.y + blockIdx.y * blockDim.y;
+  const auto& gidz = threadIdx.z + blockIdx.z * blockDim.z;
+  const auto& nthreadsx = gridDim.x * blockDim.x;
+  const auto& nthreadsy = gridDim.y * blockDim.y;
+  const auto& nthreadsz = gridDim.z * blockDim.z;
+
+  for (int i0=0; i0<dims[0]; ++i0) {
+    for (int i1=gidz; i1<dims[1]; i1+=nthreadsz) {
+      for (int i2=gidy; i2<dims[2]; i2+=nthreadsy) {
+        for (int i3=gidx; i3<dims[3]; i3+=nthreadsx) {
+          const auto& x = input[i0 * input_strides[0]
+                                + i1 * input_strides[1]
+                                + i2 * input_strides[2]
+                                + i3 * input_strides[3]];
+          auto& y = output[i0 * output_strides[0]
+                           + i1 * output_strides[1]
+                           + i2 * output_strides[2]
+                           + i3 * output_strides[3]];
+          y = x;
+        }
+      }
+    }
+  }
+
+}
+
+} // namespace <anon>
+
+template <typename TensorDataType>
+void copy_tensor(
+  cudaStream_t stream,
+  const std::vector<size_t>& dims,
+  const TensorDataType* input,
+  const std::vector<size_t>& input_strides,
+  TensorDataType* output,
+  const std::vector<size_t>& output_strides) {
+
+  // Check inputs
+  if (dims.empty() || dims.size() > 4) {
+    LBANN_ERROR("invalid number of tensor dimensions (",dims.size(),")");
+  }
+  if (dims.size() != input_strides.size()) {
+    LBANN_ERROR(
+      "number of input strides (",input_strides.size(),") ",
+      "does not match number of tensor dimensions (",dims.size(),")");
+  }
+  if (dims.size() != output_strides.size()) {
+    LBANN_ERROR(
+      "number of output strides (",output_strides.size(),") ",
+      "does not match number of tensor dimensions (",dims.size(),")");
+  }
+
+  // Pad tensor dimensions to 4D
+  std::vector<int>
+    rdims(dims.rbegin(), dims.rend()),
+    input_rstrides(input_strides.rbegin(), input_strides.rend()),
+    output_rstrides(output_strides.rbegin(), output_strides.rend());
+  rdims.resize(4, 1);
+  input_rstrides.resize(4, input_rstrides.back());
+  output_rstrides.resize(4, output_rstrides.back());
+
+  // Launch CUDA kernel
+  const auto size = std::accumulate(
+    dims.begin(), dims.end(), 1, std::multiplies<int>());
+  if (size > 0) {
+    constexpr size_t block_size = 64;
+    dim3 block_dims, grid_dims;
+    block_dims.x = block_size;
+    block_dims.y = 1;
+    block_dims.z = 1;
+    grid_dims.x = (rdims[0] + block_dims.x - 1) / block_dims.x;
+    grid_dims.y = (rdims[1] + block_dims.y - 1) / block_dims.y;
+    grid_dims.z = (rdims[2] + block_dims.z - 1) / block_dims.z;
+    grid_dims.y = El::Min(grid_dims.y, 65535);
+    grid_dims.z = El::Min(grid_dims.z, 65535);
+    copy_4d_kernel<<<grid_dims, block_dims, 0, stream>>>(
+      {rdims[3], rdims[2], rdims[1], rdims[0]},
+      input,
+      {input_rstrides[3], input_rstrides[2],
+          input_rstrides[1], input_rstrides[0]},
+      output,
+      {output_rstrides[3], output_rstrides[2],
+          output_rstrides[1], output_rstrides[0]});
+  }
+
+}
+
+#if defined(LBANN_HAS_HALF) && defined(LBANN_HAS_GPU_HALF)
+template <>
+void copy_tensor<cpu_fp16>(
+  cudaStream_t stream,
+  const std::vector<size_t>& dims,
+  const cpu_fp16* input,
+  const std::vector<size_t>& input_strides,
+  cpu_fp16* output,
+  const std::vector<size_t>& output_strides) {
+  copy_tensor<fp16>(
+    stream,
+    dims,
+    reinterpret_cast<const fp16*>(input),
+    input_strides,
+    reinterpret_cast<fp16*>(output),
+    output_strides);
+}
+#endif // defined(LBANN_HAS_HALF) && defined(LBANN_HAS_GPU_HALF)
+
+// Explicit template instantiation
+#define PROTO(T)                                \
+  template void copy_tensor<T>(                 \
+    cudaStream_t stream,                        \
+    const std::vector<size_t>& dims,            \
+    const T* input,                             \
+    const std::vector<size_t>& input_strides,   \
+    T* output,                                  \
+    const std::vector<size_t>& output_strides);
+#define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_CPU_HALF
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
 
 } // namespace cuda
 } // namespace lbann


### PR DESCRIPTION
The GRU layer requires reordering tensors since we operate with `mini_batch_size x sequence_length x dim` data while cuDNN operates with `sequence_length x mini_batch_size x dim`. This PR replaces a bunch of `cudaMemcpy` s with a single CUDA kernel. The kernel API is very general and can be used for general tensor transposes, although the performance is likely poor for other use-cases. It might be something we want to move over to DiHydrogen in the future.

The GRU layer passes metric checking and gradient checking on Lassen. The mini-batch time in the ATOM VAE model dropped from 0.058 sec to 0.040 sec. [Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM303-1).