### PR TITLE
Utility function to detect system in Bamboo tests

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -3,6 +3,7 @@ import copy
 import math
 import os
 import re
+import socket
 import sys
 import numpy as np
 import pytest
@@ -1016,6 +1017,15 @@ def print_diff_files(dcmp):
             all_warns.append(d)
 
     return any_files_differ, all_diffs, all_warns
+
+
+def system(lbann):
+    """Name of compute system."""
+    compute_center = lbann.contrib.launcher.compute_center()
+    if compute_center != "unknown":
+        return getattr(lbann.contrib, compute_center).systems.system()
+    else:
+        return re.sub(r'\d+', '', socket.gethostname())
 
 
 # Get the number of GPUs per compute node.

--- a/bamboo/compiler_tests/build_script.sh
+++ b/bamboo/compiler_tests/build_script.sh
@@ -53,10 +53,8 @@ then
 
     BRAIN_DIR=/usr/workspace/wsb/brain
 
-    # CUDA-y things (Use the newest)
-    ARCH=$(uname -i)
-    export NCCL_DIR=$(ls -d --color=no ${BRAIN_DIR}/nccl2/*cuda11*${ARCH} | tail -n1)
     # Use the latest cuDNN 8
+    ARCH=$(uname -i)
     export CUDNN_DIR=$(find ${BRAIN_DIR}/cudnn -maxdepth 2 -type d | grep "cudnn-8.*/cuda-11.*_${ARCH}" | sort -r | head -1)
 
     # Unit testing framework

--- a/bamboo/compiler_tests/build_script.sh
+++ b/bamboo/compiler_tests/build_script.sh
@@ -43,9 +43,8 @@ then
             MPI_MODULE=$(echo ${MPI_LIBRARY} | sed -e 's|-|/|g')
         fi
 
-        # Use the latest CUDA 10, since it's compatible with other
-        # CUDA 10.* libraries
-        CUDA_MODULE=$(ml --terse avail cuda |& sed -n '/\/10\./p' | tail -n1)
+        # Use the latest CUDA 11
+        CUDA_MODULE=$(ml --terse avail cuda |& sed -n '/\/11\./p' | tail -n1)
 
         # Load up the appropriate modules
         module load ${COMPILER_MODULE} ${MPI_MODULE} ${CUDA_MODULE} cmake/3.14.5
@@ -56,9 +55,9 @@ then
 
     # CUDA-y things (Use the newest)
     ARCH=$(uname -i)
-    export NCCL_DIR=$(ls -d --color=no ${BRAIN_DIR}/nccl2/*cuda10*${ARCH} | tail -n1)
-    # Right now, we only support cuDNN 7 versions.
-    export CUDNN_DIR=$(find ${BRAIN_DIR}/cudnn -maxdepth 2 -type d | grep "cudnn-7.*/cuda-10.*_${ARCH}" | sort -r | head -1)
+    export NCCL_DIR=$(ls -d --color=no ${BRAIN_DIR}/nccl2/*cuda11*${ARCH} | tail -n1)
+    # Use the latest cuDNN 8
+    export CUDNN_DIR=$(find ${BRAIN_DIR}/cudnn -maxdepth 2 -type d | grep "cudnn-8.*/cuda-11.*_${ARCH}" | sort -r | head -1)
 
     # Unit testing framework
     export CLARA_DIR=${WORKSPACE_DIR}/stable_dependencies/clara

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -240,7 +240,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note (tym1 10/28/20): Requires that LBANN be built with CUDA >=11.0
-# and cuDNN >=8.0.4.
-# for test in tools.create_tests(setup_experiment, __file__):
-#     globals()[test.__name__] = test
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -5,6 +5,7 @@ import os.path
 import sys
 import numpy as np
 import scipy.special
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -82,6 +83,13 @@ def setup_experiment(lbann):
         lbann (module): Module for LBANN Python frontend
 
     """
+
+    # Skip test on non-GPU systems
+    if not tools.gpus_per_node(lbann):
+        message = f'{os.path.basename(__file__)} requires GPUs'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)
     model = construct_model(lbann)
@@ -232,5 +240,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# for test in tools.create_tests(setup_experiment, __file__):
-#     globals()[test.__name__] = test
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_gru.py
+++ b/bamboo/unit_tests/test_unit_layer_gru.py
@@ -240,5 +240,7 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for test in tools.create_tests(setup_experiment, __file__):
-    globals()[test.__name__] = test
+# Note (tym1 10/28/20): Requires that LBANN be built with CUDA >=11.0
+# and cuDNN >=8.0.4.
+# for test in tools.create_tests(setup_experiment, __file__):
+#     globals()[test.__name__] = test

--- a/bamboo/unit_tests/test_unit_layer_uniform_hash.py
+++ b/bamboo/unit_tests/test_unit_layer_uniform_hash.py
@@ -5,6 +5,7 @@ import os
 import os.path
 import sys
 import numpy as np
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -53,6 +54,13 @@ def setup_experiment(lbann):
         lbann (module): Module for LBANN Python frontend
 
     """
+
+    # Skip test on non-GPU systems
+    if not tools.gpus_per_node(lbann):
+        message = f'{os.path.basename(__file__)} requires GPUs'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)
     model = construct_model(lbann)
@@ -155,8 +163,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-# Note (tym 7/17/20): Tests are disabled for now since the uniform
-# hash layer is only supported on GPU. Restore these tests when it is
-# supported on CPU.
-# for test in tools.create_tests(setup_experiment, __file__):
-#     globals()[test.__name__] = test
+for test in tools.create_tests(setup_experiment, __file__):
+    globals()[test.__name__] = test


### PR DESCRIPTION
This PR uses the approach from PR #1635 to allow us to skip Bamboo tests on unsupported systems. For example, if we wanted to only run the LeNet test on Pascal, we would add the following to the `setup_experiment` function in `test_integration_lenet.py`:
```python
    if tools.system(lbann) != 'pascal':
	message = f'{os.path.basename(__file__)} is only supported on pascal system'
	print('Skip - ' + message)
	pytest.skip(message)
```
Pinging @samadejacobs 

I've also taken the liberty of enabling GPU-only tests for the uniform hash and GRU layers. [Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM307-1).