### PR TITLE
Feature modular trainer split

### DIFF
--- a/applications/ATOM/eval_atom_wae.py
+++ b/applications/ATOM/eval_atom_wae.py
@@ -278,7 +278,7 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
-    if(run_args.procs_per_trainer)
+    if(run_args.procs_per_trainer):
       m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(

--- a/applications/ATOM/eval_atom_wae.py
+++ b/applications/ATOM/eval_atom_wae.py
@@ -175,8 +175,8 @@ def construct_model(run_args):
     #Dump output (activation) for post processing
     if(run_args.dump_outputs_dir):
       pred_tensor = lbann.Concatenation(arg_max, name='pred_tensor')
-      callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval, 
-                       execution_modes='test', 
+      callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval,
+                       execution_modes='test',
                        directory=run_args.dump_outputs_dir,
                        layers=f'inp pred_tensor {waemodel.q_mu.name}'))
     # Construct model
@@ -238,7 +238,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         #name=None,
-        #procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -279,6 +278,8 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
+    if(run_args.procs_per_trainer)
+      m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(
         trainer,

--- a/applications/ATOM/eval_atom_wae_dec.py
+++ b/applications/ATOM/eval_atom_wae_dec.py
@@ -133,7 +133,7 @@ def construct_model(run_args):
             weights=waemodel.emb_weights
     )
 
-    
+
     pred, arg_max = waemodel.forward_decoder(x_emb,z)
 
     recon = waemodel.compute_loss(x, pred)
@@ -164,8 +164,8 @@ def construct_model(run_args):
     #Dump output (activation) for post processing
     pred_tensor = lbann.Concatenation(arg_max, name='pred_tensor')
     conc_out = lbann.Concatenation([input_,pred_tensor], name='conc_out')
-    callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval, 
-                       execution_modes='test', 
+    callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval,
+                       execution_modes='test',
                        directory=run_args.dump_outputs_dir,
                        layers=f'{conc_out.name}'))
     # Construct model
@@ -227,7 +227,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         #name=None,
-        #procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -268,6 +267,8 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
+    if(run_args.procs_per_trainer)
+      m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(
         trainer,

--- a/applications/ATOM/eval_atom_wae_dec.py
+++ b/applications/ATOM/eval_atom_wae_dec.py
@@ -267,7 +267,7 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
-    if(run_args.procs_per_trainer)
+    if(run_args.procs_per_trainer):
       m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(

--- a/applications/ATOM/eval_atom_wae_enc.py
+++ b/applications/ATOM/eval_atom_wae_enc.py
@@ -151,8 +151,8 @@ def construct_model(run_args):
 
     #Dump output (activation) for post processing
     conc_out = lbann.Concatenation([input_,latentz], name='conc_out')
-    callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval, 
-                       execution_modes='test', 
+    callbacks.append(lbann.CallbackDumpOutputs(batch_interval=run_args.dump_outputs_interval,
+                       execution_modes='test',
                        directory=run_args.dump_outputs_dir,
                        layers=f'{conc_out.name}'))
     # Construct model
@@ -213,7 +213,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         #name=None,
-        #procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -254,6 +253,8 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
+    if(run_args.procs_per_trainer)
+      m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(
         trainer,

--- a/applications/ATOM/eval_atom_wae_enc.py
+++ b/applications/ATOM/eval_atom_wae_enc.py
@@ -253,7 +253,7 @@ def main():
     m_lbann_args=f"--load_model_weights_dir_is_complete --load_model_weights_dir={run_args.dump_model_dir} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}"
     if(run_args.data_reader_prototext):
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
-    if(run_args.procs_per_trainer)
+    if(run_args.procs_per_trainer):
       m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(

--- a/applications/ATOM/train_atom_char_rnn.py
+++ b/applications/ATOM/train_atom_char_rnn.py
@@ -247,7 +247,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         name=None,
-        procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -295,7 +294,7 @@ def main():
         procs_per_node=ppn,
         job_name=run_args.job_name,
         experiment_dir=experiment_dir,
-        lbann_args=f"--vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}",
+        lbann_args=f"--procs_per_trainer={run_args.procs_per_trainer} --vocab={run_args.vocab} --num_samples={run_args.num_samples} --sequence_length={run_args.sequence_length}  --num_io_threads={run_args.num_io_threads} --no_header={run_args.no_header} --delimiter={run_args.delimiter}",
     )
 
     print("LBANN launcher status:\n" + str(status))

--- a/applications/ATOM/train_atom_vae.py
+++ b/applications/ATOM/train_atom_vae.py
@@ -255,7 +255,7 @@ def main():
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
     if(run_args.ltfb):
       m_lbann_args = " ".join((m_lbann_args, "--ltfb"))
-    if(run_args.procs_per_trainer)
+    if(run_args.procs_per_trainer):
       m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(

--- a/applications/ATOM/train_atom_vae.py
+++ b/applications/ATOM/train_atom_vae.py
@@ -213,7 +213,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         name=None,
-        procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -256,6 +255,8 @@ def main():
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
     if(run_args.ltfb):
       m_lbann_args = " ".join((m_lbann_args, "--ltfb"))
+    if(run_args.procs_per_trainer)
+      m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(
         trainer,

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -249,7 +249,6 @@ def main():
     trainer = lbann.Trainer(
         run_args.batch_size,
         name=None,
-        procs_per_trainer=run_args.procs_per_trainer,
     )
 
     # define data_reader
@@ -292,6 +291,8 @@ def main():
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
     if(run_args.ltfb):
       m_lbann_args = " ".join((m_lbann_args, "--ltfb"))
+    if(run_args.procs_per_trainer)
+      m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(
         trainer,

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -291,7 +291,7 @@ def main():
       m_lbann_args = " ".join((m_lbann_args, " --use_data_store --preload_data_store "))
     if(run_args.ltfb):
       m_lbann_args = " ".join((m_lbann_args, "--ltfb"))
-    if(run_args.procs_per_trainer)
+    if(run_args.procs_per_trainer):
       m_lbann_args = " ".join((m_lbann_args, f"--procs_per_trainer={run_args.procs_per_trainer}"))
 
     status = lbann.contrib.launcher.run(

--- a/applications/physics/ICF/eval_macc_surrogate.py
+++ b/applications/physics/ICF/eval_macc_surrogate.py
@@ -193,8 +193,7 @@ def construct_model():
 
 if __name__ == '__main__':
 
-    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size,
-                            procs_per_trainer=args.procs_per_trainer)
+    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size)
     model = construct_model()
     # Setup optimizer
     opt = lbann.Adam(learn_rate=0.0001,beta1=0.9,beta2=0.99,eps=1e-8)
@@ -219,6 +218,7 @@ if __name__ == '__main__':
                                    f'--metadata={metadata_prototext}',
                                    f'--load_model_weights_dir={args.pretrained_dir}',
                                    f'--index_list_test={args.index_list_test}',
-                                   f'--data_filedir_test={args.data_filedir_test}'],
+                                   f'--data_filedir_test={args.data_filedir_test}',
+                                   f'--procs_per_trainer={run_args.procs_per_trainer}'],
                                    **kwargs)
     print(status)

--- a/applications/physics/ICF/pre_train_jag_wae.py
+++ b/applications/physics/ICF/pre_train_jag_wae.py
@@ -155,8 +155,7 @@ def construct_model():
 if __name__ == '__main__':
     import lbann
 
-    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size,
-                            procs_per_trainer=args.procs_per_trainer)
+    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size)
     model = construct_model()
     # Setup optimizer
     opt = lbann.Adam(learn_rate=0.0001,beta1=0.9,beta2=0.99,eps=1e-8)
@@ -178,6 +177,7 @@ if __name__ == '__main__':
                                    f'--index_list_train={args.index_list_train}',
                                    f'--index_list_test={args.index_list_test}',
                                    f'--data_filedir_train={args.data_filedir_train}',
-                                   f'--data_filedir_test={args.data_filedir_test}'],
+                                   f'--data_filedir_test={args.data_filedir_test}',
+                                   f'--procs_per_trainer={run_args.procs_per_trainer}'],
                                    **kwargs)
     print(status)

--- a/applications/physics/ICF/train_macc_surrogate.py
+++ b/applications/physics/ICF/train_macc_surrogate.py
@@ -200,8 +200,7 @@ def construct_model():
 if __name__ == '__main__':
     import lbann
 
-    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size,
-                            procs_per_trainer=args.procs_per_trainer)
+    trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size)
     model = construct_model()
     # Setup optimizer
     opt = lbann.Adam(learn_rate=0.0001,beta1=0.9,beta2=0.99,eps=1e-8)
@@ -225,6 +224,7 @@ if __name__ == '__main__':
                                    f'--index_list_train={args.index_list_train}',
                                    f'--index_list_test={args.index_list_test}',
                                    f'--data_filedir_train={args.data_filedir_train}',
-                                   f'--data_filedir_test={args.data_filedir_test}'],
+                                   f'--data_filedir_test={args.data_filedir_test}',
+                                   f'--procs_per_trainer={run_args.procs_per_trainer}'],
                                    **kwargs)
     print(status)

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -83,8 +83,7 @@ void print_parameters(const lbann_comm& comm,
                       ::lbann_data::LbannPB& p,
                       std::vector<int>& root_random_seeds,
                       std::vector<int>& random_seeds,
-                      std::vector<int>& data_seq_random_seeds,
-                      int procs_per_trainer);
+                      std::vector<int>& data_seq_random_seeds);
 
 /** @brief prints usage information */
 void print_help(const lbann_comm& comm);

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -83,7 +83,8 @@ void print_parameters(const lbann_comm& comm,
                       ::lbann_data::LbannPB& p,
                       std::vector<int>& root_random_seeds,
                       std::vector<int>& random_seeds,
-                      std::vector<int>& data_seq_random_seeds);
+                      std::vector<int>& data_seq_random_seeds,
+                      int procs_per_trainer);
 
 /** @brief prints usage information */
 void print_help(const lbann_comm& comm);

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -40,7 +40,7 @@ const int lbann_default_random_seed = 42;
 #define NUM_VALIDATE_SAMPLES "Num validate samples"
 #define NUM_TEST_SAMPLES "Num test samples"
 #define ALLOW_GLOBAL_STATISTICS "LTFB Allow global statistics"
-#define PROCS_PER_TRAINER "LTFB processes per trainer"
+#define PROCS_PER_TRAINER "Processes per trainer"
 
 void construct_std_options();
 

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -40,15 +40,19 @@ const int lbann_default_random_seed = 42;
 #define NUM_VALIDATE_SAMPLES "Num validate samples"
 #define NUM_TEST_SAMPLES "Num test samples"
 #define ALLOW_GLOBAL_STATISTICS "LTFB Allow global statistics"
+#define PROCS_PER_TRAINER "LTFB processes per trainer"
 
 void construct_std_options();
+
+int allocate_trainer_resources(lbann_comm *comm);
 
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                                            lbann_data::Trainer* pb_trainer,
                                            lbann_data::LbannPB &pb,
-                                           options *opts);
+                                           options *opts,
+                                           int procs_per_trainer);
 
-  std::unique_ptr<thread_pool> construct_io_thread_pool(lbann_comm *comm, options *opts, bool serialized_io);
+std::unique_ptr<thread_pool> construct_io_thread_pool(lbann_comm *comm, options *opts, bool serialized_io);
 
 std::unique_ptr<model> build_model_from_prototext(
     int argc, char **argv,

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -49,8 +49,7 @@ int allocate_trainer_resources(lbann_comm *comm);
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                                            lbann_data::Trainer* pb_trainer,
                                            lbann_data::LbannPB &pb,
-                                           options *opts,
-                                           int procs_per_trainer);
+                                           options *opts);
 
 std::unique_ptr<thread_pool> construct_io_thread_pool(lbann_comm *comm, options *opts, bool serialized_io);
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -145,6 +145,9 @@ int main(int argc, char *argv[]) {
     //to activate, must specify --st_on on cmd line
     stack_profiler::get()->activate(comm->get_rank_in_world());
 
+    // Split MPI into trainers
+    int procs_per_trainer = allocate_trainer_resources(comm.get());
+
     // Load the prototexts specificed on the command line
     auto pbs = protobuf_utils::load_prototext(master, argc, argv);
     // Optionally over-ride some values in the prototext for each model
@@ -156,7 +159,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, pb, opts);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, pb, opts, procs_per_trainer);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
     stack_profiler::get()->activate(comm->get_rank_in_world());
 
     // Split MPI into trainers
-    int procs_per_trainer = allocate_trainer_resources(comm.get());
+    allocate_trainer_resources(comm.get());
 
     // Load the prototexts specificed on the command line
     auto pbs = protobuf_utils::load_prototext(master, argc, argv);
@@ -159,7 +159,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, pb, opts, procs_per_trainer);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, pb, opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 
   try {
     // Split MPI into trainers
-    int procs_per_trainer = allocate_trainer_resources(comm.get());
+    allocate_trainer_resources(comm.get());
 
     // Initialize options db (this parses the command line)
     options *opts = options::get();
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -83,6 +83,9 @@ int main(int argc, char *argv[]) {
   const bool master = comm->am_world_master();
 
   try {
+    // Split MPI into trainers
+    int procs_per_trainer = allocate_trainer_resources(comm.get());
+
     // Initialize options db (this parses the command line)
     options *opts = options::get();
     opts->init(argc, argv);
@@ -103,7 +106,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -93,7 +93,7 @@ int main(int argc, char *argv[]) {
 
   try {
     // Split MPI into trainers
-    int procs_per_trainer = allocate_trainer_resources(comm.get());
+    allocate_trainer_resources(comm.get());
 
     // Initialize options db (this parses the command line)
     options *opts = options::get();
@@ -125,7 +125,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -92,6 +92,9 @@ int main(int argc, char *argv[]) {
   }
 
   try {
+    // Split MPI into trainers
+    int procs_per_trainer = allocate_trainer_resources(comm.get());
+
     // Initialize options db (this parses the command line)
     options *opts = options::get();
     opts->init(argc, argv);
@@ -122,7 +125,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 
   try {
     // Split MPI into trainers
-    int procs_per_trainer = allocate_trainer_resources(comm.get());
+    allocate_trainer_resources(comm.get());
 
     // Initialize options db (this parses the command line)
     options *opts = options::get();
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -83,6 +83,9 @@ int main(int argc, char *argv[]) {
   const bool master = comm->am_world_master();
 
   try {
+    // Split MPI into trainers
+    int procs_per_trainer = allocate_trainer_resources(comm.get());
+
     // Initialize options db (this parses the command line)
     options *opts = options::get();
     opts->init(argc, argv);
@@ -103,7 +106,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 

--- a/model_zoo/lbann_help.cpp
+++ b/model_zoo/lbann_help.cpp
@@ -47,6 +47,9 @@ int main(int argc, char *argv[]) {
               << std::endl;
     std::terminate();
   }
+  // Output help message from the arg_parser
+  std::cout << arg_parser << std::endl;
+  // Output manual help message
   print_help(std::cerr);
   return EXIT_SUCCESS;
 }

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -57,6 +57,9 @@ int main(int argc, char *argv[]) {
   const bool master = comm->am_world_master();
 
   try {
+    // Split MPI into trainers
+    int procs_per_trainer = allocate_trainer_resources(comm.get());
+
     // Initialize options db (this parses the command line)
     options *opts = options::get();
     opts->init(argc, argv);
@@ -77,7 +80,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
     int training_dr_linearized_data_size = -1;

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[]) {
 
   try {
     // Split MPI into trainers
-    int procs_per_trainer = allocate_trainer_resources(comm.get());
+    allocate_trainer_resources(comm.get());
 
     // Initialize options db (this parses the command line)
     options *opts = options::get();
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts, procs_per_trainer);
+    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
     int training_dr_linearized_data_size = -1;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -924,7 +924,6 @@ void print_help(std::ostream& os)
        "  --mini_batch_size=<int>\n"
        "  --num_epochs=<int>\n"
        "  --hydrogen_block_size=<int>\n"
-       "  --procs_per_trainer=<int>\n"
        "  --num_parallel_readers=<int>\n"
        "  --serialize_io=<bool>\n"
        "      force data readers to use a single thread for I/O\n"

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -835,8 +835,7 @@ void print_parameters(const lbann_comm& comm,
                       lbann_data::LbannPB& p,
                       std::vector<int>& root_random_seeds,
                       std::vector<int>& random_seeds,
-                      std::vector<int>& data_seq_random_seeds,
-                      int procs_per_trainer)
+                      std::vector<int>& data_seq_random_seeds)
 {
   if (!comm.am_world_master()) {
     return;
@@ -865,7 +864,7 @@ void print_parameters(const lbann_comm& comm,
             << "  mini_batch_size:            " << t.mini_batch_size() << std::endl
             << "  num_epochs:                 " << m.num_epochs()  << std::endl
             << "  hydrogen_block_size:        " << t.hydrogen_block_size()  << std::endl
-            << "  procs_per_trainer:          " << procs_per_trainer  << std::endl
+            << "  procs_per_trainer:          " << comm.get_procs_per_trainer()  << std::endl
             << "  num_parallel_readers:       " << t.num_parallel_readers()  << std::endl
             << "  serialize_io:               " << t.serialize_io()  << std::endl
             << "  cuda:                       " << (disable_cuda ? "disabled" : "enabled") << std::endl

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -816,9 +816,6 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
   if (opts->has_int("hydrogen_block_size")) {
     trainer->set_hydrogen_block_size(opts->get_int("hydrogen_block_size"));
   }
-  if (opts->has_int("procs_per_trainer")) {
-    trainer->set_procs_per_trainer(opts->get_int("procs_per_trainer"));
-  }
   if (opts->has_int("num_parallel_readers")) {
     trainer->set_num_parallel_readers(opts->get_int("num_parallel_readers"));
   }
@@ -838,7 +835,8 @@ void print_parameters(const lbann_comm& comm,
                       lbann_data::LbannPB& p,
                       std::vector<int>& root_random_seeds,
                       std::vector<int>& random_seeds,
-                      std::vector<int>& data_seq_random_seeds)
+                      std::vector<int>& data_seq_random_seeds,
+                      int procs_per_trainer)
 {
   if (!comm.am_world_master()) {
     return;
@@ -867,7 +865,7 @@ void print_parameters(const lbann_comm& comm,
             << "  mini_batch_size:            " << t.mini_batch_size() << std::endl
             << "  num_epochs:                 " << m.num_epochs()  << std::endl
             << "  hydrogen_block_size:        " << t.hydrogen_block_size()  << std::endl
-            << "  procs_per_trainer:          " << t.procs_per_trainer()  << std::endl
+            << "  procs_per_trainer:          " << procs_per_trainer  << std::endl
             << "  num_parallel_readers:       " << t.num_parallel_readers()  << std::endl
             << "  serialize_io:               " << t.serialize_io()  << std::endl
             << "  cuda:                       " << (disable_cuda ? "disabled" : "enabled") << std::endl

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -37,16 +37,6 @@ message Trainer {
   // Unique identifier
   string name = 1;
 
-  // Parallel processes per trainer
-  //
-  // The number of processes per trainer must evenly divide the total
-  // number of MPI ranks. The number of resulting trainers is
-  // num_procs / procs_per_trainer.
-  //
-  // If procs_per_trainer is not provided, then all MPI ranks are
-  // assigned to one trainer.
-  int64 procs_per_trainer = 2;
-
   // I/O threads per parallel process
   //
   // These threads are typically used to perform data ingestion in the

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -98,8 +98,12 @@ int allocate_trainer_resources(lbann_comm *comm) {
     procs_per_trainer = comm->get_procs_in_world();
   }
 
-  // Set up the communicator and split the grid if necessary
-  comm->split_trainers(procs_per_trainer);
+  // Set up the communicator and get the grid based on the commandline spec.
+  // We do not currently support splitting different trainers in different ways,
+  // as this implies different grids.
+  if (procs_per_trainer != comm->get_procs_per_trainer()) {
+    comm->split_trainers(procs_per_trainer);
+  }
 
   return procs_per_trainer;
 }
@@ -137,13 +141,6 @@ std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
     if (pb_trainer->hydrogen_block_size() > 0) {
       El::SetBlocksize(pb_trainer->hydrogen_block_size());
     }
-
-    // Set up the communicator and get the grid based on the trainers' spec.
-    // We do not currently support splitting different trainers in different ways,
-    // as this implies different grids.
-    // if (procs_per_trainer != comm->get_procs_per_trainer()) {
-    //   comm->split_trainers(procs_per_trainer);
-    // }
 
     // Display how the OpenMP threads are provisioned
     // if (opts->has_string("print_affinity")) {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -76,8 +76,8 @@ void construct_std_options() {
                       "Allow the print_statistics callback to report "
                       "global (inter-trainer) summary statistics.");
   arg_parser.add_option(PROCS_PER_TRAINER,
-                        {"--ltfb_procs_per_trainer"},
-                        utils::ENV("LBANN_LTFB_PROCS_PER_TRAINER"),
+                        {"--procs_per_trainer"},
+                        utils::ENV("LBANN_PROCS_PER_TRAINER"),
                         "Number of MPI ranks per LBANN trainer, "
                         "If the field is not set (or set to 0) then "
                         " all MPI ranks are assigned to one trainer."

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -96,7 +96,6 @@ int allocate_trainer_resources(lbann_comm *comm) {
 
   if (procs_per_trainer == 0) {
     procs_per_trainer = comm->get_procs_in_world();
-    //    arg_parser.<int>(PROCS_PER_TRAINER) = comm->get_procs_in_world();;
   }
 
   // Set up the communicator and split the grid if necessary

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -112,11 +112,10 @@ int allocate_trainer_resources(lbann_comm *comm) {
 std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                                            lbann_data::Trainer* pb_trainer,
                                            lbann_data::LbannPB &pb,
-                                           options *opts,
-                                           int procs_per_trainer) {
+                                           options *opts) {
   try {
-    if (pb_trainer->num_parallel_readers() > procs_per_trainer) {
-      pb_trainer->set_num_parallel_readers(procs_per_trainer);
+    if (pb_trainer->num_parallel_readers() > comm->get_procs_per_trainer()) {
+      pb_trainer->set_num_parallel_readers(comm->get_procs_per_trainer());
     }
 
     // Adjust the number of parallel readers; this may be adjusted
@@ -267,7 +266,7 @@ std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
                 << std::endl;
 
       // User feedback
-      print_parameters(*comm, pb, root_random_seeds, random_seeds, data_seq_random_seeds, procs_per_trainer);
+      print_parameters(*comm, pb, root_random_seeds, random_seeds, data_seq_random_seeds);
     }
 
     return trainer;


### PR DESCRIPTION
Separate the splitting of the MPI communicator from the creation of the trainer object.  Change the procs_per_trainer option to only be a command line or environment argument, not a trainer prototext field.