### PR TITLE
Refactor namespace cudnn to dnnlib

### DIFF
--- a/include/lbann/layers/activations/log_softmax.hpp
+++ b/include/lbann/layers/activations/log_softmax.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #if defined LBANN_HAS_CUDNN
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #endif
 
 namespace lbann {

--- a/include/lbann/layers/activations/log_softmax.hpp
+++ b/include/lbann/layers/activations/log_softmax.hpp
@@ -129,7 +129,7 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
   /** Tensor cuDNN descriptors. */
-  cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
 #endif // LBANN_HAS_CUDNN
 
 };

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/distconv.hpp"
 #if defined LBANN_HAS_CUDNN
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // defined LBANN_HAS_CUDNN
 #include "lbann/utils/dnn_lib/cudnn/softmax.hpp"
 

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -154,7 +154,7 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
   /** Tensor cuDNN descriptors. */
-  cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
 #endif // LBANN_HAS_CUDNN
 
 // Minimum output value to avoid denormalized floats

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -39,8 +39,10 @@
 #include <array>
 #endif // LBANN_HAS_DISTCONV
 
+
 namespace lbann {
 
+// TODO: find a way put these in cudnn.hpp
 // Forward declarations
 namespace cudnn {
 template <typename U>

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/dnn_lib/cudnn/convolution.hpp"
 

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -86,7 +86,7 @@ public:
   using DMatDT = El::Matrix<TensorDataType, D>;
 
 #ifdef LBANN_HAS_CUDNN
-  using ScalingType = cudnn::ScalingParamType<TensorDataType>;
+  using ScalingType = dnn_lib::ScalingParamType<TensorDataType>;
 #else
   using ScalingType = TensorDataType;
 #endif // LBANN_HAS_CUDNN
@@ -124,15 +124,15 @@ protected:
    *  @details Must be cached since it isn't used until setup.
    */
   cudnnMathType_t m_convolution_math_type =
-    cudnn::get_default_convolution_math_type();
+    dnn_lib::get_default_convolution_math_type();
   /** Convolution kernel cuDNN descriptor. */
-  cudnn::FilterDescriptor m_kernel_cudnn_desc;
+  dnn_lib::FilterDescriptor m_kernel_cudnn_desc;
   /** Convolution cuDNN descriptor. */
-  cudnn::ConvolutionDescriptor m_convolution_cudnn_desc;
+  dnn_lib::ConvolutionDescriptor m_convolution_cudnn_desc;
   /** Bias tensor cuDNN descriptor. */
-  cudnn::TensorDescriptor m_bias_cudnn_desc;
+  dnn_lib::TensorDescriptor m_bias_cudnn_desc;
   /** Tensor cuDNN descriptors. */
-  cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
   /** Forward algorithm cache (mini-batch size -> algo). */
   std::unordered_map<int, fwd_conv_alg> m_fwd_cudnn_algos;
   /** Backward data algorithm cache (mini-batch size -> algo). */
@@ -206,12 +206,12 @@ private:
   /** Get the cuDNN algorithm to use for forward prop. */
   fwd_conv_alg get_forward_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnn::TensorDescriptor& input_desc,
+    const dnn_lib::TensorDescriptor& input_desc,
     const TensorDataType* input,
-    const cudnn::FilterDescriptor& kernel_desc,
+    const dnn_lib::FilterDescriptor& kernel_desc,
     const TensorDataType* kernel,
-    const cudnn::ConvolutionDescriptor& conv_desc,
-    const cudnn::TensorDescriptor& output_desc,
+    const dnn_lib::ConvolutionDescriptor& conv_desc,
+    const dnn_lib::TensorDescriptor& output_desc,
     TensorDataType* output,
     size_t ws_size,
     TensorDataType* ws);
@@ -219,12 +219,12 @@ private:
   /** Get the cuDNN algorithm to use for backward-data. */
   bwd_data_conv_alg get_backward_data_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnn::FilterDescriptor& kernel_desc,
+    const dnn_lib::FilterDescriptor& kernel_desc,
     const TensorDataType* kernel,
-    const cudnn::TensorDescriptor& prev_error_signal_desc,
+    const dnn_lib::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
-    const cudnn::ConvolutionDescriptor& conv_desc,
-    const cudnn::TensorDescriptor& error_signal_desc,
+    const dnn_lib::ConvolutionDescriptor& conv_desc,
+    const dnn_lib::TensorDescriptor& error_signal_desc,
     TensorDataType* error_signal,
     size_t ws_size,
     TensorDataType* ws);
@@ -235,12 +235,12 @@ private:
    */
   bwd_filter_conv_alg get_backward_filter_algo_cudnn(
     const int local_mini_batch_size,
-    const cudnn::TensorDescriptor& input_desc,
+    const dnn_lib::TensorDescriptor& input_desc,
     const TensorDataType* input,
-    const cudnn::TensorDescriptor& prev_error_signal_desc,
+    const dnn_lib::TensorDescriptor& prev_error_signal_desc,
     const TensorDataType* prev_error_signal,
-    const cudnn::ConvolutionDescriptor& conv_desc,
-    const cudnn::FilterDescriptor& kernel_gradient_desc,
+    const dnn_lib::ConvolutionDescriptor& conv_desc,
+    const dnn_lib::FilterDescriptor& kernel_gradient_desc,
     size_t ws_size,
     TensorDataType* ws);
 #endif // LBANN_HAS_CUDNN

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -111,10 +111,10 @@ private:
   using LocalMat = El::Matrix<TensorDataType, El::Device::GPU>;
 
   // cuDNN descriptors
-  cudnn::RNNDescriptor m_rnn_cudnn_desc;
-  cudnn::RNNDataDescriptor m_input_cudnn_desc;
-  cudnn::RNNDataDescriptor m_output_cudnn_desc;
-  cudnn::TensorDescriptor m_hidden_cudnn_desc;
+  dnn_lib::RNNDescriptor m_rnn_cudnn_desc;
+  dnn_lib::RNNDataDescriptor m_input_cudnn_desc;
+  dnn_lib::RNNDataDescriptor m_output_cudnn_desc;
+  dnn_lib::TensorDescriptor m_hidden_cudnn_desc;
 
   // cuDNN workspaces
   LocalMat m_input_sequence_workspace;

--- a/include/lbann/layers/learning/gru.hpp
+++ b/include/lbann/layers/learning/gru.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #ifdef LBANN_HAS_CUDNN
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // LBANN_HAS_CUDNN
 
 /// GPU GRU layer requires CUDA 11.0 and cuDNN 8.0.4 or newer

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -28,7 +28,7 @@
 #define LBANN_LAYER_REGULARIZER_DROPOUT_HPP_INCLUDED
 
 #include "lbann/models/model.hpp"
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/random_number_generators.hpp"
 #include "lbann/utils/dnn_lib/cudnn/dropout.hpp"
 

--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -243,11 +243,11 @@ protected:
     // Initialize cuDNN objects
     auto&& input_desc = m_tensors_cudnn_desc.get_prev_activations();
     auto&& output_desc = m_tensors_cudnn_desc.get_activations();
-    size_t size = cudnn::get_dropout_reserve_space_size(input_desc);
+    size_t size = dnn_lib::get_dropout_reserve_space_size(input_desc);
     m_reserve_space.Resize((size + sizeof(TensorDataType) - 1) / sizeof(TensorDataType), 1);
 
     // Apply dropout on the GPU
-    cudnn::dropout_forward(m_dropout_cudnn_desc,
+    dnn_lib::dropout_forward(m_dropout_cudnn_desc,
                            input_desc,
                            local_input,
                            output_desc,
@@ -275,7 +275,7 @@ protected:
     } else {
       if (local_gradient_wrt_input.Height() > 0
           && local_gradient_wrt_input.Width() > 0) {
-        cudnn::dropout_backward(m_dropout_cudnn_desc,
+        dnn_lib::dropout_backward(m_dropout_cudnn_desc,
                                 m_tensors_cudnn_desc.get_prev_error_signals(),
                                 local_gradient_wrt_output,
                                 m_tensors_cudnn_desc.get_error_signals(),
@@ -292,7 +292,7 @@ protected:
   void setup_dropout_cudnn_desc() {
 
     // Setup RNG state
-    size_t size = cudnn::get_dropout_states_size();
+    size_t size = dnn_lib::get_dropout_states_size();
     m_states.Resize((size + sizeof(TensorDataType) - 1) / sizeof(TensorDataType), 1);
 
     // Setup dropout descriptor
@@ -311,9 +311,9 @@ protected:
 
 #ifdef LBANN_HAS_CUDNN
   /** Dropout cuDNN descriptor. */
-  cudnn::DropoutDescriptor m_dropout_cudnn_desc;
+  dnn_lib::DropoutDescriptor m_dropout_cudnn_desc;
   /** Tensor cuDNN descriptors. */
-  cudnn::entrywise_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::entrywise_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
   /** RNG state for cuDNN dropout. */
   El::Matrix<TensorDataType, El::Device::GPU> m_states;
   /** Work space for cuDNN dropout. */

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -28,7 +28,7 @@
 #define LBANN_LAYER_LOCAL_RESPONSE_NORMALIZATION_HPP_INCLUDED
 
 #include <vector>
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/dnn_lib/cudnn/local_response_normalization.hpp"
 

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -48,7 +48,7 @@ template <typename TensorDataType,
           El::Device Dev = El::Device::CPU>
 class local_response_normalization_layer : public data_type_layer<TensorDataType> {
 #ifdef LBANN_HAS_CUDNN
-  using ScalingType = cudnn::ScalingParamType<TensorDataType>;
+  using ScalingType = dnn_lib::ScalingParamType<TensorDataType>;
 #else
   using ScalingType = TensorDataType;
 #endif // LBANN_HAS_CUDNN
@@ -167,9 +167,9 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
   /** LRN cuDNN descriptor. */
-  cudnn::LRNDescriptor m_lrn_cudnn_desc;
+  dnn_lib::LRNDescriptor m_lrn_cudnn_desc;
   /** Tensor cuDNN descriptors. */
-  cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
 #endif // LBANN_HAS_CUDNN
 
   /// GPU implementation of forward propagation
@@ -182,7 +182,7 @@ private:
     if (local_input.Height() > 0 && local_input.Width() > 0) {
       const ScalingType zero = El::TypeTraits<ScalingType>::Zero();
       const ScalingType one = El::TypeTraits<ScalingType>::One();
-      cudnn::lrn_cross_channel_forward(
+      dnn_lib::lrn_cross_channel_forward(
         m_lrn_cudnn_desc,
         one,
         m_tensors_cudnn_desc.get_prev_activations(),
@@ -206,7 +206,7 @@ private:
     if (local_input.Height() > 0 && local_input.Width() > 0) {
       const ScalingType zero = El::TypeTraits<ScalingType>::Zero();
       const ScalingType one = El::TypeTraits<ScalingType>::One();
-      cudnn::lrn_cross_channel_backward(
+      dnn_lib::lrn_cross_channel_backward(
         m_lrn_cudnn_desc,
         one,
         m_tensors_cudnn_desc.get_activations(),

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -89,9 +89,9 @@ private:
 
 #ifdef LBANN_HAS_CUDNN
   /** Pooling descriptor. */
-  cudnn::PoolingDescriptor m_pooling_cudnn_desc;
+  dnn_lib::PoolingDescriptor m_pooling_cudnn_desc;
   /** Tensor cuDNN descriptors. */
-  cudnn::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
+  dnn_lib::data_parallel_layer_tensor_manager<TensorDataType> m_tensors_cudnn_desc;
 #endif // LBANN_HAS_CUDNN
 
   friend class unpooling_layer<TensorDataType, T_layout, Dev>;
@@ -306,13 +306,13 @@ private:
 #ifndef LBANN_HAS_CUDNN
     LBANN_ERROR("cuDNN not detected");
 #else
-    using ScalingType = cudnn::ScalingParamType<TensorDataType>;
+    using ScalingType = dnn_lib::ScalingParamType<TensorDataType>;
     const auto& local_input = this->get_local_prev_activations();
     auto& local_output = this->get_local_activations();
     if (local_input.Height() > 0 && local_input.Width() > 0) {
       const auto zero = El::TypeTraits<ScalingType>::Zero();
       const auto one = El::TypeTraits<ScalingType>::One();
-      cudnn::pooling_forward(m_pooling_cudnn_desc,
+      dnn_lib::pooling_forward(m_pooling_cudnn_desc,
                              one,
                              m_tensors_cudnn_desc.get_prev_activations(),
                              local_input,
@@ -328,7 +328,7 @@ private:
 #ifndef LBANN_HAS_CUDNN
     LBANN_ERROR("cuDNN not detected");
 #else
-    using ScalingType = cudnn::ScalingParamType<TensorDataType>;
+    using ScalingType = dnn_lib::ScalingParamType<TensorDataType>;
     const auto& local_input = this->get_local_prev_activations();
     const auto& local_output = this->get_local_activations();
     const auto& local_gradient_wrt_output = this->get_local_prev_error_signals();
@@ -340,7 +340,7 @@ private:
       const auto zero = El::TypeTraits<ScalingType>::Zero();
 
       // Perform backprop on GPU
-      cudnn::pooling_backward(m_pooling_cudnn_desc,
+      dnn_lib::pooling_backward(m_pooling_cudnn_desc,
                               one,
                               m_tensors_cudnn_desc.get_activations(),
                               local_output,

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -30,7 +30,7 @@
 #include <utility>
 #include <vector>
 #include "lbann/layers/data_type_layer.hpp"
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/im2col.hpp"
 #include "lbann/utils/distconv.hpp"

--- a/include/lbann/utils/dnn_lib/cudnn.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn.hpp
@@ -24,8 +24,8 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_UTILS_CUDNN_HPP
-#define LBANN_UTILS_CUDNN_HPP
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_HPP
+#define LBANN_UTILS_DNN_LIB_CUDNN_HPP
 
 #include "lbann/base.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
@@ -915,4 +915,4 @@ cudnnMathType_t get_default_convolution_math_type() noexcept;
 } // namespace lbann
 
 #endif // LBANN_HAS_CUDNN
-#endif // LBANN_UTILS_CUDNN_HPP
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_HPP

--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_CONVOLUTION_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_CONVOLUTION_HPP_
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/cudnn.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
 #include "utils.hpp"

--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_CONVOLUTION_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_CONVOLUTION_HPP_
 
-#include "lbann/utils/dnn_lib/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
 #include "utils.hpp"
@@ -194,7 +194,7 @@ void convolution_forward(
   El::AbstractMatrix<TensorDataType>& y,
   El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -250,7 +250,7 @@ void convolution_backward_data(
   El::AbstractMatrix<TensorDataType>& dx,
   El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -302,7 +302,7 @@ void convolution_backward_bias(
   El::AbstractDistMatrix<TensorDataType>& db,
   El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -346,7 +346,7 @@ void convolution_backward_filter(
   El::AbstractDistMatrix<TensorDataType>& dw,
   El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -396,7 +396,7 @@ void add_tensor(ScalarParameterType const& alpha_in,
                 El::AbstractMatrix<TensorDataType>& C,
                 El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);

--- a/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/dropout.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_DROPOUT_HPP_
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
 #include "utils.hpp"

--- a/include/lbann/utils/dnn_lib/cudnn/local_response_normalization.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/local_response_normalization.hpp
@@ -69,7 +69,7 @@ void lrn_cross_channel_forward(LRNDescriptor const& normDesc,
                                lrn_mode mode = lrn_mode::CROSS_CHANNEL_DIM1)
 {
 
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -119,7 +119,7 @@ void lrn_cross_channel_backward(LRNDescriptor const& normDesc,
                                 lrn_mode mode = lrn_mode::CROSS_CHANNEL_DIM1)
 {
 
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);

--- a/include/lbann/utils/dnn_lib/cudnn/local_response_normalization.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/local_response_normalization.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_LRN_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_LRN_HPP_
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
 #include "utils.hpp"

--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -48,7 +48,7 @@ void pooling_forward(PoolingDescriptor const& poolingDesc,
                      El::AbstractMatrix<TensorDataType>& y,
                      El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
@@ -93,7 +93,7 @@ void pooling_backward(PoolingDescriptor const& poolingDesc,
                       El::AbstractMatrix<TensorDataType>& dx,
                       El::SyncInfo<El::Device::GPU> const& si)
 {
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);

--- a/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/pooling.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_POOLING_HPP_
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
 #include "utils.hpp"

--- a/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
@@ -108,7 +108,7 @@ void softmax_forward(
   if (x.IsEmpty())
     return;
 
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(y),
                                      gpu::get_sync_info(x));
   auto handle_manager = internal::make_default_handle_manager(multisync);
@@ -142,7 +142,7 @@ void softmax_backward(
   if (y.IsEmpty())
     return;
 
-  using LibScalingParamT = cudnn::ScalingParamType<TensorDataType>;
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(dx),
                                      gpu::get_sync_info(y),
                                      gpu::get_sync_info(dy));

--- a/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/softmax.hpp
@@ -26,7 +26,7 @@
 #ifndef LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
 #define LBANN_UTILS_DNN_LIB_CUDNN_SOFTMAX_HPP_
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 #include "utils.hpp"
 

--- a/include/lbann/utils/dnn_lib/cudnn/utils.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/utils.hpp
@@ -53,7 +53,7 @@ public:
         CHECK_CUDNN(cudnnSetStream(handle_, old_stream_));
     }
     catch (std::exception const& e) {
-      std::cerr << "Caught error in ~cudnn::StreamManager().\n\n  e.what(): "
+      std::cerr << "Caught error in ~dnn_lib::StreamManager().\n\n  e.what(): "
                 << e.what() << "\n\nCalling std::terminate()."
                 << std::endl;
       std::terminate();

--- a/include/lbann/utils/dnn_lib/dnn_lib.hpp
+++ b/include/lbann/utils/dnn_lib/dnn_lib.hpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////////
+//// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+//// Produced at the Lawrence Livermore National Laboratory.
+//// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+//// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+////
+//// LLNL-CODE-697807.
+//// All rights reserved.
+////
+//// This file is part of LBANN: Livermore Big Artificial Neural Network
+//// Toolkit. For details, see http://software.llnl.gov/LBANN or
+//// https://github.com/LLNL/LBANN.
+////
+//// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+//// may not use this file except in compliance with the License.  You may
+//// obtain a copy of the License at:
+////
+//// http://www.apache.org/licenses/LICENSE-2.0
+////
+//// Unless required by applicable law or agreed to in writing, software
+//// distributed under the License is distributed on an "AS IS" BASIS,
+//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//// implied. See the License for the specific language governing
+//// permissions and limitations under the license.
+//////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_DNN_LIB_HPP
+#define LBANN_UTILS_DNN_LIB_DNN_LIB_HPP
+
+#ifdef LBANN_HAS_DNN_LIB
+
+namespace lbann {
+//namespace dnn_lib {
+//} // namespace dnn_lib
+} // namespace lbann
+#endif // LBANN_HAS_MIOPEN
+#endif // LBANN_UTILS_DNN_LIB_DNN_LIB_HPP

--- a/include/lbann/utils/dnn_lib/helpers.hpp
+++ b/include/lbann/utils/dnn_lib/helpers.hpp
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_DNN_LIB_HELPERS_HPP
+#define LBANN_UTILS_DNN_LIB_HELPERS_HPP
+
+#include "lbann_config.hpp"
+
+#if defined LBANN_HAS_CUDNN || defined LBANN_HAS_MIOPEN
+#define LBANN_HAS_DNN_LIB
+#endif
+
+// Import the GPU __device__ function library
+#if defined LBANN_HAS_CUDNN
+#include "cudnn.hpp"
+namespace lbann {
+namespace dnn_lib = ::lbann::cudnn;
+}// namespace lbann
+
+#elif defined LBANN_HAS_MIOPEN
+
+// For now, this is placeholder.
+#include "miopen.hpp"
+namespace lbann {
+namespace dnn_lib = ::lbann::miopen;
+}// namespace lbann
+
+#endif // LBANN_HAS_CUDnn
+
+#if defined LBANN_HAS_DNN_LIB
+#include "dnn_lib.hpp"
+#endif // LBANN_HAS_DNN_LIB
+
+#endif // LBANN_UTILS_DNN_LIB_HELPERS_HPP

--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -1,0 +1,38 @@
+////////////////////////////////////////////////////////////////////////////////
+//// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+//// Produced at the Lawrence Livermore National Laboratory.
+//// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+//// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+////
+//// LLNL-CODE-697807.
+//// All rights reserved.
+////
+//// This file is part of LBANN: Livermore Big Artificial Neural Network
+//// Toolkit. For details, see http://software.llnl.gov/LBANN or
+//// https://github.com/LLNL/LBANN.
+////
+//// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+//// may not use this file except in compliance with the License.  You may
+//// obtain a copy of the License at:
+////
+//// http://www.apache.org/licenses/LICENSE-2.0
+////
+//// Unless required by applicable law or agreed to in writing, software
+//// distributed under the License is distributed on an "AS IS" BASIS,
+//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//// implied. See the License for the specific language governing
+//// permissions and limitations under the license.
+//////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_MIOPEN_HPP
+#define LBANN_UTILS_DNN_LIB_MIOPEN_HPP
+
+#ifdef LBANN_HAS_MIOPEN
+
+#include <miopen.h>
+
+namespace lbann {
+namespace miopen {
+} // namespace miopen
+} // namespace lbann
+#endif // LBANN_HAS_MIOPEN
+#endif // LBANN_UTILS_DNN_LIB_MIOPEN_HPP

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -32,7 +32,7 @@
 #include "lbann/data_store/data_store_conduit.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #ifdef LBANN_HAS_CUDNN
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/cudnn.hpp"
 #endif // LBANN_HAS_CUDNN
 
 #include <lbann.pb.h>

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -32,7 +32,7 @@
 #include "lbann/data_store/data_store_conduit.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #ifdef LBANN_HAS_CUDNN
-#include "lbann/utils/dnn_lib/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // LBANN_HAS_CUDNN
 
 #include <lbann.pb.h>
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
     }
 #ifdef LBANN_HAS_CUDNN
     if (use_cudnn_tensor_ops)
-      cudnn::default_to_tensor_ops();
+      dnn_lib::default_to_tensor_ops();
 #endif // LBANN_HAS_CUDNN
 #ifdef LBANN_HAS_CUDA
     if (use_cublas_tensor_ops)

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -130,7 +130,7 @@ void finalize(lbann_comm* comm) {
   dc::finalize();
 #endif
 #ifdef LBANN_HAS_CUDNN
-  cudnn::destroy();
+  dnn_lib::destroy();
 #endif
 #ifdef LBANN_HAS_PYTHON
   python::finalize();

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -45,7 +45,7 @@
 #include "lbann/utils/stack_trace.hpp"
 
 #ifdef LBANN_HAS_CUDNN
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #endif
 #ifdef LBANN_HAS_PYTHON
 #include "lbann/utils/python.hpp"

--- a/src/layers/activations/log_softmax.cu
+++ b/src/layers/activations/log_softmax.cu
@@ -253,7 +253,7 @@ void fp_compute_impl(log_softmax_layer<TensorDataType, data_layout::DATA_PARALLE
   const TensorDataType one = 1;
   const auto& local_input = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_prev_activations());
   auto& local_output = dynamic_cast<El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_activations());
-  cudnn::softmax_forward(one,
+  dnn_lib::softmax_forward(one,
                          l.m_tensors_cudnn_desc.get_prev_activations(),
                          local_input,
                          zero,
@@ -271,7 +271,7 @@ void bp_compute_impl(log_softmax_layer<TensorDataType, data_layout::DATA_PARALLE
   const auto& local_output = dynamic_cast<const GPUMatType&>(l.get_local_activations());
   const auto& local_gradient_wrt_output = dynamic_cast<const GPUMatType&>(l.get_local_prev_error_signals());
   auto& local_gradient_wrt_input = dynamic_cast<GPUMatType&>(l.get_local_error_signals());
-  cudnn::softmax_backward(one,
+  dnn_lib::softmax_backward(one,
                           l.m_tensors_cudnn_desc.get_activations(),
                           local_output,
                           l.m_tensors_cudnn_desc.get_prev_error_signals(),

--- a/src/layers/activations/softmax.cu
+++ b/src/layers/activations/softmax.cu
@@ -289,12 +289,12 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   }
 #endif // LBANN_HAS_DISTCONV
 
-  const cudnn::ScalingParamType<TensorDataType> zero = 0.;
-  const cudnn::ScalingParamType<TensorDataType> one = 1.;
+  const dnn_lib::ScalingParamType<TensorDataType> zero = 0.;
+  const dnn_lib::ScalingParamType<TensorDataType> one = 1.;
   const auto& local_input = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_prev_activations());
   auto& local_output = dynamic_cast<El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_activations());
   if (!local_input.IsEmpty()) {
-    cudnn::softmax_forward(one,
+    dnn_lib::softmax_forward(one,
                            l.m_tensors_cudnn_desc.get_prev_activations(),
                            local_input,
                            zero,
@@ -317,12 +317,12 @@ void bp_compute_impl(softmax_layer<TensorDataType, data_layout::DATA_PARALLEL, E
   }
 #endif // LBANN_HAS_DISTCONV
 
-  const cudnn::ScalingParamType<TensorDataType> zero = 0.;
-  const cudnn::ScalingParamType<TensorDataType> one = 1.;
+  const dnn_lib::ScalingParamType<TensorDataType> zero = 0.;
+  const dnn_lib::ScalingParamType<TensorDataType> one = 1.;
   const auto& local_output = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_activations());
   const auto& local_gradient_wrt_output = dynamic_cast<const El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_prev_error_signals());
   auto& local_gradient_wrt_input = dynamic_cast<El::Matrix<TensorDataType, El::Device::GPU>&>(l.get_local_error_signals());
-  cudnn::softmax_backward(one,
+  dnn_lib::softmax_backward(one,
                           l.m_tensors_cudnn_desc.get_activations(),
                           local_output,
                           l.m_tensors_cudnn_desc.get_prev_error_signals(),

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -29,12 +29,12 @@
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
+#include "lbann/utils/dnn_lib/cudnn/convolution.hpp"
 #include "lbann/utils/distconv.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/im2col.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer.hpp"
-#include "lbann/utils/dnn_lib/cudnn/convolution.hpp"
 #include "lbann/weights/initializer.hpp"
 #include "lbann/weights/variance_scaling_initializers.hpp"
 

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/layer.hpp"
 #include "lbann/layers/learning/base_convolution.hpp"
 #include "lbann/models/model.hpp"
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/distconv.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/im2col.hpp"

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -424,6 +424,7 @@ base_convolution_layer<TensorDataType,Device>
 #else
 
   // Useful constants
+  using ScalingType = cudnn::ScalingParamType<TensorDataType>;
   const auto zero = El::TypeTraits<ScalingType>::Zero();
   const auto one = El::TypeTraits<ScalingType>::One();
 
@@ -502,6 +503,7 @@ apply_transposed_convolution_cudnn(bool during_forward_prop) {
 #else
 
   // Useful constants
+  using ScalingType = cudnn::ScalingParamType<TensorDataType>;
   const auto zero = El::TypeTraits<ScalingType>::Zero();
   const auto one = El::TypeTraits<ScalingType>::One();
 
@@ -1233,7 +1235,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
                             this->get_prev_error_signals(),
                             dst_scale, *m_bias_gradient, false);
     } else {
-      m_bias_gradient->scale(dst_scale, gpu::get_sync_info(bias_gradient).Stream());
+      m_bias_gradient->scale(dst_scale, gpu::get_sync_info(l).Stream());
     }
   }
 
@@ -1251,7 +1253,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
                             dst_scale,
                             *m_kernel_gradient, false);
   } else {
-    m_kernel_gradient->scale(dst_scale, gpu::get_sync_info(kernel_gradient).Stream());
+    m_kernel_gradient->scale(dst_scale, gpu::get_sync_info(l).Stream());
   }
 }
 

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -298,7 +298,7 @@ cudnnMathType_t convert_to_cudnn_math_type(ProtoTensorOpEnumType mt)
   switch (mt)
   {
   case lbann_data::DEFAULT_TENSOR_OPS:
-    return cudnn::get_default_convolution_math_type();
+    return dnn_lib::get_default_convolution_math_type();
   case lbann_data::NO_TENSOR_OPS:
     return CUDNN_DEFAULT_MATH;
   case lbann_data::USE_TENSOR_OPS:

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -256,7 +256,7 @@ void gru_layer<TensorDataType, Layout, Device>::setup_gpu() {
   const size_t input_size = this->get_input_size(0) / sequence_length;
 
   // RNN descriptor
-  static cudnn::DropoutDescriptor dropout_desc;
+  static dnn_lib::DropoutDescriptor dropout_desc;
   dropout_desc.set(0, nullptr, 0, 0);
   m_rnn_cudnn_desc.set(
     CUDNN_RNN_ALGO_STANDARD,
@@ -264,9 +264,9 @@ void gru_layer<TensorDataType, Layout, Device>::setup_gpu() {
     CUDNN_RNN_DOUBLE_BIAS,
     CUDNN_UNIDIRECTIONAL,
     CUDNN_LINEAR_INPUT,
-    cudnn::get_data_type<TensorDataType>(),
-    cudnn::get_data_type<TensorDataType>(),
-    cudnn::get_default_convolution_math_type(),
+    dnn_lib::get_data_type<TensorDataType>(),
+    dnn_lib::get_data_type<TensorDataType>(),
+    dnn_lib::get_default_convolution_math_type(),
     input_size,
     m_hidden_size,
     m_hidden_size,  // proj_size
@@ -292,7 +292,7 @@ namespace {
 template <typename TensorDataType>
 void pack_cudnn_rnn_weights(
   const cudnnHandle_t& handle,
-  const cudnn::RNNDescriptor& rnn_desc,
+  const dnn_lib::RNNDescriptor& rnn_desc,
   const El::SyncInfo<El::Device::GPU>& sync_info,
   size_t input_size,
   size_t hidden_size,
@@ -302,7 +302,7 @@ void pack_cudnn_rnn_weights(
   const std::vector<El::Matrix<TensorDataType,El::Device::GPU>>& weights_list) {
 
   // Construct objects
-  static cudnn::TensorDescriptor matrix_desc, bias_desc;
+  static dnn_lib::TensorDescriptor matrix_desc, bias_desc;
   El::Matrix<TensorDataType,El::Device::GPU> packed_weights_view;
   packed_weights_view.SetSyncInfo(sync_info);
 
@@ -438,9 +438,9 @@ void fp_compute_impl(
   // GPU objects
   auto&& sync_info = input_sequence.GetSyncInfo();
   auto&& stream = sync_info.Stream();
-  auto&& handle = cudnn::get_handle();
+  auto&& handle = dnn_lib::get_handle();
   auto&& rnn_desc = l.m_rnn_cudnn_desc;
-  const auto data_type = cudnn::get_data_type<TensorDataType>();
+  const auto data_type = dnn_lib::get_data_type<TensorDataType>();
 
   // Configure input and output tensor descriptors
   std::vector<int> sequence_lengths(workspace_mini_batch_size, sequence_length);
@@ -620,7 +620,7 @@ namespace {
 template <typename TensorDataType>
 void unpack_cudnn_rnn_weights(
   const cudnnHandle_t& handle,
-  const cudnn::RNNDescriptor& rnn_desc,
+  const dnn_lib::RNNDescriptor& rnn_desc,
   const El::SyncInfo<El::Device::GPU>& sync_info,
   size_t input_size,
   size_t hidden_size,
@@ -630,7 +630,7 @@ void unpack_cudnn_rnn_weights(
   const std::vector<El::Matrix<TensorDataType,El::Device::GPU>>& weights_list) {
 
   // Construct objects
-  static cudnn::TensorDescriptor matrix_desc, bias_desc;
+  static dnn_lib::TensorDescriptor matrix_desc, bias_desc;
   El::Matrix<TensorDataType,El::Device::GPU> packed_weights_view;
   packed_weights_view.SetSyncInfo(sync_info);
 
@@ -743,7 +743,7 @@ void bp_compute_impl(
   // GPU objects
   auto&& sync_info = output_sequence_grad.GetSyncInfo();
   auto&& stream = sync_info.Stream();
-  auto&& handle = cudnn::get_handle();
+  auto&& handle = dnn_lib::get_handle();
   auto&& rnn_desc = l.m_rnn_cudnn_desc;
 
   // Define closure to send weight gradients to optimizers

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -298,7 +298,7 @@ cudnnMathType_t convert_to_cudnn_math_type(ProtoTensorOpEnumType mt)
   switch (mt)
   {
   case lbann_data::DEFAULT_TENSOR_OPS:
-    return cudnn::get_default_convolution_math_type();
+    return dnn_lib::get_default_convolution_math_type();
   case lbann_data::NO_TENSOR_OPS:
     return CUDNN_DEFAULT_MATH;
   case lbann_data::USE_TENSOR_OPS:

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/cudnn.hpp"
 #include "lbann/utils/number_theory.hpp"
 
 #include "El.hpp"

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -26,7 +26,7 @@
 
 #define LBANN_UTILS_DISTCONV_INSTANTIATE
 #include "lbann/utils/distconv.hpp"
-#include "lbann/utils/cudnn.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/layers/layer.hpp"
 #include <cstdlib>
 


### PR DESCRIPTION
This establishes the `dnn_lib` namespace and lays the groundwork for supporting multiple DNN libraries in that namespace:

- `cudnn::` --> `dnn_lib::`
- replace `cudnn` in variable and function names with `dnn`
- aliasing for DNN library types
- establish the `dnn_lib/helpers.hpp` header that will load the appropriate DNN library code for LBANN layers
- replace `LBANN_HAS_CUDNN` with `LBANN_HAS_DNN_LIB` where appropriate
  - Some things will remain cuDNN-exclusive, primarily the RNN stuff in the GRU layer, as there is not equivalent for MIOpen
- cuDNN-specific code (i.e., `RNNDataDescriptor`) is moved to `cudnn.hpp` header while the rest lives in `dnn_lib.hpp`
- Moves the layer class enums (e.g., conv algos) to their own file (`dnn_enums.hpp`)
- Moves the `to_{dnn_lib}` and `from_{dnn_lib}` functions to `cudnn.hpp`

This PR contains changes from #1674 and #1675 and will need to be rebased when those are merged.

Note: this does not address some of the larger changes necessary in the convolution and pooling layers.  Those changes are captured in #1686 and #1687, respectively.