### PR TITLE
Replace raw weights pointers with smart pointers

### DIFF
--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -237,8 +237,6 @@ protected:
 
 private:
 
-  void setup_weights(size_t idx, weights& w) override;
-
   /** @brief Attempt to take ownership of the previous error signal.
    *
    *  If the underlying matrix has the right datatype and

--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -146,7 +146,7 @@ void channelwise_scale_bias_layer<TensorDataType, Layout, Dev>
   // Construct default weights if needed
   // Note: Scale is initialized to 1 and bias to 0
   if (!this->has_weights()) {
-    auto w = make_unique<WeightsType>(this->get_comm());
+    auto w = std::make_shared<WeightsType>(this->get_comm());
     std::vector<TensorDataType> vals(2*num_channels,
                                      El::TypeTraits<TensorDataType>::Zero());
     std::fill(vals.begin(), vals.begin()+num_channels,
@@ -156,7 +156,7 @@ void channelwise_scale_bias_layer<TensorDataType, Layout, Dev>
     w->set_name(this->get_name() + "_weights");
     w->set_initializer(std::move(init));
     w->set_optimizer(std::move(opt));
-    this->add_weights(w.get());
+    this->add_weights(w);
     this->m_model->add_weights(std::move(w));
   }
   if (this->num_weights() != 1) {

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -203,14 +203,14 @@ void embedding_layer<TensorDataType,Layout,Device>::setup_data(size_t max_mini_b
   // Note: Randomly drawn from normal distribution with mean 0 and
   // standard deviation 1.
   if (!this->has_weights()) {
-    auto w = make_unique<WeightsType>(this->get_comm());
+    auto w = std::make_shared<WeightsType>(this->get_comm());
     auto init = make_unique<normal_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::Zero(),
                                                                 El::TypeTraits<TensorDataType>::One());
     auto opt = this->m_model->template create_optimizer<TensorDataType>();
     w->set_name(this->get_name() + "_weights");
     w->set_initializer(std::move(init));
     w->set_optimizer(std::move(opt));
-    this->add_weights(w.get());
+    this->add_weights(w);
     this->m_model->add_weights(std::move(w));
   }
   if (this->num_weights() != 1) {

--- a/include/lbann/layers/learning/entrywise_scale_bias.hpp
+++ b/include/lbann/layers/learning/entrywise_scale_bias.hpp
@@ -151,7 +151,7 @@ entrywise_scale_bias_layer<TensorDataType, Layout, Dev>
     // Construct default weights if needed
     // Note: Scale is initialized to 1 and bias to 0
     if (!this->has_weights()) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       std::vector<TensorDataType> vals(2*output_size,
                                        El::TypeTraits<TensorDataType>::Zero());
       std::fill(vals.begin(), vals.begin()+output_size,
@@ -161,7 +161,7 @@ entrywise_scale_bias_layer<TensorDataType, Layout, Dev>
       w->set_name(this->get_name() + "_weights");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->add_weights(w.get());
+      this->add_weights(w);
       this->m_model->add_weights(std::move(w));
     }
     if (this->num_weights() != 1) {

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -295,39 +295,39 @@ protected:
     }
     this->set_num_weights(4);
     if (!this->has_weights(0)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::One());
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_scale");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->set_weights(0, w.get());
+      this->set_weights(0, w);
       this->m_model->add_weights(std::move(w));
     }
     if (!this->has_weights(1)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::Zero());
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_bias");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->set_weights(1, w.get());
+      this->set_weights(1, w);
       this->m_model->add_weights(std::move(w));
     }
     if (!this->has_weights(2)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::Zero());
       w->set_name(this->get_name() + "_running_mean");
       w->set_initializer(std::move(init));
-      this->set_weights(2, w.get());
+      this->set_weights(2, w);
       this->m_model->add_weights(std::move(w));
     }
     if (!this->has_weights(3)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::One());
       w->set_name(this->get_name() + "_running_variance");
       w->set_initializer(std::move(init));
-      this->set_weights(3, w.get());
+      this->set_weights(3, w);
       this->m_model->add_weights(std::move(w));
     }
 

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -130,19 +130,19 @@ protected:
     }
     this->set_num_weights(2);
     if (!this->has_weights(0)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::Zero());
       w->set_name(this->get_name() + "_running_mean");
       w->set_initializer(std::move(init));
-      this->set_weights(0, w.get());
+      this->set_weights(0, w);
       this->m_model->add_weights(std::move(w));
     }
     if (!this->has_weights(1)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<TensorDataType>>(El::TypeTraits<TensorDataType>::One());
       w->set_name(this->get_name() + "_running_variance");
       w->set_initializer(std::move(init));
-      this->set_weights(1, w.get());
+      this->set_weights(1, w);
       this->m_model->add_weights(std::move(w));
     }
 

--- a/include/lbann/layers/transform/weights.hpp
+++ b/include/lbann/layers/transform/weights.hpp
@@ -114,13 +114,13 @@ public:
 
     // Initialize default weights if none are provided
     if (!this->has_weights()) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto init = make_unique<constant_initializer<DataType>>(DataType(0));
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_weights");
       w->set_initializer(std::move(init));
       w->set_optimizer(std::move(opt));
-      this->add_weights(w.get());
+      this->add_weights(w);
       this->m_model->add_weights(std::move(w));
     }
     if (this->num_weights() != 1) {

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -138,8 +138,8 @@ public:
   const std::vector<Layer*> get_layers() const;
 
   const std::vector<weights*> get_weights() const;
-
   std::vector<weights*> get_weights();
+  std::vector<ViewingWeightsPtr> get_weights_pointers() const;
 
   /** @brief Get the list of callbacks for the model. */
   virtual std::vector<observer_ptr<callback_base>> get_callbacks() {
@@ -186,7 +186,7 @@ public:
   virtual void add_layer(OwningLayerPtr&& l);
 
   /** @brief Add weights to model. */
-  void add_weights(std::unique_ptr<weights> w);
+  void add_weights(OwningWeightsPtr&& w);
 
   /** @brief Register a new callback for the model. */
   void add_callback(std::shared_ptr<callback_base> cb);
@@ -196,9 +196,6 @@ public:
 
   /** @brief Register a new metric for the model. */
   void add_metric(metric *m);
-
-  /** @brief Replace the model's weights. */
-  void replace_weights(std::vector<weights *>& w);
 
   /** @brief Copy trained weights from input parameter w.
    *
@@ -301,7 +298,7 @@ protected:
    */
   virtual void remap_pointers(
     const std::unordered_map<Layer*,ViewingLayerPtr>& layer_map,
-    const std::unordered_map<weights*,weights*>& weights_map);
+    const std::unordered_map<weights*,ViewingWeightsPtr>& weights_map);
 
   /** @brief
    *
@@ -431,7 +428,7 @@ private:
   std::vector<OwningLayerPtr> m_layers;
 
   /** @brief Trainable parameters. */
-  std::vector<std::unique_ptr<weights>> m_weights;
+  std::vector<OwningWeightsPtr> m_weights;
 
   /** @details If a layer needs to construct an optimizer during
    *  setup, it will make a copy of the default optimizer. This object

--- a/include/lbann/objective_functions/objective_function.hpp
+++ b/include/lbann/objective_functions/objective_function.hpp
@@ -116,9 +116,9 @@ class objective_function {
   /** Set list of pointers to layers. */
   void set_layer_pointers(std::vector<ViewingLayerPtr> layers);
   /** Get list of pointers to weights. */
-  std::vector<weights*> get_weights_pointers() const;
+  std::vector<ViewingWeightsPtr> get_weights_pointers() const;
   /** Set list of pointers to weights. */
-  void set_weights_pointers(std::vector<weights*> w);
+  void set_weights_pointers(std::vector<ViewingWeightsPtr> w);
 
   /** Get the time spent evaluating the objective function. */
   EvalType get_evaluation_time() const { return m_evaluation_time; }

--- a/include/lbann/objective_functions/objective_function_term.hpp
+++ b/include/lbann/objective_functions/objective_function_term.hpp
@@ -85,9 +85,9 @@ class objective_function_term {
   /** Set list of pointers to layers. */
   void set_layer_pointers(std::vector<ViewingLayerPtr> layers);
   /** Get list of pointers to weights. */
-  std::vector<weights*> get_weights_pointers() const { return m_weights; }
+  std::vector<ViewingWeightsPtr> get_weights_pointers() const;
   /** Set list of pointers to weights. */
-  void set_weights_pointers(std::vector<weights*> w) { m_weights = w; }
+  void set_weights_pointers(std::vector<ViewingWeightsPtr> w);
 
  protected:
 
@@ -97,7 +97,7 @@ class objective_function_term {
   /** Layers used to compute objective function term. */
   std::vector<ViewingLayerPtr> m_layers;
   /** Weights used to compute objective function term. */
-  std::vector<weights*> m_weights;
+  std::vector<ViewingWeightsPtr> m_weights;
 
   /** Get LBANN communicator. */
   lbann_comm& get_comm() { return *m_comm; }

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -44,8 +44,37 @@ class WeightsData;
 namespace lbann {
 
 // Forward declaration
+class weights;
 class weights_initializer;
 class optimizer;
+
+/** @brief Smart pointer to manage ownership of a weights object
+ *
+ *  This should be treated @b exactly like a @c
+ *  std::unique_ptr<weights> , i.e. there should be exactly one
+ *  instance per pointer and the copy constructor and copy-assignment
+ *  operators should never be used. Using this like a @c
+ *  std::shared_ptr may lead to unexpected behavior.
+ *
+ *  The @b only reason this is not a @c std::unique_ptr is because
+ *  Cereal cannot natively serialize raw pointers. However, it can
+ *  accommodate @c std::weak_ptr . In an ideal world, Cereal would
+ *  support a non-owning smart pointer to an object in @c
+ *  std::unique_ptr (possibly the experimental @c observer_ptr ), but
+ *  we can make do by managing weights with @c std::shared_ptr .
+ *
+ *  @todo Replace with @c std::unique_ptr<weights> when C++ and Cereal
+ *  support @c std::observer_ptr .
+ */
+using OwningWeightsPtr = std::shared_ptr<weights>;
+/** @brief Smart pointer to reference a weights object
+ *
+ *  See @c OwningWeightsPtr
+ *
+ *  @todo Replace with @c std::observer_ptr<Weights> when supported by
+ *  C++ and Cereal.
+ */
+using ViewingWeightsPtr = std::weak_ptr<weights>;
 
 /** Neural network weights.
  *  Weights are tensors that act as trainable parameters for a neural

--- a/include/lbann/weights/weights_proxy.hpp
+++ b/include/lbann/weights/weights_proxy.hpp
@@ -78,6 +78,7 @@ class WeightsProxy
   using ValuesType = El::AbstractDistMatrix<TensorDataType>;
   /** @brief Convenience typedef for poitners to weights values. */
   using ValuesPtrType = std::unique_ptr<ValuesType>;
+
 public:
 
   /** @name Constructors */
@@ -120,8 +121,9 @@ public:
   WeightsProxy(WeightsProxy<T> const& other)
     : WeightsProxy()
   {
-    if (!other.master_weights_.expired()) {
-      this->setup(other.master_weights_);
+    auto ptr = other.master_weights_pointer();
+    if (!ptr.expired()) {
+      this->setup(ptr);
     }
   }
 
@@ -253,10 +255,16 @@ public:
    *  valid if not empty(). Users are expected to ensure this
    *  contract.
    */
-  weights const& master_weights() const noexcept(!LBANN_IN_DEBUG_MODE)
+  weights const& master_weights() const
   {
-    LBANN_DEBUG_ASSERT_POINTER(master_weights_);
+    LBANN_DEBUG_ASSERT_POINTER(master_weights_.lock());
     return *master_weights_.lock();
+  }
+
+  ViewingWeightsPtr master_weights_pointer() const noexcept(!LBANN_IN_DEBUG_MODE)
+  {
+    LBANN_DEBUG_ASSERT_POINTER(master_weights_.lock());
+    return master_weights_;
   }
 
   ///@}

--- a/include/lbann/weights/weights_proxy.hpp
+++ b/include/lbann/weights/weights_proxy.hpp
@@ -74,9 +74,6 @@ namespace lbann {
 template <typename TensorDataType>
 class WeightsProxy
 {
-  /** @brief The data_type_weights type for which the proxy would just
-   *         be a view. */
-  using DataTypeWeights = data_type_weights<TensorDataType>;
   /** @brief The type of weights values. */
   using ValuesType = El::AbstractDistMatrix<TensorDataType>;
   /** @brief Convenience typedef for poitners to weights values. */
@@ -94,38 +91,23 @@ public:
    *  @param w Master weights object, which must have a valid storage
    *           matrix initialized internally.
    */
-  WeightsProxy(weights const& w)
-    : master_weights_{&w},
-      values_{setup_values_(w)}
-  {}
-
-  /** @brief Construct a proxy given the master object.
-   *
-   *  This is a shortcut for the case that the master weights dynamic
-   *  type is already known.
-   *
-   *  @param w Master weights object, which must have a valid storage
-   *           matrix initialized internally.
-   *
-   *  @tparam T (Deduced) The type of the input weights object's
-   *                      values.
-   */
-  template <typename T>
-  WeightsProxy(data_type_weights<T> const& w)
-    : master_weights_{&w},
-      values_{setup_values_(w)}
-  {}
+  WeightsProxy(ViewingWeightsPtr const& w)
+  {
+    if (!w.expired()) {
+      this->setup(w);
+    }
+  }
 
   /** @brief Copy a WeightsProxy object.
    *
    *  Creates a new proxy to the same weights object.
    */
   WeightsProxy(WeightsProxy const& other)
-    : master_weights_(other.master_weights_),
-      values_(other.master_weights_
-              ? setup_values_(*other.master_weights_)
-              : nullptr)
-  {}
+  {
+    if (!other.master_weights_.expired()) {
+      this->setup(other.master_weights_);
+    }
+  }
 
   /** @brief Copy a WeightsProxy object.
    *
@@ -138,8 +120,9 @@ public:
   WeightsProxy(WeightsProxy<T> const& other)
     : WeightsProxy()
   {
-    if (!other.empty())
-      this->setup(other.master_weights());
+    if (!other.master_weights_.expired()) {
+      this->setup(other.master_weights_);
+    }
   }
 
   /** @brief Move a WeightsProxy object.
@@ -148,8 +131,8 @@ public:
    *  for WeightsProxy objects of the same static type.
    */
   WeightsProxy(WeightsProxy&& other) noexcept
-    : master_weights_{other.master_weights_},
-      values_{std::move(other.values_)}
+  : master_weights_{std::move(other.master_weights_)},
+    values_{std::move(other.values_)}
   {
     other.clear();
   }
@@ -187,25 +170,6 @@ public:
     return *this;
   }
 
-  /** @brief Assignment from data_type_weights object.
-   *
-   *  @tparam T (Deduced) The type of the input weights object's
-   *                      values.
-   */
-  template <typename T>
-  WeightsProxy& operator=(data_type_weights<T> const& w)
-  {
-    this->setup(w);
-    return *this;
-  }
-
-  /** @brief Assignment from data_type_weights object */
-  WeightsProxy& operator=(weights const& w)
-  {
-    this->setup(w);
-    return *this;
-  }
-
   /** @brief Move assignment from another proxy object. */
   WeightsProxy& operator=(WeightsProxy&& other) noexcept
   {
@@ -224,8 +188,8 @@ public:
    */
   void clear() noexcept
   {
+    master_weights_.reset();
     values_.reset();
-    master_weights_ = nullptr;
   }
 
   /** @brief Provide setup function for delayed construction.
@@ -234,24 +198,15 @@ public:
    *
    *  @param w The weights object to be proxied.
    */
-  void setup(weights const& w)
+  void setup(ViewingWeightsPtr const& w)
   {
-    this->internal_setup_(w);
-  }
-
-  /** @brief Provide setup function for delayed construction.
-   *
-   *  This overwrites any existing data.
-   *
-   *  @param w The weights object to be proxied.
-   *
-   *  @tparam T (Deduced) The type of the input weights object's
-   *                      values.
-   */
-  template <typename T>
-  void setup(data_type_weights<T> const& w)
-  {
-    this->internal_setup_(w);
+    master_weights_ = w;
+    if (master_weights_.expired()) {
+      values_.reset();
+    }
+    else {
+      values_ = setup_values_(*master_weights_.lock());
+    }
   }
 
   /** @brief Synchronize the held values with the master set.
@@ -263,7 +218,7 @@ public:
   void synchronize_with_master()
   {
     if (!empty()) {
-      const auto& master_values = master_weights_->get_values();
+      const auto& master_values = master_weights_.lock()->get_values();
       if (values_->Viewing()) {
         El::LockedView(*values_, dynamic_cast<const ValuesType&>(master_values));
       }
@@ -301,7 +256,7 @@ public:
   weights const& master_weights() const noexcept(!LBANN_IN_DEBUG_MODE)
   {
     LBANN_DEBUG_ASSERT_POINTER(master_weights_);
-    return *master_weights_;
+    return *master_weights_.lock();
   }
 
   ///@}
@@ -321,25 +276,8 @@ private:
   /** @name Private setup functions */
   ///@{
 
-  /** @brief Internal mechanics of the setup routine.
-   *
-   *  The purpose for this simple indirection is to ignore a more
-   *  complicated SFINAE indirection in the public interface. This
-   *  function is only called by the public setup() functions.
-   *
-   *  @tparam WeightsType (Deduced) The type of the input weights
-   *                      object.
-   */
-  template <class WeightsType>
-  void internal_setup_(WeightsType const& w)
-  {
-    auto vals = setup_values_(w);
-    master_weights_ = &w;
-    std::swap(vals, values_);
-  }
-
   /** @brief Establish the view of the master data. */
-  ValuesPtrType setup_values_(DataTypeWeights const& dtw) const
+  ValuesPtrType setup_values_(data_type_weights<TensorDataType> const& dtw) const
   {
     auto const& vals = dtw.get_values();
     ValuesPtrType ret(vals.Construct(vals.Grid(), vals.Root()));
@@ -387,7 +325,7 @@ private:
   ///@{
 
   /** @brief The proxied master weights. */
-  weights const* master_weights_ = nullptr;
+  ViewingWeightsPtr master_weights_;
 
   /** @brief The values in this data type. */
   ValuesPtrType values_;

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -89,14 +89,6 @@ data_type_layer<TensorDataType>& data_type_layer<TensorDataType>::operator=(cons
 }
 
 template <typename TensorDataType>
-void data_type_layer<TensorDataType>::setup_weights(size_t idx, weights& w) {
-  if (idx >= m_weights_proxy.size()) {
-    m_weights_proxy.resize(idx+1);
-  }
-  m_weights_proxy[idx].setup(w);
-}
-
-template <typename TensorDataType>
 void data_type_layer<TensorDataType>::forward_prop() {
   const auto fp_start = get_time();
 
@@ -105,9 +97,9 @@ void data_type_layer<TensorDataType>::forward_prop() {
     if ((m_weights_proxy.size() == 0) || m_weights_proxy[0].empty()) {
       auto const num_weights = this->num_weights();
       m_weights_proxy.resize(num_weights);
+      const auto ptrs = this->get_weights_pointers();
       for (size_t ii = 0; ii < num_weights; ++ii) {
-        auto& w = this->get_weights(ii);
-        m_weights_proxy[ii].setup(w);
+        m_weights_proxy[ii].setup(ptrs[ii]);
       }
     }
     for (auto& wp : m_weights_proxy)

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -319,14 +319,14 @@ base_convolution_layer<TensorDataType,Device>
     this->set_num_weights(1);
   }
   if (!this->has_weights(0)) {
-    auto w = make_unique<WeightsType>(this->get_comm());
+    auto w = std::make_shared<WeightsType>(this->get_comm());
     auto init = make_unique<he_initializer<TensorDataType>>(probability_distribution::gaussian);
     auto opt = this->m_model->template create_optimizer<TensorDataType>();
 
     w->set_name(this->get_name() + "_kernel");
     w->set_initializer(std::move(init));
     w->set_optimizer(std::move(opt));
-    this->set_weights(0, w.get());
+    this->set_weights(0, w);
     this->m_model->add_weights(std::move(w));
   }
   auto& kernel_weights = this->get_weights(0);
@@ -347,11 +347,11 @@ base_convolution_layer<TensorDataType,Device>
   // Set up bias if needed.
   if (m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero()) {
     if (!this->has_weights(1)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_bias");
       w->set_optimizer(std::move(opt));
-      this->set_weights(1, w.get());
+      this->set_weights(1, w);
       this->m_model->add_weights(std::move(w));
     }
     auto& bias_weights = this->get_weights(1);

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -172,13 +172,13 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
 
   // Create default linearity weights if needed
   if (!this->has_weights(0)) {
-    auto w = make_unique<WeightsType>(this->get_comm());
+    auto w = std::make_shared<WeightsType>(this->get_comm());
     auto init = make_unique<he_initializer<TensorDataType>>(probability_distribution::gaussian);
     auto opt = this->m_model->template create_optimizer<TensorDataType>();
     w->set_name(this->get_name() + "_linearity_weights");
     w->set_initializer(std::move(init));
     w->set_optimizer(std::move(opt));
-    this->set_weights(0, w.get());
+    this->set_weights(0, w);
     this->m_model->add_weights(std::move(w));
   }
 
@@ -205,11 +205,11 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
     dist.colDist = El::STAR;
     dist.rowDist = El::STAR;
     if (!this->has_weights(1)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_bias_weights");
       w->set_optimizer(std::move(opt));
-      this->set_weights(1, w.get());
+      this->set_weights(1, w);
       this->m_model->add_weights(std::move(w));
     }
     auto& bias_weights = this->get_weights(1);

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -143,13 +143,13 @@ void fully_connected_layer<TensorDataType, T_layout, Dev>
     this->set_num_weights(1);
   }
   if (!this->has_weights(0)) {
-    auto w = make_unique<WeightsType>(this->get_comm());
+    auto w = std::make_shared<WeightsType>(this->get_comm());
     auto init = make_unique<he_initializer<TensorDataType>>(probability_distribution::gaussian);
     auto opt = this->m_model->template create_optimizer<TensorDataType>();
     w->set_name(this->get_name() + "_linearity_weights");
     w->set_initializer(std::move(init));
     w->set_optimizer(std::move(opt));
-    this->set_weights(0, w.get());
+    this->set_weights(0, w);
     this->m_model->add_weights(std::move(w));
   }
   auto& linearity_weights = this->get_weights(0);
@@ -177,11 +177,11 @@ void fully_connected_layer<TensorDataType, T_layout, Dev>
   // Set up bias if needed.
   if (m_bias_scaling_factor != El::TypeTraits<TensorDataType>::Zero()) {
     if (!this->has_weights(1)) {
-      auto w = make_unique<WeightsType>(this->get_comm());
+      auto w = std::make_shared<WeightsType>(this->get_comm());
       auto opt = this->m_model->template create_optimizer<TensorDataType>();
       w->set_name(this->get_name() + "_bias_weights");
       w->set_optimizer(std::move(opt));
-      this->set_weights(1, w.get());
+      this->set_weights(1, w);
       this->m_model->add_weights(std::move(w));
     }
     auto& bias_weights = this->get_weights(1);

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -202,13 +202,13 @@ void gru_layer<TensorDataType, Layout, Device>
     const auto scale = El::To<TensorDataType>(1./std::sqrt(m_hidden_size));
     for (size_t i=0; i<m_num_layers; ++i) {
       for (size_t j=0; j<4; ++j) {
-        auto w = make_unique<data_type_weights<TensorDataType>>(this->get_comm());
+        auto w = std::make_shared<data_type_weights<TensorDataType>>(this->get_comm());
         auto init = make_unique<uniform_initializer<TensorDataType>>(-scale, scale);
         auto opt = this->m_model->template create_optimizer<TensorDataType>();
         w->set_name(lbann::build_string(this->get_name(),"_",weight_names[j],"_l",i));
         w->set_initializer(std::move(init));
         w->set_optimizer(std::move(opt));
-        this->set_weights(4*i+j, w.get());
+        this->set_weights(4*i+j, w);
         this->m_model->add_weights(std::move(w));
       }
     }

--- a/src/objective_functions/objective_function.cpp
+++ b/src/objective_functions/objective_function.cpp
@@ -173,20 +173,20 @@ void objective_function::set_layer_pointers(std::vector<ViewingLayerPtr> layers)
   }
 }
 
-std::vector<weights*> objective_function::get_weights_pointers() const {
-  std::vector<weights*> w;
+std::vector<ViewingWeightsPtr> objective_function::get_weights_pointers() const {
+  std::vector<ViewingWeightsPtr> w;
   for (objective_function_term *term : m_terms) {
-    std::vector<weights*> term_weights = term->get_weights_pointers();
+    auto term_weights = term->get_weights_pointers();
     w.insert(w.end(), term_weights.begin(), term_weights.end());
   }
   return w;
 }
 
-void objective_function::set_weights_pointers(std::vector<weights*> w) {
+void objective_function::set_weights_pointers(std::vector<ViewingWeightsPtr> w) {
   auto it = w.begin();
   for (objective_function_term *term : m_terms) {
     const size_t num_weights = term->get_weights_pointers().size();
-    std::vector<weights*> term_weights(it, it + num_weights);
+    std::vector<ViewingWeightsPtr> term_weights(it, it + num_weights);
     term->set_weights_pointers(term_weights);
     it += num_weights;
   }

--- a/src/objective_functions/objective_function_term.cpp
+++ b/src/objective_functions/objective_function_term.cpp
@@ -48,4 +48,12 @@ void objective_function_term::set_layer_pointers(std::vector<ViewingLayerPtr> la
   m_layers = std::move(layers);
 }
 
+std::vector<ViewingWeightsPtr> objective_function_term::get_weights_pointers() const {
+  return m_weights;
+}
+
+void objective_function_term::set_weights_pointers(std::vector<ViewingWeightsPtr> w) {
+  m_weights = std::move(w);
+}
+
 }  // namespace lbann

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -156,14 +156,13 @@ std::vector<OwningLayerPtr> construct_layer_graph(
       if (proto_datatype == TypeToProtoDataType<TensorDataType>::value  \
           && layout == T_layout                                         \
           && device == T_device) {                                      \
-        auto l_ = construct_layer<TensorDataType, T_layout, T_device>(  \
+        l = construct_layer<TensorDataType, T_layout, T_device>(        \
           comm,                                                         \
           training_dr_linearized_data_size,                             \
           num_parallel_readers,                                         \
           proto_layer);                                                 \
-        l.reset(l_.release());                                          \
-      }                                                                 \
-    } while (0)
+  }                                                                     \
+} while (0)
 
 #define PROTO_DEVICE(T, Device) \
     TEMPLATE_INSTANTIATION(T, data_layout::DATA_PARALLEL, Device); \


### PR DESCRIPTION
This is a followup to PR #1691 that replaces `weights*` with `std::weak_ptr<weights>`. [No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM311-2).