### PR TITLE
Update the versions of Aluminum, Hydrogen, and DiHydrogen in superbuild

### DIFF
--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -647,9 +647,7 @@ if [ "${WITH_CUDA}" == "ON" ]; then
 
     # NCCL
     if [[ -z $NCCL_DIR ]]; then
-        # Subsequent 2.4.X versions are known to have a performance
-        # regression. See the release notes.
-        NCCL_VER=${NCCL_VER:-2.4.2-1}
+        NCCL_VER=${NCCL_VER:-2.7.8-1}
         NCCL_DIR=/usr/workspace/wsb/brain/nccl2/nccl_${NCCL_VER}+cuda${CUDA_TOOLKIT_VERSION}_${ARCH}
     fi
     if [[ ! -d $NCCL_DIR ]]; then

--- a/superbuild/aluminum/CMakeLists.txt
+++ b/superbuild/aluminum/CMakeLists.txt
@@ -11,7 +11,7 @@ else ()
     CACHE STRING "The URL from which to clone Aluminum")
 endif ()
 
-set(ALUMINUM_TAG "v0.4.0"
+set(ALUMINUM_TAG "master"
   CACHE STRING "The git tag to checkout for Aluminum")
 
 set(ALUMINUM_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"

--- a/superbuild/dihydrogen/CMakeLists.txt
+++ b/superbuild/dihydrogen/CMakeLists.txt
@@ -11,7 +11,7 @@ else ()
     CACHE STRING "The URL from which to clone DiHydrogen")
 endif ()
 
-set(DIHYDROGEN_TAG "master"
+set(DIHYDROGEN_TAG "develop"
   CACHE STRING "The git tag to checkout for DiHydrogen")
 
 set(DIHYDROGEN_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"

--- a/superbuild/hydrogen/CMakeLists.txt
+++ b/superbuild/hydrogen/CMakeLists.txt
@@ -109,7 +109,7 @@ else ()
 endif ()
 
 # ... then the tag.
-set(HYDROGEN_TAG "v1.4.0"
+set(HYDROGEN_TAG "hydrogen"
   CACHE STRING "The git tag or hash to checkout for Hydrogen")
 
 if (HYDROGEN_CUSTOM_SOURCE_DIR)


### PR DESCRIPTION
This PR updates the versions of Aluminum, Hydrogen and DiHydrogen of the superbuild script. It also update the NCCL version from 2.4.2 to 2.7.8 by default that is supported by the current version of Aluminum.