### PR TITLE
Distribute ingestion of offline node2vec walks

### DIFF
--- a/applications/graph/node2vec/data/offline_walks.py
+++ b/applications/graph/node2vec/data/offline_walks.py
@@ -91,8 +91,7 @@ def get_sample(index):
     # Count number of times each vertex is visited
     # Note: Update noise distribution if there are enough visits.
     global visit_counts, total_visit_count
-    for vertex in walks[index]:
-        visit_counts[vertex] += np.int64(1)
+    visit_counts[walks[index]] += 1
     total_visit_count += len(walks[index])
     if total_visit_count > 2*noise_visit_count:
         update_noise_distribution()

--- a/applications/graph/node2vec/data/offline_walks.py
+++ b/applications/graph/node2vec/data/offline_walks.py
@@ -10,6 +10,7 @@ import configparser
 import os
 import os.path
 import numpy as np
+import pandas as pd
 
 # Load config file
 config_file = os.getenv('LBANN_NODE2VEC_CONFIG_FILE')
@@ -31,11 +32,11 @@ num_negative_samples = config.getint('Skip-gram', 'num_negative_samples')
 noise_distribution_exp = config.getfloat('Skip-gram', 'noise_distribution_exp')
 
 # Load walks from file
-### @todo Pandas
 ### @todo Partial read on each MPI rank
 if not walk_file:
     raise RuntimeError(f'No walk file specified in {config_file}')
-walks = np.loadtxt(walk_file, dtype=np.int64)
+walks = pd.read_csv(walk_file, delimiter=' ', header=None, dtype=np.int64)
+walks = walks.to_numpy()
 if not num_walks:
     num_walks = walks.shape[0]
 if not walk_length:

--- a/applications/graph/node2vec/data/offline_walks.py
+++ b/applications/graph/node2vec/data/offline_walks.py
@@ -1,9 +1,9 @@
 """Dataset for offline random walks.
 
-This script loads random walks that have been generated offline. It is
+This script loads graph walks that have been generated offline. It is
 intended to be imported by the Python data reader and used in a
-Skip-Gram algorithm. Data samples consists of a random walk and
-negative samples.
+Skip-Gram algorithm. Data samples are sequences of vertex indices,
+corresponding to a graph walk and negative samples.
 
 """
 import configparser
@@ -19,6 +19,10 @@ current_file = os.path.realpath(__file__)
 app_dir = os.path.dirname(os.path.dirname(current_file))
 sys.path.append(os.path.join(app_dir))
 import utils
+
+# ----------------------------------------------
+# Configuration
+# ----------------------------------------------
 
 # Load config file
 config_file = os.getenv('LBANN_NODE2VEC_CONFIG_FILE')
@@ -41,6 +45,20 @@ epoch_size = config.getint('Skip-gram', 'epoch_size')
 num_negative_samples = config.getint('Skip-gram', 'num_negative_samples')
 noise_distribution_exp = config.getfloat('Skip-gram', 'noise_distribution_exp')
 
+# Configure RNG
+rng_pid = None
+def initialize_rng():
+    """Initialize NumPy random seed if needed.
+
+    Seed should be initialized independently on each process. We
+    reinitialize if we detect a process fork.
+
+    """
+    global rng_pid
+    if rng_pid != os.getpid():
+        rng_pid = os.getpid()
+        np.random.seed()
+
 # Determine MPI rank
 if 'OMPI_COMM_WORLD_RANK' not in os.environ:
     warnings.warn(
@@ -52,7 +70,12 @@ if 'OMPI_COMM_WORLD_RANK' not in os.environ:
 mpi_rank = int(os.getenv('OMPI_COMM_WORLD_RANK', default=0))
 mpi_size = int(os.getenv('OMPI_COMM_WORLD_SIZE', default=1))
 
+# ----------------------------------------------
+# Walks
+# ----------------------------------------------
+
 # Load walks from file
+# Note: Each MPI rank loads a subset of the walk file
 if not walk_file:
     raise RuntimeError(f'No walk file specified in {config_file}')
 if not num_walks:
@@ -72,6 +95,8 @@ walks = pd.read_csv(
     nrows=local_num_walks,
 )
 walks = walks.to_numpy()
+
+# Check that walk data is valid
 if not walk_length:
     walk_length = walks.shape[1]
 if not num_vertices:
@@ -86,59 +111,116 @@ assert walks.shape[1] == walk_length, \
 assert num_vertices > 0, \
     f'Walks in {walk_file} have invalid vertex indices'
 
-# Noise distribution for negative sampling
-# Note: We count the number of times each vertex has been visited and
-# periodically recompute the noise distribution.
+# Randomly sample local walks
+walk_index_cache = []
+walk_index_cache_pos = 0
+def choose_walk():
+    """Randomly choose one of the local walks.
+
+    Random numbers are generated in batches to amortize Python
+    overheads.
+
+    """
+    global walk_index_cache, walk_index_cache_pos
+    if walk_index_cache_pos >= len(walk_index_cache):
+        initialize_rng()
+        walk_index_cache_pos = 0
+        walk_index_cache = np.random.randint(
+            local_num_walks,
+            size=1024,
+            dtype=np.int64,
+        )
+        record_walk_visits(walks[walk_index_cache])
+    index = walk_index_cache[walk_index_cache_pos]
+    walk_index_cache_pos += 1
+    return walks[index]
+
+# ----------------------------------------------
+# Negative sampling
+# ----------------------------------------------
+
+# Keep track how often we visit each vertex
+# Note: Start with one visit per vertex for Laplace smoothing.
 visit_counts = np.ones(num_vertices, dtype=np.int64)
 total_visit_count = num_vertices
+def record_walk_visits(walks):
+    """Record visits to vertices in a graph walk.
+
+    Recomputes negative sampling distribution
+
+    """
+    global visit_counts, total_visit_count
+    visit_counts[walks] += np.int64(1)
+    total_visit_count += len(walks) * walk_length
+
+# Probability distribution for negative sampling
 noise_cdf = np.zeros(num_vertices, dtype=np.float64)
 noise_visit_count = 0
 def update_noise_distribution():
-    global noise_cdf, noise_visit_count
-    np.float_power(
-        visit_counts,
-        noise_distribution_exp,
-        out=noise_cdf,
-        dtype=np.float64,
-    )
-    np.cumsum(noise_cdf, out=noise_cdf)
-    noise_cdf *= np.float64(1 / noise_cdf[-1])
-    noise_visit_count = total_visit_count
-update_noise_distribution()
+    """Recomputes negative sampling probability distribution, if needed.
 
-# Need to reseed RNG after forking processes
-need_to_seed_rng = True
-
-def get_sample(_):
-    """Get a single data sample.
-
-    Consists of a sequence from a random walk and several negative
-    samples.
+    The distribution is recomputed if enough new vertices have been
+    visited.
 
     """
-
-    # Check if RNG needs to be reseeded
-    global need_to_seed_rng
-    if need_to_seed_rng:
-        np.random.seed()
-        need_to_seed_rng = False
-
-    # Randomly choose walk
-    walk = walks[np.random.randint(local_num_walks)]
-
-    # Count number of times each vertex is visited
-    # Note: Update noise distribution if there are enough visits.
-    global visit_counts, total_visit_count
-    visit_counts[walk] += 1
-    total_visit_count += len(walk)
+    global noise_visit_count
     if total_visit_count > 2*noise_visit_count:
-        update_noise_distribution()
 
-    # Return negative samples and walk
-    negative_samples = np.searchsorted(
-        noise_cdf,
-        np.random.rand(num_negative_samples),
-    )
+        # Reset negative samples
+        global negative_samples_cache_pos, negative_samples_cache
+        negative_samples_cache = []
+        negative_samples_cache_pos = 0
+
+        # Update noise distribution if there are enough new visits
+        global noise_cdf
+        np.float_power(
+            visit_counts,
+            noise_distribution_exp,
+            out=noise_cdf,
+            dtype=np.float64,
+        )
+        np.cumsum(noise_cdf, out=noise_cdf)
+        noise_cdf *= np.float64(1 / noise_cdf[-1])
+        noise_visit_count = total_visit_count
+
+# Initial negative sampling distribution is uniform
+update_noise_distribution()
+
+# Generate negative sampling
+negative_samples_cache = []
+negative_samples_cache_pos = 0
+def generate_negative_samples():
+    """Generate negative samples.
+
+    Returns an array with num_negative_samples entries. Negative
+    samples are generated in batches to amortize Python overheads.
+
+    """
+    global negative_samples_cache, negative_samples_cache_pos
+    if negative_samples_cache_pos >= len(negative_samples_cache):
+        initialize_rng()
+        rands = np.random.uniform(size=1024*num_negative_samples)
+        negative_samples_cache_pos = 0
+        negative_samples_cache = np.searchsorted(noise_cdf, rands)
+    pos_start = negative_samples_cache_pos
+    pos_end = negative_samples_cache_pos + num_negative_samples
+    negative_samples_cache_pos = pos_end
+    return negative_samples_cache[pos_start:pos_end]
+
+# ----------------------------------------------
+# Sample access functions
+# ----------------------------------------------
+
+def get_sample(*args):
+    """Get a single data sample.
+
+    A data sample consists of a graph walk and several negative
+    samples. Input arguments are ignored.
+
+    """
+    walk = choose_walk()
+    update_noise_distribution()
+    negative_samples = generate_negative_samples()
     return np.concatenate((negative_samples, walk))
 
 def num_samples():

--- a/applications/graph/node2vec/data/offline_walks.py
+++ b/applications/graph/node2vec/data/offline_walks.py
@@ -9,8 +9,16 @@ negative samples.
 import configparser
 import os
 import os.path
+import subprocess
+import sys
+import warnings
 import numpy as np
 import pandas as pd
+
+current_file = os.path.realpath(__file__)
+app_dir = os.path.dirname(os.path.dirname(current_file))
+sys.path.append(os.path.join(app_dir))
+import utils
 
 # Load config file
 config_file = os.getenv('LBANN_NODE2VEC_CONFIG_FILE')
@@ -21,6 +29,7 @@ if not config_file:
 if not os.path.exists(config_file):
     raise FileNotFoundError(f'Could not find config file at {config_file}')
 config = configparser.ConfigParser()
+config.read(os.path.join(app_dir, 'default.config'))
 config.read(config_file)
 
 # Options from config file
@@ -28,29 +37,54 @@ num_vertices = config.getint('Graph', 'num_vertices', fallback=0)
 walk_file = config.get('Walks', 'file', fallback=None)
 walk_length = config.getint('Walks', 'walk_length', fallback=0)
 num_walks = config.getint('Walks', 'num_walks', fallback=0)
+epoch_size = config.getint('Skip-gram', 'epoch_size')
 num_negative_samples = config.getint('Skip-gram', 'num_negative_samples')
 noise_distribution_exp = config.getfloat('Skip-gram', 'noise_distribution_exp')
 
+# Determine MPI rank
+if 'OMPI_COMM_WORLD_RANK' not in os.environ:
+    warnings.warn(
+        'Could not detect MPI environment variables. '
+        'We expect that LBANN is run with '
+        'Open MPI or one of its derivatives.',
+        warning.RuntimeWarning,
+    )
+mpi_rank = int(os.getenv('OMPI_COMM_WORLD_RANK', default=0))
+mpi_size = int(os.getenv('OMPI_COMM_WORLD_SIZE', default=1))
+
 # Load walks from file
-### @todo Partial read on each MPI rank
 if not walk_file:
     raise RuntimeError(f'No walk file specified in {config_file}')
-walks = pd.read_csv(walk_file, delimiter=' ', header=None, dtype=np.int64)
-walks = walks.to_numpy()
 if not num_walks:
-    num_walks = walks.shape[0]
+    with open(walk_file, 'r') as f:
+        result = subprocess.run(['wc','-l'], stdin=f, stdout=subprocess.PIPE)
+    num_walks = int(result.stdout.decode('utf-8'))
+local_num_walks = utils.ceildiv(num_walks, mpi_size)
+start_walk = local_num_walks * mpi_rank
+end_walk = min(local_num_walks * (mpi_rank + 1), num_walks)
+local_num_walks = end_walk - start_walk
+walks = pd.read_csv(
+    walk_file,
+    delimiter=' ',
+    header=None,
+    dtype=np.int64,
+    skiprows=start_walk,
+    nrows=local_num_walks,
+)
+walks = walks.to_numpy()
 if not walk_length:
     walk_length = walks.shape[1]
 if not num_vertices:
     num_vertices = np.amax(walks) + 1
-assert walks.shape[0] == num_walks, \
-    f'Found {walks.shape[0]} walks in {walk_file}, ' \
-    f'but expected {num_walks}'
+assert walks.shape[0] > 0, f'Did not load any walks from {walk_file}'
+assert walks.shape[0] == local_num_walks, \
+    f'Read {walks.shape[0]} walks from {walk_file}, ' \
+    f'but expected to read {local_num_walks}'
 assert walks.shape[1] == walk_length, \
     f'Found walks of length {walks.shape[1]} in {walk_file}, ' \
     f'but expected a walk length of {walk_length}'
 assert num_vertices > 0, \
-    f'Random walks in {walk_file} have invalid vertex indices'
+    f'Walks in {walk_file} have invalid vertex indices'
 
 # Noise distribution for negative sampling
 # Note: We count the number of times each vertex has been visited and
@@ -75,7 +109,7 @@ update_noise_distribution()
 # Need to reseed RNG after forking processes
 need_to_seed_rng = True
 
-def get_sample(index):
+def get_sample(_):
     """Get a single data sample.
 
     Consists of a sequence from a random walk and several negative
@@ -89,11 +123,14 @@ def get_sample(index):
         np.random.seed()
         need_to_seed_rng = False
 
+    # Randomly choose walk
+    walk = walks[np.random.randint(local_num_walks)]
+
     # Count number of times each vertex is visited
     # Note: Update noise distribution if there are enough visits.
     global visit_counts, total_visit_count
-    visit_counts[walks[index]] += 1
-    total_visit_count += len(walks[index])
+    visit_counts[walk] += 1
+    total_visit_count += len(walk)
     if total_visit_count > 2*noise_visit_count:
         update_noise_distribution()
 
@@ -102,11 +139,17 @@ def get_sample(index):
         noise_cdf,
         np.random.rand(num_negative_samples),
     )
-    return np.concatenate((negative_samples, walks[index]))
+    return np.concatenate((negative_samples, walk))
 
 def num_samples():
-    """Number of samples in dataset."""
-    return num_walks
+    """Number of samples per "epoch".
+
+    This data reader samples randomly with replacement, so epochs are
+    not meaningful. However, it is convenient to group data samples
+    into "epochs" so that we don't need to change LBANN's data model.
+
+    """
+    return epoch_size
 
 def sample_dims():
     """Dimensions of a data sample."""

--- a/applications/graph/node2vec/default.config
+++ b/applications/graph/node2vec/default.config
@@ -12,5 +12,6 @@ return_param = 0.25
 inout_param = 0.25
 
 [Skip-gram]
+epoch_size = 0
 num_negative_samples = 20
 noise_distribution_exp = 0.75

--- a/applications/graph/node2vec/default.config
+++ b/applications/graph/node2vec/default.config
@@ -1,0 +1,16 @@
+# Config file with defaults
+
+[Graph]
+file =
+num_vertices = 0
+
+[Walks]
+file =
+walk_length = 100
+num_walks = 0
+return_param = 0.25
+inout_param = 0.25
+
+[Skip-gram]
+num_negative_samples = 20
+noise_distribution_exp = 0.75

--- a/applications/graph/node2vec/main.py
+++ b/applications/graph/node2vec/main.py
@@ -112,6 +112,12 @@ if not num_vertices:
     raise RuntimeError('Number of graph vertices not provided in config file')
 config.set('Graph', 'num_vertices', str(num_vertices))
 
+# Get epoch size
+epoch_size = config.getint('Skip-gram', 'epoch_size', fallback=0)
+if not epoch_size:
+    epoch_size = 100 * args.mini_batch_size
+config.set('Skip-gram', 'epoch_size', str(epoch_size))
+
 # Write config file to work directory
 config_file = os.path.join(args.work_dir, 'experiment.config')
 with open(config_file, 'w') as f:
@@ -125,6 +131,7 @@ walk_file = config.get('Walks', 'file', fallback=None)
 walk_length = config.getint('Walks', 'walk_length')
 return_param = config.getfloat('Walks', 'return_param')
 inout_param = config.getfloat('Walks', 'inout_param')
+epoch_size = config.getint('Skip-gram', 'epoch_size')
 num_negative_samples = config.getint('Skip-gram', 'num_negative_samples')
 
 # ----------------------------------
@@ -134,15 +141,8 @@ num_negative_samples = config.getint('Skip-gram', 'num_negative_samples')
 # Construct data reader
 if args.offline_walks:
     assert walk_file, 'Walk file must be specified for offline node2vec'
-    # Note: Train one epoch if epoch size isn't provided
-    epoch_size = config.getint(
-        'Walks',
-        'num_walks',
-        fallback=args.num_iterations*args.mini_batch_size,
-    )
     reader = data.data_readers.make_offline_data_reader()
 else:
-    epoch_size = 100 * args.mini_batch_size
     assert graph_file, 'Graph file must be specified for online node2vec'
     # Note: Preprocess graph with HavoqGT and store in shared memory
     # before starting LBANN.

--- a/applications/graph/node2vec/test/test_offline_walks.py
+++ b/applications/graph/node2vec/test/test_offline_walks.py
@@ -48,9 +48,8 @@ def profile_dataset():
     import cProfile
     import offline_walks
     output_file = os.path.join(root_dir, 'benchmark_dataset.prof')
-    num_iters = 1000
     def func():
-        for _ in range(1000):
+        for _ in range(5000):
             offline_walks.get_sample(0)
     cProfile.runctx('func()', globals(), locals(), filename=output_file)
 

--- a/applications/graph/node2vec/test/test_offline_walks.py
+++ b/applications/graph/node2vec/test/test_offline_walks.py
@@ -1,38 +1,64 @@
+import os
 import os.path
 import random
 import sys
 
 # Local paths
 root_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-sys.path.append(root_dir)
+sys.path.append(os.path.join(root_dir, 'data'))
 
 def test_dataset():
-    import dataset
+    """Make sure offline walk ingestion produces sane data.
 
-    # Check max node ID
-    max_graph_node_id = dataset.max_graph_node_id()
-    assert max_graph_node_id >= 0, 'Negative graph node ID'
-    assert max_graph_node_id != 0, \
-        'Max graph node ID is zero, ' \
-        'which implies graph has only one node or node IDs are negative'
+    The LBANN_NODE2VEC_CONFIG_FILE environment variable must be set.
 
-    # Check sample dimensions
-    sample_dims = dataset.sample_dims()
-    assert len(sample_dims) == 1, 'Unexpected dimensions for data sample'
-    assert sample_dims[0] > 0, 'Invalid dimensions for data sample'
+    """
+    import offline_walks
+
+    # Check graph size
+    num_vertices = offline_walks.num_vertices
+    assert num_vertices >= 0, 'Negative graph size'
+    assert num_vertices != 0, 'Graph has no vertices'
 
     # Check number of samples
-    num_samples = dataset.num_samples()
+    num_samples = offline_walks.num_samples()
     assert num_samples >= 0, 'Invalid number of data samples'
     assert num_samples != 0, 'Dataset has no data samples'
 
+    # Check sample dimensions
+    sample_dims = offline_walks.sample_dims()
+    assert len(sample_dims) == 1, 'Unexpected dimensions for data sample'
+    assert sample_dims[0] > 0, 'Invalid dimensions for data sample'
+
     # Check samples
-    indices = [random.randint(0, num_samples-1) for _ in range(20)]
+    indices = [random.randrange(num_samples) for _ in range(1000)]
     indices.append(0)
     indices.append(num_samples-1)
     for index in indices:
-        sample = dataset.get_sample(index)
+        sample = offline_walks.get_sample(index)
         assert sample.shape == sample_dims, 'Unexpected dimensions for data sample'
         for node in sample:
-            assert 0 <= node <= max_graph_node_id, \
+            assert 0 <= node < num_vertices, \
                 'Invalid graph node ID in data sample'
+
+def profile_dataset():
+    """Profile offline walk ingestion.
+
+    The LBANN_NODE2VEC_CONFIG_FILE environment variable must be set. A
+    cProfile file is output to benchmark_dataset.prof in the
+    application dir, which can be visualized with SnakeViz.
+
+    """
+    import cProfile
+    import offline_walks
+    output_file = os.path.join(root_dir, 'benchmark_dataset.prof')
+    num_iters = 1000
+    num_samples = offline_walks.num_samples()
+    indices = [random.randrange(num_samples) for _ in range(num_iters)]
+    def func():
+        for i in indices:
+            offline_walks.get_sample(i)
+    cProfile.runctx('func()', globals(), locals(), filename=output_file)
+
+if __name__ == '__main__':
+    test_dataset()

--- a/applications/graph/node2vec/test/test_offline_walks.py
+++ b/applications/graph/node2vec/test/test_offline_walks.py
@@ -23,7 +23,6 @@ def test_dataset():
     # Check number of samples
     num_samples = offline_walks.num_samples()
     assert num_samples >= 0, 'Invalid number of data samples'
-    assert num_samples != 0, 'Dataset has no data samples'
 
     # Check sample dimensions
     sample_dims = offline_walks.sample_dims()
@@ -31,11 +30,8 @@ def test_dataset():
     assert sample_dims[0] > 0, 'Invalid dimensions for data sample'
 
     # Check samples
-    indices = [random.randrange(num_samples) for _ in range(1000)]
-    indices.append(0)
-    indices.append(num_samples-1)
-    for index in indices:
-        sample = offline_walks.get_sample(index)
+    for _ in range(1000):
+        sample = offline_walks.get_sample(0)
         assert sample.shape == sample_dims, 'Unexpected dimensions for data sample'
         for node in sample:
             assert 0 <= node < num_vertices, \
@@ -53,11 +49,9 @@ def profile_dataset():
     import offline_walks
     output_file = os.path.join(root_dir, 'benchmark_dataset.prof')
     num_iters = 1000
-    num_samples = offline_walks.num_samples()
-    indices = [random.randrange(num_samples) for _ in range(num_iters)]
     def func():
-        for i in indices:
-            offline_walks.get_sample(i)
+        for _ in range(1000):
+            offline_walks.get_sample(0)
     cProfile.runctx('func()', globals(), locals(), filename=output_file)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR builds on work by @andy-yoo and @KIwabuchi to better accommodate node2vec with walks generated offline. It makes several changes:
- Data ingestion is configured with an INI file rather than by directly editing the Python script.
- The walk data is parsed with the Pandas `read_csv` function for performance.
- Each MPI rank only loads a subset of the walk data. Data samples are drawn randomly with replacement from the local walk data.
- The probability distribution for negative sampling is updated online.
- Performance is optimized by batching the NumPy routines. When I run on a Lassen node, runtime dropped from 0.084 sec/step to 0.011 sec/step (compare with 0.066 sec/step for the online implementation).

This is intended to allow training with extremely large walk data files. To use, first create a config file:
```
[Graph]
num_vertices = 12345678

[Walks]
file = mywalks.txt
walk_length = 100
num_walks = 123456780
```
See `default.config` for a list of options. Note that the data script will read `default.config` for defaults, so you don't need to specify all the options. The config file can be passed into the main node2vec driver:
```sh
python3 main.py --offline-walks --config myexperiment.config
```
You can also specify the config file with the `LBANN_NODE2VEC_CONFIG_FILE` environment variable.