### PR TITLE
Refactor pooling layer for cuDNN abstraction

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -176,12 +176,6 @@ execution_mode exec_mode_from_string(std::string const& str);
 /** @brief Extract an execution_mode from a stream. */
 std::istream& operator>>(std::istream& os, execution_mode& e);
 
-/** Pooling layer mode */
-enum class pool_mode {invalid, max, average, average_no_pad};
-
-/** returns a string representation of the pool_mode */
-std::string get_pool_mode_name(pool_mode m);
-
 /*
  * endsWith: http://thispointer.com/c-how-to-check-if-a-string-ends-with-an-another-given-string/
  * Case Sensitive Implementation of endsWith()

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -54,6 +54,27 @@ inline pooling_mode to_pool_mode(std::string m)
   }
 }
 
+#ifdef LBANN_HAS_DNN_LIB
+namespace dnn_lib {
+
+inline dnnPoolingMode_t to_dnn_lib(pooling_mode m)
+{
+  switch(m)
+  {
+#ifdef LBANN_HAS_CUDNN
+  case pooling_mode::MAX: return CUDNN_POOLING_MAX;
+  case pooling_mode::MAX_DETERMINISTIC: return CUDNN_POOLING_MAX_DETERMINISTIC;
+  case pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING: return CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
+  case pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING: return CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
+#endif // LBANN_HAS_CUDNN
+  default:
+    LBANN_ERROR("Invalid pooling mode requested");
+  }
+}
+
+} // namespace dnn_lib
+#endif // LBANN_HAS_DNN_LIB
+
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType,
           data_layout T_layout = data_layout::DATA_PARALLEL,
@@ -263,7 +284,7 @@ protected:
 #else
 
     // Set pooling descriptor
-    m_pooling_dnn_desc.set(dnn_lib::to_cudnn(m_pool_mode),
+    m_pooling_dnn_desc.set(dnn_lib::to_dnn_lib(m_pool_mode),
                            dnn_lib::DNN_PROPAGATE_NAN,
                            m_pool_dims.size(),
                            m_pool_dims.data(),

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -40,6 +40,20 @@
 
 namespace lbann {
 
+inline pooling_mode to_pool_mode(std::string m)
+{
+#ifndef LBANN_DETERMINISTIC
+  if (m == "max")            return pooling_mode::MAX;
+#else
+  if (m == "max")            return pooling_mode::MAX_DETERMINISTIC;
+#endif // LBANN_DETERMINISTIC
+  if (m == "average")        return pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING;
+  if (m == "average_no_pad") return pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING;
+  else {
+    LBANN_ERROR("Invalid pooling mode requested.");
+  }
+}
+
 #ifdef LBANN_HAS_DISTCONV
 template <typename TensorDataType,
           data_layout T_layout = data_layout::DATA_PARALLEL,
@@ -71,7 +85,7 @@ class pooling_layer : public data_type_layer<TensorDataType> {
 private:
 
   /** Pooling mode. */
-  pool_mode m_pool_mode;
+  pooling_mode m_pool_mode;
 
   /** Pooling window dimensions. */
   std::vector<int> m_pool_dims;
@@ -105,7 +119,7 @@ public:
                 int pool_dim,
                 int pad,
                 int stride,
-                pool_mode mode)
+                pooling_mode mode)
     : pooling_layer(comm,
                     num_data_dims,
                     std::vector<int>(num_data_dims, pool_dim),
@@ -118,7 +132,7 @@ public:
                 std::vector<int> pool_dims,
                 std::vector<int> pads,
                 std::vector<int> strides,
-                pool_mode mode)
+                pooling_mode mode)
     : data_type_layer<TensorDataType>(comm),
       m_pool_mode(mode),
       m_pool_dims(pool_dims),
@@ -185,10 +199,14 @@ public:
     ss.str(std::string{});
     ss.clear();
     switch (m_pool_mode) {
-    case pool_mode::max:            ss << "max";              break;
-    case pool_mode::average:        ss << "average";          break;
-    case pool_mode::average_no_pad: ss << "average (no pad)"; break;
-    case pool_mode::invalid:
+    case pooling_mode::MAX:
+      ss << "max"; break;
+    case pooling_mode::MAX_DETERMINISTIC:
+      ss << "max (deterministic)"; break;
+    case pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING:
+      ss << "average"; break;
+    case pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING:
+      ss << "average (no pad)"; break;
     default:
       ss << "invalid";
     }
@@ -245,26 +263,8 @@ protected:
 #else
 
     // Set pooling descriptor
-    cudnnPoolingMode_t dnn_pool_mode;
-    switch(m_pool_mode) {
-    case pool_mode::max:
-    #ifndef LBANN_DETERMINISTIC
-      dnn_pool_mode = CUDNN_POOLING_MAX; break;
-    #else
-      dnn_pool_mode = CUDNN_POOLING_MAX_DETERMINISTIC; break;
-    #endif
-    case pool_mode::average:
-      dnn_pool_mode = CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING; break;
-    case pool_mode::average_no_pad:
-      dnn_pool_mode = CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING; break;
-    default:
-      std::stringstream err;
-      err << "no GPU implementation for pooling mode " << static_cast<int>(m_pool_mode);
-      LBANN_ERROR(err.str());
-      dnn_pool_mode = CUDNN_POOLING_MAX;
-    }
-    m_pooling_dnn_desc.set(dnn_pool_mode,
-                           CUDNN_PROPAGATE_NAN,
+    m_pooling_dnn_desc.set(dnn_lib::to_cudnn(m_pool_mode),
+                           dnn_lib::DNN_PROPAGATE_NAN,
                            m_pool_dims.size(),
                            m_pool_dims.data(),
                            m_pads.data(),
@@ -359,7 +359,7 @@ private:
 
   /// Pooling forward propagation with im2col
   void fp_compute_im2col() {
-    if(m_pool_mode != pool_mode::max && m_pool_mode != pool_mode::average) {
+    if(m_pool_mode != pooling_mode::MAX && m_pool_mode != pooling_mode::MAX_DETERMINISTIC && m_pool_mode != pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING) {
       LBANN_ERROR("CPU pooling layer only supports max and average pooling");
     }
 
@@ -374,7 +374,7 @@ private:
     const int num_per_output_channel = this->get_output_size() / num_channels;
 
     // Initialize max pool indices if needed
-    if(m_pool_mode == pool_mode::max) {
+    if(m_pool_mode == pooling_mode::MAX || m_pool_mode == pooling_mode::MAX_DETERMINISTIC) {
       m_max_pool_indices.assign(this->get_output_size() * local_width, 0);
     }
 
@@ -397,7 +397,7 @@ private:
              m_pool_dims.data(),
              m_strides.data());
 
-      if(m_pool_mode == pool_mode::max) {
+      if(m_pool_mode == pooling_mode::MAX || m_pool_mode == pooling_mode::MAX_DETERMINISTIC) {
         // Apply max pooling
         TensorDataType *output_buffer = local_output.Buffer(0, sample);
         int *indices_buffer = &m_max_pool_indices[sample * this->get_output_size()];
@@ -421,7 +421,7 @@ private:
         }
       }
 
-      if(m_pool_mode == pool_mode::average) {
+      if(m_pool_mode == pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING) {
         // Apply average pooling
         TensorDataType *output_buffer = local_output.Buffer(0, sample);
         LBANN_OMP_PARALLEL_FOR
@@ -447,7 +447,7 @@ private:
   /// Pooling forward propagation with im2col
   void bp_compute_im2col() {
     using CPUMatType = El::Matrix<TensorDataType, El::Device::CPU>;
-    if(m_pool_mode != pool_mode::max && m_pool_mode != pool_mode::average) {
+    if(m_pool_mode != pooling_mode::MAX && m_pool_mode != pooling_mode::MAX_DETERMINISTIC && m_pool_mode != pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING) {
       LBANN_ERROR("CPU pooling layer only supports max and average pooling");
     }
 
@@ -469,7 +469,7 @@ private:
     for(int sample = 0; sample < local_width; ++sample) {
 
       // Compute gradient w.r.t. im2col matrix for max pooling
-      if(m_pool_mode == pool_mode::max) {
+      if(m_pool_mode == pooling_mode::MAX || m_pool_mode == pooling_mode::MAX_DETERMINISTIC) {
 
         // Clear im2col matrix
         El::Zero(im2col_mat);
@@ -494,7 +494,7 @@ private:
       }
 
       // Compute gradient w.r.t. im2col matrix for average pooling
-      if(m_pool_mode == pool_mode::average) {
+      if(m_pool_mode == pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING) {
         const TensorDataType *gradient_wrt_output_buffer
           = local_gradient_wrt_output.LockedBuffer(0, sample);
         LBANN_OMP_PARALLEL_FOR
@@ -671,11 +671,13 @@ setup_layer(size_t workspace_capacity) {
 
   std::string mode;
   switch(l.m_pool_mode) {
-    case pool_mode::max:
+    case pooling_mode::MAX:
       mode = "MAX"; break;
-    case pool_mode::average:
+    case pooling_mode::MAX_DETERMINISTIC:
+      mode = "MAX"; break;
+    case pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING:
       mode = "AVERAGE"; break;
-    case pool_mode::average_no_pad:
+    case pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING:
       mode = "AVERAGE_NO_PAD"; break;
     default:
       LBANN_ERROR("pooling_layer: no DISTCONV implementation for pooling mode");

--- a/include/lbann/layers/transform/unpooling.hpp
+++ b/include/lbann/layers/transform/unpooling.hpp
@@ -74,7 +74,8 @@ class unpooling_layer : public data_type_layer<TensorDataType> {
         this->get_type()," layer \"",this->get_name(),"\" "
         "does not have a valid pooling layer as a hint layer");
     }
-    if (hint_layer->m_pool_mode != pool_mode::max) {
+    if(hint_layer->m_pool_mode != pooling_mode::MAX &&
+       hint_layer->m_pool_mode != pooling_mode::MAX_DETERMINISTIC) {
       LBANN_ERROR("unpooling layer is only supported with max pooling");
     }
     if (hint_layer->using_gpus()) {

--- a/include/lbann/utils/dnn_lib/cudnn.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn.hpp
@@ -236,12 +236,30 @@ inline cudnnPoolingMode_t to_cudnn(pooling_mode m)
 {
   switch(m)
   {
-  case pooling_mode::MAX: return CUDNN_POOLING_MAX;
+  case pooling_mode::MAX:
+#ifdef LBANN_DETERMINISTIC
+    return CUDNN_POOLING_MAX_DETERMINISTIC;
+#else
+    return CUDNN_POOLING_MAX;
+#endif // LBANN_DETERMINISTIC
   case pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING: return CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING;
   case pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING: return CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING;
   case pooling_mode::MAX_DETERMINISTIC: return CUDNN_POOLING_MAX_DETERMINISTIC;
   default:
-    LBANN_ERROR("Invalid pooling mode requested");
+    LBANN_ERROR("Invalid pooling mode requested.");
+  }
+}
+
+inline pooling_mode from_cudnn(cudnnPoolingMode_t m)
+{
+  switch(m)
+  {
+  case CUDNN_POOLING_MAX: return pooling_mode::MAX;
+  case CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING: return pooling_mode::AVERAGE_COUNT_INCLUDE_PADDING;
+  case CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING: return pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING;
+  case CUDNN_POOLING_MAX_DETERMINISTIC: return pooling_mode::MAX_DETERMINISTIC;
+  default:
+    LBANN_ERROR("Invalid pooling mode requested.");
   }
 }
 

--- a/include/lbann/utils/dnn_lib/dnn_lib.hpp
+++ b/include/lbann/utils/dnn_lib/dnn_lib.hpp
@@ -546,13 +546,13 @@ public:
    *  Allocates a new handle if one doesn't already exist.
    */
   void set(
-    dnnPoolingMode_t mode,
+    pooling_mode mode,
     dnnNanPropagation_t maxpoolingNanOpt,
     std::vector<int> const& window_dims,
     std::vector<int> const& padding,
     std::vector<int> const& stride);
   void set(
-    dnnPoolingMode_t mode,
+    pooling_mode mode,
     dnnNanPropagation_t nan_prop,
     int num_dims,
     int const window_dims[],

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -147,17 +147,6 @@ void finalize(lbann_comm* comm) {
   El::Finalize();
 }
 
-/** hack to avoid long switch/case statement; users should ignore; of interest to developers */
-static std::vector<std::string> pool_mode_names = { "invalid", "max", "average", "average_no_pad" };
-
-/** returns a string representation of the pool_mode */
-std::string get_pool_mode_name(pool_mode m) {
-  if ((int)m < 1 or (int)m >= (int)pool_mode_names.size()) {
-    LBANN_ERROR("Invalid pool_mode");
-  }
-  return pool_mode_names[(int)m];
-}
-
 matrix_format data_layout_to_matrix_format(data_layout layout) {
   matrix_format format;
   switch(layout) {

--- a/src/layers/transform/pooling.cpp
+++ b/src/layers/transform/pooling.cpp
@@ -71,10 +71,6 @@ std::unique_ptr<Layer> build_pooling_layer_from_pbuf(
 
   const auto& mode_str = params.pool_mode();
   pooling_mode mode = to_pool_mode(mode_str);
-  //pool_mode mode = pool_mode::invalid;
-  //if (mode_str == "max" )            { mode = pool_mode::max; }
-  //if (mode_str == "average" )        { mode = pool_mode::average; }
-  //if (mode_str == "average_no_pad" ) { mode = pool_mode::average_no_pad; }
   if (params.has_vectors()) {
     const auto& dims = parse_list<int>(params.pool_dims());
     const auto& pads = parse_list<int>(params.pool_pads());

--- a/src/layers/transform/pooling.cpp
+++ b/src/layers/transform/pooling.cpp
@@ -70,10 +70,11 @@ std::unique_ptr<Layer> build_pooling_layer_from_pbuf(
   const auto& params = proto_layer.pooling();
 
   const auto& mode_str = params.pool_mode();
-  pool_mode mode = pool_mode::invalid;
-  if (mode_str == "max" )            { mode = pool_mode::max; }
-  if (mode_str == "average" )        { mode = pool_mode::average; }
-  if (mode_str == "average_no_pad" ) { mode = pool_mode::average_no_pad; }
+  pooling_mode mode = to_pool_mode(mode_str);
+  //pool_mode mode = pool_mode::invalid;
+  //if (mode_str == "max" )            { mode = pool_mode::max; }
+  //if (mode_str == "average" )        { mode = pool_mode::average; }
+  //if (mode_str == "average_no_pad" ) { mode = pool_mode::average_no_pad; }
   if (params.has_vectors()) {
     const auto& dims = parse_list<int>(params.pool_dims());
     const auto& pads = parse_list<int>(params.pool_pads());

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -883,7 +883,7 @@ PoolingDescriptor::PoolingDescriptor(const PoolingDescriptor& rhs)
     cudnnGetPoolingNdDescriptor(
       rhs.desc_, num_dims, &mode, &nan_prop, &num_dims,
       window_dims.data(), padding.data(), strides.data()));
-  this->set(mode, nan_prop, window_dims, padding, strides);
+  this->set(cudnn::from_cudnn(mode), nan_prop, window_dims, padding, strides);
 }
 
 PoolingDescriptor::PoolingDescriptor(PoolingDescriptor&& rhs)
@@ -935,7 +935,7 @@ void PoolingDescriptor::create()
 }
 
 void PoolingDescriptor::set(
-  cudnnPoolingMode_t mode,
+  pooling_mode mode,
   cudnnNanPropagation_t nan_prop,
   std::vector<int> const& window_dims,
   std::vector<int> const& padding,
@@ -948,7 +948,7 @@ void PoolingDescriptor::set(
 }
 
 void PoolingDescriptor::set(
-  cudnnPoolingMode_t mode,
+  pooling_mode mode,
   cudnnNanPropagation_t nan_prop,
   int num_dims,
   int const window_dims[],
@@ -958,7 +958,8 @@ void PoolingDescriptor::set(
   this->create();
   CHECK_CUDNN(
     cudnnSetPoolingNdDescriptor(
-      desc_, mode, nan_prop, num_dims, window_dims, padding, stride));
+      desc_, cudnn::to_cudnn(mode), nan_prop,
+      num_dims, window_dims, padding, stride));
 }
 
 void swap(PoolingDescriptor& lhs, PoolingDescriptor& rhs)


### PR DESCRIPTION
Addressed the cuDNN-specific code remaining in the pooling layer, specifically involving the pooling mode.  This adds an enum class for `pooling_mode` and adds functions for converting between parameter string input (e.g., "max"), `lbann::pooling_mode` and DNN library-specific values.

This PR includes work from #1679  and #1686 and should be rebased after they are merged.