### PR TITLE
LBANN always sets the Hydrogen RNG seed

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -30,6 +30,7 @@ Build system:
  - C++14 or newer standard with CUDA (CMake: "-DCMAKE_CUDA_STANDARD=14")
 
 Bug fixes:
+ - Fixed a bug where LBANN didn't set the Hydrogen RNG seed
 
 Retired features:
 

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -58,13 +58,11 @@ bool save_rng_to_checkpoint(persist& p, lbann_comm* comm, bool is_distributed) {
     rng_seq << get_data_seq_generator();
     rng_seq.close();
 
-#ifdef LBANN_SET_EL_RNG
     rng_name = dirname + "/EL_generator";
     std::ofstream rng_EL(rng_name);
     if(!rng_EL) { LBANN_ERROR("Failed to open ", rng_name); }
     rng_EL << El::Generator();
     rng_EL.close();
-#endif
   }
 
   for(int i = 0; i < get_num_io_generators(); i++) {
@@ -151,12 +149,10 @@ bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm) {
   if(!rng_seq) { LBANN_ERROR("Failed to open ", rng_name); }
   rng_seq >> get_data_seq_generator();
 
-#ifdef LBANN_SET_EL_RNG
   rng_name = dirname + "/EL_generator";
   std::ifstream rng_EL(rng_name);
   if(!rng_EL) { LBANN_ERROR("Failed to open ", rng_name); }
   rng_EL >> El::Generator();
-#endif
 
   std::string rank_in_trainer;
   if (comm == nullptr) {

--- a/src/utils/random_number_generators.cpp
+++ b/src/utils/random_number_generators.cpp
@@ -144,7 +144,6 @@ void init_random(int seed, int num_io_RNGs, lbann_comm *comm) {
     get_fast_generator().seed(seed);
 #endif
 
-#ifdef LBANN_SET_EL_RNG
     // Set Elemental's RNG seed
     auto elemental_seed = hash_combine(seed, 104729); // 10000th prime
     int mpi_initialized = 0;
@@ -159,8 +158,6 @@ void init_random(int seed, int num_io_RNGs, lbann_comm *comm) {
                         : hash_combine(elemental_seed, comm->get_rank_in_trainer()));
     }
     El::Generator().seed(elemental_seed);
-#endif
-
   } else {
     // Seed with a random value.
     std::random_device rd;
@@ -175,9 +172,7 @@ void init_random(int seed, int num_io_RNGs, lbann_comm *comm) {
     get_generator().seed(rand_val);
     get_fast_generator().seed(rand_val);
 #endif
-#ifdef LBANN_SET_EL_RNG
     El::Generator().seed(rand_val);
-#endif
   }
 
   init_io_random(seed, num_io_RNGs);


### PR DESCRIPTION
Removed the LBANN_SET_EL_RNG flag from the code base.  Nominally,
LBANN will always want to set the RNG in Hydrogen.