### PR TITLE
Better support for unknown systems in Python contrib launcher

### DIFF
--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -49,16 +49,22 @@ _center = 'unknown'
 launcher = lbann.launcher
 if is_lc_center():
     _center = 'lc'
-    import lbann.contrib.lc.launcher
-    launcher = lbann.contrib.lc.launcher
+    import lbann.contrib.lc.systems
+    if lbann.contrib.lc.systems.is_lc_system():
+        import lbann.contrib.lc.launcher
+        launcher = lbann.contrib.lc.launcher
 elif is_nersc_center():
     _center = 'nersc'
-    import lbann.contrib.nersc.launcher
-    launcher = lbann.contrib.nersc.launcher
+    import lbann.contrib.nersc.systems
+    if lbann.contrib.nersc.systems.is_nersc_system():
+        import lbann.contrib.nersc.launcher
+        launcher = lbann.contrib.nersc.launcher
 elif is_olcf_center():
     _center = 'olcf'
-    import lbann.contrib.olcf.launcher
-    launcher = lbann.contrib.olcf.launcher
+    import lbann.contrib.olcf.systems
+    if lbann.contrib.olcf.systems.is_olcf_system():
+        import lbann.contrib.olcf.launcher
+        launcher = lbann.contrib.olcf.launcher
 
 def compute_center():
     """Name of organization that operates current system."""

--- a/python/lbann/contrib/lc/systems.py
+++ b/python/lbann/contrib/lc/systems.py
@@ -24,28 +24,27 @@ _system_params = {
     'ray':      SystemParams(40, 4, 'lsf'),
     'sierra':   SystemParams(44, 4, 'lsf'),
     'rzansel':  SystemParams(44, 4, 'lsf'),
+    'rzhasgpu': SystemParams(16, 2, 'slurm'),
 }
 
 # Detect system
 _system = re.sub(r'\d+', '', socket.gethostname())
-if _system not in _system_params.keys():
-    _system = None
 
 # ==============================================
 # Access functions
 # ==============================================
 
 def system():
-    """Name of LC system."""
-    if _system:
-        return _system
-    else:
-        raise RuntimeError('unknown system '
-                           '(' + socket.gethostname() + ')')
+    """Name of system.
+
+    Hostname with trailing digits removed.
+
+    """
+    return _system
 
 def is_lc_system(system = system()):
     """Whether current system is a supported LC system."""
-    return (system is not None) and (system in _system_params.keys())
+    return _system in _system_params.keys()
 
 def gpus_per_node(system = system()):
     """Number of GPUs per node."""

--- a/python/lbann/contrib/nersc/systems.py
+++ b/python/lbann/contrib/nersc/systems.py
@@ -21,24 +21,22 @@ _system_params = {
 
 # Detect system
 _system = re.sub(r'\d+', '', socket.gethostname())
-if _system not in _system_params.keys():
-    _system = None
 
 # ==============================================
 # Access functions
 # ==============================================
 
 def system():
-    """Name of NERSC system."""
-    if _system:
-        return _system
-    else:
-        raise RuntimeError('unknown system '
-                           '(' + socket.gethostname() + ')')
+    """Name of system.
+
+    Hostname with trailing digits removed.
+
+    """
+    return _system
 
 def is_nersc_system(system = system()):
     """Whether current system is a supported NERSC system."""
-    return (system is not None) and (system in _system_params.keys())
+    return _system in _system_params.keys()
 
 def gpus_per_node(system = system()):
     """Number of GPUs per node."""

--- a/python/lbann/contrib/olcf/systems.py
+++ b/python/lbann/contrib/olcf/systems.py
@@ -20,24 +20,22 @@ _system_params = {
 
 # Detect system
 _system = re.sub(r'\d+', '', socket.gethostname())
-if _system not in _system_params.keys():
-    _system = None
 
 # ==============================================
 # Access functions
 # ==============================================
 
 def system():
-    """Name of OLCF system."""
-    if _system:
-        return _system
-    else:
-        raise RuntimeError('unknown system '
-                           '(' + socket.gethostname() + ')')
+    """Name of system.
+
+    Hostname with trailing digits removed.
+
+    """
+    return _system
 
 def is_olcf_system(system = system()):
     """Whether current system is a supported OLCF system."""
-    return (system is not None) and (system in _system_params.keys())
+    return _system in _system_params.keys()
 
 def gpus_per_node(system = system()):
     """Number of GPUs per node."""


### PR DESCRIPTION
`lbann.contrib.launcher.run` fails when a user runs on an unknown system within a known computing center. This PR changes the behavior so that it falls back to `lbann.run` if it doesn't recognize the system.