### PR TITLE
Refactor dnn_lib convolution parameter type from distmatrix to matrix

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -47,7 +47,7 @@ void convolution_forward(
   TensorDescriptor const& xDesc,
   El::AbstractMatrix<TensorDataType> const& x,
   FilterDescriptor const& wDesc,
-  El::AbstractDistMatrix<TensorDataType> const& w,
+  El::AbstractMatrix<TensorDataType> const& w,
   ConvolutionDescriptor const& convDesc,
   fwd_conv_alg alg,
   El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
@@ -81,7 +81,7 @@ void convolution_forward(
   TensorDescriptor const& xDesc,
   El::AbstractMatrix<TensorDataType> const& x,
   FilterDescriptor const& wDesc,
-  El::AbstractDistMatrix<TensorDataType> const& w,
+  El::AbstractMatrix<TensorDataType> const& w,
   ConvolutionDescriptor const& convDesc,
   fwd_conv_alg alg,
   El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
@@ -101,7 +101,7 @@ template <typename TensorDataType, typename ScalarParameterType>
 void convolution_backward_data(
   ScalarParameterType const& alpha_in,
   FilterDescriptor const& wDesc,
-  El::AbstractDistMatrix<TensorDataType> const& w,
+  El::AbstractMatrix<TensorDataType> const& w,
   TensorDescriptor const& dyDesc,
   El::AbstractMatrix<TensorDataType> const& dy,
   ConvolutionDescriptor const& convDesc,
@@ -135,7 +135,7 @@ template <typename TensorDataType, typename ScalarParameterType>
 void convolution_backward_data(
   ScalarParameterType const& alpha_in,
   FilterDescriptor const& wDesc,
-  El::AbstractDistMatrix<TensorDataType> const& w,
+  El::AbstractMatrix<TensorDataType> const& w,
   TensorDescriptor const& dyDesc,
   El::AbstractMatrix<TensorDataType> const& dy,
   ConvolutionDescriptor const& convDesc,
@@ -161,7 +161,7 @@ void convolution_backward_bias(
   El::AbstractMatrix<TensorDataType> const& dy,
   ScalarParameterType const& beta_in,
   TensorDescriptor const& dbDesc,
-  El::AbstractDistMatrix<TensorDataType>& db,
+  El::AbstractMatrix<TensorDataType>& db,
   El::SyncInfo<El::Device::GPU> const& si)
 {
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
@@ -184,7 +184,7 @@ void convolution_backward_bias(
   El::AbstractMatrix<TensorDataType> const& dy,
   ScalarParameterType const& beta_in,
   TensorDescriptor const& dbDesc,
-  El::AbstractDistMatrix<TensorDataType>& db)
+  El::AbstractMatrix<TensorDataType>& db)
 {
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(db),
                                      gpu::get_sync_info(dy));
@@ -205,7 +205,7 @@ void convolution_backward_filter(
   El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
   ScalarParameterType const& beta_in,
   FilterDescriptor const& dwDesc,
-  El::AbstractDistMatrix<TensorDataType>& dw,
+  El::AbstractMatrix<TensorDataType>& dw,
   El::SyncInfo<El::Device::GPU> const& si)
 {
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
@@ -239,7 +239,7 @@ void convolution_backward_filter(
   El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
   ScalarParameterType const& beta_in,
   FilterDescriptor const& dwDesc,
-  El::AbstractDistMatrix<TensorDataType>& dw)
+  El::AbstractMatrix<TensorDataType>& dw)
 {
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(dw),
                                      gpu::get_sync_info(workSpace),
@@ -252,7 +252,7 @@ void convolution_backward_filter(
 template <typename TensorDataType, typename ScalarParameterType>
 void add_tensor(ScalarParameterType const& alpha_in,
                 TensorDescriptor const& aDesc,
-                El::AbstractDistMatrix<TensorDataType> const& A,
+                El::AbstractMatrix<TensorDataType> const& A,
                 ScalarParameterType const& beta_in,
                 TensorDescriptor const& cDesc,
                 El::AbstractMatrix<TensorDataType>& C,
@@ -274,7 +274,7 @@ void add_tensor(ScalarParameterType const& alpha_in,
 template <typename TensorDataType, typename ScalarParameterType>
 void add_tensor(ScalarParameterType const& alpha_in,
                 TensorDescriptor const& aDesc,
-                El::AbstractDistMatrix<TensorDataType> const& A,
+                El::AbstractMatrix<TensorDataType> const& A,
                 ScalarParameterType const& beta_in,
                 TensorDescriptor const& cDesc,
                 El::AbstractMatrix<TensorDataType>& C)

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -484,7 +484,7 @@ base_convolution_layer<TensorDataType,Device>
                                input_desc,
                                input,
                                m_kernel_dnn_desc,
-                               kernel,
+                               kernel.LockedMatrix(),
                                m_convolution_dnn_desc,
                                convolution_dnn_algorithm,
                                workspace,
@@ -562,7 +562,7 @@ apply_transposed_convolution_dnn(bool during_forward_prop) {
   // Perform transposed convolution
   dnn_lib::convolution_backward_data(one,
                                      m_kernel_dnn_desc,
-                                     kernel,
+                                     kernel.LockedMatrix(),
                                      input_desc,
                                      input,
                                      m_convolution_dnn_desc,
@@ -588,7 +588,7 @@ void base_convolution_layer<TensorDataType,Device>::apply_bias_dnn() {
     const auto& bias = this->weights_values(1);
     dnn_lib::add_tensor(m_bias_scaling_factor,
                         m_bias_dnn_desc,
-                        bias,
+                        bias.LockedMatrix(),
                         one,
                         m_tensors_dnn_desc.get_activations(),
                         local_output);
@@ -629,7 +629,7 @@ base_convolution_layer<TensorDataType,Device>
         local_gradient_wrt_output,
         dst_scale,
         m_bias_dnn_desc,
-        bias_gradient);
+        bias_gradient.Matrix());
     } else {
       El::Scale(dst_scale_dt, bias_gradient);
     }
@@ -678,7 +678,7 @@ base_convolution_layer<TensorDataType,Device>
           workspace,
           dst_scale,
           m_kernel_dnn_desc,
-          kernel_gradient);
+          kernel_gradient.Matrix());
       } else {
         bwd_filter_conv_alg kernel_gradient_dnn_algorithm
           = get_backward_filter_algo_dnn(
@@ -699,7 +699,7 @@ base_convolution_layer<TensorDataType,Device>
           workspace,
           dst_scale,
           m_kernel_dnn_desc,
-          kernel_gradient);
+          kernel_gradient.Matrix());
       }
     } else {
       El::Scale(dst_scale_dt, kernel_gradient);


### PR DESCRIPTION
In the `dnn_lib` functions for the convolution layer, several matrices had type `El::DistMatrix`.  This PR refactors those parameters to be of type `El::Matrix` and avoid the requirement of distributed matrices for these function calls.