### PR TITLE
Abstract cuDNN from Pooling implementation

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -123,10 +123,10 @@ void pooling_backward(PoolingDescriptor poolingDesc,
                       TensorDescriptor const& dxDesc,
                       El::AbstractMatrix<TensorDataType>& dx)
 {
-  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
-                                     gpu::get_sync_info(dy),
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(dx),
                                      gpu::get_sync_info(x),
-                                     gpu::get_sync_info(dx));
+                                     gpu::get_sync_info(dy),
+                                     gpu::get_sync_info(y));
   pooling_backward(poolingDesc,
                    alpha_in, yDesc, y, dyDesc, dy,
                    xDesc, x, beta_in, dxDesc, dx,

--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -34,6 +34,7 @@
 namespace lbann
 {
 
+#ifdef LBANN_HAS_CUDNN
 namespace cudnn
 {
 
@@ -134,5 +135,6 @@ void pooling_backward(PoolingDescriptor const& poolingDesc,
 }
 
 }// namespace cudnn
+#endif // LBANN_HAS_CUDNN
 }// namespace lbann
 #endif // LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -1,0 +1,138 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_
+#define LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_
+
+#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
+
+#include "utils.hpp"
+
+namespace lbann
+{
+
+namespace cudnn
+{
+
+template <typename TensorDataType, typename ScalarParameterType>
+void pooling_forward(PoolingDescriptor poolingDesc,
+                     ScalarParameterType const& alpha_in,
+                     TensorDescriptor const& xDesc,
+                     El::AbstractMatrix<TensorDataType> const& x,
+                     ScalarParameterType const& beta_in,
+                     TensorDescriptor const& yDesc,
+                     El::AbstractMatrix<TensorDataType>& y,
+                     El::SyncInfo<El::Device::GPU> const& si)
+{
+  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  auto handle_manager = internal::make_default_handle_manager(si);
+  auto alpha = El::To<LibScalingParamT>(alpha_in);
+  auto beta = El::To<LibScalingParamT>(beta_in);
+  CHECK_CUDNN(cudnnPoolingForward(handle_manager.get(),
+                                  poolingDesc,
+                                  &alpha,
+                                  xDesc,
+                                  x.LockedBuffer(),
+                                  &beta,
+                                  yDesc,
+                                  y.Buffer()));
+}
+
+template <typename TensorDataType, typename ScalarParameterType>
+void pooling_forward(PoolingDescriptor poolingDesc,
+                     ScalarParameterType const& alpha_in,
+                     TensorDescriptor const& xDesc,
+                     El::AbstractMatrix<TensorDataType> const& x,
+                     ScalarParameterType const& beta_in,
+                     TensorDescriptor const& yDesc,
+                     El::AbstractMatrix<TensorDataType>& y)
+{
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+                                     gpu::get_sync_info(x));
+  pooling_forward(poolingDesc,
+                  alpha_in, xDesc, x,
+                  beta_in, yDesc, y,
+                  multisync);
+}
+
+template <typename TensorDataType, typename ScalarParameterType>
+void pooling_backward(PoolingDescriptor poolingDesc,
+                      ScalarParameterType const& alpha_in,
+                      TensorDescriptor const& yDesc,
+                      El::AbstractMatrix<TensorDataType> const& y,
+                      TensorDescriptor const& dyDesc,
+                      El::AbstractMatrix<TensorDataType> const& dy,
+                      TensorDescriptor const& xDesc,
+                      El::AbstractMatrix<TensorDataType> const& x,
+                      ScalarParameterType const& beta_in,
+                      TensorDescriptor const& dxDesc,
+                      El::AbstractMatrix<TensorDataType>& dx,
+                      El::SyncInfo<El::Device::GPU> const& si)
+{
+  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  auto handle_manager = internal::make_default_handle_manager(si);
+  auto alpha = El::To<LibScalingParamT>(alpha_in);
+  auto beta = El::To<LibScalingParamT>(beta_in);
+  CHECK_CUDNN(cudnnPoolingBackward(handle_manager.get(),
+                                   poolingDesc,
+                                   &alpha,
+                                   yDesc,
+                                   y.LockedBuffer(),
+                                   dyDesc,
+                                   dy.LockedBuffer(),
+                                   xDesc,
+                                   x.LockedBuffer(),
+                                   &beta,
+                                   dxDesc,
+                                   dx.Buffer()));
+}
+
+template <typename TensorDataType, typename ScalarParameterType>
+void pooling_backward(PoolingDescriptor poolingDesc,
+                      ScalarParameterType const& alpha_in,
+                      TensorDescriptor const& yDesc,
+                      El::AbstractMatrix<TensorDataType> const& y,
+                      TensorDescriptor const& dyDesc,
+                      El::AbstractMatrix<TensorDataType> const& dy,
+                      TensorDescriptor const& xDesc,
+                      El::AbstractMatrix<TensorDataType> const& x,
+                      ScalarParameterType const& beta_in,
+                      TensorDescriptor const& dxDesc,
+                      El::AbstractMatrix<TensorDataType>& dx)
+{
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
+                                     gpu::get_sync_info(dy),
+                                     gpu::get_sync_info(x),
+                                     gpu::get_sync_info(dx));
+  pooling_backward(poolingDesc,
+                   alpha_in, yDesc, y, dyDesc, dy,
+                   xDesc, x, beta_in, dxDesc, dx,
+                   multisync);
+}
+
+}// namespace cudnn
+}// namespace lbann
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_

--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -38,7 +38,7 @@ namespace cudnn
 {
 
 template <typename TensorDataType, typename ScalarParameterType>
-void pooling_forward(PoolingDescriptor poolingDesc,
+void pooling_forward(PoolingDescriptor const& poolingDesc,
                      ScalarParameterType const& alpha_in,
                      TensorDescriptor const& xDesc,
                      El::AbstractMatrix<TensorDataType> const& x,
@@ -62,7 +62,7 @@ void pooling_forward(PoolingDescriptor poolingDesc,
 }
 
 template <typename TensorDataType, typename ScalarParameterType>
-void pooling_forward(PoolingDescriptor poolingDesc,
+void pooling_forward(PoolingDescriptor const& poolingDesc,
                      ScalarParameterType const& alpha_in,
                      TensorDescriptor const& xDesc,
                      El::AbstractMatrix<TensorDataType> const& x,
@@ -79,7 +79,7 @@ void pooling_forward(PoolingDescriptor poolingDesc,
 }
 
 template <typename TensorDataType, typename ScalarParameterType>
-void pooling_backward(PoolingDescriptor poolingDesc,
+void pooling_backward(PoolingDescriptor const& poolingDesc,
                       ScalarParameterType const& alpha_in,
                       TensorDescriptor const& yDesc,
                       El::AbstractMatrix<TensorDataType> const& y,
@@ -111,7 +111,7 @@ void pooling_backward(PoolingDescriptor poolingDesc,
 }
 
 template <typename TensorDataType, typename ScalarParameterType>
-void pooling_backward(PoolingDescriptor poolingDesc,
+void pooling_backward(PoolingDescriptor const& poolingDesc,
                       ScalarParameterType const& alpha_in,
                       TensorDescriptor const& yDesc,
                       El::AbstractMatrix<TensorDataType> const& y,


### PR DESCRIPTION
Builds off work in #1638 and #1643 to abstract the cuDNN API calls out of the Pooling layer. Depends on #1642, needs to be rebased after #1642 is merged.