### PR TITLE
Abstract cuDNN from Dropout implementation

### DIFF
--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -244,6 +244,8 @@ protected:
     // Initialize cuDNN objects
     auto&& input_desc = m_tensors_cudnn_desc.get_prev_activations();
     auto&& output_desc = m_tensors_cudnn_desc.get_activations();
+    size_t size = cudnn::get_dropout_reserve_space_size(input_desc);
+    m_reserve_space.Resize((size + sizeof(TensorDataType) - 1) / sizeof(TensorDataType), 1);
 
     // Apply dropout on the GPU
     cudnn::dropout_forward(m_dropout_cudnn_desc,
@@ -291,8 +293,7 @@ protected:
   void setup_dropout_cudnn_desc() {
 
     // Setup RNG state
-    size_t size;
-    cudnn::get_dropout_state_size(size, m_states);
+    size_t size = cudnn::get_dropout_states_size();
     m_states.Resize((size + sizeof(TensorDataType) - 1) / sizeof(TensorDataType), 1);
 
     // Setup dropout descriptor

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+//#ifndef LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+//#define LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+
+#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
+
+#include "utils.hpp"
+
+namespace lbann
+{
+
+namespace cudnn
+{
+
+template <typename TensorDataType>
+void get_dropout_state_size(size_t& size,
+                            El::Matrix<TensorDataType, El::Device::GPU> m_states)
+{
+  auto handle_manager = internal::make_default_handle_manager(gpu::get_sync_info(m_states));
+  CHECK_CUDNN(cudnnDropoutGetStatesSize(handle_manager.get(), &size));
+}
+
+template <typename TensorDataType>
+void dropout_forward(DropoutDescriptor dropoutDesc,
+                     TensorDescriptor xDesc,
+                     El::AbstractMatrix<TensorDataType> const& x,
+                     TensorDescriptor yDesc,
+                     El::AbstractMatrix<TensorDataType>& y,
+                     El::AbstractMatrix<TensorDataType>& workspace,
+                     El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size;
+  CHECK_CUDNN(cudnnDropoutGetReserveSpaceSize(xDesc, &size));
+  workspace.Resize((size + sizeof(TensorDataType) - 1) / sizeof(TensorDataType), 1);
+  auto handle_manager = internal::make_default_handle_manager(si);
+  CHECK_CUDNN(
+    cudnnDropoutForward(handle_manager.get(),
+                        dropoutDesc,
+                        xDesc,
+                        x.LockedBuffer(),
+                        yDesc,
+                        y.Buffer(),
+                        workspace.Buffer(),
+                        workspace.Height() * sizeof(TensorDataType)));
+}
+
+template <typename TensorDataType>
+void dropout_forward(DropoutDescriptor dropoutDesc,
+                     TensorDescriptor xDesc,
+                     El::AbstractMatrix<TensorDataType> const& x,
+                     TensorDescriptor yDesc,
+                     El::AbstractMatrix<TensorDataType>& y,
+                     El::AbstractMatrix<TensorDataType>& workspace)
+{
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+                                     gpu::get_sync_info(x),
+                                     gpu::get_sync_info(workspace));
+  dropout_forward(dropoutDesc, xDesc, x, yDesc, y, workspace, multisync);
+}
+
+template <typename TensorDataType>
+void dropout_backward(DropoutDescriptor dropoutDesc,
+                      TensorDescriptor yDesc,
+                      El::AbstractMatrix<TensorDataType> const& y,
+                      TensorDescriptor xDesc,
+                      El::AbstractMatrix<TensorDataType>& x,
+                      El::AbstractMatrix<TensorDataType>& workspace,
+                      El::SyncInfo<El::Device::GPU> const& si)
+{
+  auto handle_manager = internal::make_default_handle_manager(si);
+  CHECK_CUDNN(
+    cudnnDropoutBackward(handle_manager.get(),
+                         dropoutDesc,
+                         yDesc,
+                         y.LockedBuffer(),
+                         xDesc,
+                         x.Buffer(),
+                         workspace.Buffer(),
+                         workspace.Height() * sizeof(TensorDataType)));
+}
+
+template <typename TensorDataType>
+void dropout_backward(DropoutDescriptor dropoutDesc,
+                      TensorDescriptor yDesc,
+                      El::AbstractMatrix<TensorDataType> const& y,
+                      TensorDescriptor xDesc,
+                      El::AbstractMatrix<TensorDataType>& x,
+                      El::AbstractMatrix<TensorDataType>& workspace)
+{
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+                                     gpu::get_sync_info(x),
+                                     gpu::get_sync_info(workspace));
+  dropout_backward(dropoutDesc, yDesc, y, xDesc, x, workspace, multisync);
+}
+
+}// namespace cudnn
+}// namespace lbann
+//#endif // LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -23,8 +23,8 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-//#ifndef LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
-//#define LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_
+#define LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_
 
 #include "lbann/utils/cudnn.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
@@ -120,4 +120,4 @@ void dropout_backward(DropoutDescriptor dropoutDesc,
 
 }// namespace cudnn
 }// namespace lbann
-//#endif // LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -34,6 +34,7 @@
 namespace lbann
 {
 
+#if defined LBANN_HAS_CUDNN
 namespace cudnn
 {
 
@@ -122,5 +123,7 @@ void dropout_backward(DropoutDescriptor dropoutDesc,
 }
 
 }// namespace cudnn
+#endif // LBANN_HAS_CUDNN
+  
 }// namespace lbann
 #endif // LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -78,7 +78,7 @@ void dropout_forward(DropoutDescriptor dropoutDesc,
                      El::AbstractMatrix<TensorDataType> const& x,
                      TensorDescriptor yDesc,
                      El::AbstractMatrix<TensorDataType>& y,
-                     El::AbstractMatrix<TensorDataType>& workspace)
+                     El::AbstractMatrix<TensorDataType>& workSpace)
 {
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(workSpace),
                                      gpu::get_sync_info(y),

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -57,7 +57,7 @@ void dropout_forward(DropoutDescriptor dropoutDesc,
                      El::AbstractMatrix<TensorDataType> const& x,
                      TensorDescriptor yDesc,
                      El::AbstractMatrix<TensorDataType>& y,
-                     El::AbstractMatrix<TensorDataType>& workspace,
+                     El::AbstractMatrix<TensorDataType>& workSpace,
                      El::SyncInfo<El::Device::GPU> const& si)
 {
   auto handle_manager = internal::make_default_handle_manager(si);
@@ -68,8 +68,8 @@ void dropout_forward(DropoutDescriptor dropoutDesc,
                         x.LockedBuffer(),
                         yDesc,
                         y.Buffer(),
-                        workspace.Buffer(),
-                        workspace.Height() * sizeof(TensorDataType)));
+                        workSpace.Buffer(),
+                        workSpace.Height() * sizeof(TensorDataType)));
 }
 
 template <typename TensorDataType>
@@ -80,10 +80,10 @@ void dropout_forward(DropoutDescriptor dropoutDesc,
                      El::AbstractMatrix<TensorDataType>& y,
                      El::AbstractMatrix<TensorDataType>& workspace)
 {
-  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
-                                     gpu::get_sync_info(x),
-                                     gpu::get_sync_info(workspace));
-  dropout_forward(dropoutDesc, xDesc, x, yDesc, y, workspace, multisync);
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(workSpace),
+                                     gpu::get_sync_info(y),
+                                     gpu::get_sync_info(x));
+  dropout_forward(dropoutDesc, xDesc, x, yDesc, y, workSpace, multisync);
 }
 
 template <typename TensorDataType>
@@ -92,7 +92,7 @@ void dropout_backward(DropoutDescriptor dropoutDesc,
                       El::AbstractMatrix<TensorDataType> const& y,
                       TensorDescriptor xDesc,
                       El::AbstractMatrix<TensorDataType>& x,
-                      El::AbstractMatrix<TensorDataType>& workspace,
+                      El::AbstractMatrix<TensorDataType>& workSpace,
                       El::SyncInfo<El::Device::GPU> const& si)
 {
   auto handle_manager = internal::make_default_handle_manager(si);
@@ -103,8 +103,8 @@ void dropout_backward(DropoutDescriptor dropoutDesc,
                          y.LockedBuffer(),
                          xDesc,
                          x.Buffer(),
-                         workspace.Buffer(),
-                         workspace.Height() * sizeof(TensorDataType)));
+                         workSpace.Buffer(),
+                         workSpace.Height() * sizeof(TensorDataType)));
 }
 
 template <typename TensorDataType>
@@ -113,12 +113,12 @@ void dropout_backward(DropoutDescriptor dropoutDesc,
                       El::AbstractMatrix<TensorDataType> const& y,
                       TensorDescriptor xDesc,
                       El::AbstractMatrix<TensorDataType>& x,
-                      El::AbstractMatrix<TensorDataType>& workspace)
+                      El::AbstractMatrix<TensorDataType>& workSpace)
 {
-  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(workSpace),
                                      gpu::get_sync_info(x),
-                                     gpu::get_sync_info(workspace));
-  dropout_backward(dropoutDesc, yDesc, y, xDesc, x, workspace, multisync);
+                                     gpu::get_sync_info(y));
+  dropout_backward(dropoutDesc, yDesc, y, xDesc, x, workSpace, multisync);
 }
 
 }// namespace cudnn


### PR DESCRIPTION
Builds off the infrastructure established in #1638 and #1643 to abstract the cuDNN API calls out of dropout layer. Depends on #1642 and needs to be rebased after #1642 is merged.