### PR TITLE
Manage objective function terms with smart pointers

### DIFF
--- a/include/lbann/objective_functions/objective_function.hpp
+++ b/include/lbann/objective_functions/objective_function.hpp
@@ -44,7 +44,7 @@ class objective_function {
   /** Copy assignment operator. */
   objective_function& operator=(const objective_function& other);
   /** Destructor. */
-  ~objective_function();
+  ~objective_function() = default;
   /** Copy function. */
   objective_function* copy() const { return new objective_function(*this); }
 
@@ -59,13 +59,10 @@ class objective_function {
     }
   }
 
-  /** Add a term to the objective function.
-   *  The objective function takes ownership of the objective function
-   *  term and deallocates it during destruction.
-   */
-  void add_term(objective_function_term* term) { m_terms.push_back(term); }
+  /** Add a term to the objective function. */
+  void add_term(std::unique_ptr<objective_function_term> term);
   /** Get list of objective function terms. */
-  std::vector<objective_function_term*> get_terms() { return m_terms; }
+  std::vector<objective_function_term*> get_terms();
 
   /** Setup objective function. */
   void setup(model& m);
@@ -133,7 +130,7 @@ class objective_function {
  private:
 
   /** List of objective function terms. */
-  std::vector<objective_function_term*> m_terms;
+  std::vector<std::unique_ptr<objective_function_term>> m_terms;
 
   /** Objective funciton statistics. */
   std::map<execution_mode,metric_statistics> m_statistics;

--- a/src/objective_functions/objective_function.cpp
+++ b/src/objective_functions/objective_function.cpp
@@ -35,19 +35,15 @@ objective_function::objective_function(const objective_function& other)
   : m_statistics(other.m_statistics),
     m_evaluation_time(other.m_evaluation_time),
     m_differentiation_time(other.m_differentiation_time) {
-  m_terms = other.m_terms;
-  for (auto& term : m_terms) {
-    term = term->copy();
+  for (const auto& ptr : other.m_terms) {
+    m_terms.emplace_back(ptr ? ptr->copy() : nullptr);
   }
 }
 
 objective_function& objective_function::operator=(const objective_function& other) {
-  for (const auto& term : m_terms) {
-    if (term != nullptr) { delete term; }
-  }
-  m_terms = other.m_terms;
-  for (auto& term : m_terms) {
-    term = term->copy();
+  m_terms.clear();
+  for (const auto& ptr : other.m_terms) {
+    m_terms.emplace_back(ptr ? ptr->copy() : nullptr);
   }
   m_statistics = other.m_statistics;
   m_evaluation_time = other.m_evaluation_time;
@@ -55,19 +51,22 @@ objective_function& objective_function::operator=(const objective_function& othe
   return *this;
 }
 
-objective_function::~objective_function() {
-  for (const auto& term : m_terms) {
-    if (term != nullptr) { delete term; }
+void objective_function::add_term(std::unique_ptr<objective_function_term> term) {
+  m_terms.push_back(std::move(term));
+}
+
+std::vector<objective_function_term*> objective_function::get_terms() {
+  std::vector<objective_function_term*> ptrs;
+  for (const auto& ptr : m_terms) {
+    ptrs.push_back(ptr.get());
   }
+  return ptrs;
 }
 
 void objective_function::setup(model& m) {
-  for (objective_function_term *term : m_terms) {
+  for (auto&& term : m_terms) {
     if (term == nullptr) {
-      std::stringstream err;
-      err << __FILE__ << " " << __LINE__ << " :: "
-          << "a term in the objective function is a null pointer";
-      throw lbann_exception(err.str());
+      LBANN_ERROR("a term in the objective function is a null pointer");
     }
     term->setup(m);
   }
@@ -77,7 +76,7 @@ void objective_function::start_evaluation(execution_mode mode,
                                           int mini_batch_size) {
   const auto start_time = get_time();
   prof_region_begin("obj-start-eval", prof_colors[0], false);
-  for (const auto& term : m_terms) {
+  for (auto&& term : m_terms) {
     prof_region_begin(("obj-start-eval-" + term->name()).c_str(), prof_colors[1], false);
     term->start_evaluation();
     prof_region_end(("obj-start-eval-" + term->name()).c_str(), false);
@@ -91,7 +90,7 @@ EvalType objective_function::finish_evaluation(execution_mode mode,
   const auto start_time = get_time();
   EvalType value = EvalType(0);
   prof_region_begin("obj-finish-eval", prof_colors[0], false);
-  for (const auto& term : m_terms) {
+  for (auto&& term : m_terms) {
     prof_region_begin(("obj-finish-eval-" + term->name()).c_str(), prof_colors[1], false);
     value += term->finish_evaluation();
     prof_region_end(("obj-finish-eval-" + term->name()).c_str(), false);
@@ -106,7 +105,7 @@ EvalType objective_function::finish_evaluation(execution_mode mode,
 void objective_function::differentiate() {
   const auto start_time = get_time();
   prof_region_begin("obj-differentiate", prof_colors[0], false);
-  for (const auto& term : m_terms) {
+  for (auto&& term : m_terms) {
     prof_region_begin(("obj-differentiate-" + term->name()).c_str(), prof_colors[1], false);
     term->differentiate();
     prof_region_end(("obj-differentiate-" + term->name()).c_str(), false);
@@ -118,7 +117,7 @@ void objective_function::differentiate() {
 void objective_function::compute_weight_regularization() {
   const auto start_time = get_time();
   prof_region_begin("obj-weight-regularization", prof_colors[0], false);
-  for (const auto& term : m_terms) {
+  for (auto&& term : m_terms) {
     prof_region_begin(("obj-weight-regularization-" + term->name()).c_str(), prof_colors[1], false);
     term->compute_weight_regularization();
     prof_region_end(("obj-weight-regularization-" + term->name()).c_str(), false);
@@ -148,7 +147,7 @@ int objective_function::get_statistics_num_samples(execution_mode mode) const {
 
 std::vector<ViewingLayerPtr> objective_function::get_layer_pointers() const {
   std::vector<ViewingLayerPtr> layers;
-  for (objective_function_term *term : m_terms) {
+  for (const auto& term : m_terms) {
     auto term_layers = term->get_layer_pointers();
     layers.insert(layers.end(), term_layers.begin(), term_layers.end());
   }
@@ -157,25 +156,22 @@ std::vector<ViewingLayerPtr> objective_function::get_layer_pointers() const {
 
 void objective_function::set_layer_pointers(std::vector<ViewingLayerPtr> layers) {
   auto it = layers.begin();
-  for (objective_function_term *term : m_terms) {
+  for (auto&& term : m_terms) {
     const size_t num_layers = term->get_layer_pointers().size();
     std::vector<ViewingLayerPtr> term_layers(it, it + num_layers);
     term->set_layer_pointers(term_layers);
     it += num_layers;
   }
   if (it != layers.end()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to set an invalid number of layer pointers "
-        << "(expected " << it - layers.begin() << ", "
-        << "found " << layers.size() << ")";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(
+      "attempted to set an invalid number of layer pointers ",
+      "(expected ",it-layers.begin(),", found ",layers.size(),")");
   }
 }
 
 std::vector<weights*> objective_function::get_weights_pointers() const {
   std::vector<weights*> w;
-  for (objective_function_term *term : m_terms) {
+  for (const auto& term : m_terms) {
     std::vector<weights*> term_weights = term->get_weights_pointers();
     w.insert(w.end(), term_weights.begin(), term_weights.end());
   }
@@ -184,19 +180,16 @@ std::vector<weights*> objective_function::get_weights_pointers() const {
 
 void objective_function::set_weights_pointers(std::vector<weights*> w) {
   auto it = w.begin();
-  for (objective_function_term *term : m_terms) {
+  for (auto&& term : m_terms) {
     const size_t num_weights = term->get_weights_pointers().size();
     std::vector<weights*> term_weights(it, it + num_weights);
     term->set_weights_pointers(term_weights);
     it += num_weights;
   }
   if (it != w.end()) {
-    std::stringstream err;
-    err << __FILE__ << " " << __LINE__ << " :: "
-        << "attempted to set an invalid number of weights pointers "
-        << "(expected " << it - w.begin() << ", "
-        << "found " << w.size() << ")";
-    throw lbann_exception(err.str());
+    LBANN_ERROR(
+      "attempted to set an invalid number of weights pointers ",
+      "(expected ",it-w.begin(),", found ",w.size(),")");
   }
 }
 

--- a/src/proto/factories/objective_function_factory.cpp
+++ b/src/proto/factories/objective_function_factory.cpp
@@ -45,13 +45,13 @@ construct_objective_function(const lbann_data::ObjectiveFunction& proto_obj) {
   // Weight regularization terms
   for (int i=0; i<proto_obj.l2_weight_regularization_size(); ++i) {
     const auto& params = proto_obj.l2_weight_regularization(i);
-    obj->add_term(new l2_weight_regularization(params.scale_factor()));
+    obj->add_term(make_unique<l2_weight_regularization>(params.scale_factor()));
   }
 
   // Layer terms
   for (int i=0; i<proto_obj.layer_term_size(); ++i) {
     const auto& params = proto_obj.layer_term(i);
-    obj->add_term(new layer_term(params.scale_factor()));
+    obj->add_term(make_unique<layer_term>(params.scale_factor()));
   }
 
   // Return objective function


### PR DESCRIPTION
This PR changes the model class to store objective function terms inside std::unique_ptr s. This allows the model to takes advantage of smart pointer support in Cereal. See Issue #155. [No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM313-1).