### PR TITLE
Feature add tournament execution mode

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -24,6 +24,9 @@ Internal features:
 I/O & data readers:
  - Experimental data reader that generates graph random walks with
    HavoqGT
+ - Added explict tournament execution mode
+ - Added support to split training data reader into validation and
+   tournament readers
 
 Build system:
  - Hydrogen v1.5.0
@@ -40,6 +43,10 @@ Bug fixes:
  - Fixed the data coordinator's interface to input_layer
 
 Retired features:
+ - Removed deprecated JAG leader mode which was made obsolete when the
+   data reader moved into the data coordinator
+ - Removed the deprecated partitioned data reader modes that were used
+   to partition and overlap data sets for multiple models
 
 ============================== Release Notes: v0.101 ==============================
 

--- a/applications/ATOM/eval_atom_wae.py
+++ b/applications/ATOM/eval_atom_wae.py
@@ -217,6 +217,7 @@ def construct_data_reader(run_args):
     data_reader.shuffle = True
     data_reader.percent_of_data_to_use = 1.0
     data_reader.validation_percent = 0.1
+    data_reader.tournament_percent = 0.1
     data_reader.python.module = module_name
     data_reader.python.module_dir = module_dir
     data_reader.python.sample_function = "get_sample"

--- a/applications/ATOM/train_atom_vae.py
+++ b/applications/ATOM/train_atom_vae.py
@@ -190,6 +190,7 @@ def construct_data_reader(run_args):
     data_reader.shuffle = True
     data_reader.percent_of_data_to_use = 1.0
     data_reader.validation_percent = 0.1
+    data_reader.tournament_percent = 0.1
     data_reader.python.module = module_name
     data_reader.python.module_dir = module_dir
     data_reader.python.sample_function = "get_sample"

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -226,7 +226,7 @@ def construct_data_reader(run_args):
     data_reader.shuffle = True
     data_reader.percent_of_data_to_use = 1.0
     data_reader.validation_percent = 0.1
-    data_reader.tournament_percent = 0.2
+    data_reader.tournament_percent = 0.1
     data_reader.python.module = module_name
     data_reader.python.module_dir = module_dir
     data_reader.python.sample_function = "get_sample"

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -226,6 +226,7 @@ def construct_data_reader(run_args):
     data_reader.shuffle = True
     data_reader.percent_of_data_to_use = 1.0
     data_reader.validation_percent = 0.1
+    data_reader.tournament_percent = 0.2
     data_reader.python.module = module_name
     data_reader.python.module_dir = module_dir
     data_reader.python.sample_function = "get_sample"

--- a/applications/physics/data/jag_conduit_reader.prototext
+++ b/applications/physics/data/jag_conduit_reader.prototext
@@ -21,6 +21,7 @@ data_reader {
     index_list_per_model: false
 
     validation_percent: 0.1
+    tournament_percent: 0.1
     absolute_sample_count: 0
     percent_of_data_to_use: 1.0
     disable_responses: true
@@ -40,6 +41,7 @@ data_reader {
     index_list_per_model: false
 
     validation_percent: 0
+    tournament_percent: 0
     absolute_sample_count: 0
     percent_of_data_to_use: 0.1
     disable_responses: true

--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -109,8 +109,6 @@ def construct_data_reader(lbann):
 
     """
 
-    # Note: The training data reader should be removed when
-    # https://github.com/LLNL/lbann/issues/1098 is resolved.
     message = lbann.reader_pb2.DataReader()
     message.reader.extend([
         tools.create_python_data_reader(
@@ -128,6 +126,14 @@ def construct_data_reader(lbann):
             'num_samples',
             'sample_dims',
             'validate',
+        ),
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'tournament',
         ),
     ])
     return message
@@ -195,6 +201,15 @@ def augment_test_func(test_func):
                     partner = int(match.group(3))
                     ltfb_partners[trainer].append(partner)
                     ltfb_winners[trainer].append(winner)
+
+                # Metric value on tournament set
+                match = re.search(
+                    'model0 \\(instance ([0-9]+)\\) tournament weight : '
+                    '([0-9.]+)',
+                    line)
+                if match:
+                    trainer = int(match.group(1))
+                    metric_values[trainer].append(float(match.group(2)))
 
                 # Metric value on validation set
                 match = re.search(

--- a/bamboo/unit_tests/test_unit_callback_ltfb_data.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb_data.py
@@ -129,8 +129,6 @@ def construct_data_reader(lbann):
 
     """
 
-    # Note: The training data reader should be removed when
-    # https://github.com/LLNL/lbann/issues/1098 is resolved.
     message = lbann.reader_pb2.DataReader()
     message.reader.extend([
         tools.create_python_data_reader(
@@ -148,6 +146,14 @@ def construct_data_reader(lbann):
             'num_val_samples',
             'sample_dims',
             'validate',
+        ),
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_val_sample',
+            'num_val_samples',
+            'sample_dims',
+            'tournament',
         ),
         tools.create_python_data_reader(
             lbann,

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -167,7 +167,7 @@ std::string to_string(data_layout const& dl);
 data_layout data_layout_from_string(std::string const& str);
 
 /// Neural network execution mode
-enum class execution_mode {training, validation, testing, prediction, invalid};
+enum class execution_mode {training, validation, testing, prediction, tournament, invalid};
 std::string to_string(execution_mode m);
 using execution_mode_iterator = enum_iterator<execution_mode, execution_mode::training, execution_mode::invalid>;
 

--- a/include/lbann/data_coordinator/data_coordinator.hpp
+++ b/include/lbann/data_coordinator/data_coordinator.hpp
@@ -415,8 +415,7 @@ class data_coordinator {
 
   /** @brief Check if the execution mode is valid (i.e. has data). */
   bool is_execution_mode_valid(execution_mode mode) const {
-    const dataset& ds = get_dataset(mode);
-    return (ds.get_total_samples() != static_cast<long>(0));
+    return (get_total_num_samples(mode) != static_cast<long>(0));
   }
 ///@}
 

--- a/include/lbann/data_coordinator/data_coordinator.hpp
+++ b/include/lbann/data_coordinator/data_coordinator.hpp
@@ -56,7 +56,7 @@ namespace lbann {
 
 class data_coordinator {
  public:
-  using dataset_map_t = std::unordered_map<execution_mode, dataset>;
+  using dataset_map_t = std::map<execution_mode, dataset>;
   using data_reader_map_t = std::map<execution_mode, generic_data_reader *>;
   using io_buffer_map_t = std::map<execution_mode, std::atomic<int>>;
 

--- a/include/lbann/data_readers/compound_data_reader.hpp
+++ b/include/lbann/data_readers/compound_data_reader.hpp
@@ -76,12 +76,12 @@ class generic_compound_data_reader : public generic_data_reader {
   //************************************************************************
   /// Apply operations to subsidiary data readers
   //************************************************************************
-  void set_validation_percent(double s) override {
-    generic_data_reader::set_validation_percent(s);
+  void set_execution_mode_split_percent(execution_mode m, double s) override {
+    generic_data_reader::set_execution_mode_split_percent(m, s);
     /// Don't propagate the validation percentage to subsidiary readers
     /// The percentage is applied at the top level
     for (auto&& reader : m_data_readers) {
-      reader->set_validation_percent(0);
+      reader->set_execution_mode_split_percent(m, 0);
     }
   }
 

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -101,10 +101,6 @@ class generic_data_reader {
     m_master(false),
     m_gan_labelling(false), //default, not GAN
     m_gan_label_value(0),  //If GAN, default for fake label, discriminator model
-    m_is_partitioned(false),
-    m_partition_overlap(0),
-    m_partition_mode(0),
-    m_procs_per_partition(1),
     m_io_thread_pool(nullptr),
     m_jag_partitioned(false),
     m_keep_sample_order(false),
@@ -617,20 +613,11 @@ class generic_data_reader {
    */
   void select_subset_of_data();
 
-  /// called by select_subset_of_data() if data set is partitioned
-  void select_subset_of_data_partitioned();
-
   /**
    * Replaced the shuffled index set with the unused index set, empying the
    * unused set.
    */
   virtual void use_unused_index_set(execution_mode m);
-
-  /// partition the dataset amongst the models
-  void set_partitioned(bool is_partitioned=true, double overlap=0.0, int mode=0);
-
-  /// returns true if the data set is partitioned
-  bool is_partitioned() const { return m_is_partitioned; }
 
   /// Does the data reader have a unqiue sample list per model
   virtual bool has_list_per_model() const { return false; }
@@ -870,31 +857,6 @@ private:
   //var to support GAN
   bool m_gan_labelling; //boolean flag of whether its GAN binary label, default is false
   int m_gan_label_value; //zero(0) or 1 label value for discriminator, default is 0
-
-   /// if true, dataset is partitioned amongst several models,
-   /// with options overlap (yeah, I know, if there's overlap its
-   /// not technically a partition)
-   bool m_is_partitioned;
-
-   /// if m_is_partitioned, this determines the amount of overlap
-   /// Has no effect if m_is_partitioned = false
-   double m_partition_overlap;
-
-   /// mode = 1: share overlap_percent/2 with left and right nabors
-   /// mode = 2: there's a set of overlap indices common to all models
-   int m_partition_mode;
-
-   /// only relevant if m_is_partitioned = true.  Currently this is same as
-   /// comm->num_models()
-   int m_num_partitions;
-
-   /// only relevant if m_is_partitioned = true.  Currently this is same as
-   /// comm->get_trainer_rank())
-   int m_my_partition;
-
-   /// only relevant if m_is_partitioned = true.  Currently this is same as
-   /// comm->get_procs_per_trainer)
-   int m_procs_per_partition;
 
   std::vector<std::vector<char>> m_thread_buffer;
 

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -544,7 +544,7 @@ class generic_data_reader {
   /// Get the number of unused samples in this dataset.
   int get_num_unused_data(execution_mode m) const {
     if(m_unused_indices.count(m)) {
-      return (int)m_unused_indices.size();
+      return (int)m_unused_indices.at(m).size();
     }else {
       LBANN_ERROR("Invalid execution mode ", to_string(m), " for unused indices");
     }

--- a/include/lbann/data_readers/data_reader_jag_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_jag_conduit.hpp
@@ -158,10 +158,6 @@ class data_reader_jag_conduit : public generic_data_reader {
   // void set_open_hdf5_files(std::shared_ptr<hdf5_file_handles>& f);
   // /// Get the set of open hdf5 data files
   // std::shared_ptr<hdf5_file_handles>& get_open_hdf5_files();
-  /// Set the leader of local data reader group
-  void set_leading_reader(data_reader_jag_conduit* r);
-  /// Get the leader of local data reader group
-  data_reader_jag_conduit* get_leading_reader();
 #else
   /// See if the image size is consistent with the linearized size
   void check_image_data();
@@ -439,12 +435,6 @@ class data_reader_jag_conduit : public generic_data_reader {
   static std::unordered_map<std::string, int> m_num_local_readers;
   /// locally addressable id in case of multiple data reader instances attached to a model
   int m_local_reader_id;
-
-  /**
-   * The leading data reader among the local readers, which actually does the
-   * file IO and data shuffling.
-   */
-  data_reader_jag_conduit* m_leading_reader;
 
   CPUMat m_data_cache;
   CPUMat m_response_cache;

--- a/include/lbann/io/persist.hpp
+++ b/include/lbann/io/persist.hpp
@@ -47,6 +47,7 @@ enum class persist_type {
   prediction_context,
   training_context,
   testing_context,
+  tournament_context,
   validation_context,
 };
 
@@ -62,8 +63,8 @@ inline persist_type execution_mode_to_persist_type(execution_mode m) {
     return persist_type::testing_context;
   case execution_mode::prediction:
     return persist_type::prediction_context;
-  // case execution_mode::tournament:
-  //   return persist_type::tournament;
+  case execution_mode::tournament:
+    return persist_type::tournament_context;
   case execution_mode::invalid:
   default:
     LBANN_ERROR("Invalid execution mode specified");
@@ -88,6 +89,8 @@ inline std::string to_string(persist_type pt) {
     return "training";
   case persist_type::validation_context:
     return "validation";
+  case persist_type::tournament_context:
+    return "tournament";
   case persist_type::testing_context:
     return "testing";
   default:

--- a/include/lbann/proto/proto_common.hpp
+++ b/include/lbann/proto/proto_common.hpp
@@ -67,10 +67,7 @@ void customize_data_readers_sample_list(const lbann_comm& comm,
 void init_data_readers(
   lbann_comm *comm,
   const ::lbann_data::LbannPB& p,
-  std::map<execution_mode, generic_data_reader *>& data_readers,
-  bool is_shareable_training_data_reader,
-  bool is_shareable_testing_data_reader,
-  bool is_shareable_validation_data_reader = false);
+  std::map<execution_mode, generic_data_reader *>& data_readers);
 
 /** @brief adjusts the number of parallel data readers */
 void set_num_parallel_readers(const lbann_comm& comm, ::lbann_data::LbannPB& p);

--- a/model_zoo/tests/data_reader_tests/jag_single_layer_ae.prototext
+++ b/model_zoo/tests/data_reader_tests/jag_single_layer_ae.prototext
@@ -1,6 +1,5 @@
 model {
   name: "ae_model"
-  shareable_training_data_reader:false
   serialize_io: true
   data_layout: "data_parallel"
   mini_batch_size: 128

--- a/model_zoo/tests/model_jag_single_layer_ae.prototext
+++ b/model_zoo/tests/model_jag_single_layer_ae.prototext
@@ -6,7 +6,6 @@ trainer {
   mini_batch_size: 128
   serialize_io: true
   num_parallel_readers: 1
-  shareable_training_data_reader:false
 
   ###################################################
   # Callbacks

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -224,6 +224,8 @@ std::string to_string(execution_mode m) {
     return "testing";
   case execution_mode::prediction:
     return "prediction";
+  case execution_mode::tournament:
+    return "tournament";
   case execution_mode::invalid:
     return "invalid";
   default:
@@ -240,6 +242,8 @@ execution_mode exec_mode_from_string(std::string const& str) {
     return execution_mode::testing;
   else if (str == "prediction" || str == "predict")
     return execution_mode::prediction;
+  else if (str == "tournament")
+    return execution_mode::tournament;
   else if (str == "invalid")
     return execution_mode::invalid;
   else

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -310,10 +310,10 @@ EvalType evaluate(model& m, const std::string& metric_name) {
 
   // Mark the data store as loading - Note that this is a temporary fix
   // for the current use of the tournament
-  m.mark_data_store_explicitly_loading(execution_mode::validation);
+  m.mark_data_store_explicitly_loading(execution_mode::tournament);
 
   // Evaluate model on validation set
-  c.get_trainer().evaluate(&m, execution_mode::validation);
+  c.get_trainer().evaluate(&m, execution_mode::tournament);
 
   // Get metric value
   bool found_metric = false;
@@ -321,7 +321,7 @@ EvalType evaluate(model& m, const std::string& metric_name) {
   for (const auto& met : m.get_metrics()) {
     if (met->name() == metric_name) {
       found_metric = true;
-      metric_value = met->get_mean_value(execution_mode::validation);
+      metric_value = met->get_mean_value(execution_mode::tournament);
       break;
     }
   }
@@ -332,7 +332,7 @@ EvalType evaluate(model& m, const std::string& metric_name) {
 
   // Mark the data store as loaded - Note that this is a temporary fix
   // for the current use of the tournament
-  m.make_data_store_preloaded(execution_mode::validation);
+  m.make_data_store_preloaded(execution_mode::tournament);
 
   // Clean up and return metric value
   m.reset_mode(c, original_mode);

--- a/src/callbacks/monitor_io.cpp
+++ b/src/callbacks/monitor_io.cpp
@@ -43,9 +43,9 @@ void monitor_io::on_epoch_end(model *m) {
   lbann_comm *comm = m->get_comm();
   std::cout << "Rank " << comm->get_trainer_rank() << "."
             << comm->get_rank_in_trainer() << " processed "
-            << dc.get_num_samples_trained() << " training samples of "
-            << dc.get_total_num_training_samples() << " ("
-            << dc.get_num_samples_trained() / c.get_epoch() << " per epoch)" << std::endl;
+            << dc.get_num_samples(execution_mode::training) << " training samples of "
+            << dc.get_total_num_samples(execution_mode::training) << " ("
+            << dc.get_num_samples(execution_mode::training) / c.get_epoch() << " per epoch)" << std::endl;
 }
 
 void monitor_io::on_test_end(model *m) {
@@ -54,9 +54,9 @@ void monitor_io::on_test_end(model *m) {
   lbann_comm *comm = m->get_comm();
   std::cout << "Rank " << comm->get_trainer_rank() << "."
             << comm->get_rank_in_trainer() << " processed "
-            << dc.get_num_samples_tested() << " test samples of "
-            << dc.get_total_num_testing_samples() << " ("
-            << dc.get_num_samples_tested() / c.get_epoch()
+            << dc.get_num_samples(execution_mode::testing) << " test samples of "
+            << dc.get_total_num_samples(execution_mode::testing) << " ("
+            << dc.get_num_samples(execution_mode::testing) / c.get_epoch()
             << " per epoch)" << std::endl;
 }
 

--- a/src/callbacks/print_statistics.cpp
+++ b/src/callbacks/print_statistics.cpp
@@ -60,7 +60,7 @@ void print_statistics::on_epoch_begin(model *m) {
   lbann_comm *comm = m->get_comm();
   if (comm->am_world_master()) {
     // Print message
-    std::cout << "--------------------------------------------------------------------------------"
+    std::cout << "--------------------------------------------------------------------------------------------"
               << std::endl;
     std::cout << "[" << c.get_epoch() << "] Epoch : stats formated [tr/v/te/to]"
               << " iter/epoch ="
@@ -126,7 +126,7 @@ void print_statistics::on_epoch_begin(model *m) {
               << "+" << dc.get_world_master_mini_batch_adjustment(execution_mode::tournament)
               << "]"
               << std::endl;
-    std::cout << "--------------------------------------------------------------------------------"
+    std::cout << "--------------------------------------------------------------------------------------------"
               << std::endl;
   }
 }

--- a/src/callbacks/print_statistics.cpp
+++ b/src/callbacks/print_statistics.cpp
@@ -62,7 +62,7 @@ void print_statistics::on_epoch_begin(model *m) {
     // Print message
     std::cout << "--------------------------------------------------------------------------------"
               << std::endl;
-    std::cout << "[" << c.get_epoch() << "] Epoch : stats formated [tr/v/te]"
+    std::cout << "[" << c.get_epoch() << "] Epoch : stats formated [tr/v/te/to]"
               << " iter/epoch ="
               << " ["
               << dc.get_num_iterations_per_epoch(execution_mode::training)
@@ -70,6 +70,8 @@ void print_statistics::on_epoch_begin(model *m) {
               << dc.get_num_iterations_per_epoch(execution_mode::validation)
               << "/"
               << dc.get_num_iterations_per_epoch(execution_mode::testing)
+              << "/"
+              << dc.get_num_iterations_per_epoch(execution_mode::tournament)
               << "]"
               << std::endl;
     std::cout << std::setfill(' ') << std::setw(23)
@@ -80,6 +82,8 @@ void print_statistics::on_epoch_begin(model *m) {
               << std::setw(4) << dc.get_global_mini_batch_size(execution_mode::validation)
               << "/"
               << std::setw(4) << dc.get_global_mini_batch_size(execution_mode::testing)
+              << "/"
+              << std::setw(4) << dc.get_global_mini_batch_size(execution_mode::tournament)
               << "]"
               << " global last MB ="
               << " ["
@@ -91,6 +95,9 @@ void print_statistics::on_epoch_begin(model *m) {
               << "/"
               << std::setw(4) << dc.get_global_last_mini_batch_size(execution_mode::testing)
               << std::setw(2) << " "
+              << "/"
+              << std::setw(4) << dc.get_global_last_mini_batch_size(execution_mode::tournament)
+              << std::setw(2) << " "
               << "]"
               << std::endl;
     std::cout << std::setfill(' ') << std::setw(23)
@@ -101,6 +108,8 @@ void print_statistics::on_epoch_begin(model *m) {
               << std::setw(4) << dc.get_mini_batch_size(execution_mode::validation)
               << "/"
               << std::setw(4) << dc.get_mini_batch_size(execution_mode::testing)
+              << "/"
+              << std::setw(4) << dc.get_mini_batch_size(execution_mode::tournament)
               << "]"
               << "  local last MB ="
               << " ["
@@ -112,6 +121,9 @@ void print_statistics::on_epoch_begin(model *m) {
               << "/"
               << std::setw(4) << dc.get_last_mini_batch_size(execution_mode::testing)
               << "+" << dc.get_world_master_mini_batch_adjustment(execution_mode::testing)
+              << "/"
+              << std::setw(4) << dc.get_last_mini_batch_size(execution_mode::tournament)
+              << "+" << dc.get_world_master_mini_batch_adjustment(execution_mode::tournament)
               << "]"
               << std::endl;
     std::cout << "--------------------------------------------------------------------------------"
@@ -144,6 +156,9 @@ void print_statistics::report_results(model *m) {
     break;
   case execution_mode::validation:
     mode_string = "validation";
+    break;
+  case execution_mode::tournament:
+    mode_string = "tournament";
     break;
   case execution_mode::testing:
     mode_string = "test";

--- a/src/callbacks/timer.cpp
+++ b/src/callbacks/timer.cpp
@@ -100,6 +100,9 @@ void timer::timing_end(model& m) {
   case execution_mode::validation:
     mode_string = "validation";
     break;
+  case execution_mode::tournament:
+    mode_string = "tournament";
+    break;
   case execution_mode::testing:
     mode_string = "test";
     break;

--- a/src/data_coordinator/data_coordinator.cpp
+++ b/src/data_coordinator/data_coordinator.cpp
@@ -36,16 +36,11 @@ void data_coordinator::setup(thread_pool& io_thread_pool, int max_mini_batch_siz
 
   m_data_readers = data_readers;
 
-  if(m_data_readers[execution_mode::training] != nullptr) {
-    this->m_training_dataset.total_samples() = m_data_readers[execution_mode::training]->get_num_data();
-  }
-
-  if(m_data_readers[execution_mode::validation] != nullptr) {
-    this->m_validation_dataset.total_samples() = m_data_readers[execution_mode::validation]->get_num_data();
-  }
-
-  if(m_data_readers[execution_mode::testing] != nullptr) {
-    this->m_testing_dataset.total_samples() = m_data_readers[execution_mode::testing]->get_num_data();
+  // Initialize the data sets
+  for(auto m : execution_mode_iterator()) {
+    if(this->m_data_readers.count(m)) {
+      this->m_datasets[m].total_samples() = m_data_readers[m]->get_num_data();
+    }
   }
 
   /// @todo BVE FIXME the list of execution modes should not include

--- a/src/data_readers/data_reader_jag_conduit.cpp
+++ b/src/data_readers/data_reader_jag_conduit.cpp
@@ -94,19 +94,7 @@ int data_reader_jag_conduit::get_local_id(const std::string role) const {
   return m_local_reader_id;
 }
 
-void data_reader_jag_conduit::set_leading_reader(data_reader_jag_conduit* r) {
-  m_leading_reader = r;
-}
-
-data_reader_jag_conduit* data_reader_jag_conduit::get_leading_reader() {
-  return m_leading_reader;
-}
-
 void data_reader_jag_conduit::shuffle_indices(rng_gen& gen) {
-  if ((m_leading_reader != this) && (m_leading_reader != nullptr)) {
-    m_shuffled_indices = m_leading_reader->get_shuffled_indices();
-    return;
-  }
   generic_data_reader::shuffle_indices(gen);
   m_sample_list.compute_epochs_file_usage(get_shuffled_indices(), get_mini_batch_size(), *m_comm);
 }
@@ -153,8 +141,6 @@ void data_reader_jag_conduit::copy_members(const data_reader_jag_conduit& rhs) {
   m_input_filter = rhs.m_input_filter;
   m_input_prefix_filter = rhs.m_input_prefix_filter;
   m_local_reader_id = rhs.m_local_reader_id;
-  //TODO: need  to make sure this is what we want
-  m_leading_reader = rhs.m_leading_reader;
 
   El::Copy(rhs.m_data_cache, m_data_cache);
   El::Copy(rhs.m_response_cache, m_response_cache);
@@ -227,7 +213,6 @@ void data_reader_jag_conduit::set_defaults() {
   m_input_filter.clear();
   m_input_prefix_filter.clear();
   m_local_reader_id = 0;
-  m_leading_reader = this;
   m_cached_data_mb_size = 0;
   m_cached_response_mb_size = 0;
   m_cached_label_mb_size = 0;
@@ -761,12 +746,6 @@ void data_reader_jag_conduit::load() {
               << m_gan_labelling <<" : " << m_gan_label_value << std::endl;
   }
 
-  if ((m_leading_reader != this) && (m_leading_reader != nullptr)) {
-    // The following member variables of the leadering reader should have been
-    // copied when this was copy-constructed: m_sample_list, and m_open_hdf5_files
-    return;
-  }
-
   m_shuffled_indices.clear();
 
   if(is_master()) {
@@ -1195,8 +1174,6 @@ std::string data_reader_jag_conduit::to_string(const std::vector< std::vector<da
 }
 
 std::string data_reader_jag_conduit::get_description() const {
-  std::stringstream leading_reader;
-  leading_reader << m_leading_reader;
   std::string ret = std::string("data_reader_jag_conduit:\n")
     + " - independent: " + data_reader_jag_conduit::to_string(m_independent_groups) + "\n"
     + " - dependent: " + data_reader_jag_conduit::to_string(m_dependent_groups) + "\n"
@@ -1208,8 +1185,7 @@ std::string data_reader_jag_conduit::get_description() const {
     + " - inputs: "   + std::to_string(get_linearized_input_size()) + "\n"
     + " - linearized data size: "   + std::to_string(get_linearized_data_size()) + "\n"
     + " - uniform_input_type: " + (m_uniform_input_type? "true" : "false") + "\n"
-    + " - leading DR: " + (m_leading_reader == this ? "true" : "false")
-    + " (ptr=" + leading_reader.str() + ")\n";
+    + ")\n";
   if (!m_scalar_filter.empty()) {
     ret += " - scalar filter:";
     for (const auto& f: m_scalar_filter) {
@@ -1467,9 +1443,6 @@ int data_reader_jag_conduit::reuse_labels(CPUMat& Y) {
 }
 
 int data_reader_jag_conduit::fetch_data(CPUMat& X, El::Matrix<El::Int>& indices_fetched) {
-  if ((m_leading_reader != this) && (m_leading_reader != nullptr)) {
-    return m_leading_reader->reuse_data(X);
-  }
   m_cached_data_mb_size = generic_data_reader::fetch_data(X, indices_fetched);
   El::Copy(X, m_data_cache);
 
@@ -1477,9 +1450,6 @@ int data_reader_jag_conduit::fetch_data(CPUMat& X, El::Matrix<El::Int>& indices_
 }
 
 int data_reader_jag_conduit::fetch_responses(CPUMat& Y) {
-  if ((m_leading_reader != this) && (m_leading_reader != nullptr)) {
-    return m_leading_reader->reuse_responses(Y);
-  }
   m_cached_response_mb_size = generic_data_reader::fetch_responses(Y);
   El::Copy(Y, m_response_cache);
 
@@ -1487,9 +1457,6 @@ int data_reader_jag_conduit::fetch_responses(CPUMat& Y) {
 }
 
 int data_reader_jag_conduit::fetch_labels(CPUMat& Y) {
-  if ((m_leading_reader != this) && (m_leading_reader != nullptr)) {
-    return m_leading_reader->reuse_labels(Y);
-  }
   m_cached_label_mb_size = generic_data_reader::fetch_labels(Y);
   El::Copy(Y, m_label_cache);
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1094,6 +1094,7 @@ void model::do_model_forward_prop_begin_cbs(execution_mode mode) {
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_evaluate_forward_prop_begin(this);
       break;
@@ -1112,6 +1113,7 @@ void model::do_model_forward_prop_end_cbs(execution_mode mode) {
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_evaluate_forward_prop_end(this);
       break;
@@ -1133,6 +1135,7 @@ void model::do_layer_forward_prop_begin_cbs(execution_mode mode, Layer *l) {
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_evaluate_forward_prop_begin(this, l);
       break;
@@ -1154,6 +1157,7 @@ void model::do_layer_forward_prop_end_cbs(execution_mode mode, Layer *l) {
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_evaluate_forward_prop_end(this, l);
       break;

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -378,8 +378,6 @@ void init_data_readers(
 
       reader->set_gan_labelling(readme.gan_labelling());
       reader->set_gan_label_value(readme.gan_label_value());
-
-      reader->set_partitioned(readme.is_partitioned(), readme.partition_overlap(), readme.partition_mode());
     }
 
     if (readme.role() == "train") {

--- a/src/proto/reader.proto
+++ b/src/proto/reader.proto
@@ -38,7 +38,7 @@ message DataReader {
 
 message Reader {
   string name = 1; //mnist, nci, nci_regression, numpy, imagenet, synthetic, merge_samples
-  string role = 3; //train, validation, test
+  string role = 3; //train, validation, test, tournament
   bool shuffle = 4;
   string data_filedir = 5;
   string data_local_filedir = 50; //to support data_store
@@ -46,6 +46,7 @@ message Reader {
   string label_filename = 7;
   string sample_list = 8;
   double validation_percent = 9;
+  double tournament_percent = 10;
   int64 absolute_sample_count = 11;
   int64 first_n = 200;
   double percent_of_data_to_use = 12;

--- a/src/proto/reader.proto
+++ b/src/proto/reader.proto
@@ -77,14 +77,6 @@ message Reader {
 
   int32 max_files_to_load = 1000;
 
-  //------------- start of only for partitioned data sets ------------------
-  bool is_partitioned = 300;
-  double partition_overlap = 301;
-  int32 partition_mode = 302;
-       // 1 - share a portion of your data with two neighbors;
-       // 2 - there's a set of overlap indices that are common to all models
-  //------------- end of only for partitioned data sets ------------------
-
   //------------- start of only for sample lists ------------------
   bool sample_list_per_trainer = 400;
   bool sample_list_per_model   = 401;

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -51,11 +51,6 @@ message Trainer {
   // Advanced options
   // -------------------------------
 
-  // BVE FIXME these should go away
-  bool shareable_training_data_reader = 42; // Can the data reader be shared across multiple models( e.g. GAN)
-  bool shareable_testing_data_reader = 43; // Can the data reader be shared across multiple models (e.g. GAN)
-  bool shareable_validation_data_reader = 44; // Can the data reader be shared across multiple models (e.g. GAN)
-
   // If false, trainers will have their trainer rank mixed into their random seed.
   bool random_init_trainers_identically = 4;
 

--- a/src/training_algorithms/sgd_training_algorithm.cpp
+++ b/src/training_algorithms/sgd_training_algorithm.cpp
@@ -172,6 +172,7 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
   // Return early if execution mode is invalid
   if (!dc.is_execution_mode_valid(mode)) return;
   if (mode != execution_mode::validation
+      && mode != execution_mode::tournament
       && mode != execution_mode::testing) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
@@ -233,6 +234,8 @@ void sgd_training_algorithm::do_evaluate_begin_cbs(model& model, execution_mode 
     switch (mode) {
     case execution_mode::validation:
       cb->on_validation_begin(&model); break;
+    case execution_mode::tournament:
+      cb->on_validation_begin(&model); break;
     case execution_mode::testing:
       cb->on_test_begin(&model); break;
     default:
@@ -245,6 +248,8 @@ void sgd_training_algorithm::do_evaluate_end_cbs(model& model, execution_mode mo
   for (const auto& cb : model.get_callbacks()) {
     switch (mode) {
     case execution_mode::validation:
+      cb->on_validation_end(&model); break;
+    case execution_mode::tournament:
       cb->on_validation_end(&model); break;
     case execution_mode::testing:
       cb->on_test_end(&model); break;
@@ -277,6 +282,7 @@ void sgd_training_algorithm::do_batch_begin_cbs(model& model, execution_mode mod
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_batch_evaluate_begin(&model);
       break;
@@ -297,6 +303,7 @@ void sgd_training_algorithm::do_batch_end_cbs(model& model, execution_mode mode)
       }
       break;
     case execution_mode::validation:
+    case execution_mode::tournament:
     case execution_mode::testing:
       cb->on_batch_evaluate_end(&model);
       break;

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -242,12 +242,7 @@ std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
     // Initialize data readers
     //@todo: code not in place for correctly handling image preprocessing
     std::map<execution_mode, generic_data_reader *> data_readers;
-    bool is_shared_training_data_reader = pb_trainer->shareable_training_data_reader();
-    bool is_shared_testing_data_reader = pb_trainer->shareable_testing_data_reader();
-    if (opts->has_string("share_testing_data_readers")) {
-      is_shared_testing_data_reader = opts->get_bool("share_testing_data_readers");
-    }
-    init_data_readers(comm, pb, data_readers, is_shared_training_data_reader, is_shared_testing_data_reader);
+    init_data_readers(comm, pb, data_readers);
 
     trainer->setup(std::move(io_thread_pool), data_readers);
 


### PR DESCRIPTION
Adds a new execution mode for LTFB tournaments.  Creates the ability to split a training data reader into validation and tournament data sets.  Removed some deprecated features, namely the ability to set a lead JAG data reader and partition the data reader index lists between data readers that used to be attached to individual models.