### PR TITLE
Fix build errors when Distconv is enabled

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -77,6 +77,11 @@ using mpicuda_backend = ::Al::MPICUDABackend;
 #else
 using mpicuda_backend = lbann::Al::dummy_backend;
 #endif  // defined(LBANN_HAS_ALUMINUM) && defined(AL_HAS_MPI_CUDA)
+#if defined(LBANN_HAS_ALUMINUM) && defined(AL_HAS_HOST_TRANSFER)
+using hosttransfer_backend = ::Al::HostTransferBackend;
+#else
+using hosttransfer_backend = lbann::Al::dummy_backend;
+#endif  // defined(LBANN_HAS_ALUMINUM) && defined(AL_HAS_HOST_TRANSFER)
 using mpicuda_req_type = mpicuda_backend::req_type;
 static const mpicuda_req_type mpicuda_null_req = mpicuda_backend::null_req;
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -199,9 +199,9 @@ bool is_cosmoflow_parallel_io_enabled();
 p2p::P2P &get_p2p();
 #endif // DISTCONV_HAS_P2P
 
-/** Get Aluminum MPI-CUDA backend
+/** Get Aluminum host-transfer backend
  */
-Al::mpicuda_backend::comm_type &get_mpicuda();
+Al::hosttransfer_backend::comm_type &get_hosttransfer();
 
 /** Get Distconv backend handle.
  */

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1241,7 +1241,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
                             this->get_prev_error_signals(),
                             dst_scale, *m_bias_gradient, false);
     } else {
-      m_bias_gradient->scale(dst_scale, gpu::get_sync_info(l).Stream());
+      m_bias_gradient->scale(dst_scale, gpu::get_sync_info(bias_gradient).Stream());
     }
   }
 
@@ -1259,7 +1259,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
                             dst_scale,
                             *m_kernel_gradient, false);
   } else {
-    m_kernel_gradient->scale(dst_scale, gpu::get_sync_info(l).Stream());
+    m_kernel_gradient->scale(dst_scale, gpu::get_sync_info(kernel_gradient).Stream());
   }
 }
 


### PR DESCRIPTION
This PR fixes some build errors when Distconv is enabled, mainly by replacing the MPI CUDA backend with the host-transfer backend.