### PR TITLE
Minor tweaks for half data type constants

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -19,6 +19,7 @@ Internal features:
  - Wrapper classes for CUDA Graphs API
  - Elementary examples of using complex numbers
  - cuDNN handles are now wrapped in RAII management classes
+ - Improved HWLOC compatility for v1.11 and v2.x
 
 I/O & data readers:
  - Experimental data reader that generates graph random walks with

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -28,12 +28,15 @@ Building with `Spack <https://github.com/llnl/spack>`_
 Setup Spack
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-1.  Download and install `Spack <https://github.com/llnl/spack>`_.
+1.  Download and install `Spack <https://github.com/llnl/spack>`_
+    using the following commands.
     Additionally setup shell support as discussed
     `here <https://spack.readthedocs.io/en/latest/module_file_support.html#id2>`_.
 
     .. code-block:: bash
 
+        git clone https://github.com/spack/spack.git spack.git
+        export SPACK_ROOT=<path to installation>/spack.git
         source ${SPACK_ROOT}/share/spack/setup-env.sh
 
 

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -745,16 +745,16 @@ setup_layer(size_t workspace_capacity) {
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void pooling_distconv_adapter<TensorDataType, Layout, Device>::
 fp_compute() {
-  m_pooling->forward(TensorDataType{1}, this->get_prev_activations(),
-                     TensorDataType{0}, this->get_activations());
+  m_pooling->forward(El::To<TensorDataType>(1), this->get_prev_activations(),
+                     El::To<TensorDataType>(0), this->get_activations());
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void pooling_distconv_adapter<TensorDataType, Layout, Device>::
 bp_compute() {
-  m_pooling->backward(TensorDataType{1}, this->get_activations(),
+  m_pooling->backward(El::To<TensorDataType>(1), this->get_activations(),
                       this->get_prev_error_signals(),
-                      this->get_prev_activations(), TensorDataType{0},
+                      this->get_prev_activations(), El::To<TensorDataType>(0),
                       this->get_error_signals());
 }
 #endif // LBANN_HAS_DISTCONV

--- a/scripts/install_lbann.sh
+++ b/scripts/install_lbann.sh
@@ -245,7 +245,7 @@ EOF
 else
     LBANN_ENV="${LBANN_ENV:-lbann-${SPACK_ARCH_TARGET}}"
     BUILD_SPECS=$(cat <<EOF
-  - lbann@develop${GPU_VARIANTS}+dihydrogen+distconv
+  - lbann@test${GPU_VARIANTS}+dihydrogen+distconv${HALF_VARIANTS}
 EOF
 )
 fi

--- a/src/layers/activations/relu.cu
+++ b/src/layers/activations/relu.cu
@@ -36,7 +36,7 @@ namespace {
 template <typename TensorDataType>
 struct op {
   inline __device__ TensorDataType operator()(TensorDataType x) const {
-    return x > TensorDataType{0} ? x : TensorDataType{0};
+    return x > El::To<TensorDataType>(0) ? x : El::To<TensorDataType>(0);
   }
 };
 
@@ -48,7 +48,7 @@ struct op {
 template <typename TensorDataType>
 struct op_backprop {
   inline __device__ TensorDataType operator()(TensorDataType x, TensorDataType dy) const {
-    return x > TensorDataType{0} ? dy : TensorDataType{0};
+    return x > El::To<TensorDataType>(0) ? dy : El::To<TensorDataType>(0);
   }
 };
 
@@ -56,17 +56,17 @@ struct op_backprop {
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void fp_compute_distconv(relu_distconv_adapter<TensorDataType, Layout, Device> &dc) {
   assert_always(Layout == data_layout::DATA_PARALLEL);
-  dc.m_relu->forward(TensorDataType{1}, dc.get_prev_activations(),
-                     TensorDataType{0}, dc.get_activations());
+  dc.m_relu->forward(El::To<TensorDataType>(1), dc.get_prev_activations(),
+                     El::To<TensorDataType>(0), dc.get_activations());
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void bp_compute_distconv(relu_distconv_adapter<TensorDataType, Layout, Device> &dc) {
   assert_always(Layout == data_layout::DATA_PARALLEL);
-  dc.m_relu->backward(TensorDataType{1}, dc.get_activations(),
+  dc.m_relu->backward(El::To<TensorDataType>(1), dc.get_activations(),
                       dc.get_prev_error_signals(),
                       dc.get_prev_activations(),
-                      TensorDataType{0}, dc.get_error_signals());
+                      El::To<TensorDataType>(0), dc.get_error_signals());
 }
 #endif // LBANN_HAS_DISTCONV
 } // namespace

--- a/src/layers/activations/relu.cu
+++ b/src/layers/activations/relu.cu
@@ -36,7 +36,7 @@ namespace {
 template <typename TensorDataType>
 struct op {
   inline __device__ TensorDataType operator()(TensorDataType x) const {
-    return x > El::To<TensorDataType>(0) ? x : El::To<TensorDataType>(0);
+    return x > TensorDataType{0.f} ? x : TensorDataType{0.f};
   }
 };
 
@@ -48,7 +48,7 @@ struct op {
 template <typename TensorDataType>
 struct op_backprop {
   inline __device__ TensorDataType operator()(TensorDataType x, TensorDataType dy) const {
-    return x > El::To<TensorDataType>(0) ? dy : El::To<TensorDataType>(0);
+    return x > TensorDataType{0.f} ? dy : TensorDataType{0.f};
   }
 };
 
@@ -56,17 +56,17 @@ struct op_backprop {
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void fp_compute_distconv(relu_distconv_adapter<TensorDataType, Layout, Device> &dc) {
   assert_always(Layout == data_layout::DATA_PARALLEL);
-  dc.m_relu->forward(El::To<TensorDataType>(1), dc.get_prev_activations(),
-                     El::To<TensorDataType>(0), dc.get_activations());
+  dc.m_relu->forward(TensorDataType{1.f}, dc.get_prev_activations(),
+                     TensorDataType{0.f}, dc.get_activations());
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void bp_compute_distconv(relu_distconv_adapter<TensorDataType, Layout, Device> &dc) {
   assert_always(Layout == data_layout::DATA_PARALLEL);
-  dc.m_relu->backward(El::To<TensorDataType>(1), dc.get_activations(),
+  dc.m_relu->backward(TensorDataType{1.f}, dc.get_activations(),
                       dc.get_prev_error_signals(),
                       dc.get_prev_activations(),
-                      El::To<TensorDataType>(0), dc.get_error_signals());
+                      TensorDataType{0.f}, dc.get_error_signals());
 }
 #endif // LBANN_HAS_DISTCONV
 } // namespace

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1128,7 +1128,7 @@ void base_convolution_adapter<TensorDataType, Device>::setup_fp_tensors() {
   const dc::LocaleMPI loc(dc::get_mpi_comm(), false);
   m_kernel = make_unique<TensorDevType>(kernel_shape, loc, shared_dist);
 
-  if (layer.m_bias_scaling_factor != TensorDataType(0)) {
+  if (layer.m_bias_scaling_factor != El::To<TensorDataType>(0)) {
     dc::Shape bias_shape(dc::get_num_dims(layer), 1);
     bias_shape[dc::get_channel_dim()] = layer.get_output_dims()[0];
     m_bias = make_unique<TensorDevType>(bias_shape, loc, shared_dist);
@@ -1155,7 +1155,7 @@ void base_convolution_adapter<TensorDataType, Device>::setup_bp_tensors() {
             kernel_optimizer->get_gradient().Buffer()));
 
   // Bias tensor. Shared by all procs
-  if (l.m_bias_scaling_factor != TensorDataType(0)) {
+  if (l.m_bias_scaling_factor != El::To<TensorDataType>(0)) {
     auto* bias_optimizer = static_cast<data_type_optimizer<TensorDataType>*>(l.get_weights(1).get_optimizer());
     if (bias_optimizer != nullptr) {
       dc::Shape bias_shape(dc::get_num_dims(l), 1);
@@ -1178,7 +1178,7 @@ void base_convolution_adapter<TensorDataType, Device>::setup_layer(
   m_conv = make_unique<dc::Convolution<TensorDataType>>(
     dc::get_backend(), dc::get_num_dims(layer),
     dc::get_halo_exchange_method());
-  if (layer.m_bias_scaling_factor != TensorDataType(0)) {
+  if (layer.m_bias_scaling_factor != El::To<TensorDataType>(0)) {
     m_conv->setup_bias(*m_bias);
     m_conv->setup_bias_gradient(*m_bias_gradient);
   }
@@ -1190,19 +1190,19 @@ void base_convolution_adapter<TensorDataType, Device>::fp_compute_convolution() 
     TensorDataType, Device>&>(this->layer());
   assert0(dc::tensor::View(
             *m_kernel, l.weights_values(0).LockedBuffer()));
-  m_conv->forward(TensorDataType{1}, this->get_prev_activations(),
-                  *m_kernel, TensorDataType{0}, this->get_activations());
+  m_conv->forward(El::To<TensorDataType>(1), this->get_prev_activations(),
+                  *m_kernel, El::To<TensorDataType>(0), this->get_activations());
 }
 
 template <typename TensorDataType, El::Device Device>
 void base_convolution_adapter<TensorDataType, Device>::fp_apply_bias() {
   auto &l = dynamic_cast<base_convolution_layer<
     TensorDataType, Device>&>(this->layer());
-  if (l.m_bias_scaling_factor == TensorDataType(0)) return;
+  if (l.m_bias_scaling_factor == El::To<TensorDataType>(0)) return;
   assert0(dc::tensor::View(
             *m_bias, l.weights_values(1).LockedBuffer()));
   m_conv->apply_bias(l.m_bias_scaling_factor, *m_bias,
-                     TensorDataType{1}, this->get_activations());
+                     El::To<TensorDataType>(1), this->get_activations());
 }
 
 template <typename TensorDataType, El::Device Device>
@@ -1211,9 +1211,9 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_da
     TensorDataType, Device>&>(this->layer());
   assert0(dc::tensor::View(
             *m_kernel, l.weights_values(0).LockedBuffer()));
-  m_conv->backward_data(TensorDataType{1}, *m_kernel,
+  m_conv->backward_data(El::To<TensorDataType>(1), *m_kernel,
                         this->get_prev_error_signals(),
-                        TensorDataType{0}, this->get_error_signals());
+                        El::To<TensorDataType>(0), this->get_error_signals());
 }
 
 template <typename TensorDataType, El::Device Device>
@@ -1222,7 +1222,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
     TensorDataType, Device>&>(this->layer());
   const bool has_local_data = this->get_prev_activations().get_local_size() > 0 &&
     this->get_prev_error_signals().get_local_size() > 0;
-  if (l.m_bias_scaling_factor != TensorDataType(0)
+  if (l.m_bias_scaling_factor != El::To<TensorDataType>(0)
       && l.get_weights(1).get_optimizer() != nullptr) {
     auto* bias_optimizer = l.get_weights(1).get_optimizer();
     TensorDataType dst_scale{0}, gradient_scale{0};

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1225,7 +1225,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
   if (l.m_bias_scaling_factor != El::To<TensorDataType>(0)
       && l.get_weights(1).get_optimizer() != nullptr) {
     auto* bias_optimizer = l.get_weights(1).get_optimizer();
-    TensorDataType dst_scale{0}, gradient_scale{0};
+    TensorDataType dst_scale{El::To<TensorDataType>(0)}, gradient_scale{El::To<TensorDataType>(0)};
     auto& bias_gradient = bias_optimizer->get_gradient_buffer(
       dst_scale, gradient_scale, true);
     assert0(dc::tensor::View(*m_bias_gradient,
@@ -1241,7 +1241,7 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
 
   auto* kernel_optimizer = l.get_weights(0).get_optimizer();
   if (kernel_optimizer == nullptr) return;
-  TensorDataType dst_scale{0}, gradient_scale{0};
+  TensorDataType dst_scale{El::To<TensorDataType>(0)}, gradient_scale{El::To<TensorDataType>(0)};
   auto& kernel_gradient = kernel_optimizer->get_gradient_buffer(
     dst_scale, gradient_scale, true);
   assert0(dc::tensor::View(

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -427,11 +427,11 @@ void batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::bp_com
 
   auto* scale_optimizer = l.get_weights(0).get_optimizer();
   if (scale_optimizer != nullptr) {
-    scale_optimizer->add_to_gradient(*l.m_scale_gradient, TensorDataType{1}, true);
+    scale_optimizer->add_to_gradient(*l.m_scale_gradient, El::To<TensorDataType>(1), true);
   }
   auto* bias_optimizer = l.get_weights(1).get_optimizer();
   if (bias_optimizer != nullptr) {
-    bias_optimizer->add_to_gradient(*l.m_bias_gradient, TensorDataType{1}, true);
+    bias_optimizer->add_to_gradient(*l.m_bias_gradient, El::To<TensorDataType>(1), true);
   }
 
   m_bn->backward_stage2(this->get_prev_activations(), this->get_prev_error_signals(),

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -427,11 +427,11 @@ void batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::bp_com
 
   auto* scale_optimizer = l.get_weights(0).get_optimizer();
   if (scale_optimizer != nullptr) {
-    scale_optimizer->add_to_gradient(*l.m_scale_gradient, El::To<TensorDataType>(1), true);
+    scale_optimizer->add_to_gradient(*l.m_scale_gradient, TensorDataType{1.f}, true);
   }
   auto* bias_optimizer = l.get_weights(1).get_optimizer();
   if (bias_optimizer != nullptr) {
-    bias_optimizer->add_to_gradient(*l.m_bias_gradient, El::To<TensorDataType>(1), true);
+    bias_optimizer->add_to_gradient(*l.m_bias_gradient, TensorDataType{1.f}, true);
   }
 
   m_bn->backward_stage2(this->get_prev_activations(), this->get_prev_error_signals(),

--- a/src/layers/regularizers/entrywise_batch_normalization.cu
+++ b/src/layers/regularizers/entrywise_batch_normalization.cu
@@ -89,8 +89,8 @@ __global__ void compute_statistics_kernel(size_t size,
     mean = sum / statistics_count_dt;
     const auto sqmean = sqsum / statistics_count_dt;
     var = (sqmean - mean * mean) * statistics_count_dt / TensorDataType(statistics_count - 1);
-    _running_mean = decay * _running_mean + (TensorDataType{1} - decay) * mean;
-    _running_var = decay * _running_var + (TensorDataType{1} - decay) * var;
+    _running_mean = decay * _running_mean + (El::To<TensorDataType>(1) - decay) * mean;
+    _running_var = decay * _running_var + (El::To<TensorDataType>(1) - decay) * var;
   }
 }
 

--- a/src/layers/regularizers/entrywise_batch_normalization.cu
+++ b/src/layers/regularizers/entrywise_batch_normalization.cu
@@ -89,8 +89,8 @@ __global__ void compute_statistics_kernel(size_t size,
     mean = sum / statistics_count_dt;
     const auto sqmean = sqsum / statistics_count_dt;
     var = (sqmean - mean * mean) * statistics_count_dt / TensorDataType(statistics_count - 1);
-    _running_mean = decay * _running_mean + (El::To<TensorDataType>(1) - decay) * mean;
-    _running_var = decay * _running_var + (El::To<TensorDataType>(1) - decay) * var;
+    _running_mean = decay * _running_mean + (TensorDataType{1.f} - decay) * mean;
+    _running_var = decay * _running_var + (TensorDataType{1.f} - decay) * var;
   }
 }
 


### PR DESCRIPTION
Changed the instantiation of constants from using TensorDataType to use the El::To<TensorDataType> pattern