### PR TITLE
Remove pointer to LBANN comm in layer class

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -207,6 +207,7 @@ class Layer {
 
 public:
 
+  /// @todo Remove lbann_comm* argument
   Layer(lbann_comm *comm);
   Layer(const Layer& other);
   Layer& operator=(const Layer& other);
@@ -428,7 +429,7 @@ public:
 
 
   /** Get reference to LBANN communicator. */
-  lbann_comm* get_comm() const { return m_comm; }
+  lbann_comm* get_comm() const;
 
   // ===========================================================
   // Hint layer access functions
@@ -600,9 +601,6 @@ protected:
   // ===========================================================
   // Protected class members
   // ===========================================================
-
-  /** Reference to LBANN communicator. */
-  lbann_comm *m_comm;
 
   /** Expected number of parent layers.
    *  A negative value indicates no limit.

--- a/include/lbann/layers/transform/tessellate.hpp
+++ b/include/lbann/layers/transform/tessellate.hpp
@@ -194,7 +194,7 @@ protected:
 
     // Accumulate local error signals, if needed
     if (m_input_v->DistData() != gradient_wrt_input.DistData()) {
-      this->m_comm->allreduce(*m_input_v, m_input_v->RedundantComm());
+      this->get_comm()->allreduce(*m_input_v, m_input_v->RedundantComm());
       El::Copy(*m_input_v, gradient_wrt_input);
     }
 

--- a/src/layers/distconv_adapter.cpp
+++ b/src/layers/distconv_adapter.cpp
@@ -214,7 +214,7 @@ void distconv_adapter::adjust_parallel_strategy() {
       ps.depth_groups : 1;
   auto h = ps.height_groups != 0 ? ps.height_groups : 1;
   auto w = ps.width_groups != 0 ? ps.width_groups : 1;
-  auto np = layer().m_comm->get_procs_per_trainer();
+  auto np = layer().get_comm()->get_procs_per_trainer();
 
   const auto spatial_prod = d * h * w;
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -48,8 +48,7 @@
 namespace lbann {
 
 Layer::Layer(lbann_comm *comm)
-  : m_comm(comm),
-    m_frozen(false) {
+  : m_frozen(false) {
 
   // Initialize layer name
   static int num_layers = 0;
@@ -62,7 +61,6 @@ Layer::Layer(lbann_comm *comm)
 }
 
 Layer::Layer(const Layer& other) :
-  m_comm(other.m_comm),
   m_expected_num_parent_layers(other.m_expected_num_parent_layers),
   m_expected_num_child_layers(other.m_expected_num_child_layers),
   m_model(other.m_model),
@@ -83,7 +81,6 @@ Layer::Layer(const Layer& other) :
 Layer& Layer::operator=(const Layer& other) {
 
   // Shallow copies
-  m_comm = other.m_comm;
   m_expected_num_parent_layers = other.m_expected_num_parent_layers;
   m_expected_num_child_layers = other.m_expected_num_child_layers;
   m_model = other.m_model;
@@ -206,6 +203,16 @@ description Layer::get_description() const {
   }
 
   return desc;
+}
+
+lbann_comm* Layer::get_comm() const {
+  if (m_model == nullptr) {
+    LBANN_ERROR(
+      "attempted to get communicator from ",
+      get_type()," layer \"",get_name(),"\" ",
+      "before it was configured");
+  }
+  return m_model->get_comm();
 }
 
 bool Layer::update() {
@@ -380,7 +387,7 @@ bool Layer::is_frozen() const {
 void Layer::setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata) {
   setup_pointers();
   setup_dims(dr_metadata);
-  setup_matrices(m_comm->get_trainer_grid());
+  setup_matrices(get_comm()->get_trainer_grid());
 #ifdef LBANN_HAS_DISTCONV
   prepare_distconv(dr_metadata);
 #endif // LBANN_HAS_DISTCONV

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -377,7 +377,7 @@ void batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::fp_com
                        m_var, is_training);
 
   if (l.m_statistics_group_size == 0) {
-    l.m_comm->allreduce(*l.m_mean_and_var, l.m_mean_and_var->RedundantComm(),
+    l.get_comm()->allreduce(*l.m_mean_and_var, l.m_mean_and_var->RedundantComm(),
                         El::mpi::SUM);
   } else if (l.m_statistics_group_size == 1) {
     // Local aggregation
@@ -417,7 +417,7 @@ void batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::bp_com
   // Accumulate gradients
   if (is_training) {
     if (l.m_statistics_group_size == 0) {
-      l.m_comm->allreduce(*l.m_mean_and_var_gradient,
+      l.get_comm()->allreduce(*l.m_mean_and_var_gradient,
                           l.m_mean_and_var_gradient->RedundantComm(),
                           El::mpi::SUM);
     }
@@ -498,7 +498,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute() {
     int num_per_sum;
     if (this->m_statistics_group_size == 0) {
       // Global statistics aggregation; allreduce on fused buffer.
-      this->m_comm->allreduce(*this->m_mean_and_var,
+      this->get_comm()->allreduce(*this->m_mean_and_var,
                               this->m_mean_and_var->RedundantComm(),
                               El::mpi::SUM);
       num_per_sum = channel_size * width;
@@ -507,15 +507,15 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute() {
       num_per_sum = channel_size * local_width;
     } else {
       // Grouped batchnorm. Allreduce on fused buffer.
-      this->m_comm->allreduce(
+      this->get_comm()->allreduce(
         *this->m_mean_and_var,
-        this->m_comm->get_packed_group_comm(this->m_statistics_group_size),
+        this->get_comm()->get_packed_group_comm(this->m_statistics_group_size),
         El::mpi::SUM);
       if (this->m_num_per_sum_cache.count(width) == 0) {
         num_per_sum = channel_size * local_width;
-        num_per_sum = this->m_comm->allreduce(
+        num_per_sum = this->get_comm()->allreduce(
           num_per_sum,
-          this->m_comm->get_packed_group_comm(this->m_statistics_group_size));
+          this->get_comm()->get_packed_group_comm(this->m_statistics_group_size));
         this->m_num_per_sum_cache[width] = num_per_sum;
       } else {
         num_per_sum = this->m_num_per_sum_cache[width];
@@ -651,13 +651,13 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute() {
   if (is_training) {
     if (this->m_statistics_group_size == 0) {
       // Global aggregation; allreduce on fused buffer.
-      this->m_comm->allreduce(*this->m_mean_and_var_gradient,
+      this->get_comm()->allreduce(*this->m_mean_and_var_gradient,
                         this->m_mean_and_var_gradient->RedundantComm(),
                         El::mpi::SUM);
     } else if (this->m_statistics_group_size > 1) {
       // Grouped batchnorm; allreduce on fused buffer.
-      this->m_comm->allreduce(*this->m_mean_and_var_gradient,
-                        this->m_comm->get_packed_group_comm(this->m_statistics_group_size),
+      this->get_comm()->allreduce(*this->m_mean_and_var_gradient,
+                        this->get_comm()->get_packed_group_comm(this->m_statistics_group_size),
                         El::mpi::SUM);
     }
   } else {


### PR DESCRIPTION
This removes the LBANN communicator pointer that's maintained by the layer class. The layer now accesses the communicator via its model. The goal of this work is to make the base layer class default-constructible. However, this PR does not touch any of the layer constructors to avoid merge conflicts with other work.

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM318-1).