### PR TITLE
Manage metrics with smart pointers

### DIFF
--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -80,7 +80,7 @@ public:
         std::unique_ptr<lbann_data::Optimizer> default_optimizer_msg = nullptr);
   model(const model& other);
   model& operator=(const model& other);
-  virtual ~model();
+  virtual ~model() = default;
   virtual std::unique_ptr<model> copy_model() const = 0;
 
   /** Archive for checkpoint and restart */
@@ -118,9 +118,7 @@ public:
   }
 
   /** @brief Return the model's metrics. */
-  virtual const std::vector<metric*>& get_metrics() const {
-    return m_metrics;
-  }
+  std::vector<metric*> get_metrics() const;
 
   /** @brief Size of model's list of layers. */
   El::Int get_num_layers() const noexcept;
@@ -195,7 +193,7 @@ public:
   //  void add_callbacks(std::vector<std::shared_ptr<callback_base>>& cb);
 
   /** @brief Register a new metric for the model. */
-  void add_metric(metric *m);
+  void add_metric(std::unique_ptr<metric> m);
 
   /** @brief Replace the model's weights. */
   void replace_weights(std::vector<weights *>& w);
@@ -446,7 +444,7 @@ private:
   /** @brief Numerical quantities to evaluate model performance.
    *  @details Does not affect training.
    */
-  std::vector<metric*> m_metrics;
+  std::vector<std::unique_ptr<metric>> m_metrics;
 
   /** @brief Current callbacks to process. */
   std::vector<std::shared_ptr<callback_base>> m_callbacks;

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -91,13 +91,11 @@ model::model(const model& other) :
   m_objective_function = (other.m_objective_function
                           ? make_unique<objective_function>(*other.m_objective_function)
                           : nullptr);
-  m_metrics = other.m_metrics;
-  m_callbacks = other.m_callbacks;
-  for (auto& m : m_metrics) {
-    m = m->copy();
+  for (const auto& m : other.m_metrics) {
+    m_metrics.emplace_back(m ? m->copy() : nullptr);
   }
-  for (auto& cb : m_callbacks) {
-    cb.reset(cb->copy());
+  for (const auto& cb : other.m_callbacks) {
+    m_callbacks.emplace_back(cb ? cb->copy() : nullptr);
   }
 
   // Copy layers
@@ -134,7 +132,6 @@ model& model::operator=(const model& other) {
 
   // Delete objects
   if (m_execution_context  != nullptr) { delete m_execution_context; } /// @todo BVE FIXME what do we do with smart pointers here
-  for (const auto& m : m_metrics)      { delete m; }
 
   // Shallow copies
   m_comm = other.m_comm;
@@ -146,13 +143,13 @@ model& model::operator=(const model& other) {
   m_objective_function = (other.m_objective_function
                           ? make_unique<objective_function>(*other.m_objective_function)
                           : nullptr);
-  m_metrics            = other.m_metrics;
-  m_callbacks          = other.m_callbacks;
-  for (auto& m : m_metrics) {
-    m = m->copy();
+  m_metrics.clear();
+  for (const auto& m : other.m_metrics) {
+    m_metrics.emplace_back(m ? m->copy() : nullptr);
   }
-  for (auto& cb : m_callbacks) {
-    cb.reset(cb->copy());
+  m_callbacks.clear();
+  for (const auto& cb : other.m_callbacks) {
+    m_callbacks.emplace_back(cb ? cb->copy() : nullptr);
   }
 
   // Copy layers
@@ -186,10 +183,6 @@ model& model::operator=(const model& other) {
   remap_pointers(layer_map, weights_map);
 
   return *this;
-}
-
-model::~model() {
-  for (const auto& m : m_metrics)      { delete m; }
 }
 
 // =============================================
@@ -286,6 +279,14 @@ description model::get_description() const {
   // Result
   return desc;
 
+}
+
+std::vector<metric*> model::get_metrics() const {
+  std::vector<metric*> ptrs;
+  for (const auto& ptr : m_metrics) {
+    ptrs.push_back(ptr.get());
+  }
+  return ptrs;
 }
 
 El::Int model::get_num_layers() const noexcept {
@@ -403,16 +404,20 @@ void model::add_weights(std::unique_ptr<weights> ptr) {
 
 void model::add_callback(std::shared_ptr<callback_base> cb) {
   if (cb == nullptr) {
-    throw lbann_exception("model: Attempted to add null pointer as a callback.");
+    LBANN_ERROR(
+      "attempted to add a null pointer as callback to ",
+      "model \"",get_name(),"\"");
   }
-  m_callbacks.push_back(std::move(cb));
+  m_callbacks.emplace_back(std::move(cb));
 }
 
-void model::add_metric(metric *m) {
+void model::add_metric(std::unique_ptr<metric> m) {
   if (m == nullptr) {
-    throw lbann_exception("model: Attempted to add null pointer as a metric.");
+    LBANN_ERROR(
+      "attempted to add a null pointer as a metric to ",
+      "model \"",get_name(),"\"");
   }
-  m_metrics.push_back(m);
+  m_metrics.emplace_back(std::move(m));
 }
 
 void model::replace_weights(std::vector<weights*>& new_weights) {
@@ -753,8 +758,8 @@ void model::add_evaluation_layers(std::unordered_set<Layer*>& layer_set,
   }
 
   // Add evaluation layers corresponding to layer metrics
-  for (auto* m : m_metrics) {
-    auto* met = dynamic_cast<layer_metric*>(m);
+  for (auto& ptr : m_metrics) {
+    auto* met = dynamic_cast<layer_metric*>(ptr.get());
     if (met != nullptr) {
       auto* l_raw_ptr = &met->get_layer();
       if (layer_set.count(l_raw_ptr) == 0) {

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -283,9 +283,9 @@ std::unique_ptr<model> construct_model(
 
   // Instantiate model
   auto m = instantiate_model(comm, std::move(obj), proto_opt, proto_model);
-  for (auto&& l   : layer_list   ) { m->add_layer(std::move(l));    }
-  for (auto&& w   : weights_list ) { m->add_weights(std::move(w));  }
-  for (auto&& met : metric_list  ) { m->add_metric(met.release());  }
+  for (auto&& l   : layer_list   ) { m->add_layer(std::move(l)); }
+  for (auto&& w   : weights_list ) { m->add_weights(std::move(w)); }
+  for (auto&& met : metric_list  ) { m->add_metric(std::move(met)); }
   for (auto&& cb  : callback_list) { m->add_callback(std::move(cb)); }
   const auto& name = proto_model.name();
   if (!name.empty()) {


### PR DESCRIPTION
This PR changes the model class to store metrics inside `std::unique_ptr` s. This allows the model to takes advantage of smart pointer support in Cereal. [No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM312-1).

With this PR, there are no more objects in the model class that are managed with raw points (except for the execution context, which seems to be a bit inconsistent in its ownership). I think we can close #155.