### PR TITLE
Distconv's convolution and pooling tests

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -758,13 +758,11 @@ def create_tests(setup_func,
             assert 'procs_per_node' not in _kwargs.keys()
             if procs_per_node == "auto":
                 procs_per_node = lbann.contrib.lc.systems.gpus_per_node()
+                if procs_per_node == 0:
+                    e = 'this test requires GPUs.'
+                    print('Skip - ' + e)
+                    pytest.skip(e)
             _kwargs['procs_per_node'] = procs_per_node
-
-        # FIXME
-        if "procs_per_node" in _kwargs.keys():
-            print("procs_per_node={}".format(_kwargs["procs_per_node"]))
-        else:
-            print("no procs_per_node")
 
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -662,7 +662,6 @@ def assert_failure(return_code, expected_error, error_file_name):
 
 def create_tests(setup_func,
                  test_file,
-                 procs_per_node=None,
                  test_name_base=None,
                  **kwargs):
     """Create functions that can interact with PyTest
@@ -689,9 +688,6 @@ def create_tests(setup_func,
             lbann.reader_pb2.DataReader, lbann.Optimizer)`.
         test_file (str): Python script being run by PyTest. In most
             cases, use `__file__`.
-        procs_per_node (int or str, optional): The number of processes
-            per node to pass into `lbann.contrib.launcher.run`.
-            If "auto" is set, gpus_per_node() is passed instead.
         test_name (str, optional): Descriptive name (default: test
             file name with '.py' removed).
         **kwargs: Keyword arguments to pass into
@@ -713,7 +709,7 @@ def create_tests(setup_func,
         # Make sure test name is prefixed with 'test_'
         test_name_base = 'test_' + test_name_base
 
-    def test_func(cluster, executables, dir_name, procs_per_node, compiler_name):
+    def test_func(cluster, executables, dir_name, compiler_name):
         """Function that can interact with PyTest.
 
         Returns a dict containing log files and other output data.
@@ -752,17 +748,6 @@ def create_tests(setup_func,
                                                'experiments',
                                                test_name)
 
-        # Setup the number of processes
-        if procs_per_node is not None:
-            assert 'procs_per_node' not in _kwargs.keys()
-            if procs_per_node == "auto":
-                procs_per_node = gpus_per_node(lbann)
-                if procs_per_node == 0:
-                    e = 'this test requires GPUs.'
-                    print('Skip - ' + e)
-                    pytest.skip(e)
-            _kwargs['procs_per_node'] = procs_per_node
-
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:
             _kwargs['work_dir'] = os.path.join(_kwargs['work_dir'], _kwargs['work_subdir'])
@@ -798,11 +783,11 @@ def create_tests(setup_func,
 
     # Specific test functions for different build configurations
     def test_func_clang6(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, procs_per_node, 'clang6')
+        return test_func(cluster, exes, dirname, 'clang6')
     def test_func_gcc7(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, procs_per_node, 'gcc7')
+        return test_func(cluster, exes, dirname, 'gcc7')
     def test_func_intel19(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, procs_per_node, 'intel19')
+        return test_func(cluster, exes, dirname, 'intel19')
     test_func_clang6.__name__ = '{}_clang6'.format(test_name_base)
     test_func_gcc7.__name__ = '{}_gcc7'.format(test_name_base)
     test_func_intel19.__name__ = '{}_intel19'.format(test_name_base)

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -1001,6 +1001,6 @@ def gpus_per_node(lbann):
 
 # Get the environment variables for Distconv.
 def get_distconv_environment():
-    # TODO: Use the default halo exchange and shuffle method.
+    # TODO: Use the default halo exchange and shuffle method. See https://github.com/LLNL/lbann/issues/1659
     return {"LBANN_DISTCONV_HALO_EXCHANGE": "AL",
             "LBANN_DISTCONV_TENSOR_SHUFFLER": "AL"}

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -691,8 +691,7 @@ def create_tests(setup_func,
             cases, use `__file__`.
         procs_per_node (int or str, optional): The number of processes
             per node to pass into `lbann.contrib.launcher.run`.
-            If "auto" is set, lbann.contrib.lc.systems.gpus_per_node()
-            is passed instead.
+            If "auto" is set, gpus_per_node() is passed instead.
         test_name (str, optional): Descriptive name (default: test
             file name with '.py' removed).
         **kwargs: Keyword arguments to pass into
@@ -757,7 +756,7 @@ def create_tests(setup_func,
         if procs_per_node is not None:
             assert 'procs_per_node' not in _kwargs.keys()
             if procs_per_node == "auto":
-                procs_per_node = lbann.contrib.lc.systems.gpus_per_node()
+                procs_per_node = gpus_per_node(lbann)
                 if procs_per_node == 0:
                     e = 'this test requires GPUs.'
                     print('Skip - ' + e)
@@ -1003,3 +1002,12 @@ def print_diff_files(dcmp):
             all_warns.append(d)
 
     return any_files_differ, all_diffs, all_warns
+
+# Get the number of GPUs per compute node.
+# Return 0 if the system is unknown.
+def gpus_per_node(lbann):
+    compute_center = lbann.contrib.launcher.compute_center()
+    if compute_center != "unknown":
+        return getattr(lbann.contrib, compute_center).systems.gpus_per_node()
+    else:
+        return 0

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -988,6 +988,7 @@ def print_diff_files(dcmp):
 
     return any_files_differ, all_diffs, all_warns
 
+
 # Get the number of GPUs per compute node.
 # Return 0 if the system is unknown.
 def gpus_per_node(lbann):
@@ -996,3 +997,10 @@ def gpus_per_node(lbann):
         return getattr(lbann.contrib, compute_center).systems.gpus_per_node()
     else:
         return 0
+
+
+# Get the environment variables for Distconv.
+def get_distconv_environment():
+    # TODO: Use the default halo exchange and shuffle method.
+    return {"LBANN_DISTCONV_HALO_EXCHANGE": "AL",
+            "LBANN_DISTCONV_TENSOR_SHUFFLER": "AL"}

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -662,6 +662,7 @@ def assert_failure(return_code, expected_error, error_file_name):
 
 def create_tests(setup_func,
                  test_file,
+                 procs_per_node=None,
                  test_name_base=None,
                  **kwargs):
     """Create functions that can interact with PyTest
@@ -688,6 +689,10 @@ def create_tests(setup_func,
             lbann.reader_pb2.DataReader, lbann.Optimizer)`.
         test_file (str): Python script being run by PyTest. In most
             cases, use `__file__`.
+        procs_per_node (int or str, optional): The number of processes
+            per node to pass into `lbann.contrib.launcher.run`.
+            If "auto" is set, lbann.contrib.lc.systems.gpus_per_node()
+            is passed instead.
         test_name (str, optional): Descriptive name (default: test
             file name with '.py' removed).
         **kwargs: Keyword arguments to pass into
@@ -709,7 +714,7 @@ def create_tests(setup_func,
         # Make sure test name is prefixed with 'test_'
         test_name_base = 'test_' + test_name_base
 
-    def test_func(cluster, executables, dir_name, compiler_name):
+    def test_func(cluster, executables, dir_name, procs_per_node, compiler_name):
         """Function that can interact with PyTest.
 
         Returns a dict containing log files and other output data.
@@ -748,6 +753,19 @@ def create_tests(setup_func,
                                                'experiments',
                                                test_name)
 
+        # Setup the number of processes
+        if procs_per_node is not None:
+            assert 'procs_per_node' not in _kwargs.keys()
+            if procs_per_node == "auto":
+                procs_per_node = lbann.contrib.lc.systems.gpus_per_node()
+            _kwargs['procs_per_node'] = procs_per_node
+
+        # FIXME
+        if "procs_per_node" in _kwargs.keys():
+            print("procs_per_node={}".format(_kwargs["procs_per_node"]))
+        else:
+            print("no procs_per_node")
+
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:
             _kwargs['work_dir'] = os.path.join(_kwargs['work_dir'], _kwargs['work_subdir'])
@@ -783,11 +801,11 @@ def create_tests(setup_func,
 
     # Specific test functions for different build configurations
     def test_func_clang6(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, 'clang6')
+        return test_func(cluster, exes, dirname, procs_per_node, 'clang6')
     def test_func_gcc7(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, 'gcc7')
+        return test_func(cluster, exes, dirname, procs_per_node, 'gcc7')
     def test_func_intel19(cluster, exes, dirname):
-        return test_func(cluster, exes, dirname, 'intel19')
+        return test_func(cluster, exes, dirname, procs_per_node, 'intel19')
     test_func_clang6.__name__ = '{}_clang6'.format(test_name_base)
     test_func_gcc7.__name__ = '{}_gcc7'.format(test_name_base)
     test_func_intel19.__name__ = '{}_intel19'.format(test_name_base)

--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -40,7 +40,7 @@ def make_random_array(shape, seed):
     return x.reshape(shape).astype(np.float32)
 
 # Data
-_num_samples = 23
+_num_samples = 8
 _sample_dims = [6,16,16]
 _sample_size = functools.reduce(operator.mul, _sample_dims)
 _samples = make_random_array([_num_samples] + _sample_dims, 7)
@@ -197,7 +197,8 @@ def construct_model(lbann):
         val = z
     except:
         # Precomputed value
-        val = 381.7401227915947
+        val = 398.6956458317758 # _num_samples=8
+        # val = 381.7401227915947 # _num_samples=23
     tol = 8 * val * np.finfo(np.float32).eps
 
     callbacks.append(lbann.CallbackCheckMetric(
@@ -211,8 +212,7 @@ def construct_model(lbann):
     # Gradient checking
     # ------------------------------------------
 
-    # TODO: Make CallbackCheckGradients work with Distconv.
-    # callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
 
     # ------------------------------------------
     # Construct model

--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -287,5 +287,6 @@ def construct_data_reader(lbann):
 # Create test functions that can interact with PyTest
 # Note: Create test name by removing ".py" from file name
 _test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, _test_name,
+                               environment=tools.get_distconv_environment()):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -189,7 +189,8 @@ def construct_model(lbann):
                               conv_pads=tools.str_list(pads),
                               conv_dilations=tools.str_list(dilations),
                               has_bias=False,
-                              parallel_strategy=create_parallel_strategy(4))
+                              parallel_strategy=create_parallel_strategy(
+                                  lbann.contrib.lc.systems.gpus_per_node()))
         z = lbann.L2Norm2(y)
         obj.append(z)
         metrics.append(lbann.Metric(z, name='basic {}D 3^n convolution'.format(num_dims)))
@@ -283,5 +284,5 @@ def construct_data_reader(lbann):
 # Create test functions that can interact with PyTest
 # Note: Create test name by removing ".py" from file name
 _test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name, procs_per_node=4):
+for test in tools.create_tests(setup_experiment, _test_name, procs_per_node="auto"):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -231,10 +231,7 @@ def construct_model(lbann):
     # Gradient checking
     # ------------------------------------------
 
-    callbacks.append(lbann.CallbackCheckGradients(
-        error_on_failure=True,
-        step_size=20.0, # TODO: Use the default step size.
-    ))
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
 
     # ------------------------------------------
     # Construct model

--- a/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_convolution_distconv.py
@@ -190,7 +190,7 @@ def construct_model(lbann):
                               conv_dilations=tools.str_list(dilations),
                               has_bias=False,
                               parallel_strategy=create_parallel_strategy(
-                                  lbann.contrib.lc.systems.gpus_per_node()))
+                                  tools.gpus_per_node(lbann)))
         z = lbann.L2Norm2(y)
         obj.append(z)
         metrics.append(lbann.Metric(z, name='basic {}D 3^n convolution'.format(num_dims)))

--- a/bamboo/unit_tests/test_unit_layer_identity_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_identity_distconv.py
@@ -200,5 +200,6 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__):
+for test in tools.create_tests(setup_experiment, __file__,
+                               environment=tools.get_distconv_environment()):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_identity_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_identity_distconv.py
@@ -82,12 +82,18 @@ def construct_model(lbann):
     # Data-parallel layout with distconv
     # ------------------------------------------
 
+    num_height_groups = tools.gpus_per_node(lbann)
+    if num_height_groups == 0:
+        e = 'this test requires GPUs.'
+        print('Skip - ' + e)
+        pytest.skip(e)
+
     # LBANN implementation
     x = x_lbann
     x = lbann.Reshape(x, dims="4 4 3")
     y = lbann.Identity(x, data_layout='data_parallel',
                        parallel_strategy=create_parallel_strategy(
-                           tools.gpus_per_node(lbann)))
+                           num_height_groups))
     x = lbann.Reshape(x, dims="48")
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -194,5 +200,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__, procs_per_node="auto"):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_identity_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_identity_distconv.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import sys
 import numpy as np
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -86,7 +87,7 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 4 3")
     y = lbann.Identity(x, data_layout='data_parallel',
                        parallel_strategy=create_parallel_strategy(
-                           lbann.contrib.lc.systems.gpus_per_node()))
+                           tools.gpus_per_node(lbann)))
     x = lbann.Reshape(x, dims="48")
     z = lbann.L2Norm2(y)
     obj.append(z)

--- a/bamboo/unit_tests/test_unit_layer_identity_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_identity_distconv.py
@@ -85,7 +85,8 @@ def construct_model(lbann):
     x = x_lbann
     x = lbann.Reshape(x, dims="4 4 3")
     y = lbann.Identity(x, data_layout='data_parallel',
-                       parallel_strategy=create_parallel_strategy(4))
+                       parallel_strategy=create_parallel_strategy(
+                           lbann.contrib.lc.systems.gpus_per_node()))
     x = lbann.Reshape(x, dims="48")
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -192,5 +193,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__, procs_per_node=4):
+for test in tools.create_tests(setup_experiment, __file__, procs_per_node="auto"):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
@@ -90,7 +90,8 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.LeakyRelu(x, negative_slope=0.01,
                         data_layout='data_parallel',
-                        parallel_strategy=create_parallel_strategy(4))
+                        parallel_strategy=create_parallel_strategy(
+                            lbann.contrib.lc.systems.gpus_per_node()))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -121,7 +122,8 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.LeakyRelu(x, negative_slope=2,
                         data_layout='model_parallel',
-                        parallel_strategy=create_parallel_strategy(4))
+                        parallel_strategy=create_parallel_strategy(
+                            lbann.contrib.lc.systems.gpus_per_node()))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -201,5 +203,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__, procs_per_node=4):
+for test in tools.create_tests(setup_experiment, __file__, procs_per_node="auto"):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
@@ -210,5 +210,6 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__):
+for test in tools.create_tests(setup_experiment, __file__,
+                               environment=tools.get_distconv_environment()):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_leaky_relu_distconv.py
@@ -91,7 +91,7 @@ def construct_model(lbann):
     y = lbann.LeakyRelu(x, negative_slope=0.01,
                         data_layout='data_parallel',
                         parallel_strategy=create_parallel_strategy(
-                            lbann.contrib.lc.systems.gpus_per_node()))
+                            tools.gpus_per_node(lbann)))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -123,7 +123,7 @@ def construct_model(lbann):
     y = lbann.LeakyRelu(x, negative_slope=2,
                         data_layout='model_parallel',
                         parallel_strategy=create_parallel_strategy(
-                            lbann.contrib.lc.systems.gpus_per_node()))
+                            tools.gpus_per_node(lbann)))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)

--- a/bamboo/unit_tests/test_unit_layer_pooling.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling.py
@@ -1,0 +1,291 @@
+import functools
+import math
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+def make_random_array(shape, seed):
+    """Hacked function to generate a random array.
+
+    NumPy's RNG produces different values with different NumPy
+    versions. This function is helpful when array values must be
+    identical across all runs, e.g. when checking against precomputed
+    metric values.
+
+    Args:
+        shape (Iterable of int): Array dimensions
+        seed (int): Parameter for RNG. Must be non-zero.
+    Returns:
+        numpy.ndarray: Array of `np.float32`. Values will be in
+            [-0.5,0.5).
+
+    """
+    size = functools.reduce(operator.mul, shape)
+    eps = np.finfo(np.float32).eps
+    x = (seed / np.linspace(math.sqrt(eps), 0.1, size)) % 1 - 0.5
+    return x.reshape(shape).astype(np.float32)
+
+# Data
+_num_samples = 23
+_sample_dims = [6,11,7]
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = make_random_array([_num_samples] + _sample_dims, 7)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:].reshape(-1)
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# PyTorch pooling
+# ==============================================
+
+def pytorch_pooling(data,
+                    kernel_dims,
+                    stride=1,
+                    padding=0):
+    """Wrapper around PyTorch pooling.
+
+    Input and output data are NumPy arrays.
+
+    """
+
+    # Convert input data to PyTorch tensors with 64-bit floats
+    import torch
+    import torch.nn.functional
+    if type(data) is np.ndarray:
+        data = torch.from_numpy(data)
+    if data.dtype is not torch.float64:
+        data = data.astype(torch.float64)
+
+    # Perform pooling with PyTorch
+    output = None
+    if len(kernel_dims) == 1:
+        output = torch.nn.functional.avg_pool1d(
+            data, kernel_dims, stride, padding,
+        )
+    if len(kernel_dims) == 2:
+        output = torch.nn.functional.avg_pool2d(
+            data, kernel_dims, stride, padding,
+        )
+    if len(kernel_dims) == 3:
+        output = torch.nn.functional.avg_pool3d(
+            data, kernel_dims, stride, padding,
+        )
+    if output is None:
+        raise ValueError('PyTorch only supports 1D, 2D, and 3D pooling')
+
+    # Return output as NumPy array
+    return output.numpy()
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples() // 2
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Sum with a weights layer so that gradient checking will
+    # verify that error signals are correct.
+    x_weights = lbann.Weights(optimizer=lbann.SGD(),
+                              initializer=lbann.ConstantInitializer(value=0.0),
+                              name='input_weights')
+    x = lbann.Sum(lbann.Reshape(lbann.Input(),
+                                dims=tools.str_list(_sample_dims)),
+                  lbann.WeightsLayer(weights=x_weights,
+                                     dims=tools.str_list(_sample_dims)))
+    x_lbann = x
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # 3x3 average pooling
+    # ------------------------------------------
+    # 3x3 average pool, stride=1, pad=1, dilation=1, bias
+
+    # Pooling settings
+    kernel_dims = (5, _sample_dims[0], 3, 3)
+    strides = (1, 1)
+    pads = (1, 1)
+    pool_mode = "average"
+
+    # Apply pooling
+    x = x_lbann
+    y = lbann.Pooling(x,
+                      num_dims=2,
+                      has_vectors=True,
+                      pool_dims=tools.str_list(kernel_dims[2:]),
+                      pool_strides=tools.str_list(strides),
+                      pool_pads=tools.str_list(pads),
+                      pool_mode=pool_mode)
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='3x3 average pooling'))
+
+    # PyTorch implementation
+    try:
+        x = _samples
+        y = pytorch_pooling(
+            x,
+            kernel_dims[2:],
+            stride=strides, padding=pads,
+        )
+        z = tools.numpy_l2norm2(y) / _num_samples
+        val = z
+    except:
+        # Precomputed value
+        val = 10.44275178160873
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # 2x4 strided average pooling
+    # ------------------------------------------
+
+    # Pooling settings
+    kernel_dims = (3, _sample_dims[0], 2, 4)
+    strides = (3, 1)
+    pads = (1, 0)
+    pool_mode = "average"
+
+    # Apply pooling
+    x = x_lbann
+    y = lbann.Pooling(x,
+                      num_dims=2,
+                      has_vectors=True,
+                      pool_dims=tools.str_list(kernel_dims[2:]),
+                      pool_strides=tools.str_list(strides),
+                      pool_pads=tools.str_list(pads),
+                      pool_mode=pool_mode)
+    z = lbann.L2Norm2(y)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='2x4 average pooling'))
+
+    # PyTorch implementation
+    try:
+        x = _samples
+        y = pytorch_pooling(
+            x,
+            kernel_dims[2:],
+            stride=strides, padding=pads,
+        )
+        z = tools.numpy_l2norm2(y) / _num_samples
+        val = z
+    except:
+        # Precomputed value
+        val = 2.936493136591308
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Gradient checking
+    # ------------------------------------------
+
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+# Note: Create test name by removing ".py" from file name
+_test_name = os.path.splitext(os.path.basename(current_file))[0]
+for test in tools.create_tests(setup_experiment, _test_name):
+    globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
@@ -205,7 +205,8 @@ def construct_model(lbann):
                           pool_strides=tools.str_list(p["strides"]),
                           pool_pads=tools.str_list(p["pads"]),
                           pool_mode=p["pool_mode"],
-                          parallel_strategy=create_parallel_strategy(4))
+                          parallel_strategy=create_parallel_strategy(
+                              lbann.contrib.lc.systems.gpus_per_node()))
         z = lbann.L2Norm2(y)
 
         # Since max pooling is not differentiable, we only use average pooling.
@@ -304,5 +305,5 @@ def construct_data_reader(lbann):
 # Create test functions that can interact with PyTest
 # Note: Create test name by removing ".py" from file name
 _test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name, procs_per_node=4):
+for test in tools.create_tests(setup_experiment, _test_name, procs_per_node="auto"):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
@@ -206,7 +206,7 @@ def construct_model(lbann):
                           pool_pads=tools.str_list(p["pads"]),
                           pool_mode=p["pool_mode"],
                           parallel_strategy=create_parallel_strategy(
-                              lbann.contrib.lc.systems.gpus_per_node()))
+                              tools.gpus_per_node(lbann)))
         z = lbann.L2Norm2(y)
 
         # Since max pooling is not differentiable, we only use average pooling.

--- a/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
@@ -253,10 +253,7 @@ def construct_model(lbann):
     # Gradient checking
     # ------------------------------------------
 
-    callbacks.append(lbann.CallbackCheckGradients(
-        error_on_failure=True,
-        step_size=10.0, # TODO: Use the default step size.
-    ))
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
 
     # ------------------------------------------
     # Construct model

--- a/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
@@ -40,7 +40,7 @@ def make_random_array(shape, seed):
     return x.reshape(shape).astype(np.float32)
 
 # Data
-_num_samples = 23
+_num_samples = 8
 _sample_dims = [64,16,16]
 _sample_dims_3d = [4,16,16,16]
 _sample_size = functools.reduce(operator.mul, _sample_dims)
@@ -104,7 +104,7 @@ def setup_experiment(lbann):
 
     """
     mini_batch_size = num_samples() // 2
-    trainer = lbann.Trainer(mini_batch_size)
+    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
@@ -145,8 +145,12 @@ def construct_model(lbann):
     pool_configs = []
 
     # 3x3 pooling with same padding
-    for mode, val in [("average", 830.2573008820838),
-                      ("max", 1167.667676299899)]:
+    for mode, val in [
+            ("average", 700.1066377082393), # _num_samples=8
+            ("max", 1255.4813455546334), # _num_samples=8
+            # ("average", 830.2573008820838), # _num_samples=23
+            # ("max", 1167.667676299899), # _num_samples=23
+    ]:
         pool_configs.append({
             "name": "3x3 {} pooling".format(mode),
             "kernel_dims": (3, 3),
@@ -157,8 +161,12 @@ def construct_model(lbann):
         })
 
     # 2x2 strided pooling
-    for mode, val in [("average", 293.61402789516825),
-                      ("max", 351.4916288366334)]:
+    for mode, val in [
+            ("average", 263.76437243059104), # _num_samples=23
+            ("max", 358.66104389177207), # _num_samples=23
+            # ("average", 293.61402789516825), # _num_samples=23
+            # ("max", 351.4916288366334), # _num_samples=23
+    ]:
         pool_configs.append({
             "name": "2x2 {} pooling".format(mode),
             "kernel_dims": (2, 2),
@@ -169,8 +177,12 @@ def construct_model(lbann):
         })
 
     # 2x2x2 3D pooling
-    for mode, val in [("average", 89.61246528381926),
-                      ("max", 198.65624293856985)]:
+    for mode, val in [
+            ("average", 59.3851451701403), # _num_samples=8
+            ("max", 216.75871475407558), # _num_samples=8
+            # ("average", 89.61246528381926), # _num_samples=23
+            # ("max", 198.65624293856985), # _num_samples=23
+    ]:
         pool_configs.append({
             "name": "2x2x2 {} pooling".format(mode),
             "kernel_dims": (2, 2, 2),
@@ -233,8 +245,10 @@ def construct_model(lbann):
     # Gradient checking
     # ------------------------------------------
 
-    # TODO: Make CallbackCheckGradients work with Distconv.
-    # callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+    callbacks.append(lbann.CallbackCheckGradients(
+        error_on_failure=True,
+        step_size=10.0, # TODO: Use the default step size.
+    ))
 
     # ------------------------------------------
     # Construct model

--- a/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_pooling_distconv.py
@@ -309,5 +309,6 @@ def construct_data_reader(lbann):
 # Create test functions that can interact with PyTest
 # Note: Create test name by removing ".py" from file name
 _test_name = os.path.splitext(os.path.basename(current_file))[0]
-for test in tools.create_tests(setup_experiment, _test_name):
+for test in tools.create_tests(setup_experiment, _test_name,
+                               environment=tools.get_distconv_environment()):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_relu_distconv.py
@@ -89,7 +89,8 @@ def construct_model(lbann):
     x = x_lbann
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='data_parallel',
-                   parallel_strategy=create_parallel_strategy(4))
+                   parallel_strategy=create_parallel_strategy(
+                       lbann.contrib.lc.systems.gpus_per_node()))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -119,7 +120,8 @@ def construct_model(lbann):
     x = x_lbann
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='model_parallel',
-                   parallel_strategy=create_parallel_strategy(4))
+                   parallel_strategy=create_parallel_strategy(
+                       lbann.contrib.lc.systems.gpus_per_node()))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -199,5 +201,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__, procs_per_node=4):
+for test in tools.create_tests(setup_experiment, __file__, procs_per_node="auto"):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_relu_distconv.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import sys
 import numpy as np
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -85,12 +86,18 @@ def construct_model(lbann):
     # Data-parallel layout
     # ------------------------------------------
 
+    num_height_groups = tools.gpus_per_node(lbann)
+    if num_height_groups == 0:
+        e = 'this test requires GPUs.'
+        print('Skip - ' + e)
+        pytest.skip(e)
+
     # LBANN implementation
     x = x_lbann
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='data_parallel',
                    parallel_strategy=create_parallel_strategy(
-                       tools.gpus_per_node(lbann)))
+                       num_height_groups))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -121,7 +128,7 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='model_parallel',
                    parallel_strategy=create_parallel_strategy(
-                       tools.gpus_per_node(lbann)))
+                       num_height_groups))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -201,5 +208,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__, procs_per_node="auto"):
+for test in tools.create_tests(setup_experiment, __file__):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_relu_distconv.py
@@ -208,5 +208,6 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__):
+for test in tools.create_tests(setup_experiment, __file__,
+                               environment=tools.get_distconv_environment()):
     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_relu_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_relu_distconv.py
@@ -90,7 +90,7 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='data_parallel',
                    parallel_strategy=create_parallel_strategy(
-                       lbann.contrib.lc.systems.gpus_per_node()))
+                       tools.gpus_per_node(lbann)))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)
@@ -121,7 +121,7 @@ def construct_model(lbann):
     x = lbann.Reshape(x, dims="4 2 6")
     y = lbann.Relu(x, data_layout='model_parallel',
                    parallel_strategy=create_parallel_strategy(
-                       lbann.contrib.lc.systems.gpus_per_node()))
+                       tools.gpus_per_node(lbann)))
     y = lbann.Reshape(y, dims=str(sample_dims()))
     z = lbann.L2Norm2(y)
     obj.append(z)


### PR DESCRIPTION
This PR adds or modifies the following unit tests:
* `test_unit_layer_convolution_distconv.py`: Tests 3x3 and 3x3x3 convolution that are currently supported by Distconv. The height dimension is partitioned by 4 GPUs for both 2D and 3D layers.
* `test_unit_layer_pooling_distconv.py`: Tests 3x3 "same" pooling, and 2x2 and 2x2x2 strided pooling that is currently supported by Distconv. The height dimension is partitioned by 4 GPUs for both 2D and 3D layers.
* `test_unit_layer_pooling.py`: Tests various types of 2D and 3D pooling layers. Distconv is not used in this test.