### PR TITLE
Disable global statistics

### DIFF
--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -36,6 +36,7 @@ const int lbann_default_random_seed = 42;
 
 #define MAX_RNG_SEEDS_DISPLAY "RNG seeds per trainer to display"
 #define NUM_IO_THREADS "Num. IO threads"
+#define ALLOW_GLOBAL_STATISTICS "LTFB Allow global statistics"
 
 void construct_std_options();
 

--- a/src/callbacks/timer.cpp
+++ b/src/callbacks/timer.cpp
@@ -26,6 +26,8 @@
 
 #include "lbann/callbacks/timer.hpp"
 #include "lbann/utils/timer.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/lbann_library.hpp"
 #include <algorithm>
 
 namespace lbann {
@@ -107,66 +109,104 @@ void timer::timing_end(model& m) {
 
   // Report timing results
   auto& comm = *m.get_comm();
-  const El::Int num_models = comm.get_num_trainers();
+  const El::Int num_trainers = comm.get_num_trainers();
   if (comm.am_trainer_master()) {
 
-    // Gather timing results in world master
-    std::vector<EvalType> run_time_list(num_models);
-    std::vector<EvalType> mean_list(num_models);
-    std::vector<EvalType> min_list(num_models);
-    std::vector<EvalType> max_list(num_models);
-    std::vector<EvalType> stdev_list(num_models);
-    if (comm.am_world_master()) {
-      comm.intertrainer_gather(run_time, run_time_list);
-      comm.intertrainer_gather(batch_time_mean, mean_list);
-      comm.intertrainer_gather(batch_time_min, min_list);
-      comm.intertrainer_gather(batch_time_max, max_list);
-      comm.intertrainer_gather(batch_time_stdev, stdev_list);
-    } else {
-      const auto& world_master = comm.get_intertrainer_master();
-      comm.intertrainer_gather(run_time, world_master);
-      comm.intertrainer_gather(batch_time_mean, world_master);
-      comm.intertrainer_gather(batch_time_min, world_master);
-      comm.intertrainer_gather(batch_time_max, world_master);
-      comm.intertrainer_gather(batch_time_stdev, world_master);
-    }
+    auto& arg_parser = global_argument_parser();
+    bool allow_global_statistics = arg_parser.get<bool>(ALLOW_GLOBAL_STATISTICS);
+    std::stringstream report;
 
-    // Print results
-    if (comm.am_world_master()) {
-      for (El::Int i = 0; i < num_models; ++i) {
-        std::cout << m.get_name() << " (instance "<< i << ") " << mode_string << " "
-                  << "run time : " << run_time_list[i] << "s"
-                  << std::endl;
-      }
-      for (El::Int i = 0; i < num_models; ++i) {
-        std::cout << m.get_name() << " (instance " << i << ") " << mode_string << " "
-                  << "mini-batch time statistics : ";
-        if (std::isnan(mean_list[i])) {
-          std::cout << "N/A";
-        } else {
-          std::cout << mean_list[i] << "s";
-        }
-        std::cout << " mean, ";
-        if (std::isnan(max_list[i])) {
-          std::cout << "N/A";
-        } else {
-          std::cout << max_list[i] << "s";
-        }
-        std::cout << " max, ";
-        if (std::isnan(min_list[i])) {
-          std::cout << "N/A";
-        } else {
-          std::cout << min_list[i] << "s";
-        }
-        std::cout << " min, ";
-        if (std::isnan(stdev_list[i])) {
-          std::cout << "N/A";
-        } else {
-          std::cout << stdev_list[i] << "s";
-        }
-        std::cout << " stdev" << std::endl;
+    if(allow_global_statistics) {
+      // Gather timing results in world master
+      std::vector<EvalType> run_time_list(num_trainers);
+      std::vector<EvalType> mean_list(num_trainers);
+      std::vector<EvalType> min_list(num_trainers);
+      std::vector<EvalType> max_list(num_trainers);
+      std::vector<EvalType> stdev_list(num_trainers);
+      if (comm.am_world_master()) {
+        comm.intertrainer_gather(run_time, run_time_list);
+        comm.intertrainer_gather(batch_time_mean, mean_list);
+        comm.intertrainer_gather(batch_time_min, min_list);
+        comm.intertrainer_gather(batch_time_max, max_list);
+        comm.intertrainer_gather(batch_time_stdev, stdev_list);
+      } else {
+        const auto& world_master = comm.get_intertrainer_master();
+        comm.intertrainer_gather(run_time, world_master);
+        comm.intertrainer_gather(batch_time_mean, world_master);
+        comm.intertrainer_gather(batch_time_min, world_master);
+        comm.intertrainer_gather(batch_time_max, world_master);
+        comm.intertrainer_gather(batch_time_stdev, world_master);
       }
 
+      // Print results
+      if (comm.am_world_master()) {
+        for (El::Int i = 0; i < num_trainers; ++i) {
+          std::cout << m.get_name() << " (instance "<< i << ") " << mode_string << " "
+                    << "run time : " << run_time_list[i] << "s"
+                    << std::endl;
+        }
+        for (El::Int i = 0; i < num_trainers; ++i) {
+          std::cout << m.get_name() << " (instance " << i << ") " << mode_string << " "
+                    << "mini-batch time statistics : ";
+          if (std::isnan(mean_list[i])) {
+            std::cout << "N/A";
+          } else {
+            std::cout << mean_list[i] << "s";
+          }
+          std::cout << " mean, ";
+          if (std::isnan(max_list[i])) {
+            std::cout << "N/A";
+          } else {
+            std::cout << max_list[i] << "s";
+          }
+          std::cout << " max, ";
+          if (std::isnan(min_list[i])) {
+            std::cout << "N/A";
+          } else {
+            std::cout << min_list[i] << "s";
+          }
+          std::cout << " min, ";
+          if (std::isnan(stdev_list[i])) {
+            std::cout << "N/A";
+          } else {
+            std::cout << stdev_list[i] << "s";
+          }
+          std::cout << " stdev" << std::endl;
+        }
+      }
+    }else {
+      // Print results for each trainer
+      report << m.get_name() << " (instance "<< comm.get_trainer_rank() << ") " << mode_string << " "
+                << "run time : " << run_time << "s"
+                << std::endl;
+      report << m.get_name() << " (instance " << comm.get_trainer_rank() << ") " << mode_string << " "
+                << "mini-batch time statistics : ";
+      if (std::isnan(batch_time_mean)) {
+        report << "N/A";
+      } else {
+        report << batch_time_mean << "s";
+      }
+      report << " mean, ";
+      if (std::isnan(batch_time_max)) {
+        report << "N/A";
+      } else {
+        report << batch_time_max << "s";
+      }
+      report << " max, ";
+      if (std::isnan(batch_time_min)) {
+        report << "N/A";
+      } else {
+        report << batch_time_min << "s";
+      }
+      report << " min, ";
+      if (std::isnan(batch_time_stdev)) {
+        report << "N/A";
+      } else {
+        report << batch_time_stdev << "s";
+      }
+      report << " stdev" << std::endl;
+
+      std::cout << report.str() << std::flush;
     }
   }
 

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -55,6 +55,11 @@ void construct_std_options() {
                         "Number of threads available to both I/O and "
                         "initial data transformations for each rank.",
                         64);
+  arg_parser.add_flag(ALLOW_GLOBAL_STATISTICS,
+                      {"--ltfb_allow_global_statistics"},
+                      utils::ENV("LBANN_LTFB_ALLOW_GLOBAL_STATISTICS"),
+                      "Allow the print_statistics callback to report "
+                      "global (inter-trainer) summary statistics.");
 }
 
 /// Construct a trainer that contains a lbann comm object and threadpool


### PR DESCRIPTION
Updated the print_statistics and timer callbacks so that global
statistics are not computed by default.  This removes several
inter-trainer collectives that impact LTFB performance.  There is now
a command line argument --ltfb_allow_global_statistics and an
environment variable LBANN_LTFB_ALLOW_GLOBAL_STATISTICS that enable
the collectives and computation plus reporting of global statistics.