### PR TITLE
Bugfixes for distconv with CosmoFlow

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -32,6 +32,12 @@ Build system:
 
 Bug fixes:
  - Fixed a bug where LBANN didn't set the Hydrogen RNG seed
+ - Fixed both CosmoFlow and UNet models PFE as well as addressed
+   issues in the data reader and data coordinator.
+ - Fixed the HDF5 data reader to properly specify the supported I/O
+   types
+ - Fixed calculation of the linearized response size
+ - Fixed the data coordinator's interface to input_layer
 
 Retired features:
 

--- a/applications/physics/cosmology/cosmoflow/cosmoflow.py
+++ b/applications/physics/cosmology/cosmoflow/cosmoflow.py
@@ -319,7 +319,7 @@ if __name__ == "__main__":
 
     parser.add_argument(
         '--dynamically-reclaim-error-signals', action='store_true',
-        help='Allow DiHydrogen to reclaim error signals buffers (default: False)')
+        help='Allow LBANN to reclaim error signals buffers (default: False)')
 
     parser.add_argument(
         '--batch-job', action='store_true',

--- a/applications/physics/cosmology/cosmoflow/cosmoflow.py
+++ b/applications/physics/cosmology/cosmoflow/cosmoflow.py
@@ -334,7 +334,6 @@ if __name__ == "__main__":
 
     # Construct layer graph
     input = lbann.Input(
-        io_buffer='partitioned',
         target_mode='regression')
     universes = lbann.Split(input)
     secrets = lbann.Split(input)

--- a/applications/physics/cosmology/cosmoflow/cosmoflow.py
+++ b/applications/physics/cosmology/cosmoflow/cosmoflow.py
@@ -318,8 +318,8 @@ if __name__ == "__main__":
         help='the number of dropout layers from which the network is gathered (default: 1)')
 
     parser.add_argument(
-        '--keep-error-signals', action='store_true',
-        help='Keep error signals (default: False)')
+        '--dynamically-reclaim-error-signals', action='store_true',
+        help='Allow DiHydrogen to reclaim error signals buffers (default: False)')
 
     parser.add_argument(
         '--batch-job', action='store_true',
@@ -416,7 +416,9 @@ if __name__ == "__main__":
     # Runtime parameters/arguments
     environment = lbann.contrib.args.get_distconv_environment(
         num_io_partitions=args.depth_groups)
-    if args.keep_error_signals:
+    if args.dynamically_reclaim_error_signals:
+        environment['LBANN_KEEP_ERROR_SIGNALS'] = 0
+    else:
         environment['LBANN_KEEP_ERROR_SIGNALS'] = 1
     lbann_args = ['--use_data_store']
 

--- a/applications/segmentation/unet3d/unet3d.py
+++ b/applications/segmentation/unet3d/unet3d.py
@@ -271,7 +271,7 @@ if __name__ == '__main__':
 
     parser.add_argument(
         '--dynamically-reclaim-error-signals', action='store_true',
-        help='Allow DiHydrogen to reclaim error signals buffers (default: False)')
+        help='Allow LBANN to reclaim error signals buffers (default: False)')
 
     parser.add_argument(
         '--batch-job', action='store_true',

--- a/applications/segmentation/unet3d/unet3d.py
+++ b/applications/segmentation/unet3d/unet3d.py
@@ -270,8 +270,8 @@ if __name__ == '__main__':
         .format(default_test_dir))
 
     parser.add_argument(
-        '--keep-error-signals', action='store_true',
-        help='Keep error signals (default: False)')
+        '--dynamically-reclaim-error-signals', action='store_true',
+        help='Allow DiHydrogen to reclaim error signals buffers (default: False)')
 
     parser.add_argument(
         '--batch-job', action='store_true',
@@ -338,7 +338,9 @@ if __name__ == '__main__':
     # Runtime parameters/arguments
     environment = lbann.contrib.args.get_distconv_environment(
         num_io_partitions=args.depth_groups)
-    if args.keep_error_signals:
+    if args.dynamically_reclaim_error_signals:
+        environment['LBANN_KEEP_ERROR_SIGNALS'] = 0
+    else:
         environment['LBANN_KEEP_ERROR_SIGNALS'] = 1
     lbann_args = ['--use_data_store']
 

--- a/include/lbann/data_coordinator/buffered_data_coordinator.hpp
+++ b/include/lbann/data_coordinator/buffered_data_coordinator.hpp
@@ -141,8 +141,9 @@ class buffered_data_coordinator : public data_coordinator {
   const data_buffer<IODataType>& get_data_buffer(const data_buffer_map_t& buffer_map, const execution_mode mode) const;
   data_buffer<IODataType>& get_data_buffer(data_buffer_map_t& buffer_map, const execution_mode mode);
 
-  void distribute_from_local_matrix(execution_mode mode, AbsDistMatrixType& sample, AbsDistMatrixType& response);
-  void distribute_from_local_matrix(execution_mode mode, AbsDistMatrixType& sample);
+
+  void distribute_from_local_matrix(execution_mode mode,
+                                    std::map<input_data_type, AbsDistMatrixType*>& input_buffers);
 
 protected:
   int fetch_to_local_matrix(data_buffer_map_t& buffer_map, const execution_mode mode);

--- a/include/lbann/data_coordinator/data_coordinator.hpp
+++ b/include/lbann/data_coordinator/data_coordinator.hpp
@@ -346,8 +346,8 @@ class data_coordinator {
                       " response set size (", std::to_string(tmp_response_size),
                       ") does not match the currently established data set size (",
                       std::to_string(linearized_response_size), ")");
-          linearized_response_size = tmp_response_size;
         }
+        linearized_response_size = tmp_response_size;
       }
     }
     return linearized_response_size;

--- a/include/lbann/data_coordinator/data_coordinator.hpp
+++ b/include/lbann/data_coordinator/data_coordinator.hpp
@@ -203,9 +203,13 @@ class data_coordinator {
         map[data_reader_target_mode::INPUT] = dr->get_data_dims();
         if(dr->has_labels()) {
           map[data_reader_target_mode::CLASSIFICATION] = std::vector<int>(1, dr->get_num_labels());
+        }else {
+          map[data_reader_target_mode::CLASSIFICATION] = std::vector<int>(1, 0);
         }
         if(dr->has_responses()) {
           map[data_reader_target_mode::REGRESSION] = std::vector<int>(1, dr->get_num_responses());
+        }else {
+          map[data_reader_target_mode::REGRESSION] = std::vector<int>(1, 0);
         }
         map[data_reader_target_mode::RECONSTRUCTION] = dr->get_data_dims();
         map[data_reader_target_mode::LABEL_RECONSTRUCTION] = dr->get_data_dims();

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -315,8 +315,8 @@ class generic_data_reader {
   /// Fetch this mini-batch's responses into Y.
   virtual int fetch_responses(CPUMat& Y);
 
-  virtual bool has_labels() { return m_supported_input_types[input_data_type::LABELS]; }
-  virtual bool has_responses() { return m_supported_input_types[input_data_type::RESPONSES]; }
+  virtual bool has_labels() const { return m_supported_input_types.at(input_data_type::LABELS); }
+  virtual bool has_responses() const { return m_supported_input_types.at(input_data_type::RESPONSES); }
 
   /**
    * During the network's update phase, the data reader will

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -58,14 +58,16 @@ class hdf5_reader : public generic_data_reader {
   void load() override;
   void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
 
-  void set_has_labels(const bool b) { m_has_labels = b; }
-  void set_has_responses(const bool b) { m_has_responses = b; }
+  /// Whether to fetch a label from the last column.
+  void set_has_labels(const bool b) { m_supported_input_types[input_data_type::LABELS] = b; }
+  /// Whether to fetch a response from the last column.
+  void set_has_responses(const bool b) { m_supported_input_types[input_data_type::RESPONSES] = b; }
   void set_num_responses(const size_t num_responses) {
     m_all_responses.resize(num_responses);
   }
 
   int get_num_labels() const override {
-    if(!m_has_labels) {
+    if(!this->has_labels()) {
       return generic_data_reader::get_num_labels();
     }
     // This data reader currently assumes that the shape of the label
@@ -73,7 +75,7 @@ class hdf5_reader : public generic_data_reader {
     return m_num_features;
   }
   int get_num_responses() const override {
-    if(!m_has_responses) {
+    if(!this->has_responses()) {
       return generic_data_reader::get_num_responses();
     }
     return get_linearized_response_size();
@@ -82,7 +84,7 @@ class hdf5_reader : public generic_data_reader {
     return m_num_features;
   }
   int get_linearized_label_size() const override {
-    if(!m_has_labels) {
+    if(!this->has_labels()) {
       return generic_data_reader::get_linearized_label_size();
     }
     // This data reader currently assumes that the shape of the label
@@ -90,7 +92,7 @@ class hdf5_reader : public generic_data_reader {
     return m_num_features;
   }
   int get_linearized_response_size() const override {
-    if(!m_has_responses) {
+    if(!this->has_responses()) {
       return generic_data_reader::get_linearized_response_size();
     }
     return m_all_responses.size();
@@ -116,10 +118,6 @@ class hdf5_reader : public generic_data_reader {
   hid_t get_hdf5_data_type() const;
   conduit::DataType get_conduit_data_type(conduit::index_t num_elements) const;
 
-  /// Whether to fetch a label from the last column.
-  bool m_has_labels = false;
-  /// Whether to fetch a response from the last column.
-  bool m_has_responses = false;
   int m_image_depth = 0;
   size_t m_num_features;
   std::vector<float> m_all_responses;

--- a/include/lbann/layers/io/input_layer.hpp
+++ b/include/lbann/layers/io/input_layer.hpp
@@ -105,6 +105,14 @@ template <typename TensorDataType,
 class input_layer : public data_type_layer<TensorDataType> {
   static_assert(T_layout == data_layout::DATA_PARALLEL,
                 "input layer only supports DATA_PARALLEL data layout");
+ public:
+  /** @name Public Types */
+  ///@{
+
+  /** @brief The tensor type expected in this object. */
+  using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
+
+  ///@}
  protected:
   data_reader_target_mode m_data_reader_mode;
 

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -27,5 +27,8 @@ if (LBANN_HAS_DISTCONV)
     "${CMAKE_CURRENT_SOURCE_DIR}/data_reader_hdf5.cpp")
 endif ()
 
+# Add the subdirectories
+add_subdirectory(utils)
+
 # Propagate the files up the tree
 set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -89,8 +89,6 @@ void hdf5_reader<TensorDataType>::copy_members(const hdf5_reader &rhs) {
   }
   m_data_store->set_data_reader_ptr(this);
 
-  m_has_labels = rhs.m_has_labels;
-  m_has_responses = rhs.m_has_responses;
   m_num_features = rhs.m_num_features;
   m_data_dims = rhs.m_data_dims;
   m_hyperslab_dims = rhs.m_hyperslab_dims;
@@ -157,13 +155,13 @@ void hdf5_reader<TensorDataType>::read_hdf5_sample(int data_id, TensorDataType *
   //close data set
   CHECK_HDF5(H5Dclose(h_data));
 
-  if (m_has_labels && labels != nullptr) {
+  if (this->has_labels() && labels != nullptr) {
     assert_always(m_hyperslab_labels);
     hid_t h_labels = CHECK_HDF5(H5Dopen(h_file, m_key_labels.c_str(), H5P_DEFAULT));
     hid_t filespace_labels = CHECK_HDF5(H5Dget_space(h_labels));
     read_hdf5_hyperslab(h_labels, filespace_labels, world_rank, labels);
     CHECK_HDF5(H5Dclose(h_labels));
-  } else if (m_has_responses) {
+  } else if (this->has_responses()) {
     assert_always(labels == nullptr);
     h_data = CHECK_HDF5(H5Dopen(h_file, m_key_responses.c_str(), H5P_DEFAULT));
     CHECK_HDF5(H5Dread(h_data, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, &m_all_responses[0]));
@@ -244,7 +242,7 @@ void hdf5_reader<TensorDataType>::load() {
 
 template <typename TensorDataType>
 bool hdf5_reader<TensorDataType>::fetch_label(Mat& Y, int data_id, int mb_idx) {
-  if(!m_has_labels) {
+  if(!this->has_labels()) {
     return generic_data_reader::fetch_label(Y, data_id, mb_idx);
   }
 
@@ -299,7 +297,7 @@ void hdf5_reader<TensorDataType>::fetch_datum_conduit(Mat& X, int data_id) {
     conduit_obj.set(get_conduit_data_type(
         m_num_features / dc::get_number_of_io_partitions()));
     TensorDataType *sample_buf = conduit_obj.value();
-    if(m_has_labels) {
+    if(this->has_labels()) {
       assert_always(m_hyperslab_labels);
       auto &conduit_labels_obj = node[conduit_key + "/labels_slab"];
       conduit_labels_obj.set(get_conduit_data_type(
@@ -309,7 +307,7 @@ void hdf5_reader<TensorDataType>::fetch_datum_conduit(Mat& X, int data_id) {
     } else {
       read_hdf5_sample(data_id, sample_buf, nullptr);
     }
-    if(m_has_responses) {
+    if(this->has_responses()) {
       node[conduit_key + "/responses"].set(
           &m_all_responses[0],
           m_all_responses.size());
@@ -332,7 +330,7 @@ void hdf5_reader<TensorDataType>::fetch_datum_conduit(Mat& X, int data_id) {
 //get from a cached response
 template <typename TensorDataType>
 bool hdf5_reader<TensorDataType>::fetch_response(Mat& Y, int data_id, int mb_idx) {
-  if(!m_has_responses) {
+  if(!this->has_responses()) {
     return generic_data_reader::fetch_response(Y, data_id, mb_idx);
   }
 

--- a/src/data_readers/utils/CMakeLists.txt
+++ b/src/data_readers/utils/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Add the source files for this directory
+set_full_path(THIS_DIR_SOURCES
+  input_data_type.cpp
+  )
+
+# Propagate the files up the tree
+set(SOURCES "${SOURCES}" "${THIS_DIR_SOURCES}" PARENT_SCOPE)

--- a/src/data_readers/utils/input_data_type.cpp
+++ b/src/data_readers/utils/input_data_type.cpp
@@ -24,18 +24,20 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_INPUT_DATA_TYPE_HPP_INCLUDED
-#define LBANN_INPUT_DATA_TYPE_HPP_INCLUDED
-
-#include "lbann/utils/enum_iterator.hpp"
-#include <string>
+#include <lbann/data_readers/utils/input_data_type.hpp>
 
 namespace lbann {
 
-enum class input_data_type {SAMPLES, LABELS, RESPONSES};
-using input_data_type_iterator = enum_iterator<input_data_type, input_data_type::SAMPLES, input_data_type::RESPONSES>;
-std::string to_string(input_data_type const& idt);
-
+std::string to_string(input_data_type const& idl) {
+  switch (idl) {
+  case input_data_type::SAMPLES:
+    return "samples";
+  case input_data_type::LABELS:
+    return "labels";
+  case input_data_type::RESPONSES:
+    return "responses";
+  }
+  return "invalid input_data_type";
 }
 
-#endif // LBANN_INPUT_DATA_TYPE_HPP_INCLUDED
+}

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -104,14 +104,17 @@ void input_layer<TensorDataType, T_layout, Dev>::fp_compute() {
   int num_samples_in_batch = dc.get_current_mini_batch_size(mode);
 
   dc.update_num_samples_processed(mode, num_samples_in_batch);
-  if(this->m_expected_num_child_layers == 1) {
-    dc.distribute_from_local_matrix(mode, this->get_activations(0));
-  }else {
-    dc.distribute_from_local_matrix(mode, this->get_activations(0), this->get_activations(1));
+  std::map<input_data_type, AbsDistMatrixType*> input_buffers;
+  input_buffers[input_data_type::SAMPLES] = &(this->get_activations(0));
+  if(this->m_expected_num_child_layers > 1) {
+    if(is_for_regression()) {
+      input_buffers[input_data_type::RESPONSES] = &(this->get_activations(1));
+    }else {
+      input_buffers[input_data_type::LABELS] = &(this->get_activations(1));
+    }
   }
-  // }else {
-  //   LBANN_ERROR("could not fp_compute for I/O layers : encoutered generic_io_buffer type");
-  // }
+
+  dc.distribute_from_local_matrix(mode, input_buffers);
 
 #ifdef LBANN_HAS_DISTCONV
   if (this->distconv_enabled()) {


### PR DESCRIPTION
Updated the HDF5 data reader to use the proper ordered map
(m_supported_input_types) that tracks which types of information are
available from a data reader, specifically if responses and labels are
supported.