### PR TITLE
Make sure CPU softmax layer has access to softmax mode enum

### DIFF
--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -29,6 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/distconv.hpp"
+#include "lbann/utils/dnn_enums.hpp"
 #if defined LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/dnn_lib/softmax.hpp"


### PR DESCRIPTION
PR #1686 moved the `softmax_mode` mode enum out of `include/lbann/layers/activations/softmax.hpp` into `include/lbann/utils/dnn_enums.hpp`. We got compile errors on CPU systems because the softmax layer didn't have access to the enum, so the easy fix is to just include the header. I think this should be straightforward enough to merge once [Bamboo finishes](https://lc.llnl.gov/bamboo/browse/LBANN-TIM322-1), but I'm pinging @mrwyattii in case he has any thoughts after he gets back.