### PR TITLE
Refactor layers to use the cuDNN handle wrappers

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -6,7 +6,7 @@ Support for new network structures:
 Support for new layers:
  - "DFTAbs" layer that computes the absolute value of the channel-wise
    DFT of the input data
- 
+
 Python front-end:
 
 Performance optimizations:
@@ -18,6 +18,7 @@ Model portability & usability:
 Internal features:
  - Wrapper classes for CUDA Graphs API
  - Elementary examples of using complex numbers
+ - cuDNN handles are now wrapped in RAII management classes
 
 I/O & data readers:
 

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -125,11 +125,11 @@ protected:
   cudnnMathType_t m_convolution_math_type =
     cudnn::get_default_convolution_math_type();
   /** Convolution kernel cuDNN descriptor. */
-  cudnnFilterDescriptor_t m_kernel_cudnn_desc = nullptr;
+  cudnn::FilterDescriptor m_kernel_cudnn_desc;
   /** Convolution cuDNN descriptor. */
   cudnnConvolutionDescriptor_t m_convolution_cudnn_desc = nullptr;
   /** Bias tensor cuDNN descriptor. */
-  cudnnTensorDescriptor_t m_bias_cudnn_desc = nullptr;
+  cudnn::TensorDescriptor m_bias_cudnn_desc;
   /** Tensor cuDNN descriptors. */
   cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
   /** Forward algorithm cache (mini-batch size -> algo). */
@@ -202,9 +202,6 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
 
-  /** Copy convolution kernel cuDNN descriptor. */
-  static void copy_kernel_cudnn_desc(const cudnnFilterDescriptor_t& src,
-                                     cudnnFilterDescriptor_t& dst);
   /** Copy convolution cuDNN descriptor. */
   static void copy_convolution_cudnn_desc(
     const cudnnConvolutionDescriptor_t& src,
@@ -213,12 +210,12 @@ private:
   /** Get the cuDNN algorithm to use for forward prop. */
   cudnnConvolutionFwdAlgo_t get_forward_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnnTensorDescriptor_t& input_desc,
+    const cudnn::TensorDescriptor& input_desc,
     const TensorDataType* input,
-    const cudnnFilterDescriptor_t& kernel_desc,
+    const cudnn::FilterDescriptor& kernel_desc,
     const TensorDataType* kernel,
     const cudnnConvolutionDescriptor_t& conv_desc,
-    const cudnnTensorDescriptor_t& output_desc,
+    const cudnn::TensorDescriptor& output_desc,
     TensorDataType* output,
     size_t ws_size,
     TensorDataType* ws);
@@ -226,12 +223,12 @@ private:
   /** Get the cuDNN algorithm to use for backward-data. */
   cudnnConvolutionBwdDataAlgo_t get_backward_data_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnnFilterDescriptor_t& kernel_desc,
+    const cudnn::FilterDescriptor& kernel_desc,
     const TensorDataType* kernel,
-    const cudnnTensorDescriptor_t& prev_error_signal_desc,
+    const cudnn::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
     const cudnnConvolutionDescriptor_t& conv_desc,
-    const cudnnTensorDescriptor_t& error_signal_desc,
+    const cudnn::TensorDescriptor& error_signal_desc,
     TensorDataType* error_signal,
     size_t ws_size,
     TensorDataType* ws);
@@ -242,12 +239,12 @@ private:
    */
   cudnnConvolutionBwdFilterAlgo_t get_backward_filter_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnnTensorDescriptor_t& input_desc,
+    const cudnn::TensorDescriptor& input_desc,
     const TensorDataType* input,
-    const cudnnTensorDescriptor_t& prev_error_signal_desc,
+    const cudnn::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
     const cudnnConvolutionDescriptor_t& conv_desc,
-    const cudnnFilterDescriptor_t& kernel_gradient_desc,
+    const cudnn::FilterDescriptor& kernel_gradient_desc,
     size_t ws_size,
     TensorDataType* ws);
 #endif // LBANN_HAS_CUDNN

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -127,7 +127,7 @@ protected:
   /** Convolution kernel cuDNN descriptor. */
   cudnn::FilterDescriptor m_kernel_cudnn_desc;
   /** Convolution cuDNN descriptor. */
-  cudnnConvolutionDescriptor_t m_convolution_cudnn_desc = nullptr;
+  cudnn::ConvolutionDescriptor m_convolution_cudnn_desc;
   /** Bias tensor cuDNN descriptor. */
   cudnn::TensorDescriptor m_bias_cudnn_desc;
   /** Tensor cuDNN descriptors. */
@@ -202,11 +202,6 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
 
-  /** Copy convolution cuDNN descriptor. */
-  static void copy_convolution_cudnn_desc(
-    const cudnnConvolutionDescriptor_t& src,
-    cudnnConvolutionDescriptor_t& dst);
-
   /** Get the cuDNN algorithm to use for forward prop. */
   cudnnConvolutionFwdAlgo_t get_forward_algo_cudnn(
     const int local_mini_batch_size,
@@ -214,7 +209,7 @@ private:
     const TensorDataType* input,
     const cudnn::FilterDescriptor& kernel_desc,
     const TensorDataType* kernel,
-    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnn::ConvolutionDescriptor& conv_desc,
     const cudnn::TensorDescriptor& output_desc,
     TensorDataType* output,
     size_t ws_size,
@@ -227,7 +222,7 @@ private:
     const TensorDataType* kernel,
     const cudnn::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
-    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnn::ConvolutionDescriptor& conv_desc,
     const cudnn::TensorDescriptor& error_signal_desc,
     TensorDataType* error_signal,
     size_t ws_size,
@@ -243,7 +238,7 @@ private:
     const TensorDataType* input,
     const cudnn::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
-    const cudnnConvolutionDescriptor_t& conv_desc,
+    const cudnn::ConvolutionDescriptor& conv_desc,
     const cudnn::FilterDescriptor& kernel_gradient_desc,
     size_t ws_size,
     TensorDataType* ws);

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -147,8 +147,14 @@ void copy_activation_desc(const cudnnActivationDescriptor_t& src,
 // Wrapper classes for cuDNN types
 ////////////////////////////////////////////////////////////
 
+template <typename T>
+using BackendHandleType = typename T::handle_type;
+
 /** @brief Wrapper around @c cudnnTensorDescriptor_t */
 class TensorDescriptor {
+public:
+
+  using handle_type = cudnnTensorDescriptor_t;
 
 public:
 
@@ -207,6 +213,9 @@ private:
 
 /** Wrapper around @c cudnnFilterDescriptor_t */
 class FilterDescriptor {
+public:
+
+  using handle_type = cudnnFilterDescriptor_t;
 
 public:
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -160,8 +160,8 @@ public:
 
   TensorDescriptor(cudnnTensorDescriptor_t desc=nullptr);
   template <typename... ArgTs>
-  TensorDescriptor(ArgTs... args) {
-    set(args...);
+  TensorDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
   }
 
   ~TensorDescriptor();
@@ -175,7 +175,7 @@ public:
   /** @brief Take ownership of cuDNN object */
   void reset(cudnnTensorDescriptor_t desc=nullptr);
   /** @brief Return cuDNN object and release ownership */
-  cudnnTensorDescriptor_t release();
+  cudnnTensorDescriptor_t release() noexcept;
   /** @brief Return cuDNN object without releasing ownership */
   cudnnTensorDescriptor_t get() const noexcept;
   /** @brief Return cuDNN object without releasing ownership */
@@ -211,7 +211,7 @@ private:
 
 };
 
-/** Wrapper around @c cudnnFilterDescriptor_t */
+/** @brief Wrapper around @c cudnnFilterDescriptor_t */
 class FilterDescriptor {
 public:
 
@@ -221,8 +221,8 @@ public:
 
   FilterDescriptor(cudnnFilterDescriptor_t desc=nullptr);
   template <typename... ArgTs>
-  FilterDescriptor(ArgTs... args) {
-    set(args...);
+  FilterDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
   }
 
   ~FilterDescriptor();
@@ -236,7 +236,7 @@ public:
   /** @brief Take ownership of cuDNN object */
   void reset(cudnnFilterDescriptor_t desc=nullptr);
   /** @brief Return cuDNN object and release ownership */
-  cudnnFilterDescriptor_t release();
+  cudnnFilterDescriptor_t release() noexcept;
   /** @brief Return cuDNN object without releasing ownership */
   cudnnFilterDescriptor_t get() const noexcept;
   /** @brief Return cuDNN object without releasing ownership */
@@ -273,15 +273,15 @@ private:
 
 };
 
-/** Wrapper around @c cudnnDropoutDescriptor_t */
+/** @brief Wrapper around @c cudnnDropoutDescriptor_t */
 class DropoutDescriptor {
 
 public:
 
   DropoutDescriptor(cudnnDropoutDescriptor_t desc=nullptr);
   template <typename... ArgTs>
-  DropoutDescriptor(ArgTs... args) {
-    set(args...);
+  DropoutDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
   }
 
   ~DropoutDescriptor();
@@ -295,7 +295,7 @@ public:
   /** @brief Take ownership of cuDNN object */
   void reset(cudnnDropoutDescriptor_t desc=nullptr);
   /** @brief Return cuDNN object and release ownership */
-  cudnnDropoutDescriptor_t release();
+  cudnnDropoutDescriptor_t release() noexcept;
   /** @brief Return cuDNN object without releasing ownership */
   cudnnDropoutDescriptor_t get() const noexcept;
   /** @brief Return cuDNN object without releasing ownership */
@@ -322,15 +322,15 @@ private:
 
 };
 
-/** Wrapper around @c cudnnRNNDescriptor_t */
+/** @brief Wrapper around @c cudnnRNNDescriptor_t */
 class RNNDescriptor {
 
 public:
 
   RNNDescriptor(cudnnRNNDescriptor_t desc=nullptr);
   template <typename... ArgTs>
-  RNNDescriptor(ArgTs... args) {
-    set(args...);
+  RNNDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
   }
 
   RNNDescriptor(const RNNDescriptor&) = delete;
@@ -344,7 +344,7 @@ public:
   /** @brief Take ownership of cuDNN object */
   void reset(cudnnRNNDescriptor_t desc=nullptr);
   /** @brief Return cuDNN object and release ownership */
-  cudnnRNNDescriptor_t release();
+  cudnnRNNDescriptor_t release() noexcept;
   /** @brief Return cuDNN object without releasing ownership */
   cudnnRNNDescriptor_t get() const noexcept;
   /** @brief Return cuDNN object without releasing ownership */
@@ -406,10 +406,7 @@ public:
   operator cudnnRNNDataDescriptor_t() const noexcept;
 
   /** Create cuDNN object
-   *
-   *  Does nothing if already created.
-   */
-  void create();
+
   /** Configure cuDNN object
    *
    *  Creates cuDNN object if needed.
@@ -428,6 +425,376 @@ private:
   cudnnRNNDataDescriptor_t desc_{nullptr};
 
 };
+
+/** @brief Wrapper around @c cudnnConvolutionDescriptor_t */
+class ConvolutionDescriptor
+{
+public:
+
+  /** @brief Descriptor handle from the implementation. */
+  using DescriptorHandle_t = cudnnConvolutionDescriptor_t;
+
+public:
+
+  /** @name Constructors and destructor */
+  ///@{
+
+  /** @brief Construct from an existing handle. */
+  ConvolutionDescriptor(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Construct with the arguments to set.
+   *
+   *  A new handle will be allocated immediately.
+   */
+  template <typename... ArgTs>
+  ConvolutionDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
+  }
+
+  /** @brief Any handle resources will be freed. */
+  ~ConvolutionDescriptor();
+
+  /** @brief Copy constructor.
+   *
+   *  Constructs a new handle with identical features.
+   */
+  ConvolutionDescriptor(const ConvolutionDescriptor&);
+  /** @brief Move constructor */
+  ConvolutionDescriptor(ConvolutionDescriptor&&);
+
+  /** @brief Assignment operator. */
+  ConvolutionDescriptor& operator=(ConvolutionDescriptor);
+
+  ///@}
+  /** @name Accessors */
+  ///@{
+
+  /** @brief Return handle object and release ownership */
+  DescriptorHandle_t release() noexcept;
+  /** @brief Return handle object without releasing ownership */
+  DescriptorHandle_t get() const noexcept;
+  /** @brief Implicit conversion to handle object without releasing
+   *         ownership
+   */
+  operator DescriptorHandle_t() const noexcept;
+
+  ///@}
+  /** @name Modifiers */
+  ///@{
+
+  /** @brief Swap contents with another descriptor */
+  void swap(ConvolutionDescriptor& other);
+
+  /** @brief Take ownership of existing handle */
+  void reset(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Allocate a new handle.
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+
+  /** @brief Configure handle properties
+   *
+   *  Allocates a new handle if one doesn't already exist.
+   */
+  void set(
+    std::vector<int> const& pad,
+    std::vector<int> const& stride,
+    std::vector<int> const& dilation,
+    cudnnDataType_t data_type,
+    cudnnConvolutionMode_t mode = CUDNN_CROSS_CORRELATION);
+  void set(
+    size_t array_dim,
+    int const pad[],
+    int const stride[],
+    int const dilation[],
+    cudnnDataType_t data_type,
+    cudnnConvolutionMode_t mode = CUDNN_CROSS_CORRELATION);
+
+  /** @brief Set the math mode for this descriptor. */
+  void set_math_mode(cudnnMathType_t math_type);
+
+  /** @brief Set the group count for this descriptor. */
+  void set_group_count(int num_groups);
+
+  ///@}
+
+private:
+
+  DescriptorHandle_t desc_ = nullptr;
+
+};
+
+/** @brief Swap two convolution descriptors. */
+void swap(ConvolutionDescriptor& lhs, ConvolutionDescriptor& rhs);
+
+/** @brief Wrapper around @c cudnnActivationDescriptor_t */
+class ActivationDescriptor
+{
+public:
+
+  /** @brief Descriptor handle from the implementation. */
+  using DescriptorHandle_t = cudnnActivationDescriptor_t;
+
+public:
+
+  /** @name Constructors and destructor */
+  ///@{
+
+  /** @brief Construct from an existing handle. */
+  ActivationDescriptor(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Construct with the arguments to set.
+   *
+   *  A new handle will be allocated immediately.
+   */
+  template <typename... ArgTs>
+  ActivationDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
+  }
+
+  /** @brief Any handle resources will be freed. */
+  ~ActivationDescriptor();
+
+  /** @brief Copy constructor.
+   *
+   *  Constructs a new handle with identical features.
+   */
+  ActivationDescriptor(const ActivationDescriptor&);
+  /** @brief Move constructor */
+  ActivationDescriptor(ActivationDescriptor&&);
+
+  /** @brief Assignment operator. */
+  ActivationDescriptor& operator=(ActivationDescriptor);
+
+  ///@}
+  /** @name Accessors */
+  ///@{
+
+  /** @brief Return handle object and release ownership */
+  DescriptorHandle_t release() noexcept;
+  /** @brief Return handle object without releasing ownership */
+  DescriptorHandle_t get() const noexcept;
+  /** @brief Implicit conversion to handle object without releasing
+   *         ownership
+   */
+  operator DescriptorHandle_t() const noexcept;
+
+  ///@}
+  /** @name Modifiers */
+  ///@{
+
+  /** @brief Swap contents with another descriptor */
+  void swap(ActivationDescriptor& other);
+
+  /** @brief Take ownership of existing handle */
+  void reset(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Allocate a new handle.
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** @brief Configure handle properties
+   *
+   *  Allocates a new handle if one doesn't already exist.
+   */
+  void set(
+    cudnnActivationMode_t mode,
+    cudnnNanPropagation_t nan_prop,
+    double coeff);
+
+  ///@}
+
+private:
+
+  DescriptorHandle_t desc_ = nullptr;
+
+};
+
+/** @brief Swap two convolution descriptors. */
+void swap(ActivationDescriptor& lhs, ActivationDescriptor& rhs);
+
+/** @brief Wrapper around @c cudnnPoolingDescriptor_t */
+class PoolingDescriptor
+{
+public:
+
+  /** @brief Descriptor handle from the implementation. */
+  using DescriptorHandle_t = cudnnPoolingDescriptor_t;
+
+public:
+
+  /** @name Constructors and destructor */
+  ///@{
+
+  /** @brief Construct from an existing handle. */
+  PoolingDescriptor(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Construct with the arguments to set.
+   *
+   *  A new handle will be allocated immediately.
+   */
+  template <typename... ArgTs>
+  PoolingDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
+  }
+
+  /** @brief Any handle resources will be freed. */
+  ~PoolingDescriptor();
+
+  /** @brief Copy constructor.
+   *
+   *  Constructs a new handle with identical features.
+   */
+  PoolingDescriptor(const PoolingDescriptor&);
+  /** @brief Move constructor */
+  PoolingDescriptor(PoolingDescriptor&&);
+
+  /** @brief Assignment operator. */
+  PoolingDescriptor& operator=(PoolingDescriptor);
+
+  ///@}
+  /** @name Accessors */
+  ///@{
+
+  /** @brief Return handle object and release ownership */
+  DescriptorHandle_t release() noexcept;
+  /** @brief Return handle object without releasing ownership */
+  DescriptorHandle_t get() const noexcept;
+  /** @brief Implicit conversion to handle object without releasing
+   *         ownership
+   */
+  operator DescriptorHandle_t() const noexcept;
+
+  ///@}
+  /** @name Modifiers */
+  ///@{
+
+  /** @brief Swap contents with another descriptor */
+  void swap(PoolingDescriptor& other);
+
+  /** @brief Take ownership of existing handle */
+  void reset(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Allocate a new handle.
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** @brief Configure handle properties
+   *
+   *  Allocates a new handle if one doesn't already exist.
+   */
+  void set(
+    cudnnPoolingMode_t mode,
+    cudnnNanPropagation_t maxpoolingNanOpt,
+    std::vector<int> const& window_dims,
+    std::vector<int> const& padding,
+    std::vector<int> const& stride);
+  void set(
+    cudnnPoolingMode_t mode,
+    cudnnNanPropagation_t nan_prop,
+    int num_dims,
+    int const window_dims[],
+    int const padding[],
+    int const stride[]);
+
+  ///@}
+
+private:
+
+  DescriptorHandle_t desc_ = nullptr;
+
+};
+
+/** @brief Swap two convolution descriptors. */
+void swap(PoolingDescriptor& lhs, PoolingDescriptor& rhs);
+
+/** @brief Wrapper around @c cudnnLRNDescriptor_t */
+class LRNDescriptor
+{
+public:
+
+  /** @brief Descriptor handle from the implementation. */
+  using DescriptorHandle_t = cudnnLRNDescriptor_t;
+
+public:
+
+  /** @name Constructors and destructor */
+  ///@{
+
+  /** @brief Construct from an existing handle. */
+  LRNDescriptor(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Construct with the arguments to set.
+   *
+   *  A new handle will be allocated immediately.
+   */
+  template <typename... ArgTs>
+  LRNDescriptor(ArgTs&&... args) {
+    set(std::forward<ArgTs>(args)...);
+  }
+
+  /** @brief Any handle resources will be freed. */
+  ~LRNDescriptor();
+
+  /** @brief Copy constructor.
+   *
+   *  Constructs a new handle with identical features.
+   */
+  LRNDescriptor(const LRNDescriptor&);
+  /** @brief Move constructor */
+  LRNDescriptor(LRNDescriptor&&);
+
+  /** @brief Assignment operator. */
+  LRNDescriptor& operator=(LRNDescriptor);
+
+  ///@}
+  /** @name Accessors */
+  ///@{
+
+  /** @brief Return handle object and release ownership */
+  DescriptorHandle_t release() noexcept;
+  /** @brief Return handle object without releasing ownership */
+  DescriptorHandle_t get() const noexcept;
+  /** @brief Implicit conversion to handle object without releasing
+   *         ownership
+   */
+  operator DescriptorHandle_t() const noexcept;
+
+  ///@}
+  /** @name Modifiers */
+  ///@{
+
+  /** @brief Swap contents with another descriptor */
+  void swap(LRNDescriptor& other);
+
+  /** @brief Take ownership of existing handle */
+  void reset(DescriptorHandle_t desc=nullptr);
+
+  /** @brief Allocate a new handle.
+   *
+   *  Does nothing if already created.
+   */
+  void create();
+  /** @brief Configure handle properties
+   *
+   *  Allocates a new handle if one doesn't already exist.
+   */
+  void set(unsigned n, double alpha, double beta, double k);
+
+  ///@}
+
+private:
+
+  DescriptorHandle_t desc_ = nullptr;
+
+};
+
+/** @brief Swap two convolution descriptors. */
+void swap(LRNDescriptor& lhs, LRNDescriptor& rhs);
 
 ////////////////////////////////////////////////////////////
 // cuDNN tensor managers

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -251,6 +251,13 @@ class DropoutDescriptor {
 public:
 
   explicit DropoutDescriptor(cudnnDropoutDescriptor_t desc=nullptr);
+  DropoutDescriptor(float dropout,
+                    void* states,
+                    size_t states_size,
+                    unsigned long long seed)
+  {
+    this->set(dropout, states, states_size, seed);
+  }
 
   ~DropoutDescriptor();
 

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -376,7 +376,11 @@ public:
   /** @brief Return cuDNN object without releasing ownership */
   operator cudnnRNNDataDescriptor_t() const noexcept;
 
-  /** Create cuDNN object
+  /** @brief Allocate a new handle.
+   *
+   *  Does nothing if already created.
+   */
+  void create();
 
   /** Configure cuDNN object
    *

--- a/include/lbann/utils/cudnn.hpp
+++ b/include/lbann/utils/cudnn.hpp
@@ -207,7 +207,7 @@ public:
 
 private:
 
-  cudnnTensorDescriptor_t desc_{nullptr};
+  cudnnTensorDescriptor_t desc_ = nullptr;
 
 };
 
@@ -269,7 +269,7 @@ public:
 
 private:
 
-  cudnnFilterDescriptor_t desc_{nullptr};
+  cudnnFilterDescriptor_t desc_ = nullptr;
 
 };
 
@@ -318,7 +318,7 @@ public:
 
 private:
 
-  cudnnDropoutDescriptor_t desc_{nullptr};
+  cudnnDropoutDescriptor_t desc_ = nullptr;
 
 };
 
@@ -377,7 +377,7 @@ public:
 
 private:
 
-  cudnnRNNDescriptor_t desc_{nullptr};
+  cudnnRNNDescriptor_t desc_ = nullptr;
 
 };
 

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -74,6 +74,14 @@
     }                                                           \
   } while (0)
 
+#define LBANN_ASSERT(cond)                              \
+  if (!(cond))                                          \
+    LBANN_ERROR("The assertion " #cond " failed.")
+
+#define LBANN_ASSERT_WARNING(cond)                      \
+  if (!(cond))                                          \
+    LBANN_WARNING("The assertion " #cond " failed.")
+
 namespace lbann {
 
 /** Exception.

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -90,13 +90,11 @@ base_convolution_layer<TensorDataType,Device>::base_convolution_layer(
 #endif // LBANN_HAS_CUDNN
 {
 #ifdef LBANN_HAS_CUDNN
-  copy_kernel_cudnn_desc(other.m_kernel_cudnn_desc,
-                         m_kernel_cudnn_desc);
+  m_kernel_cudnn_desc = other.m_kernel_cudnn_desc;
   copy_convolution_cudnn_desc(other.m_convolution_cudnn_desc,
                               m_convolution_cudnn_desc);
   if (other.m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero()) {
-    cudnn::copy_tensor_desc(other.m_bias_cudnn_desc,
-                            m_bias_cudnn_desc);
+    m_bias_cudnn_desc = other.m_bias_cudnn_desc;
   }
   m_tensors_cudnn_desc.set_layer(this);
 #endif // LBANN_HAS_CUDNN
@@ -119,13 +117,11 @@ base_convolution_layer<TensorDataType,Device>
 #ifdef LBANN_HAS_CUDNN
   // Copy cuDNN objects
   m_convolution_math_type = other.m_convolution_math_type;
-  copy_kernel_cudnn_desc(other.m_kernel_cudnn_desc,
-                         m_kernel_cudnn_desc);
+  m_kernel_cudnn_desc = other.m_kernel_cudnn_desc;
   copy_convolution_cudnn_desc(other.m_convolution_cudnn_desc,
                               m_convolution_cudnn_desc);
   if (other.m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero()) {
-    cudnn::copy_tensor_desc(other.m_bias_cudnn_desc,
-                            m_bias_cudnn_desc);
+    m_bias_cudnn_desc = other.m_bias_cudnn_desc;
   }
   m_tensors_cudnn_desc = other.m_tensors_cudnn_desc;
   m_tensors_cudnn_desc.set_layer(this);
@@ -141,14 +137,8 @@ template <typename TensorDataType, El::Device Device>
 base_convolution_layer<TensorDataType,Device>
 ::~base_convolution_layer() {
 #ifdef LBANN_HAS_CUDNN
-  if (m_kernel_cudnn_desc != nullptr) {
-    CHECK_CUDNN_DTOR(cudnnDestroyFilterDescriptor(m_kernel_cudnn_desc));
-  }
   if (m_convolution_cudnn_desc != nullptr) {
     CHECK_CUDNN_DTOR(cudnnDestroyConvolutionDescriptor(m_convolution_cudnn_desc));
-  }
-  if (m_bias_cudnn_desc != nullptr) {
-    CHECK_CUDNN_DTOR(cudnnDestroyTensorDescriptor(m_bias_cudnn_desc));
   }
 #endif // LBANN_HAS_CUDNN
 }
@@ -410,12 +400,10 @@ void base_convolution_layer<TensorDataType,Device>::setup_gpu() {
   const auto& kernel_dims = this->get_kernel_dims();
 
   // Set kernel descriptor
-  CHECK_CUDNN(cudnnCreateFilterDescriptor(&m_kernel_cudnn_desc));
-  CHECK_CUDNN(cudnnSetFilterNdDescriptor(m_kernel_cudnn_desc,
-                                         cudnn::get_data_type<TensorDataType>(),
-                                         CUDNN_TENSOR_NCHW,
-                                         kernel_dims.size(),
-                                         kernel_dims.data()));
+  m_kernel_cudnn_desc.set(
+    cudnn::get_data_type<TensorDataType>(),
+    CUDNN_TENSOR_NCHW,
+    kernel_dims);
 
   // Set convolution descriptor
   CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&m_convolution_cudnn_desc));
@@ -435,7 +423,8 @@ void base_convolution_layer<TensorDataType,Device>::setup_gpu() {
   if (m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero()) {
     std::vector<int> bias_dims(output_dims.size() + 1, 1);
     bias_dims[1] = output_dims[0];
-    cudnn::set_tensor_desc<TensorDataType>(m_bias_cudnn_desc, bias_dims);
+    m_bias_cudnn_desc.set(
+      cudnn::get_data_type<TensorDataType>(), bias_dims);
   }
 
 #endif // LBANN_HAS_CUDNN
@@ -479,7 +468,7 @@ base_convolution_layer<TensorDataType,Device>
 
   // Convolution parameters
   std::vector<int> input_dims, output_dims;
-  cudnnTensorDescriptor_t input_desc, output_desc;
+  cudnn::TensorDescriptor input_desc, output_desc;
   if (during_forward_prop) {
     input_dims = this->get_input_dims();
     output_dims = this->get_output_dims();
@@ -559,7 +548,7 @@ apply_transposed_convolution_cudnn(bool during_forward_prop) {
 
   // Convolution transpose parameters
   std::vector<int> input_dims, output_dims;
-  cudnnTensorDescriptor_t input_desc, output_desc;
+  cudnn::TensorDescriptor input_desc, output_desc;
   if (during_forward_prop) {
     input_dims = this->get_input_dims();
     output_dims = this->get_output_dims();
@@ -1014,49 +1003,6 @@ void base_convolution_layer<TensorDataType,Device>
 }
 
 #ifdef LBANN_HAS_CUDNN
-
-template <typename TensorDataType, El::Device Device>
-void
-base_convolution_layer<TensorDataType,Device>
-::copy_kernel_cudnn_desc(const cudnnFilterDescriptor_t& src,
-                         cudnnFilterDescriptor_t& dst) {
-
-  // Create or destroy descriptor if needed
-  if(src != nullptr && dst == nullptr) {
-    CHECK_CUDNN(cudnnCreateFilterDescriptor(&dst));
-  }
-  else if(src == nullptr && dst != nullptr) {
-    CHECK_CUDNN(cudnnDestroyFilterDescriptor(dst));
-    dst = nullptr;
-  }
-
-  // Copy descriptor data if needed
-  if(src != nullptr) {
-    cudnnDataType_t data_type;
-    cudnnTensorFormat_t format;
-    int num_dims;
-    std::vector<int> dims(1);
-    CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
-                                           dims.size(),
-                                           &data_type,
-                                           &format,
-                                           &num_dims,
-                                           dims.data()));
-    dims.resize(num_dims);
-    CHECK_CUDNN(cudnnGetFilterNdDescriptor(src,
-                                           num_dims,
-                                           &data_type,
-                                           &format,
-                                           &num_dims,
-                                           dims.data()));
-    CHECK_CUDNN(cudnnSetFilterNdDescriptor(dst,
-                                           data_type,
-                                           format,
-                                           num_dims,
-                                           dims.data()));
-  }
-}
-
 template <typename TensorDataType, El::Device Device>
 void
 base_convolution_layer<TensorDataType,Device>
@@ -1117,12 +1063,12 @@ template <typename TensorDataType, El::Device Device>
 cudnnConvolutionFwdAlgo_t
 base_convolution_layer<TensorDataType,Device>::get_forward_algo_cudnn(
   const int local_mini_batch_size,
-  const cudnnTensorDescriptor_t& input_desc,
+  const cudnn::TensorDescriptor& input_desc,
   const TensorDataType* input,
-  const cudnnFilterDescriptor_t& kernel_desc,
+  const cudnn::FilterDescriptor& kernel_desc,
   const TensorDataType* kernel,
   const cudnnConvolutionDescriptor_t& conv_desc,
-  const cudnnTensorDescriptor_t& output_desc,
+  const cudnn::TensorDescriptor& output_desc,
   TensorDataType* output,
   size_t ws_size,
   TensorDataType* ws) {
@@ -1148,12 +1094,12 @@ template <typename TensorDataType, El::Device Device>
 cudnnConvolutionBwdDataAlgo_t
 base_convolution_layer<TensorDataType,Device>::get_backward_data_algo_cudnn(
   const int local_mini_batch_size,
-  const cudnnFilterDescriptor_t& kernel_desc,
+  const cudnn::FilterDescriptor& kernel_desc,
   const TensorDataType* kernel,
-  const cudnnTensorDescriptor_t& prev_error_signal_desc,
+  const cudnn::TensorDescriptor& prev_error_signal_desc,
   const TensorDataType* prev_error_signal,
   const cudnnConvolutionDescriptor_t& conv_desc,
-  const cudnnTensorDescriptor_t& error_signal_desc,
+  const cudnn::TensorDescriptor& error_signal_desc,
   TensorDataType* error_signal,
   size_t ws_size,
   TensorDataType* ws) {
@@ -1179,12 +1125,12 @@ template <typename TensorDataType, El::Device Device>
 cudnnConvolutionBwdFilterAlgo_t
 base_convolution_layer<TensorDataType,Device>::get_backward_filter_algo_cudnn(
   const int local_mini_batch_size,
-  const cudnnTensorDescriptor_t& input_desc,
+  const cudnn::TensorDescriptor& input_desc,
   const TensorDataType* input,
-  const cudnnTensorDescriptor_t& prev_error_signal_desc,
+  const cudnn::TensorDescriptor& prev_error_signal_desc,
   const TensorDataType* prev_error_signal,
   const cudnnConvolutionDescriptor_t& conv_desc,
-  const cudnnFilterDescriptor_t& kernel_gradient_desc,
+  const cudnn::FilterDescriptor& kernel_gradient_desc,
   size_t ws_size,
   TensorDataType* ws) {
   if (m_bwd_filter_cudnn_algos.count(local_mini_batch_size) == 0) {

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -851,7 +851,7 @@ PoolingDescriptor::~PoolingDescriptor()
   }
   catch (std::exception const& e)
   {
-    std::cerr << "Caught exception in ~ActivationDescriptor(). Shutting down."
+    std::cerr << "Caught exception in ~PoolingDescriptor(). Shutting down."
               << std::endl;
     std::terminate();
   }
@@ -974,7 +974,7 @@ LRNDescriptor::~LRNDescriptor()
   }
   catch (std::exception const& e)
   {
-    std::cerr << "Caught exception in ~ActivationDescriptor(). Shutting down."
+    std::cerr << "Caught exception in ~LRNDescriptor(). Shutting down."
               << std::endl;
     std::terminate();
   }

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -198,21 +198,12 @@ void TensorDescriptor::set(
       "and strides (",strides_in.size(),")");
   }
 
-  std::vector<int> dims, strides;
-  if (dims_in.size() < 3)
+  std::vector<int> dims=std::move(dims_in), strides=std::move(strides_in);
+  if (dims.size() < 3)
   {
     dims.resize(3, 1);
-    std::copy(dims_in.rbegin(), dims_in.rend(), dims.rbegin());
-    if (!strides_in.empty())
-    {
-      strides.resize(3, dims_in.front() * strides_in.front());
-      std::copy(strides_in.rbegin(), strides_in.rend(), strides.rbegin());
-    }
-  }
-  else
-  {
-    dims = std::move(dims_in);
-    strides = std::move(strides_in);
+    if (strides.size() < 3)
+      strides.resize(3, 1);
   }
 
   // Assume data is contiguous if no strides are provided

--- a/src/utils/unit_test/cufft_test.cpp
+++ b/src/utils/unit_test/cufft_test.cpp
@@ -90,7 +90,7 @@ void make_input_matrix(El::Matrix<El::Complex<T>, El::Device::CPU>& mat,
 }// namespace <anon>
 
 TEMPLATE_TEST_CASE("Testing cuFFT wrapper (C2C)",
-                   "[fft][cufft][gpu][cuda][utilities]",
+                   "[.cufft][fft][gpu][cuda][utilities][!nonportable]",
                    float, double)
 {
   using RealT = TestType;
@@ -181,7 +181,7 @@ TEMPLATE_TEST_CASE("Testing cuFFT wrapper (C2C)",
 }
 
 TEMPLATE_TEST_CASE("Testing cuFFT wrapper (C2C-InPlace)",
-                   "[fft][cufft][gpu][cuda][utilities]",
+                   "[.cufft][fft][gpu][cuda][utilities][!nonportable]",
                    float, double)
 {
   using RealT = TestType;


### PR DESCRIPTION
PR #1626 added some cuDNN handle wrappers, but only used them in GRU layers. This adds the rest of the required set for LBANN and pushes their use throughout LBANN layers.