### PR TITLE
Fixed dump_weights naming scheme

### DIFF
--- a/include/lbann/weights/data_type_weights.hpp
+++ b/include/lbann/weights/data_type_weights.hpp
@@ -151,6 +151,7 @@ public:
   // -----------------------------------------------
   bool save_to_checkpoint_shared(persist& p) override;
   bool load_from_checkpoint_shared(persist& p) override;
+  bool load_from_save(std::string const& ckpt_dir, std::vector<std::string> const& weight_list, El::FileFormat el_mode);
   bool load_from_save(std::string const& ckpt_dir, std::vector<std::string> const& weight_list) override;
   bool save_to_checkpoint_distributed(persist& p) override;
   bool load_from_checkpoint_distributed(persist& p) override;

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -366,7 +366,8 @@ bool data_type_weights<TensorDataType>::save_to_checkpoint_shared(lbann::persist
 {
   // define name to store weight values
   char l_name[512];
-  sprintf(l_name, "model_weights_%s_%lldx%lld", this->get_name().c_str(), m_values->Height(), m_values->Width());
+  // Note that the string model_ will be prepended to the string
+  sprintf(l_name, "weights_%s_%lldx%lld", this->get_name().c_str(), m_values->Height(), m_values->Width());
   // write weights using persist call -- uses Elemental's write function.
   p.write_distmat(persist_type::model, l_name, m_values.get());
   // if saving training state, also write out state of optimizer
@@ -417,7 +418,8 @@ template <typename TensorDataType>
 bool data_type_weights<TensorDataType>::load_from_checkpoint_shared(lbann::persist& p)
 {
   // define filename containing saved weight values
-  auto f_name = El::BuildString("model_weights_", this->get_name(), "_",
+  // Note that the string model_ will be prepended to the string
+  auto f_name = El::BuildString("weights_", this->get_name(), "_",
                                 m_values->Height(), "x", m_values->Width(),
                                 ".bin");
   p.read_distmat(persist_type::model, f_name.c_str(), m_values.get());
@@ -470,7 +472,8 @@ bool data_type_weights<TensorDataType>::load_from_save(std::string const& ckpt_d
 template <typename TensorDataType>
 bool data_type_weights<TensorDataType>::save_to_checkpoint_distributed(lbann::persist& p){
   // Functions identically to shared checkpoint except weights and parameters are saved on a per rank basis
-  auto l_name = El::BuildString("model_weights_", this->get_name(),
+  // Note that the string model_ will be prepended to the string
+  auto l_name = El::BuildString("weights_", this->get_name(),
                                 "_", m_values->LocalHeight(),
                                 "x", m_values->LocalWidth(), ".bin");
   p.write_rank_distmat(persist_type::model, l_name.c_str(), *m_values);
@@ -483,7 +486,8 @@ bool data_type_weights<TensorDataType>::save_to_checkpoint_distributed(lbann::pe
 template <typename TensorDataType>
 bool data_type_weights<TensorDataType>::load_from_checkpoint_distributed(lbann::persist& p){
   // Functions identically to shared checkpoint except weights and parameters are loaded on a per rank basis
-  auto l_name = El::BuildString("model_weights_", this->get_name(),
+  // Note that the string model_ will be prepended to the string
+  auto l_name = El::BuildString("weights_", this->get_name(),
                                 "_", m_values->LocalHeight(),
                                 "x", m_values->LocalWidth(), ".bin");
   p.read_rank_distmat(persist_type::model, l_name.c_str(), *m_values);

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -440,6 +440,8 @@ bool data_type_weights<TensorDataType>::load_from_save(std::string const& ckpt_d
     suffix = ".txt";
   }
   // create weight file name to match to weight list entry
+  // Note that the prefix model_ has to be explicitly appended since
+  // the persist class appends that string in the normal checkpoint functions
   auto l_name = El::BuildString("model_weights_", this->get_name(), "_",
                                 m_values->Height(), "x", m_values->Width(), suffix);
 


### PR DESCRIPTION
Fixed the dump_weights callback so that it used the same naming scheme
and folder hierarchy as checkpointing.  Updated all of the checkpoint
save and restore functions to properly prefix all model weights with
the model_weights prefix.  Added the ability to restore from ASCII
weight files in addition to binary files.