### PR TITLE
Replace raw layer pointers with smart pointers

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -346,9 +346,9 @@ public:
   size_t find_child_layer_index(const Layer& l) const;
 
   /** Get number of parent layers. */
-  int get_num_parents() const { return get_parent_layers().size(); }
+  int get_num_parents() const { return m_parent_layers.size(); }
   /** Get number of child layers. */
-  int get_num_children() const { return get_child_layers().size(); }
+  int get_num_children() const { return m_child_layers.size(); }
 
   std::string get_parent_names() const;
   std::string get_child_names() const;

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -374,9 +374,9 @@ public:
   void replace_child_layer(ViewingLayerPtr l, size_t index);
 
   /** @brief Remove pointers to parent layers */
-  void clear_parent_layers() { get_parent_layers().clear(); }
+  void clear_parent_layers() { m_parent_layers.clear(); }
   /** @brief Remove pointers to child layers */
-  void clear_child_layers() { get_child_layers().clear(); }
+  void clear_child_layers() { m_child_layers.clear(); }
 
   ViewingLayerPtr get_parent_layer_pointer(size_t index) const;
   ViewingLayerPtr get_child_layer_pointer(size_t index) const;

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -346,9 +346,9 @@ public:
   size_t find_child_layer_index(const Layer& l) const;
 
   /** Get number of parent layers. */
-  size_t get_num_parents() const { return get_parent_layers().size(); }
+  int get_num_parents() const { return get_parent_layers().size(); }
   /** Get number of child layers. */
-  size_t get_num_children() const { return get_child_layers().size(); }
+  int get_num_children() const { return get_child_layers().size(); }
 
   std::string get_parent_names() const;
   std::string get_child_names() const;

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -54,7 +54,7 @@ namespace lbann {
         std::stringstream err;                                              \
         err << this->get_type() << " layer \"" << this->get_name() << "\" " \
             << "has input tensors with different dimensions (";             \
-        for (size_t i = 0; i < this->get_num_parents(); ++i) {              \
+        for (int i = 0; i < this->get_num_parents(); ++i) {                 \
           const auto& dims = this->get_input_dims(i);                       \
           err << (i > 0 ? ", " : "")                                        \
               << "layer \"" << parents[i]->get_name() << "\" outputs ";     \

--- a/include/lbann/layers/math/binary.hpp
+++ b/include/lbann/layers/math/binary.hpp
@@ -54,7 +54,7 @@ namespace lbann {
         std::stringstream err;                                              \
         err << this->get_type() << " layer \"" << this->get_name() << "\" " \
             << "has input tensors with different dimensions (";             \
-        for (int i = 0; i < this->get_num_parents(); ++i) {                 \
+        for (size_t i = 0; i < this->get_num_parents(); ++i) {              \
           const auto& dims = this->get_input_dims(i);                       \
           err << (i > 0 ? ", " : "")                                        \
               << "layer \"" << parents[i]->get_name() << "\" outputs ";     \

--- a/include/lbann/layers/misc/argmax.hpp
+++ b/include/lbann/layers/misc/argmax.hpp
@@ -61,7 +61,7 @@ protected:
     if (input_dims.size() != 1) {
       LBANN_ERROR(get_type()," layer \"",this->get_name(),"\" ",
                   "expects a 1-D input tensor, ",
-                  "but parent layer \"",this->m_parent_layers[0]->get_name(),"\" ",
+                  "but parent layer \"",this->get_parent_layer().get_name(),"\" ",
                   "outputs a ",input_dims.size(),"-D tensor");
     }
 

--- a/include/lbann/layers/misc/argmin.hpp
+++ b/include/lbann/layers/misc/argmin.hpp
@@ -61,7 +61,7 @@ protected:
     if (input_dims.size() != 1) {
       LBANN_ERROR(get_type()," layer \"",this->get_name(),"\" ",
                   "expects a 1-D input tensor, ",
-                  "but parent layer \"",this->m_parent_layers[0]->get_name(),"\" ",
+                  "but parent layer \"",this->get_parent_layer().get_name(),"\" ",
                   "outputs a ",input_dims.size(),"-D tensor");
     }
 

--- a/include/lbann/metrics/layer_metric.hpp
+++ b/include/lbann/metrics/layer_metric.hpp
@@ -53,16 +53,16 @@ class layer_metric : public metric {
   }
 
   /** Set corresponding layer. */
-  void set_layer(Layer& l);
+  void set_layer(ViewingLayerPtr l);
   /** Get corresponding layer. */
   Layer& get_layer();
   /** Get corresponding layer (const). */
   const Layer& get_layer() const;
 
   /** Get list of pointers to layers. */
-  std::vector<Layer*> get_layer_pointers() const override;
+  std::vector<ViewingLayerPtr> get_layer_pointers() const override;
   /** Set list of pointers to layers. */
-  void set_layer_pointers(std::vector<Layer*> layers) override;
+  void set_layer_pointers(std::vector<ViewingLayerPtr> layers) override;
 
     /** Save metric state to checkpoint. */
   bool save_to_checkpoint_shared(persist& p);
@@ -96,7 +96,7 @@ class layer_metric : public metric {
    */
   std::string m_unit;
   /** Corresponding layer. */
-  Layer* m_layer;
+  ViewingLayerPtr m_layer;
 
   /** Get corresponding evaluation layer. */
   /*abstract_evaluation_*/Layer& get_evaluation_layer();

--- a/include/lbann/metrics/metric.hpp
+++ b/include/lbann/metrics/metric.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
+#include "lbann/layers/layer.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/io/persist.hpp"
 #include <cereal/types/base_class.hpp>
@@ -38,7 +39,6 @@ namespace lbann {
 
 // Forward declarations
 class model;
-class Layer;
 
 /** Metric statistics. */
 struct metric_statistics {
@@ -140,9 +140,9 @@ class metric {
   int get_statistics_num_samples(execution_mode mode) const;
 
   /** Get list of pointers to layers. */
-  virtual std::vector<Layer*> get_layer_pointers() const;
+  virtual std::vector<ViewingLayerPtr> get_layer_pointers() const;
   /** Set list of pointers to layers. */
-  virtual void set_layer_pointers(std::vector<Layer*> layers);
+  virtual void set_layer_pointers(std::vector<ViewingLayerPtr> layers);
 
   /** Get the time spent in evaluation for this metric (const). */
   EvalType get_evaluate_time() const { return m_evaluate_time; }

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -183,7 +183,7 @@ public:
   // ===========================================
 
   /** @brief Add layer to model. */
-  virtual void add_layer(std::unique_ptr<Layer> l);
+  virtual void add_layer(OwningLayerPtr&& l);
 
   /** @brief Add weights to model. */
   void add_weights(std::unique_ptr<weights> w);
@@ -299,8 +299,9 @@ protected:
    *  maps. If a pointer is not a key in the corresponding map, the
    *  pointer is not changed.
    */
-  virtual void remap_pointers(const std::unordered_map<Layer*,Layer*>& layer_map,
-                              const std::unordered_map<weights*,weights*>& weights_map);
+  virtual void remap_pointers(
+    const std::unordered_map<Layer*,ViewingLayerPtr>& layer_map,
+    const std::unordered_map<weights*,weights*>& weights_map);
 
   /** @brief
    *
@@ -427,7 +428,7 @@ private:
   /** @brief Tensor operations.
    *  @details The list is in execution order for forward propagation.
    */
-  std::vector<std::unique_ptr<Layer>> m_layers;
+  std::vector<OwningLayerPtr> m_layers;
 
   /** @brief Trainable parameters. */
   std::vector<std::unique_ptr<weights>> m_weights;

--- a/include/lbann/objective_functions/layer_term.hpp
+++ b/include/lbann/objective_functions/layer_term.hpp
@@ -39,7 +39,7 @@ public:
   std::string name() const override { return "evaluation layer term"; }
 
   /** Set corresponding layer. */
-  void set_layer(Layer& l);
+  void set_layer(ViewingLayerPtr l);
   /** Get corresponding layer. */
   Layer& get_layer();
   /** Get corresponding layer (const). */

--- a/include/lbann/objective_functions/objective_function.hpp
+++ b/include/lbann/objective_functions/objective_function.hpp
@@ -112,9 +112,9 @@ class objective_function {
   int get_statistics_num_samples(execution_mode mode) const;
 
   /** Get list of pointers to layers. */
-  std::vector<Layer*> get_layer_pointers() const;
+  std::vector<ViewingLayerPtr> get_layer_pointers() const;
   /** Set list of pointers to layers. */
-  void set_layer_pointers(std::vector<Layer*> layers);
+  void set_layer_pointers(std::vector<ViewingLayerPtr> layers);
   /** Get list of pointers to weights. */
   std::vector<weights*> get_weights_pointers() const;
   /** Set list of pointers to weights. */

--- a/include/lbann/objective_functions/objective_function_term.hpp
+++ b/include/lbann/objective_functions/objective_function_term.hpp
@@ -81,9 +81,9 @@ class objective_function_term {
   virtual void compute_weight_regularization() = 0;
 
   /** Get list of pointers to layers. */
-  std::vector<Layer*> get_layer_pointers() const { return m_layers; }
+  std::vector<ViewingLayerPtr> get_layer_pointers() const;
   /** Set list of pointers to layers. */
-  void set_layer_pointers(std::vector<Layer*> layers) { m_layers = layers; }
+  void set_layer_pointers(std::vector<ViewingLayerPtr> layers);
   /** Get list of pointers to weights. */
   std::vector<weights*> get_weights_pointers() const { return m_weights; }
   /** Set list of pointers to weights. */
@@ -95,7 +95,7 @@ class objective_function_term {
   EvalType m_scale_factor;
 
   /** Layers used to compute objective function term. */
-  std::vector<Layer*> m_layers;
+  std::vector<ViewingLayerPtr> m_layers;
   /** Weights used to compute objective function term. */
   std::vector<weights*> m_weights;
 

--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_PROTO_FACTORIES_HPP_INCLUDED
 #define LBANN_PROTO_FACTORIES_HPP_INCLUDED
 
+#include "lbann/layers/layer.hpp"
 #include "lbann/data_readers/data_reader.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/transforms/transform.hpp"
@@ -74,7 +75,7 @@ std::unique_ptr<model> construct_model(
   const lbann_data::Model& proto_model);
 
 /** Construct a layer graph specified with a prototext. */
-std::vector<std::unique_ptr<Layer>> construct_layer_graph(
+std::vector<OwningLayerPtr> construct_layer_graph(
   lbann_comm* comm,
   int training_dr_linearized_data_size,
   const lbann_data::Trainer& proto_trainer,

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -331,7 +331,7 @@ auto data_type_layer<TensorDataType>::get_activations(const Layer& child) const 
   if (this->get_num_children() <= 0) {
     LBANN_ERROR("This layer has no children");
   }
-  const auto child_index = find_child_layer_index(child);
+  const int child_index = find_child_layer_index(child);
   if (child_index >= get_num_children()) {
     std::stringstream err;
     err << "attempted to get activation tensor of "
@@ -344,7 +344,7 @@ auto data_type_layer<TensorDataType>::get_activations(const Layer& child) const 
 }
 template <typename TensorDataType>
 auto data_type_layer<TensorDataType>::get_error_signals(const Layer& parent) const -> const BaseDistMat& {
-  const auto parent_index = find_parent_layer_index(parent);
+  const int parent_index = find_parent_layer_index(parent);
   if (parent_index >= get_num_parents()) {
     LBANN_ERROR("attempted to get error signal tensor of "
                 "layer \"", get_name(), "\" "
@@ -484,7 +484,7 @@ void data_type_layer<TensorDataType>::setup_data(size_t max_mini_batch_size) {
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::bp_compute() {
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
     El::Zero(get_error_signals(i));
   }
 }
@@ -513,21 +513,21 @@ void data_type_layer<TensorDataType>::check_setup() {
   }
 
   // Check that tensors are initialized
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
     if (m_inputs[i] == nullptr) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized input tensor (index " << i << ")";
       LBANN_ERROR(err.str());
     }
   }
-  for (size_t i = 0; i < get_num_children(); ++i) {
+  for (int i = 0; i < get_num_children(); ++i) {
     if (m_outputs[i] == nullptr) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized output tensor (index " << i << ")";
       LBANN_ERROR(err.str());
     }
   }
-  for (size_t i = 0; i < get_num_children(); ++i) {
+  for (int i = 0; i < get_num_children(); ++i) {
     if (!m_gradient_wrt_outputs[i]) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized gradient w.r.t. output tensor "
@@ -535,7 +535,7 @@ void data_type_layer<TensorDataType>::check_setup() {
       LBANN_ERROR(err.str());
     }
   }
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
     if (!m_gradient_wrt_inputs[i]) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized gradient w.r.t. input tensor "
@@ -553,7 +553,7 @@ void data_type_layer<TensorDataType>::fp_setup_inputs(El::Int mini_batch_size) {
   const auto& alignment_dist = get_parent_layer().get_activations(*this).DistData();
 
   // Iterate through input tensors
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
@@ -611,7 +611,7 @@ void data_type_layer<TensorDataType>::fp_setup_outputs(El::Int mini_batch_size) 
                                 get_activations().DistData());
 
   // Initialize output tensors
-  for (size_t i = 0; i < get_num_children(); ++i) {
+  for (int i = 0; i < get_num_children(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_outputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
@@ -786,7 +786,7 @@ void deep_copy_error_signal(
 // etc is OK.
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::propagate_error_signals_to_parents_() {
-  for (size_t i=0; i<get_num_parents(); ++i) {
+  for (int i=0; i<get_num_parents(); ++i) {
     auto& parent = const_cast<Layer&>(get_parent_layer(i));
 
     // If my error signals persist, my parent can always view them,
@@ -806,7 +806,7 @@ void data_type_layer<TensorDataType>::propagate_error_signals_to_parents_() {
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::allocate_new_gradients_() {
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_gradient_wrt_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
@@ -827,7 +827,7 @@ template <typename TensorDataType>
 void data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(
   El::Int mini_batch_size)
 {
-  for (size_t i = 0; i < get_num_parents(); ++i) {
+  for (int i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_gradient_wrt_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -328,10 +328,10 @@ auto data_type_layer<TensorDataType>::get_local_error_signals(int parent_index) 
 // Accessing matrices corresponding to parent/child layer
 template <typename TensorDataType>
 auto data_type_layer<TensorDataType>::get_activations(const Layer& child) const -> const BaseDistMat& {
-  if(m_child_layers.empty()) {
+  if (this->get_num_children() <= 0) {
     LBANN_ERROR("This layer has no children");
   }
-  const int child_index = find_child_layer_index(&child);
+  const auto child_index = find_child_layer_index(child);
   if (child_index >= get_num_children()) {
     std::stringstream err;
     err << "attempted to get activation tensor of "
@@ -344,7 +344,7 @@ auto data_type_layer<TensorDataType>::get_activations(const Layer& child) const 
 }
 template <typename TensorDataType>
 auto data_type_layer<TensorDataType>::get_error_signals(const Layer& parent) const -> const BaseDistMat& {
-  const int parent_index = find_parent_layer_index(&parent);
+  const auto parent_index = find_parent_layer_index(parent);
   if (parent_index >= get_num_parents()) {
     LBANN_ERROR("attempted to get error signal tensor of "
                 "layer \"", get_name(), "\" "
@@ -484,7 +484,7 @@ void data_type_layer<TensorDataType>::setup_data(size_t max_mini_batch_size) {
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::bp_compute() {
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
     El::Zero(get_error_signals(i));
   }
 }
@@ -513,21 +513,21 @@ void data_type_layer<TensorDataType>::check_setup() {
   }
 
   // Check that tensors are initialized
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
     if (m_inputs[i] == nullptr) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized input tensor (index " << i << ")";
       LBANN_ERROR(err.str());
     }
   }
-  for (int i = 0; i < get_num_children(); ++i) {
+  for (size_t i = 0; i < get_num_children(); ++i) {
     if (m_outputs[i] == nullptr) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized output tensor (index " << i << ")";
       LBANN_ERROR(err.str());
     }
   }
-  for (int i = 0; i < get_num_children(); ++i) {
+  for (size_t i = 0; i < get_num_children(); ++i) {
     if (!m_gradient_wrt_outputs[i]) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized gradient w.r.t. output tensor "
@@ -535,7 +535,7 @@ void data_type_layer<TensorDataType>::check_setup() {
       LBANN_ERROR(err.str());
     }
   }
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
     if (!m_gradient_wrt_inputs[i]) {
       err << "layer \"" << get_name() << "\" has an "
           << "uninitialized gradient w.r.t. input tensor "
@@ -550,15 +550,15 @@ void data_type_layer<TensorDataType>::fp_setup_inputs(El::Int mini_batch_size) {
   if (get_num_parents() < 1) { return; }
 
   // Determine distributed matrix alignment
-  const auto& alignment_dist = m_parent_layers.front()->get_activations(*this).DistData();
+  const auto& alignment_dist = get_parent_layer().get_activations(*this).DistData();
 
   // Iterate through input tensors
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
     // Initialize input tensor
-    const auto& parent = *m_parent_layers[i];
+    const auto& parent = get_parent_layer(i);
     const auto& parent_output = parent.get_activations(*this);
     auto& input = *m_inputs[i];
     input.Empty(false);
@@ -611,7 +611,7 @@ void data_type_layer<TensorDataType>::fp_setup_outputs(El::Int mini_batch_size) 
                                 get_activations().DistData());
 
   // Initialize output tensors
-  for (int i = 0; i < get_num_children(); ++i) {
+  for (size_t i = 0; i < get_num_children(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_outputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
@@ -665,31 +665,13 @@ void assert_tensor_size(const BaseDistMat& mat,
   }
 }
 
-// Layers only store pointers-to-const to their
-// parents/children. Sometimes we need nonconst access to be able to
-// efficiently move/swap things.
-Layer& get_nonconst_layer(std::vector<Layer*> const& layers,
-                          Layer const* layer_in)
-{
-  // Thanks to the lack of const-correctness in Layers, we cannot
-  // modify parent/child layers directly, but we can through the
-  // model. Unfortunately, this costs us a linear search through the
-  // layer list. Maybe it's better to just "const-cast" things away,
-  // since const-correctness is already long gone.
-  auto p_layer_it = std::find(begin(layers), end(layers), layer_in);
-  if (p_layer_it == end(layers)) {
-    LBANN_ERROR("Layer \"", layer_in->get_name(), "\" not found in model.");
-  }
-  return **p_layer_it;
-}
-
 }// namespace <anon>
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::view_or_copy_prev_error_signal_(
   const Layer& child, const BaseDistMat& signal)
 {
-  auto layer_idx = find_child_layer_index(std::addressof(child));
+  auto layer_idx = find_child_layer_index(child);
 #ifdef LBANN_HAS_DISTCONV
   if (!keep_original_gradient_wrt_outputs(layer_idx)) return;
 #endif // LBANN_HAS_DISTCONV
@@ -715,7 +697,7 @@ template <typename TensorDataType>
 void data_type_layer<TensorDataType>::move_or_copy_prev_error_signal_(
   const Layer& child, std::unique_ptr<BaseDistMat> signal_in)
 {
-    auto layer_idx = find_child_layer_index(std::addressof(child));
+    auto layer_idx = find_child_layer_index(child);
 #ifdef LBANN_HAS_DISTCONV
   if (!keep_original_gradient_wrt_outputs(layer_idx)) return;
 #endif // LBANN_HAS_DISTCONV
@@ -756,7 +738,7 @@ template <typename TensorDataType>
 void data_type_layer<TensorDataType>::deep_copy_prev_error_signal_(
   const Layer& child, const BaseDistMat& signal)
 {
-  auto layer_idx = find_child_layer_index(std::addressof(child));
+  auto layer_idx = find_child_layer_index(child);
 #ifdef LBANN_HAS_DISTCONV
   if (!keep_original_gradient_wrt_outputs(layer_idx)) return;
 #endif // LBANN_HAS_DISTCONV
@@ -804,29 +786,27 @@ void deep_copy_error_signal(
 // etc is OK.
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::propagate_error_signals_to_parents_() {
-  auto& parents = get_parent_layers();
-  std::vector<Layer*> layer_list = get_model()->get_layers();
-  for (size_t p_idx = 0; p_idx < parents.size(); ++p_idx) {
-    Layer& parent = get_nonconst_layer(layer_list, parents[p_idx]);
+  for (size_t i=0; i<get_num_parents(); ++i) {
+    auto& parent = const_cast<Layer&>(get_parent_layer(i));
 
     // If my error signals persist, my parent can always view them,
     // assuming the distdata is right. Otherwise, my views and my data
     // will be released. Views must be copied and owned data can
     // either be copied or swapped out.
-    auto& error_signal = *m_gradient_wrt_inputs[p_idx];
+    auto& error_signal = *m_gradient_wrt_inputs[i];
     if (m_persistent_error_signals)
       attempt_view_error_signal(parent, *this, error_signal);
     else if (error_signal.Viewing())
       deep_copy_error_signal(parent, *this, error_signal);
     else
       attempt_move_error_signal(parent, *this,
-                                std::move(m_gradient_wrt_inputs[p_idx]));
+                                std::move(m_gradient_wrt_inputs[i]));
   }
 }
 
 template <typename TensorDataType>
 void data_type_layer<TensorDataType>::allocate_new_gradients_() {
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_gradient_wrt_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV
@@ -847,7 +827,7 @@ template <typename TensorDataType>
 void data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(
   El::Int mini_batch_size)
 {
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
 #ifdef LBANN_HAS_DISTCONV
     if (!keep_original_gradient_wrt_inputs(i)) continue;
 #endif // LBANN_HAS_DISTCONV

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -37,7 +37,7 @@ template <typename TensorDataType,
 void input_layer<TensorDataType, T_layout, Dev>::
 setup_dims(DataReaderMetaData& dr_metadata) {
   data_type_layer<TensorDataType>::setup_dims(dr_metadata);
-  for (int i = 0; i < this->get_num_children(); ++i) {
+  for (size_t i = 0; i < this->get_num_children(); ++i) {
     this->set_output_dims(get_data_dims(dr_metadata, i), i);
   }
 }
@@ -49,7 +49,7 @@ void input_layer<TensorDataType, T_layout, Dev>::setup_data(size_t max_mini_batc
   data_type_layer<TensorDataType>::setup_data(max_mini_batch_size);
 
   // Resize output to maximum mini-batch size
-  for (int i = 0; i < this->get_num_children(); ++i) {
+  for (size_t i = 0; i < this->get_num_children(); ++i) {
     auto& output = this->get_activations(i);
     output.Resize(output.Height(), max_mini_batch_size);
   }
@@ -213,7 +213,7 @@ input_distconv_adapter(Layer& layer, const bool shuffle_required)
   m_shuffle_required(shuffle_required) {
   // Input data is only processed when its consumer layer is also
   // enabled for distconv
-  for (int i = 0; i < layer.get_num_children(); ++i) {
+  for (size_t i = 0; i < layer.get_num_children(); ++i) {
     m_is_input_processed.push_back(layer.get_child_layers()[i]->distconv_enabled());
   }
   if (m_shuffle_required) {
@@ -263,7 +263,7 @@ template <typename TensorDataType,
 void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
   const auto sample_dist = dc::get_hydrogen_data_parallel_distribution(
       dc::get_num_dims(this->layer()));
-  for (int mat_idx = 0; mat_idx < this->layer().get_num_children(); ++mat_idx) {
+  for (size_t mat_idx = 0; mat_idx < this->layer().get_num_children(); ++mat_idx) {
     if (!is_input_processed(mat_idx)) continue;
 
     const auto shape = this->get_activations_shape(mat_idx);
@@ -434,7 +434,7 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::fp_compute() {
   const int mb_size = static_cast<sgd_execution_context&>(
       l.get_model()->get_execution_context()).get_current_mini_batch_size();
 
-  for (int mat_idx = 0; mat_idx < l.get_num_children(); ++mat_idx) {
+  for (size_t mat_idx = 0; mat_idx < l.get_num_children(); ++mat_idx) {
     if (!is_input_processed(mat_idx)) continue;
 
     // TODO: This is diabled as it raises an error when the HDF5 data

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -37,7 +37,7 @@ template <typename TensorDataType,
 void input_layer<TensorDataType, T_layout, Dev>::
 setup_dims(DataReaderMetaData& dr_metadata) {
   data_type_layer<TensorDataType>::setup_dims(dr_metadata);
-  for (size_t i = 0; i < this->get_num_children(); ++i) {
+  for (int i = 0; i < this->get_num_children(); ++i) {
     this->set_output_dims(get_data_dims(dr_metadata, i), i);
   }
 }
@@ -49,7 +49,7 @@ void input_layer<TensorDataType, T_layout, Dev>::setup_data(size_t max_mini_batc
   data_type_layer<TensorDataType>::setup_data(max_mini_batch_size);
 
   // Resize output to maximum mini-batch size
-  for (size_t i = 0; i < this->get_num_children(); ++i) {
+  for (int i = 0; i < this->get_num_children(); ++i) {
     auto& output = this->get_activations(i);
     output.Resize(output.Height(), max_mini_batch_size);
   }
@@ -213,7 +213,7 @@ input_distconv_adapter(Layer& layer, const bool shuffle_required)
   m_shuffle_required(shuffle_required) {
   // Input data is only processed when its consumer layer is also
   // enabled for distconv
-  for (size_t i = 0; i < layer.get_num_children(); ++i) {
+  for (int i = 0; i < layer.get_num_children(); ++i) {
     m_is_input_processed.push_back(layer.get_child_layers()[i]->distconv_enabled());
   }
   if (m_shuffle_required) {
@@ -263,7 +263,7 @@ template <typename TensorDataType,
 void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
   const auto sample_dist = dc::get_hydrogen_data_parallel_distribution(
       dc::get_num_dims(this->layer()));
-  for (size_t mat_idx = 0; mat_idx < this->layer().get_num_children(); ++mat_idx) {
+  for (int mat_idx = 0; mat_idx < this->layer().get_num_children(); ++mat_idx) {
     if (!is_input_processed(mat_idx)) continue;
 
     const auto shape = this->get_activations_shape(mat_idx);
@@ -434,7 +434,7 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::fp_compute() {
   const int mb_size = static_cast<sgd_execution_context&>(
       l.get_model()->get_execution_context()).get_current_mini_batch_size();
 
-  for (size_t mat_idx = 0; mat_idx < l.get_num_children(); ++mat_idx) {
+  for (int mat_idx = 0; mat_idx < l.get_num_children(); ++mat_idx) {
     if (!is_input_processed(mat_idx)) continue;
 
     // TODO: This is diabled as it raises an error when the HDF5 data

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -679,7 +679,7 @@ void Layer::replace_child_layer(ViewingLayerPtr l, size_t index) {
 }
 
 ViewingLayerPtr Layer::get_parent_layer_pointer(size_t index) const {
-  if (index >= m_child_layers.size()) {
+  if (index >= m_parent_layers.size()) {
     LBANN_ERROR(
       "attempted to get pointer to parent ",index," of ",
       get_type()," layer \"",get_name(),"\", ",

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -63,8 +63,6 @@ Layer::Layer(lbann_comm *comm)
 
 Layer::Layer(const Layer& other) :
   m_comm(other.m_comm),
-  m_parent_layers(other.m_parent_layers),
-  m_child_layers(other.m_child_layers),
   m_expected_num_parent_layers(other.m_expected_num_parent_layers),
   m_expected_num_child_layers(other.m_expected_num_child_layers),
   m_model(other.m_model),
@@ -75,6 +73,8 @@ Layer::Layer(const Layer& other) :
   m_bp_compute_time(other.m_bp_compute_time),
   m_update_time(other.m_update_time),
   m_name(other.m_name),
+  m_parent_layers(other.m_parent_layers),
+  m_child_layers(other.m_child_layers),
   m_weights(other.m_weights),
   m_output_dims_list(other.m_output_dims_list),
   m_hint_layer(other.m_hint_layer) {
@@ -84,8 +84,6 @@ Layer& Layer::operator=(const Layer& other) {
 
   // Shallow copies
   m_comm = other.m_comm;
-  m_parent_layers = other.m_parent_layers;
-  m_child_layers = other.m_child_layers;
   m_expected_num_parent_layers = other.m_expected_num_parent_layers;
   m_expected_num_child_layers = other.m_expected_num_child_layers;
   m_model = other.m_model;
@@ -96,6 +94,8 @@ Layer& Layer::operator=(const Layer& other) {
   m_bp_compute_time = other.m_bp_compute_time;
   m_update_time = other.m_update_time;
   m_name = other.m_name;
+  m_parent_layers = other.m_parent_layers;
+  m_child_layers = other.m_child_layers;
   m_weights = other.m_weights;
   m_output_dims_list = other.m_output_dims_list;
   m_hint_layer = other.m_hint_layer;
@@ -255,46 +255,13 @@ void Layer::summarize_stats(lbann_summary& summarizer, int step) {
 // Tensor dimension access functions
 // ===================================================================
 
-std::vector<int> Layer::get_input_dims(int input_index) const {
-
-  // Get parent layer
-  const auto& num_inputs = get_num_parents();
-  if (input_index < 0 || input_index >= num_inputs) {
-    std::stringstream err;
-    err << "attempted to access dimensions of invalid input tensor "
-        << "in layer \"" << get_name() << "\" "
-        << "(requested index " << input_index << ", but there are "
-        << num_inputs << " input tensors)";
-    LBANN_ERROR(err.str());
-  } else if (m_parent_layers[input_index] == nullptr) {
-    std::stringstream err;
-    err << "layer \"" << get_name() << "\" "
-        << "has a null pointer to parent layer "
-        << "(index " << input_index << ")";
-    LBANN_ERROR(err.str());
-  }
-  const auto& parent = *m_parent_layers[input_index];
-
-  // Get dimensions of corresponding output tensor in parent layer
-  const auto num_parent_outputs = parent.get_num_children();
-  const int parent_output_index = parent.find_child_layer_index(this);
-  if (parent_output_index >= num_parent_outputs) {
-    std::stringstream err;
-    err << "layer \"" << parent.get_name() << "\" is a parent of "
-        << "layer \"" << get_name() << "\", but "
-        << "\"" << get_name() << "\" is not a child of "
-        << "\"" << parent.get_name() << "\"";
-    LBANN_ERROR(err.str());
-  }
+std::vector<int> Layer::get_input_dims(size_t input_index) const {
+  const auto& parent = get_parent_layer(input_index);
+  const auto parent_output_index = parent.find_child_layer_index(*this);
   return parent.get_output_dims(parent_output_index);
-
 }
 
-// ===========================================================
-// Tensor dimension access functions
-// ===========================================================
-
-int Layer::get_input_size(int input_index) const {
+int Layer::get_input_size(size_t input_index) const {
   const auto& dims = get_input_dims(input_index);
   if (dims.empty()) {
     return 0;
@@ -304,15 +271,15 @@ int Layer::get_input_size(int input_index) const {
   }
 }
 
-std::vector<int> Layer::get_output_dims(int output_index) const {
+std::vector<int> Layer::get_output_dims(size_t output_index) const {
   const auto num_outputs = get_num_children();
-  if ((int) m_output_dims_list.size() != num_outputs) {
+  if (m_output_dims_list.size() != num_outputs) {
     std::stringstream err;
     err << "attempted to access dimensions of output tensor "
         << "in layer \"" << get_name() << "\" "
         << "before they are initialized";
     LBANN_ERROR(err.str());
-  } else if (output_index < 0 || output_index >= num_outputs) {
+  } else if (output_index >= num_outputs) {
     std::stringstream err;
     err << "attempted to access dimensions of invalid output tensor "
         << "in layer \"" << get_name() << "\" "
@@ -323,7 +290,7 @@ std::vector<int> Layer::get_output_dims(int output_index) const {
   return m_output_dims_list[output_index];
 }
 
-int Layer::get_output_size(int output_index) const {
+int Layer::get_output_size(size_t output_index) const {
   const auto& dims = get_output_dims(output_index);
   if (dims.empty()) {
     return 0;
@@ -333,9 +300,9 @@ int Layer::get_output_size(int output_index) const {
   }
 }
 
-void Layer::set_output_dims(std::vector<int> dims, int output_index) {
-  if ((int) m_output_dims_list.size() != get_num_children()
-      || (int) m_output_dims_list.size() <= output_index) {
+void Layer::set_output_dims(std::vector<int> dims, size_t output_index) {
+  if (m_output_dims_list.size() != get_num_children()
+      || m_output_dims_list.size() <= output_index) {
     // Handles case where dims are set before child layers are set
     m_output_dims_list.resize(std::max(get_num_children(),
                                        output_index + 1));
@@ -370,6 +337,14 @@ void Layer::replace_weights(Layer const& other_layer) {
     auto const& other_layer_weights = other_layer.get_weights(ii);
     this->get_weights(ii).set_values(other_layer_weights.get_values());
   }
+}
+
+void Layer::set_hint_layer(ViewingLayerPtr l) {
+  m_hint_layer = std::move(l);
+}
+
+const Layer* Layer::get_hint_layer() const {
+  return m_hint_layer.lock().get();
 }
 
 void Layer::freeze() {
@@ -408,90 +383,59 @@ void Layer::setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata) {
 }
 
 void Layer::setup_pointers() {
-  std::stringstream err;
 
   // Check that the parent pointers are valid
-  for (size_t i = 0; i < m_parent_layers.size(); ++i) {
-    const auto* parent = m_parent_layers[i];
-    if (parent == nullptr) {
-      err << "layer \"" << get_name() << "\" "
-          << "has a null pointer to parent layer " << i;
-      LBANN_ERROR(err.str());
-    }
-    const auto& parent_children = parent->m_child_layers;
-    if (std::find(parent_children.begin(), parent_children.end(), this)
-        == parent_children.end()) {
-      err << "layer \"" << parent->get_name() << "\" is a parent of "
-          << "layer \"" << get_name() << "\", but "
-          << "\"" << get_name() << "\" is not a child of "
-          << "\"" << parent->get_name() << "\"";
-      LBANN_ERROR(err.str());
+  for (size_t i = 0; i < get_num_parents(); ++i) {
+    const auto& parent = get_parent_layer(i);
+    const auto index_in_parent = parent.find_child_layer_index(*this);
+    if (index_in_parent >= parent.get_num_children()) {
+      LBANN_ERROR(
+        parent.get_type()," layer \"",parent.get_name(),"\" ",
+        "is a parent of ",get_type()," layer \"",get_name(),"\", ",
+        "but \"",get_name(),"\" is not a child of \"",parent.get_name(),"\"");
     }
   }
 
   // Check that the child pointers are valid
-  for (size_t i = 0; i < m_child_layers.size(); ++i) {
-    const auto* child = m_child_layers[i];
-    if (child == nullptr) {
-      err << "layer \"" << get_name() << "\" "
-          << "has a null pointer to child layer " << i;
-      LBANN_ERROR(err.str());
-    }
-    const auto& child_parents = child->m_parent_layers;
-    if (std::find(child_parents.begin(), child_parents.end(), this)
-        == child_parents.end()) {
-      err << "layer \"" << child->get_name() << "\" is a child of "
-          << "layer \"" << get_name() << "\", but "
-          << "\"" << get_name() << "\" is not a parent of "
-          << "\"" << child->get_name() << "\"";
-      LBANN_ERROR(err.str());
+  for (size_t i = 0; i < get_num_children(); ++i) {
+    const auto& child = get_child_layer(i);
+    const auto index_in_child = child.find_parent_layer_index(*this);
+    if (index_in_child >= child.get_num_parents()) {
+      LBANN_ERROR(
+        child.get_type()," layer \"",child.get_name(),"\" ",
+        "is a child of ",get_type()," layer \"",get_name(),"\", ",
+        "but \"",get_name(),"\" is not a parent of \"",child.get_name(),"\"");
     }
   }
 
   // Check that the number of parents/children are valid
-  if(m_expected_num_parent_layers >= 0
-     && get_num_parents() != m_expected_num_parent_layers) {
-    err << get_type() << " layer \"" << get_name() << "\" "
-        << "expects " << m_expected_num_parent_layers << " "
-        << "parent layer" << (m_expected_num_parent_layers != 1 ? "s" : "")
-        << ", but found " << get_num_parents();
-    if (get_num_parents() > 0) {
-      err << " (";
-      for (int i = 0; i < get_num_parents(); ++i) {
-        err << (i > 0 ? ", " : "")
-            << "\"" << m_parent_layers[i]->get_name() << "\"";
-      }
-      err << ")";
-    }
-    LBANN_ERROR(err.str());
+  if (m_expected_num_parent_layers >= 0
+      && get_num_parents()!= static_cast<size_t>(m_expected_num_parent_layers)) {
+    LBANN_ERROR(
+      get_type()," layer \"",get_name(),"\" "
+      "expects ",m_expected_num_parent_layers," parent layers, ",
+      "but found ",get_num_parents()," (",get_parent_names(),")");
   }
-  if(m_expected_num_child_layers >= 0
-     && get_num_children() != m_expected_num_child_layers) {
-    err << get_type() << " layer \"" << get_name() << "\" "
-        << "expects " << m_expected_num_child_layers << " "
-        << "child layer" << (m_expected_num_child_layers != 1 ? "s" : "")
-        << ", but found " << get_num_children();
-    if (get_num_children() > 0) {
-      err << " (";
-      for (int i = 0; i < get_num_children(); ++i) {
-        err << (i > 0 ? ", " : "")
-            << "\"" << m_child_layers[i]->get_name() << "\"";
-      }
-      err << ")";
-    }
-    LBANN_ERROR(err.str());
+  if (m_expected_num_child_layers >= 0
+      && get_num_children() != static_cast<size_t>(m_expected_num_child_layers)) {
+    LBANN_ERROR(
+      get_type()," layer \"",get_name(),"\" "
+      "expects ",m_expected_num_child_layers," child layers, ",
+      "but found ",get_num_children()," (",get_child_names(),")");
   }
 
 }
 
 void Layer::setup_dims(DataReaderMetaData& dr_metadata) {
   m_output_dims_list.resize(get_num_children());
-  if (m_hint_layer != nullptr) {
-    const auto& hint_dims = m_hint_layer->get_output_dims();
+  const auto* hint_layer = get_hint_layer();
+  if (hint_layer != nullptr) {
+    const auto& hint_dims = hint_layer->get_output_dims();
     for (auto& output_dims : m_output_dims_list) {
       output_dims = hint_dims;
     }
-  } else if (get_num_parents() > 0) {
+  }
+  else if (get_num_parents() > 0) {
     const auto& input_dims = get_input_dims();
     for (auto& output_dims : m_output_dims_list) {
       if (output_dims.empty()) {
@@ -505,7 +449,7 @@ void Layer::check_setup() {
   std::stringstream err;
 
   // Check tensor dimensions
-  for (int i = 0; i < get_num_parents(); ++i) {
+  for (size_t i = 0; i < get_num_parents(); ++i) {
     const auto& dims = get_input_dims(i);
     if (dims.empty()) {
       err << "layer \"" << get_name() << "\" has "
@@ -524,7 +468,7 @@ void Layer::check_setup() {
       LBANN_ERROR(err.str());
     }
   }
-  for (int i = 0; i < get_num_children(); ++i) {
+  for (size_t i = 0; i < get_num_children(); ++i) {
     const auto& dims = get_output_dims(i);
     if (dims.empty()) {
       err << "layer \"" << get_name() << "\" has "
@@ -573,7 +517,9 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
   proto->Clear();
   proto->set_name(get_name());
   proto->set_type(get_type());
-  if(!m_parent_layers.empty()) proto->set_bottom(m_parent_layers.front()->get_name());
+  if (get_num_parents() > 0) {
+    proto->set_bottom(get_parent_layer(0).get_name());
+  }
   proto->set_top(get_name());
   //Add weights
   for (auto const& w : m_weights) {
@@ -582,50 +528,189 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
   }
 }
 
-std::string Layer::get_layer_names(const std::vector<const Layer*>& list) {
-  std::string layer_names = ((list.size()==0u || !list[0])? "" : list[0]->get_name());
-
-  for (size_t i=1u; i < list.size(); ++i) {
-    if (list[i]) layer_names += ", " + list[i]->get_name();
+const Layer& Layer::get_parent_layer(size_t index) const {
+  if (index >= m_parent_layers.size()) {
+    LBANN_ERROR(
+      "attempted to access invalid parent layer of ",
+      get_type()," layer \"",get_name(),"\" ",
+      "(requested index ",index,", but there are ",
+      m_parent_layers.size()," parents)");
   }
-  return layer_names;
+  const auto l = m_parent_layers[index].lock().get();
+  if (l == nullptr) {
+    LBANN_ERROR(
+      get_type()," layer \"",get_name(),"\"",
+      "has an invalid reference to parent layer ",index);
+  }
+  return *l;
 }
 
-void Layer::add_parent_layer(const Layer* parent) {
-  const auto parent_pos = std::find(m_parent_layers.begin(),
-                                    m_parent_layers.end(),
-                                    parent);
-  if (parent != nullptr
-      && parent != this
-      && parent_pos == m_parent_layers.end()) {
-    m_parent_layers.push_back(parent);
+const Layer& Layer::get_child_layer(size_t index) const {
+  if (index >= m_child_layers.size()) {
+    LBANN_ERROR(
+      "attempted to access invalid child layer of ",
+      get_type()," layer \"",get_name(),"\" ",
+      "(requested index ",index,", but there are ",
+      m_child_layers.size()," children)");
   }
+  const auto l = m_child_layers[index].lock().get();
+  if (l == nullptr) {
+    LBANN_ERROR(
+      get_type()," layer \"",get_name(),"\"",
+      "has an invalid reference to child layer ",index);
+  }
+  return *l;
 }
 
-void Layer::add_child_layer(const Layer* child) {
-  const auto child_pos = std::find(m_child_layers.begin(),
-                                   m_child_layers.end(),
-                                   child);
-  if (child != nullptr
-      && child != this
-      && child_pos == m_child_layers.end()) {
-    m_child_layers.push_back(child);
+std::vector<const Layer*> Layer::get_parent_layers() const {
+  std::vector<const Layer*> list;
+  for (size_t i=0; i<get_num_parents(); ++i) {
+    list.push_back(&get_parent_layer(i));
   }
+  return list;
 }
 
-std::vector<Layer*> Layer::get_layer_pointers() {
-  std::vector<Layer*> layers;
-  for (const auto* parent: m_parent_layers) {
-    layers.push_back(const_cast<Layer*>(parent));
+std::vector<const Layer*> Layer::get_child_layers() const {
+  std::vector<const Layer*> list;
+  for (size_t i=0; i<get_num_children(); ++i) {
+    list.push_back(&get_child_layer(i));
   }
-  for (const auto* child: m_child_layers) {
-    layers.push_back(const_cast<Layer*>(child));
+  return list;
+}
+
+size_t Layer::find_parent_layer_index(const Layer& l) const {
+  for (size_t i=0; i<get_num_parents(); ++i) {
+    if (&get_parent_layer(i) == &l) {
+      return i;
+    }
   }
-  layers.push_back(const_cast<Layer*>(m_hint_layer));
+  LBANN_ERROR(
+    l.get_type()," layer \"",l.get_name(),"\" ",
+    "is not a parent layer of ",
+    this->get_type()," layer \"",this->get_name(),"\"");
+  return get_num_parents();
+}
+
+size_t Layer::find_child_layer_index(const Layer& l) const {
+  for (size_t i=0; i<get_num_children(); ++i) {
+    if (&get_child_layer(i) == &l) {
+      return i;
+    }
+  }
+  LBANN_ERROR(
+    l.get_type()," layer \"",l.get_name(),"\" ",
+    "is not a child layer of ",
+    this->get_type()," layer \"",this->get_name(),"\"");
+  return get_num_children();
+}
+
+std::string Layer::get_parent_names() const {
+  std::ostringstream ss;
+  for (size_t i=0; i<get_num_parents(); ++i) {
+    ss << (i>0 ? ", " : "") << get_parent_layer(i).get_name();
+  }
+  return ss.str();
+}
+
+std::string Layer::get_child_names() const {
+  std::ostringstream ss;
+  for (size_t i=0; i<get_num_children(); ++i) {
+    ss << (i>0 ? ", " : "") << get_child_layer(i).get_name();
+  }
+  return ss.str();
+}
+
+void Layer::add_parent_layer(ViewingLayerPtr l) {
+  const auto* l_ptr = l.lock().get();
+  if (l_ptr == nullptr || l_ptr == this) {
+    return;
+  }
+  for (size_t i=0; i<get_num_parents(); ++i) {
+    if (l_ptr == &get_parent_layer(i)) {
+      return;
+    }
+  }
+  m_parent_layers.emplace_back(std::move(l));
+}
+
+void Layer::add_child_layer(ViewingLayerPtr l) {
+  const auto* l_ptr = l.lock().get();
+  if (l_ptr == nullptr || l_ptr == this) {
+    return;
+  }
+  for (size_t i=0; i<get_num_children(); ++i) {
+    if (l_ptr == &get_child_layer(i)) {
+      return;
+    }
+  }
+  m_child_layers.emplace_back(std::move(l));
+}
+
+void Layer::replace_parent_layer(ViewingLayerPtr l, size_t index) {
+  if (l.expired()) {
+    LBANN_ERROR(
+      "attempted to replace parent ",index," of ",
+      get_type()," layer \"",get_name(),"\" ",
+      "with an invalid layer pointer");
+  }
+  if (index >= m_parent_layers.size()) {
+    LBANN_ERROR(
+      "attempted to replace parent ",index," of ",
+      get_type()," layer \"",get_name(),"\", ",
+      "which only has ",m_parent_layers.size()," parents");
+  }
+  m_parent_layers[index] = std::move(l);
+}
+
+void Layer::replace_child_layer(ViewingLayerPtr l, size_t index) {
+  if (l.expired()) {
+    LBANN_ERROR(
+      "attempted to replace child ",index," of ",
+      get_type()," layer \"",get_name(),"\" ",
+      "with an invalid layer pointer");
+  }
+  if (index >= m_child_layers.size()) {
+    LBANN_ERROR(
+      "attempted to replace child ",index," of ",
+      get_type()," layer \"",get_name(),"\", ",
+      "which only has ",m_child_layers.size()," children");
+  }
+  m_child_layers[index] = std::move(l);
+}
+
+ViewingLayerPtr Layer::get_parent_layer_pointer(size_t index) const {
+  if (index >= m_child_layers.size()) {
+    LBANN_ERROR(
+      "attempted to get pointer to parent ",index," of ",
+      get_type()," layer \"",get_name(),"\", ",
+      "which only has ",m_parent_layers.size()," parents");
+  }
+  return m_parent_layers[index];
+}
+
+ViewingLayerPtr Layer::get_child_layer_pointer(size_t index) const {
+  if (index >= m_child_layers.size()) {
+    LBANN_ERROR(
+      "attempted to get pointer to child ",index," of ",
+      get_type()," layer \"",get_name(),"\", ",
+      "which only has ",m_child_layers.size()," children");
+  }
+  return m_child_layers[index];
+}
+
+std::vector<ViewingLayerPtr> Layer::get_layer_pointers() {
+  std::vector<ViewingLayerPtr> layers;
+  for (const auto& l: m_parent_layers) {
+    layers.push_back(l);
+  }
+  for (const auto& l: m_child_layers) {
+    layers.push_back(l);
+  }
+  layers.push_back(m_hint_layer);
   return layers;
 }
 
-void Layer::set_layer_pointers(std::vector<Layer*> layers) {
+void Layer::set_layer_pointers(std::vector<ViewingLayerPtr> layers) {
   const size_t expected_size = (m_parent_layers.size()
                                 + m_child_layers.size()
                                 + 1);
@@ -634,11 +719,11 @@ void Layer::set_layer_pointers(std::vector<Layer*> layers) {
   }
   size_t pos = 0;
   for (auto& parent: m_parent_layers) {
-    parent = static_cast<const Layer*>(layers[pos]);
+    parent = layers[pos];
     pos++;
   }
   for (auto& child: m_child_layers) {
-    child = static_cast<const Layer*>(layers[pos]);
+    child = layers[pos];
     pos++;
   }
   m_hint_layer = layers[pos];

--- a/src/metrics/metric.cpp
+++ b/src/metrics/metric.cpp
@@ -71,11 +71,11 @@ int metric::get_statistics_num_samples(execution_mode mode) const {
   }
 }
 
-std::vector<Layer*> metric::get_layer_pointers() const {
+std::vector<ViewingLayerPtr> metric::get_layer_pointers() const {
   return {};
 }
 
-void metric::set_layer_pointers(std::vector<Layer*> layers) {
+void metric::set_layer_pointers(std::vector<ViewingLayerPtr> layers) {
   if (!layers.empty()) {
     std::stringstream err;
     err << "attempted to set layer pointers for "

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -714,6 +714,11 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
             break;
           }
         }
+        if (l_view_ptr.lock().get() == nullptr) {
+          LBANN_ERROR(
+            get_name()," could not get viewing pointer for ",
+            l_raw_ptr->get_name()," layer \"",l_raw_ptr->get_name(),"\"");
+        }
 
         // Create evaluation layer
         OwningLayerPtr eval(
@@ -765,6 +770,11 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
             l_view_ptr = l;
             break;
           }
+        }
+        if (l_view_ptr.lock().get() == nullptr) {
+          LBANN_ERROR(
+            get_name()," could not get viewing pointer for ",
+            l_raw_ptr->get_name()," layer \"",l_raw_ptr->get_name(),"\"");
         }
 
         // Create evaluation layer

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -810,7 +810,14 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
 }
 
 void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
-  for (auto& l : m_layers) {
+  for (size_t i=0; i<m_layers.size(); ++i) {
+    auto& l = m_layers[i];
+    if (l == nullptr) {
+      LBANN_ERROR(
+        "model \"",get_name(),"\" ",
+        "has a null pointer in its list of layers");
+    }
+
     while (l->get_num_children() < l->get_expected_num_child_layers()) {
 
       // Create dummy layer
@@ -855,11 +862,18 @@ void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
       add_layer(std::move(dummy));
 
     }
+
   }
 }
 
 void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
-  for (auto& l : m_layers) {
+  for (size_t i=0; i<m_layers.size(); ++i) {
+    auto& l = m_layers[i];
+    if (l == nullptr) {
+      LBANN_ERROR(
+        "model \"",get_name(),"\" ",
+        "has a null pointer in its list of layers");
+    }
 
     // Add split layer if layer expects one child but has multiple
     if (l->get_expected_num_child_layers() == 1 && l->get_num_children() != 1) {
@@ -906,9 +920,9 @@ void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
       ps = orig_ps;
 
       // Setup relationships between split layer and child layers
-      for (int i=0; i<l->get_num_children(); ++i) {
-        auto& child = const_cast<Layer&>(l->get_child_layer(i));
-        split->add_child_layer(l->get_child_layer_pointer(i));
+      for (int j=0; j<l->get_num_children(); ++j) {
+        auto& child = const_cast<Layer&>(l->get_child_layer(j));
+        split->add_child_layer(l->get_child_layer_pointer(j));
         child.replace_parent_layer(split, child.find_parent_layer_index(*l));
       }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -627,10 +627,10 @@ void model::setup_layer_topology() {
 
   // Make sure parent/child relationships are reciprocated
   for (auto& l : m_layers) {
-    for (size_t i=0; i<l->get_num_parents(); ++i) {
+    for (int i=0; i<l->get_num_parents(); ++i) {
       const_cast<Layer&>(l->get_parent_layer(i)).add_child_layer(l);
     }
-    for (size_t i=0; i<l->get_num_children(); ++i) {
+    for (int i=0; i<l->get_num_children(); ++i) {
       const_cast<Layer&>(l->get_child_layer(i)).add_parent_layer(l);
     }
   }
@@ -801,7 +801,7 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
 
 void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
   for (auto& l : m_layers) {
-    while ((int) l->get_num_children() < l->get_expected_num_child_layers()) {
+    while (l->get_num_children() < l->get_expected_num_child_layers()) {
 
       // Create dummy layer
       OwningLayerPtr dummy;
@@ -896,7 +896,7 @@ void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
       ps = orig_ps;
 
       // Setup relationships between split layer and child layers
-      for (size_t i=0; i<l->get_num_children(); ++i) {
+      for (int i=0; i<l->get_num_children(); ++i) {
         auto& child = const_cast<Layer&>(l->get_child_layer(i));
         split->add_child_layer(l->get_child_layer_pointer(i));
         child.replace_parent_layer(split, child.find_parent_layer_index(*l));

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -497,9 +497,10 @@ void model::remap_pointers(
   // Fix pointers in objective function
   if (m_objective_function != nullptr) {
     auto layer_pointers = m_objective_function->get_layer_pointers();
-    for (auto& layer_pointer : layer_pointers) {
-      if (layer_map.count(layer_pointer) > 0) {
-        layer_pointer = layer_map.at(layer_pointer).lock().get();
+    for (auto& ptr : layer_pointers) {
+      auto* raw_ptr = ptr.lock().get();
+      if (layer_map.count(raw_ptr) > 0) {
+        ptr = layer_map.at(raw_ptr);
       }
     }
     m_objective_function->set_layer_pointers(layer_pointers);
@@ -515,9 +516,10 @@ void model::remap_pointers(
   // Fix pointers in metrics
   for (const auto& m : m_metrics) {
     auto layer_pointers = m->get_layer_pointers();
-    for (auto& layer_pointer : layer_pointers) {
-      if (layer_map.count(layer_pointer) > 0) {
-        layer_pointer = layer_map.at(layer_pointer).lock().get();
+    for (auto& ptr : layer_pointers) {
+      auto* raw_ptr = ptr.lock().get();
+      if (layer_map.count(raw_ptr) > 0) {
+        ptr = layer_map.at(raw_ptr);
       }
     }
     m->set_layer_pointers(layer_pointers);
@@ -743,7 +745,7 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
         // Add evaluation layer to model
         l_raw_ptr->add_child_layer(eval);
         eval->add_parent_layer(l_view_ptr);
-        term->set_layer(*eval);
+        term->set_layer(eval);
         add_layer(std::move(eval));
 
       }
@@ -800,7 +802,7 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
         // Add evaluation layer to model
         l_raw_ptr->add_child_layer(eval);
         eval->add_parent_layer(l_view_ptr);
-        met->set_layer(*eval);
+        met->set_layer(eval);
         add_layer(std::move(eval));
 
       }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -101,7 +101,7 @@ model::model(const model& other) :
   }
 
   // Copy layers
-  std::unordered_map<Layer*,Layer*> layer_map;
+  std::unordered_map<Layer*,ViewingLayerPtr> layer_map;
   m_layers.reserve(other.m_layers.size());
   for (const auto& other_layer : other.m_layers) {
     if (other_layer == nullptr) {
@@ -110,7 +110,7 @@ model::model(const model& other) :
     }
     m_layers.emplace_back(other_layer->copy());
     m_layers.back()->set_model(this);
-    layer_map[other_layer.get()] = m_layers.back().get();
+    layer_map[other_layer.get()] = m_layers.back();
   }
 
   // Copy weights
@@ -156,7 +156,7 @@ model& model::operator=(const model& other) {
   }
 
   // Copy layers
-  std::unordered_map<Layer*,Layer*> layer_map;
+  std::unordered_map<Layer*,ViewingLayerPtr> layer_map;
   m_layers.clear();
   m_layers.reserve(other.m_layers.size());
   for (const auto& other_layer : other.m_layers) {
@@ -166,7 +166,7 @@ model& model::operator=(const model& other) {
     }
     m_layers.emplace_back(other_layer->copy());
     m_layers.back()->set_model(this);
-    layer_map[other_layer.get()] = m_layers.back().get();
+    layer_map[other_layer.get()] = m_layers.back();
   }
 
   // Copy weights
@@ -346,7 +346,7 @@ const std::vector<weights*> model::get_weights() const {
 // Model specification
 // =============================================
 
-void model::add_layer(std::unique_ptr<Layer> ptr) {
+void model::add_layer(OwningLayerPtr&& ptr) {
 
   // Check for null pointer
   if (ptr == nullptr) {
@@ -429,7 +429,7 @@ void model::replace_weights(std::vector<weights*>& new_weights) {
 
   // Replace weights in list
   std::unordered_map<weights*,weights*> weights_map;
-  std::unordered_map<Layer*,Layer*> layer_map;
+  std::unordered_map<Layer*,ViewingLayerPtr> layer_map;
   for (size_t i = 0; i < new_weights.size(); ++i) {
     weights_map[m_weights[i].get()] = new_weights[i];
     m_weights[i].reset(new_weights[i]);
@@ -473,7 +473,7 @@ void model::reorder_layers(const std::vector<El::Int>& gather_indices) {
   }
 
   // Reorder layers
-  std::vector<std::unique_ptr<Layer>> reordered_layers(gather_indices.size());
+  std::vector<OwningLayerPtr> reordered_layers(gather_indices.size());
   for (size_t i = 0; i < gather_indices.size(); ++i) {
     reordered_layers[i] = std::move(m_layers[gather_indices[i]]);
   }
@@ -490,15 +490,16 @@ void model::reorder_layers(const std::vector<El::Int>& gather_indices) {
 
 }
 
-void model::remap_pointers(const std::unordered_map<Layer*,Layer*>& layer_map,
-                           const std::unordered_map<weights*,weights*>& weights_map) {
+void model::remap_pointers(
+  const std::unordered_map<Layer*,ViewingLayerPtr>& layer_map,
+  const std::unordered_map<weights*,weights*>& weights_map) {
 
   // Fix pointers in objective function
   if (m_objective_function != nullptr) {
     auto layer_pointers = m_objective_function->get_layer_pointers();
     for (auto& layer_pointer : layer_pointers) {
       if (layer_map.count(layer_pointer) > 0) {
-        layer_pointer = layer_map.at(layer_pointer);
+        layer_pointer = layer_map.at(layer_pointer).lock().get();
       }
     }
     m_objective_function->set_layer_pointers(layer_pointers);
@@ -516,7 +517,7 @@ void model::remap_pointers(const std::unordered_map<Layer*,Layer*>& layer_map,
     auto layer_pointers = m->get_layer_pointers();
     for (auto& layer_pointer : layer_pointers) {
       if (layer_map.count(layer_pointer) > 0) {
-        layer_pointer = layer_map.at(layer_pointer);
+        layer_pointer = layer_map.at(layer_pointer).lock().get();
       }
     }
     m->set_layer_pointers(layer_pointers);
@@ -528,8 +529,9 @@ void model::remap_pointers(const std::unordered_map<Layer*,Layer*>& layer_map,
     auto layer_pointers = l.get_layer_pointers();
     auto weights_pointers = extract_weights(l);
     for (auto& ptr : layer_pointers) {
-      if (layer_map.count(ptr) > 0) {
-        ptr = layer_map.at(ptr);
+      auto* raw_ptr = ptr.lock().get();
+      if (layer_map.count(raw_ptr) > 0) {
+        ptr = layer_map.at(raw_ptr);
       }
     }
     for (auto& ptr : weights_pointers) {
@@ -585,7 +587,6 @@ void model::setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata) {
 }
 
 void model::setup_layer_topology() {
-  std::stringstream err;
 
   // Check that layer list is valid
   // Note: Throws an exception if the layer list contains two layers
@@ -596,9 +597,9 @@ void model::setup_layer_topology() {
   for (El::Int i = 0; i < get_num_layers(); ++i) {
     auto& l = get_layer(i);
     if (layer_names.count(l.get_name()) > 0) {
-      err << "model \"" << get_name() << "\" "
-          << "has multiple layers named \"" << l.get_name() << "\"";
-      LBANN_ERROR(err.str());
+      LBANN_ERROR(
+        "model \"",get_name(),"\" "
+        "has multiple layers named \"",l.get_name(),"\"");
     }
     layer_set.insert(&l);
     layer_names.insert(l.get_name());
@@ -606,28 +607,31 @@ void model::setup_layer_topology() {
   for (El::Int i = 0; i < get_num_layers(); ++i) {
     auto& l = get_layer(i);
     for (const auto& ptr : l.get_layer_pointers()) {
-      if (ptr != nullptr && layer_set.count(ptr) == 0) {
-        err << "layer \"" << l.get_name() << "\" "
-            << "(in model \"" << get_name() << "\") "
-            << "has a pointer to layer " << ptr->get_name() << "\" ";
-        if (ptr->get_model() == nullptr) {
-          err << "(not in a model)";
-        } else {
-          err << "(in model \"" << ptr->get_model()->get_name() << "\")";
+      auto* raw_ptr = ptr.lock().get();
+      if (raw_ptr != nullptr && layer_set.count(raw_ptr) == 0) {
+        auto message = build_string(
+          l.get_type()," layer \"",l.get_name(),"\" ",
+          "(in model \"",get_name(),"\") has a pointer to ",
+          raw_ptr->get_type()," layer \"",raw_ptr->get_name(),"\" ");
+        if (raw_ptr->get_model() == nullptr) {
+          message += "(not in a model)";
         }
-        LBANN_ERROR(err.str());
+        else {
+          message += build_string(
+            "(in model \"",raw_ptr->get_model()->get_name(),"\")");
+        }
+        LBANN_ERROR(message);
       }
     }
   }
 
   // Make sure parent/child relationships are reciprocated
-  for (El::Int i = 0; i < get_num_layers(); ++i) {
-    auto& l = get_layer(i);
-    for (auto* parent : l.get_parent_layers()) {
-      const_cast<Layer*>(parent)->add_child_layer(&l);
+  for (auto& l : m_layers) {
+    for (size_t i=0; i<l->get_num_parents(); ++i) {
+      const_cast<Layer&>(l->get_parent_layer(i)).add_child_layer(l);
     }
-    for (auto* child : l.get_child_layers()) {
-      const_cast<Layer*>(child)->add_parent_layer(&l);
+    for (size_t i=0; i<l->get_num_children(); ++i) {
+      const_cast<Layer&>(l->get_child_layer(i)).add_parent_layer(l);
     }
   }
 
@@ -692,28 +696,38 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
   for (auto* t : m_objective_function->get_terms()) {
     auto* term = dynamic_cast<layer_term*>(t);
     if (term != nullptr) {
-      auto& l = term->get_layer();
-      if (layer_set.count(&l) == 0) {
+      auto* l_raw_ptr = &term->get_layer();
+      if (layer_set.count(l_raw_ptr) == 0) {
         err << "model \"" << get_name() << "\" "
             << "has an objective function layer term corresponding to "
-            << "layer \"" << l.get_name() << "\", "
+            << "layer \"" << l_raw_ptr->get_name() << "\", "
             << "which isn't in the model's list of layers";
         LBANN_ERROR(err.str());
       }
-      if (dynamic_cast<abstract_evaluation_layer<DataType>*>(&l) == nullptr) {
+      if (dynamic_cast<abstract_evaluation_layer<DataType>*>(l_raw_ptr) == nullptr) {
+
+        // Get viewing pointer to layer
+        ViewingLayerPtr l_view_ptr;
+        for (auto& l : m_layers) {
+          if (l.get() == l_raw_ptr) {
+            l_view_ptr = l;
+            break;
+          }
+        }
 
         // Create evaluation layer
-        std::unique_ptr<Layer> eval(abstract_evaluation_layer<DataType>::construct(
-                                      l.get_comm(),
-                                      l.get_data_layout(),
-                                      l.get_device_allocation()));
+        OwningLayerPtr eval(
+          abstract_evaluation_layer<DataType>::construct(
+            l_raw_ptr->get_comm(),
+            l_raw_ptr->get_data_layout(),
+            l_raw_ptr->get_device_allocation()));
 
         // Set evaluation layer name
         El::Int name_index = 1;
-        std::string name = l.get_name() + "_eval";
+        std::string name = l_raw_ptr->get_name() + "_eval";
         while (layer_names.count(name) > 0) {
           name_index++;
-          name = l.get_name() + "_eval" + std::to_string(name_index);
+          name = l_raw_ptr->get_name() + "_eval" + std::to_string(name_index);
         }
         eval->set_name(name);
 
@@ -722,8 +736,8 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
         layer_names.insert(eval->get_name());
 
         // Add evaluation layer to model
-        l.add_child_layer(eval.get());
-        eval->add_parent_layer(&l);
+        l_raw_ptr->add_child_layer(eval);
+        eval->add_parent_layer(l_view_ptr);
         term->set_layer(*eval);
         add_layer(std::move(eval));
 
@@ -735,27 +749,37 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
   for (auto* m : m_metrics) {
     auto* met = dynamic_cast<layer_metric*>(m);
     if (met != nullptr) {
-      auto& l = met->get_layer();
-      if (layer_set.count(&l) == 0) {
+      auto* l_raw_ptr = &met->get_layer();
+      if (layer_set.count(l_raw_ptr) == 0) {
         err << "layer metric \"" << met->name() << "\" "
-            << "corresponds to layer \"" << l.get_name() << "\", "
+            << "corresponds to layer \"" << l_raw_ptr->get_name() << "\", "
             << "which is not in model \"" << get_name() << "\"";
         LBANN_ERROR(err.str());
       }
-      if (dynamic_cast<abstract_evaluation_layer<DataType>*>(&l) == nullptr) {
+      if (dynamic_cast<abstract_evaluation_layer<DataType>*>(l_raw_ptr) == nullptr) {
+
+        // Get viewing pointer to layer
+        ViewingLayerPtr l_view_ptr;
+        for (auto& l : m_layers) {
+          if (l.get() == l_raw_ptr) {
+            l_view_ptr = l;
+            break;
+          }
+        }
 
         // Create evaluation layer
-        std::unique_ptr<Layer> eval(abstract_evaluation_layer<DataType>::construct(
-                                      l.get_comm(),
-                                      l.get_data_layout(),
-                                      l.get_device_allocation()));
+        OwningLayerPtr eval(
+          abstract_evaluation_layer<DataType>::construct(
+            l_raw_ptr->get_comm(),
+            l_raw_ptr->get_data_layout(),
+            l_raw_ptr->get_device_allocation()));
 
         // Set evaluation layer name
         El::Int name_index = 1;
-        std::string name = l.get_name() + "_eval";
+        std::string name = l_raw_ptr->get_name() + "_eval";
         while (layer_names.count(name) > 0) {
           name_index++;
-          name = l.get_name() + "_eval" + std::to_string(name_index);
+          name = l_raw_ptr->get_name() + "_eval" + std::to_string(name_index);
         }
         eval->set_name(name);
 
@@ -764,8 +788,8 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
         layer_names.insert(eval->get_name());
 
         // Add evaluation layer to model
-        l.add_child_layer(eval.get());
-        eval->add_parent_layer(&l);
+        l_raw_ptr->add_child_layer(eval);
+        eval->add_parent_layer(l_view_ptr);
         met->set_layer(*eval);
         add_layer(std::move(eval));
 
@@ -776,14 +800,13 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
 }
 
 void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
-  for (El::Int i = 0; i < get_num_layers(); ++i) {
-    auto& l = get_layer(i);
-    while (l.get_num_children() < l.get_expected_num_child_layers()) {
+  for (auto& l : m_layers) {
+    while ((int) l->get_num_children() < l->get_expected_num_child_layers()) {
 
       // Create dummy layer
-      std::unique_ptr<Layer> dummy;
+      OwningLayerPtr dummy;
       using args_tuple = std::tuple<data_layout,El::Device>;
-      args_tuple args(l.get_data_layout(), l.get_device_allocation());
+      args_tuple args(l->get_data_layout(), l->get_device_allocation());
       if (args == args_tuple(data_layout::DATA_PARALLEL, El::Device::CPU)) {
         dummy.reset(new dummy_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>(m_comm));
       }
@@ -801,24 +824,24 @@ void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
       if (dummy == nullptr) {
         std::stringstream err;
         err << "could not construct dummy layer corresponding to "
-            << "layer \"" << l.get_name() << "\" "
+            << "layer \"" << l->get_name() << "\" "
             << "in model \"" << get_name() << "\"";
         LBANN_ERROR(err.str());
       }
 
       // Set dummy layer name
       El::Int name_index = 1;
-      std::string name = l.get_name() + "_dummy";
+      std::string name = l->get_name() + "_dummy";
       while (layer_names.count(name) > 0) {
         name_index++;
-        name = l.get_name() + "_dummy" + std::to_string(name_index);
+        name = l->get_name() + "_dummy" + std::to_string(name_index);
       }
       dummy->set_name(name);
       layer_names.insert(name);
 
       // Add dummy layer to model
-      l.add_child_layer(dummy.get());
-      dummy->add_parent_layer(&l);
+      l->add_child_layer(dummy);
+      dummy->add_parent_layer(l);
       add_layer(std::move(dummy));
 
     }
@@ -826,17 +849,15 @@ void model::add_dummy_layers(std::unordered_set<std::string>& layer_names) {
 }
 
 void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
-  for (El::Int i = 0; i < get_num_layers(); ++i) {
-    auto& l = get_layer(i);
+  for (auto& l : m_layers) {
 
     // Add split layer if layer expects one child but has multiple
-    auto& children = l.get_child_layers();
-    if (l.get_expected_num_child_layers() == 1 && children.size() != 1) {
+    if (l->get_expected_num_child_layers() == 1 && l->get_num_children() != 1) {
 
       // Create split layer
-      std::unique_ptr<Layer> split;
+      OwningLayerPtr split;
       using args_tuple = std::tuple<data_layout,El::Device>;
-      args_tuple args(l.get_data_layout(), l.get_device_allocation());
+      args_tuple args(l->get_data_layout(), l->get_device_allocation());
       if (args == args_tuple(data_layout::DATA_PARALLEL, El::Device::CPU)) {
         split.reset(new split_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>(m_comm));
       }
@@ -854,39 +875,37 @@ void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
       if (split == nullptr) {
         std::stringstream err;
         err << "could not construct split layer corresponding to "
-            << "layer \"" << l.get_name() << "\" "
+            << "layer \"" << l->get_name() << "\" "
             << "in model \"" << get_name() << "\"";
         LBANN_ERROR(err.str());
       }
 
       // Set split layer name
       El::Int name_index = 1;
-      std::string name = l.get_name() + "_split";
+      std::string name = l->get_name() + "_split";
       while (layer_names.count(name) > 0) {
         name_index++;
-        name = l.get_name() + "_split" + std::to_string(name_index);
+        name = l->get_name() + "_split" + std::to_string(name_index);
       }
       split->set_name(name);
       layer_names.insert(name);
 
       // Copy parallel strategy from parent.
       ParallelStrategy& ps = split->get_parallel_strategy();
-      ParallelStrategy& orig_ps = l.get_parallel_strategy();
+      ParallelStrategy& orig_ps = l->get_parallel_strategy();
       ps = orig_ps;
 
       // Setup relationships between split layer and child layers
-      for (auto&& const_child : children) {
-        auto* child = const_cast<Layer*>(const_child);
-        split->add_child_layer(child);
-        auto& child_parents = child->get_parent_layers();
-        std::replace(child_parents.begin(), child_parents.end(),
-                     &l, split.get());
+      for (size_t i=0; i<l->get_num_children(); ++i) {
+        auto& child = const_cast<Layer&>(l->get_child_layer(i));
+        split->add_child_layer(l->get_child_layer_pointer(i));
+        child.replace_parent_layer(split, child.find_parent_layer_index(*l));
       }
 
       // Setup relationship between current layer and split layer
-      children.clear();
-      l.add_child_layer(split.get());
-      split->add_parent_layer(&l);
+      l->clear_child_layers();
+      l->add_child_layer(split);
+      split->add_parent_layer(l);
 
       // Add split layer to layer list
       add_layer(std::move(split));

--- a/src/objective_functions/layer_term.cpp
+++ b/src/objective_functions/layer_term.cpp
@@ -31,8 +31,10 @@ namespace lbann {
 layer_term::layer_term(EvalType scale_factor)
   : objective_function_term(scale_factor) {}
 
-void layer_term::set_layer(Layer& l) {
-  set_layer_pointers({&l});
+void layer_term::set_layer(ViewingLayerPtr l) {
+  std::vector<ViewingLayerPtr> ptrs;
+  ptrs.emplace_back(std::move(l));
+  set_layer_pointers(ptrs);
 }
 
 Layer& layer_term::get_layer() {
@@ -40,13 +42,13 @@ Layer& layer_term::get_layer() {
   return *(const_cast<Layer*>(&static_cast<const layer_term&>(*this).get_layer()));
 }
 const Layer& layer_term::get_layer() const {
-  const auto& layer_pointers = get_layer_pointers();
-  if (layer_pointers.empty() || layer_pointers.front() == nullptr) {
+  const auto layer_pointers = get_layer_pointers();
+  if (layer_pointers.empty() || layer_pointers.front().expired()) {
     LBANN_ERROR("attempted to get the layer corresponding to "
                 "an objective function layer term, "
                 "but no such layer has been set");
   }
-  return *layer_pointers.front();
+  return *layer_pointers.front().lock();
 }
 
 /*abstract_evaluation_*/Layer& layer_term::get_evaluation_layer() {

--- a/src/objective_functions/objective_function.cpp
+++ b/src/objective_functions/objective_function.cpp
@@ -146,20 +146,20 @@ int objective_function::get_statistics_num_samples(execution_mode mode) const {
   }
 }
 
-std::vector<Layer*> objective_function::get_layer_pointers() const {
-  std::vector<Layer*> layers;
+std::vector<ViewingLayerPtr> objective_function::get_layer_pointers() const {
+  std::vector<ViewingLayerPtr> layers;
   for (objective_function_term *term : m_terms) {
-    std::vector<Layer*> term_layers = term->get_layer_pointers();
+    auto term_layers = term->get_layer_pointers();
     layers.insert(layers.end(), term_layers.begin(), term_layers.end());
   }
   return layers;
 }
 
-void objective_function::set_layer_pointers(std::vector<Layer*> layers) {
+void objective_function::set_layer_pointers(std::vector<ViewingLayerPtr> layers) {
   auto it = layers.begin();
   for (objective_function_term *term : m_terms) {
     const size_t num_layers = term->get_layer_pointers().size();
-    std::vector<Layer*> term_layers(it, it + num_layers);
+    std::vector<ViewingLayerPtr> term_layers(it, it + num_layers);
     term->set_layer_pointers(term_layers);
     it += num_layers;
   }

--- a/src/objective_functions/objective_function_term.cpp
+++ b/src/objective_functions/objective_function_term.cpp
@@ -40,4 +40,12 @@ void objective_function_term::setup(model& m) {
   m_comm = m.get_comm();
 }
 
+std::vector<ViewingLayerPtr> objective_function_term::get_layer_pointers() const {
+  return m_layers;
+}
+
+void objective_function_term::set_layer_pointers(std::vector<ViewingLayerPtr> layers) {
+  m_layers = std::move(layers);
+}
+
 }  // namespace lbann

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -28,8 +28,6 @@
 #include "lbann/proto/datatype_helpers.hpp"
 
 #include "lbann/layers/learning/fully_connected.hpp"
-#include "lbann/layers/transform/pooling.hpp"
-#include "lbann/layers/transform/unpooling.hpp"
 
 #include <model.pb.h>
 #include <trainer.pb.h>
@@ -46,8 +44,8 @@ namespace {
 /** Setup parent/child relationships between layers. */
 void setup_parents_and_children(
        lbann_comm* comm,
-       std::vector<Layer*>& layers,
-       std::unordered_map<std::string, Layer*>& names_to_layers,
+       const std::vector<OwningLayerPtr>& layers,
+       const std::unordered_map<std::string, ViewingLayerPtr>& names_to_layers,
        const lbann_data::Model& proto_model) {
   std::stringstream err;
   for (int i=0; i<proto_model.layer_size(); ++i) {
@@ -74,8 +72,8 @@ void setup_parents_and_children(
 }
 
 void setup_hints(
-       std::vector<Layer*>& layers,
-       const std::unordered_map<std::string, Layer*>& names_to_layers,
+       const std::vector<OwningLayerPtr>& layers,
+       const std::unordered_map<std::string, ViewingLayerPtr>& names_to_layers,
        const lbann_data::Model& proto_model) {
   std::stringstream err;
   for (int i=0; i<proto_model.layer_size(); ++i) {
@@ -92,51 +90,9 @@ void setup_hints(
   }
 }
 
-/** Setup paired pooling layers for unpooling layers. */
-void setup_unpooling_pointers(lbann_comm* comm,
-                              std::vector<Layer*>& layers,
-                              std::unordered_map<std::string, Layer*>& names_to_layers,
-                              const lbann_data::Model& proto_model) {
-  std::stringstream err;
-  for (int i=0; i<proto_model.layer_size(); ++i) {
-    {
-      unpooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>* unpool
-        = dynamic_cast<unpooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>*>(layers[i]);
-      if (unpool != nullptr) {
-        const auto& pool_name = proto_model.layer(i).unpooling().pooling_layer();
-        pooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>* pool
-          = dynamic_cast<pooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::CPU>*>(names_to_layers[pool_name]);
-        if (pool == nullptr) {
-          err << "could not find pooling layer " << pool_name << " "
-              << "to pair with unpooling layer " << unpool->get_name();
-          LBANN_ERROR(err.str());
-        }
-        unpool->set_pooling_layer(pool);
-      }
-    }
-#if defined(LBANN_HAS_GPU) && defined(LBANN_UNPOOLING_LAYER_SUPPORTS_GPU)
-    {
-      unpooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::GPU>* unpool
-        = dynamic_cast<unpooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::GPU>*>(layers[i]);
-      if (unpool != nullptr) {
-        const auto& pool_name = proto_model.layer(i).unpooling().pooling_layer();
-        pooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::GPU>* pool
-          = dynamic_cast<pooling_layer<DataType, data_layout::DATA_PARALLEL, El::Device::GPU>*>(names_to_layers[pool_name]);
-        if (pool == nullptr) {
-          err << "could not find pooling layer " << pool_name << " "
-              << "to pair with unpooling layer " << unpool->get_name();
-          LBANN_ERROR(err.str());
-        }
-        unpool->set_pooling_layer(pool);
-      }
-    }
-#endif // LBANN_HAS_GPU
-  }
-}
-
 } // namespace
 
-std::vector<std::unique_ptr<Layer>> construct_layer_graph(
+std::vector<OwningLayerPtr> construct_layer_graph(
   lbann_comm* comm,
   int training_dr_linearized_data_size,
   const lbann_data::Trainer& proto_trainer,
@@ -144,18 +100,18 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
   std::stringstream err;
 
   // List of layers
-  std::vector<std::unique_ptr<Layer>> layers;
+  std::vector<OwningLayerPtr> layers;
   layers.reserve(proto_model.layer_size());
 
   // Map from names to layer pointers
-  std::unordered_map<std::string, Layer*> names_to_layers;
+  std::unordered_map<std::string, ViewingLayerPtr> names_to_layers;
 
   // Create each layer in prototext
   for (int i=0; i<proto_model.layer_size(); ++i) {
     const auto& proto_layer = proto_model.layer(i);
 
     // Check that layer name is valid
-    auto name = proto_layer.name();
+    std::string name = proto_layer.name();
     const auto& parsed_name = parse_list<std::string>(name);
     if (!name.empty()) {
       if (parsed_name.empty() || parsed_name.front() != name) {
@@ -194,17 +150,18 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
     auto proto_datatype = proto_layer.datatype();
 
     // Construct layer
-    std::unique_ptr<Layer> l;
+    OwningLayerPtr l;
 #define TEMPLATE_INSTANTIATION(TensorDataType, T_layout, T_device)      \
     do {                                                                \
       if (proto_datatype == TypeToProtoDataType<TensorDataType>::value  \
           && layout == T_layout                                         \
           && device == T_device) {                                      \
-        l = construct_layer<TensorDataType, T_layout, T_device>(        \
+        auto l_ = construct_layer<TensorDataType, T_layout, T_device>(  \
           comm,                                                         \
           training_dr_linearized_data_size,                             \
           num_parallel_readers,                                         \
           proto_layer);                                                 \
+        l.reset(l_.release());                                          \
       }                                                                 \
     } while (0)
 
@@ -247,7 +204,7 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
       err << "layer name \"" << name << "\" is not unique";
       LBANN_ERROR(err.str());
     }
-    names_to_layers[name] = l.get();
+    names_to_layers[name] = l;
 
     if (proto_layer.freeze()) {
       #ifdef LBANN_DEBUG
@@ -263,12 +220,8 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
   }
 
   // Setup pointers between layers
-  std::vector<Layer*> layer_pointers;
-  layer_pointers.reserve(layers.size());
-  for (auto&& ptr : layers) { layer_pointers.push_back(ptr.get()); }
-  setup_parents_and_children(comm, layer_pointers, names_to_layers, proto_model);
-  setup_hints(layer_pointers, names_to_layers, proto_model);
-  setup_unpooling_pointers(comm, layer_pointers, names_to_layers, proto_model);
+  setup_parents_and_children(comm, layers, names_to_layers, proto_model);
+  setup_hints(layers, names_to_layers, proto_model);
 
   // Return layer list
   return layers;

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -103,7 +103,7 @@ void assign_layers_to_objective_function(
                     "to correspond to layer \"", params.layer(), "\", ",
                     "but no such layer exists");
       }
-      term->set_layer(*l.lock());
+      term->set_layer(l);
     }
   }
 
@@ -142,7 +142,7 @@ void assign_layers_to_metrics(
                     "to correspond to layer \"", params.layer(), "\", "
                     "but no such layer exists");
       }
-      m->set_layer(*l.lock());
+      m->set_layer(l);
     }
   }
 

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -432,9 +432,16 @@ message Layer {
     string pool_mode = 7;
   }
 
+  /** @brief Transpose of pooling layer
+   *
+   *  Requires that a pooling layer is set as the hint layer.
+   *
+   *  @warning This has not been well maintained and is probably
+   *  broken.
+   *  @todo GPU support.
+   */
   message Unpooling {
     int64 num_dims = 1;
-    string pooling_layer = 13; //should be name of the pooling layer
   }
 
 


### PR DESCRIPTION
We would like to use Cereal to serialize a model's layer graph, but it doesn't support serializing raw pointers. However, it does support serializing `std::weak_ptr`. This PR goes through and replaces all raw layer pointer state with `std::weak_ptr<Layer>`. The only significant substantive functional change is in the unpooling layer (use the hint layer instead of maintaining a pointer to a pooling layer). [Bamboo has no new failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM308-7).

Note that `std::weak_ptr` points to data in a `std::shared_ptr`. This is suboptimal since we would like for layers to be explicitly owned by models, and hence we would like to keep the layers in `std::unique_ptr<Layer>` s. There is an experimental [`std::observer_ptr`](https://en.cppreference.com/w/cpp/experimental/observer_ptr), but it is not available as of C++20 and [Bjarne doesn't like it](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1408r0.pdf). To make usage clear, I've typedef'ed `OwningLayerPtr=std::shared_ptr<Layer>` and `ViewingLayerPtr=std::weak_ptr<Layer>`.