### PR TITLE
Add optimized launcher defaults for rzansel

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -79,7 +79,7 @@ def make_batch_script(
     set_environment('MV2_USE_RDMA_CM', 0)
 
     # Optimizations for Sierra-like systems
-    if system in ('sierra', 'lassen'):
+    if system in ('sierra', 'lassen', 'rzansel'):
 
         # Set thread affinity
         # Note: Aluminum's default thread affinity is incorrect since

--- a/python/lbann/contrib/lc/systems.py
+++ b/python/lbann/contrib/lc/systems.py
@@ -23,6 +23,7 @@ _system_params = {
     'lassen':   SystemParams(44, 4, 'lsf'),
     'ray':      SystemParams(40, 4, 'lsf'),
     'sierra':   SystemParams(44, 4, 'lsf'),
+    'rzansel':  SystemParams(44, 4, 'lsf'),
 }
 
 # Detect system


### PR DESCRIPTION
I'm assuming RZAnsel is identical to Lassen and Sierra.