### PR TITLE
Include missing header in dropout layer

### DIFF
--- a/include/lbann/layers/regularizers/dropout.hpp
+++ b/include/lbann/layers/regularizers/dropout.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_LAYER_REGULARIZER_DROPOUT_HPP_INCLUDED
 #define LBANN_LAYER_REGULARIZER_DROPOUT_HPP_INCLUDED
 
+#include "lbann/layers/data_type_layer.hpp"
 #include "lbann/models/model.hpp"
 #ifdef LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/helpers.hpp"


### PR DESCRIPTION
I believe this bug is responsible for some compile errors. [Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM321-1).