### PR TITLE
Bugfix distconv

### DIFF
--- a/include/lbann/layers/io/input_layer.hpp
+++ b/include/lbann/layers/io/input_layer.hpp
@@ -183,7 +183,6 @@ class input_layer : public data_type_layer<TensorDataType> {
 #ifdef LBANN_HAS_DISTCONV
   /** @brief Extensions for distributed convolutions */
 ///{@
-  void fp_compute () override;
   using distconv_adapter_type = input_distconv_adapter<TensorDataType, T_layout, Dev>;
   friend distconv_adapter_type;
  protected:

--- a/include/lbann/utils/threads/thread_topology.hpp
+++ b/include/lbann/utils/threads/thread_topology.hpp
@@ -42,8 +42,10 @@ namespace lbann {
 #if defined(LBANN_TOPO_AWARE)
   void hwloc_print_topo();
 
+#if HWLOC_API_VERSION < 0x00020000
+  // This function is implemented in HWLOC 2.1
   int hwloc_bitmap_singlify_per_core(hwloc_topology_t topology, hwloc_bitmap_t cpuset, unsigned which);
-
+#endif
 
   hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo);
 

--- a/scripts/install_lbann.sh
+++ b/scripts/install_lbann.sh
@@ -61,7 +61,7 @@ SPACK_ARCH_TARGET=$(spack arch -t)
 SCRIPT=$(basename ${BASH_SOURCE})
 BUILD_DIR=${LBANN_HOME}/build/spack
 ENABLE_GPUS=ON
-GPU_VARIANTS="+cuda+nccl"
+GPU_VARIANTS="+cuda"
 ENABLE_HALF=OFF
 HALF_VARIANTS="~half"
 BUILD_TYPE=Release
@@ -245,7 +245,7 @@ EOF
 else
     LBANN_ENV="${LBANN_ENV:-lbann-${SPACK_ARCH_TARGET}}"
     BUILD_SPECS=$(cat <<EOF
-  - lbann@develop${GPU_VARIANTS}
+  - lbann@develop${GPU_VARIANTS}+dihydrogen+distconv
 EOF
 )
 fi

--- a/spack_environments/llnl_lc/externals-linux-rhel7-broadwell.sh
+++ b/spack_environments/llnl_lc/externals-linux-rhel7-broadwell.sh
@@ -47,9 +47,9 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-broadwell
+      - spec: hwloc@1.11.13 arch=linux-rhel7-broadwell
         prefix: /usr/lib64/libhwloc.so
     mvapich2::
       buildable: True

--- a/spack_environments/llnl_lc/externals-linux-rhel7-haswell.sh
+++ b/spack_environments/llnl_lc/externals-linux-rhel7-haswell.sh
@@ -47,9 +47,9 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-haswell
+      - spec: hwloc@1.11.13 arch=linux-rhel7-haswell
         prefix: /usr/lib64/libhwloc.so
     mvapich2::
       buildable: True

--- a/spack_environments/llnl_lc/externals-linux-rhel7-ivybridge.sh
+++ b/spack_environments/llnl_lc/externals-linux-rhel7-ivybridge.sh
@@ -47,9 +47,9 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-ivybridge
+      - spec: hwloc@1.11.13 arch=linux-rhel7-ivybridge
         prefix: /usr/lib64/libhwloc.so
     mvapich2::
       buildable: True

--- a/spack_environments/llnl_lc/externals-linux-rhel7-power8le.sh
+++ b/spack_environments/llnl_lc/externals-linux-rhel7-power8le.sh
@@ -47,9 +47,9 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-power8le
+      - spec: hwloc@1.11.13 arch=linux-rhel7-power8le
         prefix: /usr/lib64/libhwloc.so
     openblas::
       buildable: True

--- a/spack_environments/llnl_lc/externals-linux-rhel7-power9le.sh
+++ b/spack_environments/llnl_lc/externals-linux-rhel7-power9le.sh
@@ -45,9 +45,9 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-power9le
+      - spec: hwloc@1.11.13 arch=linux-rhel7-power9le
         prefix: /usr/lib64/libhwloc.so
     openblas::
       buildable: True

--- a/spack_environments/olcf/externals-linux-rhel7-power9le.sh
+++ b/spack_environments/olcf/externals-linux-rhel7-power9le.sh
@@ -26,7 +26,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 10.1.243
       target: []
       compiler: []
-      providers: {}    
+      providers: {}
       externals:
       - spec: cuda@10.1.243 arch=linux-rhel7-power9le
         modules:
@@ -41,7 +41,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 7.4.0
       target: []
       compiler: []
-      providers: {}    
+      providers: {}
       externals:
       - spec: gcc@7.4.0 arch=linux-rhel7-power9le
         modules:
@@ -49,12 +49,12 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     hwloc::
       buildable: False
       version:
-      - 2.0.2
+      - 1.11.13
       target: []
       compiler: []
-      providers: {}    
+      providers: {}
       externals:
-      - spec: hwloc@2.0.2 arch=linux-rhel7-power9le
+      - spec: hwloc@1.11.13 arch=linux-rhel7-power9le
         prefix: /usr/lib64/libhwloc.so
     openblas::
       buildable: True
@@ -77,7 +77,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
        - 20
       target: []
       compiler: []
-      providers: {}    
+      providers: {}
       externals:
       - spec: rdma-core@20 arch=linux-rhel7-power9le
         prefix: /usr
@@ -87,7 +87,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 10.3.1.2-20200121
       target: []
       compiler: []
-      providers: {}    
+      providers: {}
       externals:
       - spec: spectrum-mpi@10.3.1.2-20200121 %gcc@7.4.0 arch=linux-rhel7-power9le
         modules:

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -113,6 +113,11 @@ void input_layer<TensorDataType, T_layout, Dev>::fp_compute() {
   //   LBANN_ERROR("could not fp_compute for I/O layers : encoutered generic_io_buffer type");
   // }
 
+#ifdef LBANN_HAS_DISTCONV
+  if (this->distconv_enabled()) {
+    get_distconv_adapter().fp_compute();
+  }
+#endif // LBANN_HAS_DISTCONV
 }
 
 template <typename TensorDataType,
@@ -509,17 +514,6 @@ keep_original_outputs(int index) const {
   // The original output matrices are always needed as we copy them
   // into distconv tensors.
   return true;
-}
-
-template <typename TensorDataType,
-          data_layout T_layout,
-          El::Device Dev>
-void input_layer<TensorDataType, T_layout, Dev>::
-fp_compute() {
-  generic_input_layer<TensorDataType>::fp_compute();
-  if (this->distconv_enabled()) {
-    get_distconv_adapter().fp_compute();
-  }
 }
 #endif // LBANN_HAS_DISTCONV
 

--- a/src/utils/threads/thread_pool.cpp
+++ b/src/utils/threads/thread_pool.cpp
@@ -8,6 +8,28 @@
 #if defined(HWLOC_API_VERSION) && (HWLOC_API_VERSION < 0x00010b00)
 #define HWLOC_OBJ_NUMANODE HWLOC_OBJ_NODE
 #endif
+
+std::string print_hwloc_version(unsigned long ver) {
+  return std::string{} + std::to_string(ver >> 16) + "." + std::to_string((ver & 0x00ff00) >> 8);
+}
+
+void check_hwloc_api_version() {
+#if HWLOC_API_VERSION >= 0x00020000
+  /* headers are recent */
+  if (hwloc_get_api_version() < 0x20000) {
+    LBANN_ERROR("HWLOC runtime library ", print_hwloc_version(hwloc_get_api_version()),
+                " is older than 2.0 but LBANN was compile with HWLOC API version ",
+                print_hwloc_version(HWLOC_API_VERSION));
+  }
+#else
+  /* headers are pre-2.0 */
+  if (hwloc_get_api_version() >= 0x20000) {
+    LBANN_ERROR("HWLOC runtime library ", print_hwloc_version(hwloc_get_api_version()),
+                " is more recent than 2.0 but LBANN was compile with HWLOC API version ",
+                print_hwloc_version(HWLOC_API_VERSION));
+  }
+#endif
+}
 #endif
 
 #include <algorithm>
@@ -78,6 +100,7 @@ void thread_pool::launch_pinned_threads(
   // hwloc_obj_t core = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0);
   m_threads_offset = PU_offset;
 
+  check_hwloc_api_version();
   //  hwloc_cpuset_t current_cpuset = get_local_cpuset_for_current_thread(topo);
   int i;
   //  hwloc_obj_t obj;

--- a/src/utils/threads/thread_topology.cpp
+++ b/src/utils/threads/thread_topology.cpp
@@ -104,9 +104,15 @@ void hwloc_print_topo()
   {
     hwloc_obj_t core0 = hwloc_get_obj_by_type(topo, HWLOC_OBJ_CORE, 0);
     hwloc_obj_t parent = core0;
+#if HWLOC_API_VERSION >= 0x00020000
+    while (parent && !parent->attr->numanode.local_memory)
+      parent = parent->parent;
+    printf("%llu bytes\n", (unsigned long long) parent->attr->numanode.local_memory);
+#else
     while (parent && !parent->memory.local_memory)
       parent = parent->parent;
     printf("%llu bytes\n", (unsigned long long) parent->memory.local_memory);
+#endif
   }
 
   {
@@ -123,6 +129,7 @@ void hwloc_print_topo()
   return;
 }
 
+#if HWLOC_API_VERSION < 0x00020000
 // This function is implemented in HWLOC 2.1
 int hwloc_bitmap_singlify_per_core(hwloc_topology_t topology, hwloc_bitmap_t cpuset, unsigned which)
 {
@@ -151,6 +158,7 @@ int hwloc_bitmap_singlify_per_core(hwloc_topology_t topology, hwloc_bitmap_t cpu
   }
   return 0;
 }
+#endif
 
 hwloc_cpuset_t get_local_cpuset_for_current_thread(hwloc_topology_t topo) {
   hwloc_cpuset_t local_cpuset = hwloc_bitmap_alloc();


### PR DESCRIPTION
Fixed a bug in the input layer when DistConv is enabled.  Corrected flags in the `install_lbann.sh` script to keep up with updates to the spack recipes. Added DiHydrogen and DistConv variants to the install script when building LBANN.