### PR TITLE
Bugfix and unit tests for LTFB

### DIFF
--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -1,0 +1,263 @@
+"""Test to check weight exchanges in LTFB.
+
+Each model has a randomly initialized weights object. An LTFB round is
+performed after every training step and winners are chosen randomly.
+The log files are post-processed to make sure that the correct weights
+are propagated by LTFB.
+
+"""
+import os
+import os.path
+import random
+import re
+import sys
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# RNG
+rng_pid = None
+def initialize_rng():
+    """Initialize random seed if needed.
+
+    Seed should be initialized independently on each process. We
+    reinitialize if we detect a process fork.
+
+    """
+    global rng_pid
+    if rng_pid != os.getpid():
+        rng_pid = os.getpid()
+        random.seed()
+
+# Sample access functions
+_mini_batch_size = 2
+_num_epochs = 3
+def get_sample(index):
+    initialize_rng()
+    return (random.gauss(0,1),)
+def num_samples():
+    return _mini_batch_size
+def sample_dims():
+    return (1,)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    trainer = lbann.Trainer(_mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Layer graph
+    weight = lbann.Weights(initializer=lbann.UniformInitializer(min=0, max=1))
+    weight = lbann.WeightsLayer(weights=weight, dims=tools.str_list([1]))
+    rand = lbann.Identity(lbann.Input())
+    layers = list(lbann.traverse_layer_graph([weight, rand]))
+    for l in layers:
+        l.device = 'CPU'
+
+    # Model objects
+    metrics = [
+        lbann.Metric(weight, name='weight'),
+        lbann.Metric(rand, name='random'),
+    ]
+    callbacks = [
+        lbann.CallbackPrint(),
+        lbann.CallbackLTFB(batch_interval=1, metric='random'),
+    ]
+
+    # Construct model
+    return lbann.Model(_num_epochs,
+                       layers=layers,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train',
+        ),
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'validate',
+        ),
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+def augment_test_func(test_func):
+    """Augment test function to parse log files.
+
+    `tools.create_tests` creates functions that run an LBANN
+    experiment. This function creates augmented functions that parse
+    the log files after LBANN finishes running, e.g. to check metrics
+    or runtimes.
+
+    Note: The naive approach is to define the augmented test functions
+    in a loop. However, Python closures are late binding. In other
+    words, the function would be overwritten every time we define it.
+    We get around this overwriting problem by defining the augmented
+    function in the local scope of another function.
+
+    Args:
+        test_func (function): Test function created by
+            `tools.create_tests`.
+
+    Returns:
+        function: Test that can interact with PyTest.
+
+    """
+    test_name = test_func.__name__
+
+    # Define test function
+    def func(cluster, exes, dirname):
+
+        # Run LBANN experiment
+        experiment_output = test_func(cluster, exes, dirname)
+
+        # Parse LBANN log file
+        num_trainers = None
+        log_file = experiment_output['stdout_log_file']
+        with open(log_file) as f:
+            for line in f:
+
+                # Configure data once we figure out number of trainers
+                if num_trainers is None:
+                    match = re.search('Trainers *: ([0-9]+)', line)
+                    if match:
+                        num_trainers = int(match.group(1))
+                    else:
+                        continue
+                    ltfb_partners = [[] for _ in range(num_trainers)]
+                    ltfb_winners = [[] for _ in range(num_trainers)]
+                    metric_values = [[] for _ in range(num_trainers)]
+
+                # LTFB tournament winners
+                match = re.search(
+                    'LTFB .* '
+                    'trainer ([0-9]+) selected model from trainer ([0-9]+) '
+                    '\\(trainer [0-9]+ score .* trainer ([0-9]+) score.*\\)',
+                    line)
+                if match:
+                    trainer = int(match.group(1))
+                    winner = int(match.group(2))
+                    partner = int(match.group(3))
+                    ltfb_partners[trainer].append(partner)
+                    ltfb_winners[trainer].append(winner)
+
+                # Metric value on validation set
+                match = re.search(
+                    'model0 \\(instance ([0-9]+)\\) validation weight : '
+                    '([0-9.]+)',
+                    line)
+                if match:
+                    trainer = int(match.group(1))
+                    metric_values[trainer].append(float(match.group(2)))
+
+        # Make sure file has been parsed correctly
+        assert num_trainers, \
+            f'Error parsing {log_file} (could not find number of trainers)'
+        for trainer, partners in enumerate(ltfb_partners):
+            assert len(partners) == _num_epochs-1, \
+                f'Error parsing {log_file} ' \
+                f'(expected {_num_epochs-1} LTFB rounds, ' \
+                f'but found {len(partners)} for trainer {trainer})'
+        for trainer, winners in enumerate(ltfb_winners):
+            assert len(winners) == _num_epochs-1, \
+                f'Error parsing {log_file} ' \
+                f'(expected {_num_epochs-1} LTFB rounds, ' \
+                f'but found {len(winners)} for trainer {trainer})'
+        for trainer, vals in enumerate(metric_values):
+            assert len(vals) == _num_epochs+2*(_num_epochs-1), \
+                f'Error parsing {log_file} ' \
+                f'(expected {_num_epochs+2*(_num_epochs-1)} validation metric values, ' \
+                f'but found {len(val)} for trainer {trainer})'
+
+        # Make sure metric values match expected values
+        # Note: An LTFB round occurs once per training epoch
+        # (excluding the first epoch). Each LTFB round involves two
+        # evaluations on the validation set: once on the local model
+        # and once on a model from a partner trainer. At the end of
+        # each training epoch, we perform another evalutation on the
+        # validation set. By inspecting the metric values
+        # (corresponding to the model weight), we can make sure that
+        # LTFB is evaluating on the correct models.
+        tol = 1e-4
+        for step in range(_num_epochs-1):
+            for trainer in range(num_trainers):
+                partner = ltfb_partners[trainer][step]
+                winner = ltfb_winners[trainer][step]
+                local_val = metric_values[trainer][3*step+1]
+                partner_val = metric_values[trainer][3*step+2]
+                winner_val = metric_values[trainer][3*step+3]
+                true_local_val = metric_values[trainer][3*step]
+                true_partner_val = metric_values[partner][3*step]
+                true_winner_val = metric_values[winner][3*step]
+                assert true_local_val-tol < local_val < true_local_val+tol, \
+                    'Incorrect metric value for LTFB local model'
+                assert true_partner_val-tol < partner_val < true_partner_val+tol, \
+                    'Incorrect metric value for LTFB partner model'
+                assert true_winner_val-tol < winner_val < true_winner_val+tol, \
+                    'Incorrect metric value for LTFB winner model'
+
+    # Return test function from factory function
+    func.__name__ = test_name
+    return func
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment,
+                               __file__,
+                               nodes=2,
+                               lbann_args='--procs_per_trainer=2'):
+    globals()[test.__name__] = augment_test_func(test)

--- a/bamboo/unit_tests/test_unit_callback_ltfb_data.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb_data.py
@@ -1,0 +1,172 @@
+"""Test to check data ingestion with LTFB.
+
+LTFB requires switching between training and validation data sets in
+the middle of a training epoch. We perform metric checking to make
+sure that no samples are skipped or duplicated during these
+transitions.
+
+"""
+import os
+import os.path
+import random
+import sys
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Parameters
+_mini_batch_size = 7
+
+# Sample access functions
+def get_train_sample(index):
+    return (index,)
+def get_val_sample(index):
+    return (10+index,)
+def get_test_sample(index):
+    return (100+index,)
+def num_train_samples():
+    return 31
+def num_val_samples():
+    return 13
+def num_test_samples():
+    return 42
+def sample_dims():
+    return (1,)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    trainer = lbann.Trainer(_mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Layer graph
+    step_id = lbann.Identity(lbann.Input())
+    for l in lbann.traverse_layer_graph(step_id):
+        l.device = 'CPU'
+
+    # LTFB
+    ltfb_interval = 3
+    metrics = [lbann.Metric(step_id, name='step id')]
+    callbacks = [
+        lbann.CallbackLTFB(
+            batch_interval=ltfb_interval,
+            metric=metrics[-1].name,
+        ),
+    ]
+
+    # Metric checking
+    # Note: sum(i) = (n-1) / 2
+    train_val = (num_train_samples() - 1) / 2
+    val_val = 10 + (num_val_samples() - 1) / 2
+    test_val = 100 + (num_test_samples() - 1) / 2
+    tol = 1e-4
+    callbacks.extend([
+        lbann.CallbackCheckMetric(
+            metric=metrics[-1].name,
+            lower_bound=train_val-tol,
+            upper_bound=train_val+tol,
+            error_on_failure=True,
+            execution_modes='train'),
+        lbann.CallbackCheckMetric(
+            metric=metrics[-1].name,
+            lower_bound=val_val-tol,
+            upper_bound=val_val+tol,
+            error_on_failure=True,
+            execution_modes='validation'),
+        lbann.CallbackCheckMetric(
+            metric=metrics[-1].name,
+            lower_bound=test_val-tol,
+            upper_bound=test_val+tol,
+            error_on_failure=True,
+            execution_modes='test'),
+    ])
+
+    # Choose number of epochs so that LTFB round and epoch line up
+    num_epochs = 2 * ltfb_interval
+
+    # Construct model
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(step_id),
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_train_sample',
+            'num_train_samples',
+            'sample_dims',
+            'train',
+        ),
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_val_sample',
+            'num_val_samples',
+            'sample_dims',
+            'validate',
+        ),
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_test_sample',
+            'num_test_samples',
+            'sample_dims',
+            'test',
+        ),
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for test in tools.create_tests(setup_experiment,
+                               __file__,
+                               nodes=2,
+                               lbann_args='--procs_per_trainer=2'):
+    globals()[test.__name__] = test

--- a/include/lbann/data_coordinator/buffered_data_coordinator.hpp
+++ b/include/lbann/data_coordinator/buffered_data_coordinator.hpp
@@ -119,7 +119,7 @@ class buffered_data_coordinator : public data_coordinator {
     int max_mini_batch_size,
     std::map<execution_mode, generic_data_reader *> data_readers) override;
 
-  void fp_setup_data(data_buffer_map_t& buffer_map, El::Int cur_mini_batch_size);
+  void fp_setup_data(data_buffer<IODataType>& buffer, El::Int cur_mini_batch_size);
 
   void fetch_data(execution_mode mode) override;
 

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -122,14 +122,13 @@ int buffered_data_coordinator<TensorDataType>::fetch_to_local_matrix(data_buffer
 }
 
 template <typename TensorDataType>
-void buffered_data_coordinator<TensorDataType>::fp_setup_data(data_buffer_map_t& buffer_map, El::Int cur_mini_batch_size) {
+void buffered_data_coordinator<TensorDataType>::fp_setup_data(data_buffer<IODataType>& buffer, El::Int cur_mini_batch_size) {
 #ifdef LBANN_HAS_DISTCONV
   cur_mini_batch_size *= dc::get_number_of_io_partitions();
 #endif
   for(auto idt : input_data_type_iterator()) {
-    for (auto& buf : buffer_map) {
-      buf.second->m_input_buffers[idt]->Resize(buf.second->m_input_buffers[idt]->Height(), cur_mini_batch_size);
-    }
+    auto& mat = *buffer.m_input_buffers[idt];
+    mat.Resize(mat.Height(), cur_mini_batch_size);
   }
 }
 
@@ -139,7 +138,7 @@ void buffered_data_coordinator<TensorDataType>::fetch_data_in_background(int fut
   data_buffer_map_t& buffer_map = m_data_buffers[active_buffer_idx];
   std::lock_guard<std::mutex> guard(dr_mutex);
   int mini_batch_size = get_current_mini_batch_size(mode);
-  fp_setup_data(buffer_map, mini_batch_size);
+  fp_setup_data(*buffer_map[mode], mini_batch_size);
   fetch_to_local_matrix(buffer_map, mode);
   return;
 }


### PR DESCRIPTION
It appears that PR #1538 has broken LTFB. The root cause is because the data coordinator resized all of its data matrices at every step. However, LTFB involves switching between training and validation execution modes. In the process of configuring the data matrices to load validation data, it would clobber the data matrices for training data. I've modified the arguments to `buffered_data_coordinator::fp_setup_data` so that it only interacts with the data matrices for the current execution mode.

To help catch these kinds of errors in the future, I've also added two Bamboo unit tests:
- `test_unit_callback_ltfb.py`: Check that LTFB weight exchange is working as expected.
- `test_unit_callback_ltfb_data.py`: Check that switching between training and validation execution modes in LTFB works correctly.

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM325-1).