### PR TITLE
Refactor CUDA unary math functions

### DIFF
--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -108,8 +108,12 @@ namespace cuda {
 #ifdef __CUDACC__
 
 // Atomic add
-template <typename T> __device__ __forceinline__
-T atomic_add(T* address, T val);
+__device__ __forceinline__
+__half atomic_add(__half* address, __half val);
+__device__ __forceinline__
+float atomic_add(float* address, float val);
+__device__ __forceinline__
+double atomic_add(double* address, double val);
 
 /** @brief Sum over threads in CUDA block
  *
@@ -146,39 +150,59 @@ __device__ __forceinline__
 T block_reduce(T val);
 
 // Unary math functions
+#define DECLARE_UNARY_MATH_FUNC_WITH_TYPE(func, type)    \
+  __device__ __forceinline__ type func(type const& x)
+#define DECLARE_UNARY_MATH_FUNC(func)                 \
+  DECLARE_UNARY_MATH_FUNC_WITH_TYPE(func, __half);    \
+  DECLARE_UNARY_MATH_FUNC_WITH_TYPE(func, float);     \
+  DECLARE_UNARY_MATH_FUNC_WITH_TYPE(func, double)
 template <typename T> __device__ __forceinline__ T abs(const T& x);
-template <typename T> __device__ __forceinline__ T round(const T& x);
-template <typename T> __device__ __forceinline__ T ceil(const T& x);
-template <typename T> __device__ __forceinline__ T floor(const T& x);
-template <typename T> __device__ __forceinline__ T sqrt(const T& x);
-template <typename T> __device__ __forceinline__ T rsqrt(const T& x);
-template <typename T> __device__ __forceinline__ T exp(const T& x);
-template <typename T> __device__ __forceinline__ T expm1(const T& x);
-template <typename T> __device__ __forceinline__ T log(const T& x);
-template <typename T> __device__ __forceinline__ T log1p(const T& x);
-template <typename T> __device__ __forceinline__ T cos(const T& x);
-template <typename T> __device__ __forceinline__ T sin(const T& x);
-template <typename T> __device__ __forceinline__ T tan(const T& x);
-template <typename T> __device__ __forceinline__ T acos(const T& x);
-template <typename T> __device__ __forceinline__ T asin(const T& x);
-template <typename T> __device__ __forceinline__ T atan(const T& x);
-template <typename T> __device__ __forceinline__ T cosh(const T& x);
-template <typename T> __device__ __forceinline__ T sinh(const T& x);
-template <typename T> __device__ __forceinline__ T tanh(const T& x);
-template <typename T> __device__ __forceinline__ T acosh(const T& x);
-template <typename T> __device__ __forceinline__ T asinh(const T& x);
-template <typename T> __device__ __forceinline__ T atanh(const T& x);
-template <typename T> __device__ __forceinline__ T erf(const T& x);
-template <typename T> __device__ __forceinline__ T erfinv(const T& x);
+__device__ __forceinline__ float abs(float const& x);
+__device__ __forceinline__ double abs(double const& x);
+DECLARE_UNARY_MATH_FUNC(round);
+DECLARE_UNARY_MATH_FUNC(ceil);
+DECLARE_UNARY_MATH_FUNC(floor);
+DECLARE_UNARY_MATH_FUNC(sqrt);
+DECLARE_UNARY_MATH_FUNC(rsqrt);
+DECLARE_UNARY_MATH_FUNC(exp);
+DECLARE_UNARY_MATH_FUNC(expm1);
+DECLARE_UNARY_MATH_FUNC(log);
+DECLARE_UNARY_MATH_FUNC(log1p);
+DECLARE_UNARY_MATH_FUNC(cos);
+DECLARE_UNARY_MATH_FUNC(sin);
+DECLARE_UNARY_MATH_FUNC(tan);
+DECLARE_UNARY_MATH_FUNC(acos);
+DECLARE_UNARY_MATH_FUNC(asin);
+DECLARE_UNARY_MATH_FUNC(atan);
+DECLARE_UNARY_MATH_FUNC(cosh);
+DECLARE_UNARY_MATH_FUNC(sinh);
+DECLARE_UNARY_MATH_FUNC(tanh);
+DECLARE_UNARY_MATH_FUNC(acosh);
+DECLARE_UNARY_MATH_FUNC(asinh);
+DECLARE_UNARY_MATH_FUNC(atanh);
 template <typename T> __device__ __forceinline__ bool isfinite(const T& x);
 template <typename T> __device__ __forceinline__ bool isinf(const T& x);
 template <typename T> __device__ __forceinline__ bool isnan(const T& x);
+#undef DECLARE_UNARY_MATH_FUNC
+#undef DECLARE_UNARY_MATH_FUNC_WITH_TYPE
 
 // Binary math functions
+#define DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE(func, type)            \
+  __device__ __forceinline__ type func(type const& x, type const& y)
+#define DECLARE_BINARY_UNARY_MATH_FUNC(func)                 \
+  DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE(func, __half);    \
+  DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE(func, float);     \
+  DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE(func, double)
 template <typename T> __device__ __forceinline__ T min(const T& x, const T& y);
+DECLARE_BINARY_UNARY_MATH_FUNC(min);
 template <typename T> __device__ __forceinline__ T max(const T& x, const T& y);
+DECLARE_BINARY_UNARY_MATH_FUNC(max);
 template <typename T> __device__ __forceinline__ T mod(const T& x, const T& y);
+DECLARE_BINARY_UNARY_MATH_FUNC(mod);
 template <typename T> __device__ __forceinline__ T pow(const T& x, const T& y);
+DECLARE_BINARY_UNARY_MATH_FUNC(pow);
+#undef DECLARE_BINARY_UNARY_MATH_FUNC
+#undef DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE
 
 // Numeric limits
 template <typename T> constexpr __device__ __forceinline__ T min();

--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -197,9 +197,7 @@ template <typename T> __device__ __forceinline__ T min(const T& x, const T& y);
 DECLARE_BINARY_UNARY_MATH_FUNC(min);
 template <typename T> __device__ __forceinline__ T max(const T& x, const T& y);
 DECLARE_BINARY_UNARY_MATH_FUNC(max);
-template <typename T> __device__ __forceinline__ T mod(const T& x, const T& y);
 DECLARE_BINARY_UNARY_MATH_FUNC(mod);
-template <typename T> __device__ __forceinline__ T pow(const T& x, const T& y);
 DECLARE_BINARY_UNARY_MATH_FUNC(pow);
 #undef DECLARE_BINARY_UNARY_MATH_FUNC
 #undef DECLARE_BINARY_UNARY_MATH_FUNC_WITH_TYPE

--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -180,6 +180,8 @@ DECLARE_UNARY_MATH_FUNC(tanh);
 DECLARE_UNARY_MATH_FUNC(acosh);
 DECLARE_UNARY_MATH_FUNC(asinh);
 DECLARE_UNARY_MATH_FUNC(atanh);
+DECLARE_UNARY_MATH_FUNC(erf);
+DECLARE_UNARY_MATH_FUNC(erfinv);
 template <typename T> __device__ __forceinline__ bool isfinite(const T& x);
 template <typename T> __device__ __forceinline__ bool isinf(const T& x);
 template <typename T> __device__ __forceinline__ bool isnan(const T& x);

--- a/include/lbann/utils/impl/cuda.hpp
+++ b/include/lbann/utils/impl/cuda.hpp
@@ -45,8 +45,8 @@ namespace cuda {
 
 // Atomic add function
 #if __CUDA_ARCH__ >= 530
-template <> __device__ __forceinline__
-__half atomic_add<__half>(__half* address, __half val) {
+__device__ __forceinline__
+__half atomic_add(__half* address, __half val) {
 #if __CUDA_ARCH__ >= 700 || !defined(__CUDA_ARCH__)
   return atomicAdd(address, val);
 #else
@@ -66,12 +66,12 @@ __half atomic_add<__half>(__half* address, __half val) {
 #endif // __CUDA_ARCH__ >= 700 || !defined(__CUDA_ARCH__)
 }
 #endif // __CUDA_ARCH__ >= 530
-template <> __device__ __forceinline__
-float atomic_add<float>(float* address, float val) {
+__device__ __forceinline__
+float atomic_add(float* address, float val) {
   return atomicAdd(address, val);
 }
-template <> __device__ __forceinline__
-double atomic_add<double>(double* address, double val) {
+__device__ __forceinline__
+double atomic_add(double* address, double val) {
 #if __CUDA_ARCH__ >= 600
   return atomicAdd(address, val);
 #else
@@ -142,17 +142,17 @@ T block_reduce(T val) {
 }
 
 // Unary math functions
-#define WRAP_UNARY_CUDA_MATH_FUNCTION(func)                     \
-  template <> __device__ __forceinline__                        \
-  float func<float>(const float& x) { return ::func##f(x); }    \
-  template <> __device__ __forceinline__                        \
-  double func<double>(const double& x) { return ::func(x); }
+#define WRAP_UNARY_CUDA_MATH_FUNCTION(func)              \
+  __device__ __forceinline__                             \
+  float func(const float& x) { return ::func##f(x); }    \
+  __device__ __forceinline__                             \
+  double func(const double& x) { return ::func(x); }
 template <typename T> __device__ __forceinline__
 T abs(const T& x) { return x >= static_cast<T>(0) ? x : -x; }
-template <> __device__ __forceinline__
-float abs<float>(const float& x) { return ::fabsf(x); }
-template <> __device__ __forceinline__
-double abs<double>(const double& x) { return ::fabs(x); }
+__device__ __forceinline__
+float abs(const float& x) { return ::fabsf(x); }
+__device__ __forceinline__
+double abs(const double& x) { return ::fabs(x); }
 WRAP_UNARY_CUDA_MATH_FUNCTION(round)
 WRAP_UNARY_CUDA_MATH_FUNCTION(ceil)
 WRAP_UNARY_CUDA_MATH_FUNCTION(floor)
@@ -186,24 +186,24 @@ template <typename T> __device__ __forceinline__
 bool isnan(T const& x) { return ::isnan(x); }
 
 #if __CUDA_ARCH__ >= 530
-template <> __device__ __forceinline__
+__device__ __forceinline__
 bool isfinite(__half const& x) { return !(::__isnan(x) || ::__hisinf(x)); }
-template <> __device__ __forceinline__
+__device__ __forceinline__
 bool isinf(__half const& x) { return ::__hisinf(x); }
-template <> __device__ __forceinline__
+__device__ __forceinline__
 bool isnan(__half const& x) { return ::__hisnan(x); }
 
 // This support is far from complete!
 #define WRAP_UNARY_CUDA_HALF_MATH_FUNCTION(func)              \
-  template <> __device__ __forceinline__                      \
-  __half func<__half>(__half const& x) { return ::h##func(x); }
+  __device__ __forceinline__                                  \
+  __half func(__half const& x) { return ::h##func(x); }
 
 // FIXME (trb): This is maybe not the best long-term solution, but it
 // might be the best we can do without really digging into
 // half-precision implementation.
 #define WRAP_UNARY_CUDA_HALF_CAST_TO_FLOAT_MATH_FUNCTION(func) \
-  template <> __device__ __forceinline__                       \
-  __half func<__half>(__half const& x) { return func(float(x)); }
+  __device__ __forceinline__                                   \
+  __half func(__half const& x) { return func(float(x)); }
 
 WRAP_UNARY_CUDA_HALF_CAST_TO_FLOAT_MATH_FUNCTION(round)
 WRAP_UNARY_CUDA_HALF_MATH_FUNCTION(ceil)
@@ -215,8 +215,8 @@ WRAP_UNARY_CUDA_HALF_MATH_FUNCTION(exp)
 //
 // FIXME (trb): This is not going to be as accurate as a native expm1
 // implementation could be:
-template <> __device__ __forceinline__
-__half expm1<__half>(__half const& x) {
+__device__ __forceinline__
+__half expm1(__half const& x) {
     return ::__hsub(::hexp(x), ::__float2half(1.f));
 }
 
@@ -229,8 +229,8 @@ WRAP_UNARY_CUDA_HALF_MATH_FUNCTION(sin)
 //
 // FIXME (trb): This just uses the trig identity. Probably less
 // accurate than a native implementation.
-template <> __device__ __forceinline__
-__half tan<__half>(__half const& x) { return ::__hdiv(::hsin(x), ::hcos(x)); }
+__device__ __forceinline__
+__half tan(__half const& x) { return ::__hdiv(::hsin(x), ::hcos(x)); }
 
 WRAP_UNARY_CUDA_HALF_CAST_TO_FLOAT_MATH_FUNCTION(acos)
 WRAP_UNARY_CUDA_HALF_CAST_TO_FLOAT_MATH_FUNCTION(asin)
@@ -249,50 +249,50 @@ WRAP_UNARY_CUDA_HALF_CAST_TO_FLOAT_MATH_FUNCTION(erfinv)
 
 // Binary math functions
 #define WRAP_BINARY_CUDA_MATH_FUNCTION(func)                    \
-  template <> __device__ __forceinline__                        \
-  float func<float>(const float& x, const float& y) {           \
+  __device__ __forceinline__                                    \
+  float func(const float& x, const float& y) {                  \
     return ::func##f(x,y);                                      \
   }                                                             \
-  template <> __device__ __forceinline__                        \
-  double func<double>(const double& x, const double& y) {       \
+  __device__ __forceinline__                                    \
+  double func(const double& x, const double& y) {               \
     return ::func(x,y);                                         \
   }
 template <typename T> __device__ __forceinline__
 T min(const T& x, const T& y) { return y < x ? y : x; }
-template <> __device__ __forceinline__
-float min<float>(const float& x, const float& y) { return ::fminf(x,y); }
-template <> __device__ __forceinline__
-double min<double>(const double& x, const double& y) { return ::fmin(x,y); }
+__device__ __forceinline__
+float min(const float& x, const float& y) { return ::fminf(x,y); }
+__device__ __forceinline__
+double min(const double& x, const double& y) { return ::fmin(x,y); }
 template <typename T> __device__ __forceinline__
 T max(const T& x, const T& y) { return y > x ? y : x; }
-template <> __device__ __forceinline__
-float max<float>(const float& x, const float& y) { return ::fmaxf(x,y); }
-template <> __device__ __forceinline__
-double max<double>(const double& x, const double& y) { return ::fmax(x,y); }
+__device__ __forceinline__
+float max(const float& x, const float& y) { return ::fmaxf(x,y); }
+__device__ __forceinline__
+double max(const double& x, const double& y) { return ::fmax(x,y); }
 template <typename T> __device__ __forceinline__
 T mod(const T& x, const T& y) { return x % y; }
-template <> __device__ __forceinline__
-float mod<float>(const float& x, const float& y) { return ::fmodf(x,y); }
-template <> __device__ __forceinline__
-double mod<double>(const double& x, const double& y) { return ::fmod(x,y); }
+__device__ __forceinline__
+float mod(const float& x, const float& y) { return ::fmodf(x,y); }
+__device__ __forceinline__
+double mod(const double& x, const double& y) { return ::fmod(x,y); }
 WRAP_BINARY_CUDA_MATH_FUNCTION(pow)
 #undef WRAP_BINARY_CUDA_MATH_FUNCTION
 
-template <> __device__ __forceinline__
-__half pow<__half>(const __half& x, const __half& y)
+__device__ __forceinline__
+__half pow(const __half& x, const __half& y)
 { return pow(float(x), float(y)); }
 
-template <> __device__ __forceinline__
-__half mod<__half>(const __half& x, const __half& y)
+__device__ __forceinline__
+__half mod(const __half& x, const __half& y)
 { return mod(float(x), float(y)); }
 
 #if __CUDA_ARCH__ >= 530
-template <> __device__ __forceinline__
-__half min<__half>(const __half& x, const __half& y)
+__device__ __forceinline__
+__half min(const __half& x, const __half& y)
 { return ::__hle(x, y) ? x : y; }
 
-template <> __device__ __forceinline__
-__half max<__half>(const __half& x, const __half& y)
+__device__ __forceinline__
+__half max(const __half& x, const __half& y)
 { return ::__hle(x, y) ? y : x; }
 #endif // __CUDA_ARCH__ >= 530
 

--- a/include/lbann/utils/impl/cuda.hpp
+++ b/include/lbann/utils/impl/cuda.hpp
@@ -269,8 +269,6 @@ __device__ __forceinline__
 float max(const float& x, const float& y) { return ::fmaxf(x,y); }
 __device__ __forceinline__
 double max(const double& x, const double& y) { return ::fmax(x,y); }
-template <typename T> __device__ __forceinline__
-T mod(const T& x, const T& y) { return x % y; }
 __device__ __forceinline__
 float mod(const float& x, const float& y) { return ::fmodf(x,y); }
 __device__ __forceinline__


### PR DESCRIPTION
Refactors the declaration and definition of cuda unary math functions to avoid template specialization (and unconstrained templates) in favor or function overloading.  This addresses an issue where there is *not* a template specialization for a particular type, causing issues where the code compiles but does not link ("undefined reference to function").  

This is part 1 of 3 in porting the `gpu_lib` backend to HIP/ROCm.

One thing that we should consider with this PR is that when `__CUDA_ARCH__ < 530` we will declare `__half` type unary math functions but they will never be defined.  This could break things.  @benson31 mentioned it may not be worth continuing with support for older CUDA versions.