### PR TITLE
Abstract cuDNN from the Softmax implementation

### DIFF
--- a/include/lbann/layers/activations/log_softmax.hpp
+++ b/include/lbann/layers/activations/log_softmax.hpp
@@ -28,7 +28,9 @@
 #define LBANN_LAYERS_ACTIVATIONS_LOG_SOFTMAX_HPP_INCLUDED
 
 #include "lbann/layers/data_type_layer.hpp"
+#if defined LBANN_HAS_CUDNN
 #include "lbann/utils/cudnn.hpp"
+#endif
 
 namespace lbann {
 

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -28,8 +28,10 @@
 #define LBANN_LAYERS_ACTIVATIONS_SOFTMAX_HPP_INCLUDED
 
 #include "lbann/layers/data_type_layer.hpp"
-#include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/distconv.hpp"
+#if defined LBANN_HAS_CUDNN
+#include "lbann/utils/cudnn.hpp"
+#endif // defined LBANN_HAS_CUDNN
 #include "lbann/utils/dnn_lib/cudnn/softmax.hpp"
 
 // Threshold outputs to a minimum value.

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -30,6 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/distconv.hpp"
+#include "lbann/utils/dnn_lib/cudnn/softmax.hpp"
 
 // Threshold outputs to a minimum value.
 
@@ -41,28 +42,6 @@
 #define LBANN_ENABLE_SOFTMAX_THRESHOLD
 
 namespace lbann {
-
-/** @brief Which tensor dimensions to apply softmax over. */
-enum class softmax_mode {
-  INVALID,
-  /** @brief Sample-wise softmax.
-   *
-   *  Slice tensor along the sample dimension (assuming data in NCHW
-   *  format) and apply softmax independently to each slice (once per
-   *  sample).
-   */
-  INSTANCE,
-  /** @brief Position-wise softmax.
-   *
-   *  Split tensor along all but the channel dimension (assuming data
-   *  in NCHW format) and apply softmax independently to each piece
-   *  (once per spatial position per sample).
-   *
-   *  This is not to be confused with @c channelwise_softmax, which
-   *  slices along the sample and channel dimensions.
-   */
-  CHANNEL
-};
 
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>

--- a/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
@@ -1,0 +1,167 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+#define LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+
+#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
+
+#include "utils.hpp"
+
+namespace lbann
+{
+/** @brief Which tensor dimensions to apply softmax over. */
+enum class softmax_mode
+{
+  INVALID,
+  /** @brief Sample-wise softmax.
+   *
+   *  Slice tensor along the sample dimension (assuming data in NCHW
+   *  format) and apply softmax independently to each slice (once per
+   *  sample).
+   */
+  INSTANCE,
+  /** @brief Position-wise softmax.
+   *
+   *  Split tensor along all but the channel dimension (assuming data
+   *  in NCHW format) and apply softmax independently to each piece
+   *  (once per spatial position per sample).
+   *
+   *  This is not to be confused with @c channelwise_softmax, which
+   *  slices along the sample and channel dimensions.
+   */
+  CHANNEL
+};// enum class softmax_mode
+
+/** @brief Internal LBANN names for supported softmax algorithms. */
+enum class softmax_alg
+{
+  FAST,
+  ACCURATE,
+  LOG,
+};// enum class softmax_alg
+
+namespace cudnn
+{
+
+/** @brief Convert an LBANN softmax_mode to the cuDNN equivalent value. */
+inline cudnnSoftmaxMode_t to_cudnn(softmax_mode m)
+{
+  switch (m)
+  {
+  case softmax_mode::INSTANCE: return CUDNN_SOFTMAX_MODE_INSTANCE;
+  case softmax_mode::CHANNEL: return CUDNN_SOFTMAX_MODE_CHANNEL;
+  case softmax_mode::INVALID:
+  default:
+    LBANN_ERROR("Invalid softmax mode requested.");
+  }
+}
+
+/** @brief Convert an LBANN softmax_alg to the cuDNN equivalent value. */
+inline cudnnSoftmaxAlgorithm_t to_cudnn(softmax_alg alg)
+{
+  switch (alg)
+  {
+  case softmax_alg::FAST: return CUDNN_SOFTMAX_FAST;
+  case softmax_alg::ACCURATE: return CUDNN_SOFTMAX_ACCURATE;
+  case softmax_alg::LOG: return CUDNN_SOFTMAX_LOG;
+  default:
+    LBANN_ERROR("Invalid softmax algorithm requested.");
+  }
+}
+
+template <typename TensorDataType, typename ScalarParameterType>
+void softmax_forward(
+  ScalarParameterType const& alpha_in,
+  TensorDescriptor const& xDesc,
+  El::Matrix<TensorDataType, El::Device::GPU> const& x,
+  ScalarParameterType const& beta_in,
+  TensorDescriptor const& yDesc,
+  El::Matrix<TensorDataType, El::Device::GPU>& y,
+  softmax_mode mode,
+  softmax_alg alg = softmax_alg::ACCURATE)
+{
+  // Short-circuit if we can
+  if (x.IsEmpty())
+    return;
+
+  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+                                     gpu::get_sync_info(x));
+  auto handle_manager = internal::make_default_handle_manager(multisync);
+  auto alpha = El::To<LibScalingParamT>(alpha_in);
+  auto beta = El::To<LibScalingParamT>(beta_in);
+  CHECK_CUDNN(cudnnSoftmaxForward(handle_manager.get(),
+                                  to_cudnn(alg),
+                                  to_cudnn(mode),
+                                  &alpha,
+                                  xDesc,
+                                  x.LockedBuffer(),
+                                  &beta,
+                                  yDesc,
+                                  y.Buffer()));
+}
+
+template <typename TensorDataType, typename ScalarParameterType>
+void softmax_backward(
+  ScalarParameterType const& alpha_in,
+  TensorDescriptor const& yDesc,
+  El::Matrix<TensorDataType, El::Device::GPU> const& y,
+  TensorDescriptor const& dyDesc,
+  El::Matrix<TensorDataType, El::Device::GPU> const& dy,
+  ScalarParameterType const& beta_in,
+  TensorDescriptor const& dxDesc,
+  El::Matrix<TensorDataType, El::Device::GPU>& dx,
+  softmax_mode mode,
+  softmax_alg alg = softmax_alg::ACCURATE)
+{
+  // Short-circuit if we can
+  if (y.IsEmpty())
+    return;
+
+  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(dx),
+                                     gpu::get_sync_info(y),
+                                     gpu::get_sync_info(dy));
+  auto handle_manager = internal::make_default_handle_manager(multisync);
+  auto alpha = El::To<LibScalingParamT>(alpha_in);
+  auto beta = El::To<LibScalingParamT>(beta_in);
+  CHECK_CUDNN(cudnnSoftmaxBackward(handle_manager.get(),
+                                   to_cudnn(alg),
+                                   to_cudnn(mode),
+                                   &alpha,
+                                   yDesc,
+                                   y.LockedBuffer(),
+                                   dyDesc,
+                                   dy.LockedBuffer(),
+                                   &beta,
+                                   dxDesc,
+                                   dx.Buffer()));
+}
+
+}// namespace cudnn
+}// namespace lbann
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
@@ -28,7 +28,6 @@
 
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
-
 #include "utils.hpp"
 
 namespace lbann
@@ -64,6 +63,7 @@ enum class softmax_alg
   LOG,
 };// enum class softmax_alg
 
+#if defined LBANN_HAS_CUDNN
 namespace cudnn
 {
 
@@ -163,5 +163,6 @@ void softmax_backward(
 }
 
 }// namespace cudnn
+#endif // LBANN_HAS_CUDNN
 }// namespace lbann
 #endif // LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/utils.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/utils.hpp
@@ -28,6 +28,7 @@
 
 namespace lbann
 {
+#if defined LBANN_HAS_CUDNN
 namespace cudnn
 {
 namespace internal
@@ -63,7 +64,7 @@ public:
     : handle_{other.handle_}, old_stream_{other.old_stream_}
   {
     other.handle_ = nullptr;
-    other.old_stream = nullptr;
+    other.old_stream_ = nullptr;
   }
   StreamManager& operator=(StreamManager const& other) = delete;
   StreamManager& operator=(StreamManager&& other) = delete;
@@ -82,5 +83,6 @@ inline StreamManager make_default_handle_manager(
 
 }// namespace internal
 }// namespace cudnn
+#endif // defined LBANN_HAS_CUDNN
 }// namespace lbann
 #endif // LBANN_UTILS_DNN_LIB_CUDNN_UTILS_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/utils.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/utils.hpp
@@ -60,9 +60,10 @@ public:
   }
   StreamManager(StreamManager const& other) = delete;
   StreamManager(StreamManager&& other)
-    : handle_{other.handle_}
+    : handle_{other.handle_}, old_stream_{other.old_stream_}
   {
     other.handle_ = nullptr;
+    other.old_stream = nullptr;
   }
   StreamManager& operator=(StreamManager const& other) = delete;
   StreamManager& operator=(StreamManager&& other) = delete;

--- a/include/lbann/utils/dnn_lib/cudnn/utils.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/utils.hpp
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_UTILS_HPP_
+#define LBANN_UTILS_DNN_LIB_CUDNN_UTILS_HPP_
+
+namespace lbann
+{
+namespace cudnn
+{
+namespace internal
+{
+
+// Simple RAII class that sets the stream on creation, caches the old
+// stream, and restores it on the way out.
+class StreamManager
+{
+public:
+  StreamManager(cudnnHandle_t handle, cudaStream_t stream)
+    : handle_(handle)
+  {
+    CHECK_CUDNN(cudnnGetStream(handle_, &old_stream_));
+    CHECK_CUDNN(cudnnSetStream(handle_, stream));
+  }
+
+  ~StreamManager()
+  {
+    try {
+      if (handle_)
+        CHECK_CUDNN(cudnnSetStream(handle_, old_stream_));
+    }
+    catch (std::exception const& e) {
+      std::cerr << "Caught error in ~cudnn::StreamManager().\n\n  e.what(): "
+                << e.what() << "\n\nCalling std::terminate()."
+                << std::endl;
+      std::terminate();
+    }
+  }
+  StreamManager(StreamManager const& other) = delete;
+  StreamManager(StreamManager&& other)
+    : handle_{other.handle_}
+  {
+    other.handle_ = nullptr;
+  }
+  StreamManager& operator=(StreamManager const& other) = delete;
+  StreamManager& operator=(StreamManager&& other) = delete;
+
+  cudnnHandle_t get() const noexcept { return handle_; }
+private:
+  cudnnHandle_t handle_;
+  cudaStream_t old_stream_;
+};// struct StreamManager
+
+inline StreamManager make_default_handle_manager(
+  El::SyncInfo<El::Device::GPU> const& si)
+{
+  return StreamManager(get_handle(), si.Stream());
+}
+
+}// namespace internal
+}// namespace cudnn
+}// namespace lbann
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_UTILS_HPP_


### PR DESCRIPTION
This establishes some infrastructure for the abstraction of cuDNN APIs out of LBANN using `softmax_layer` as an example with relatively little extra clutter (cf. `convolution_layer`...).

Depends on #1638; implicitly depends on #1642, but I didn't want to include that diff in this PR for just 1 file. I'll rebase once #1642 merges.