### PR TITLE
Fixed the external definition in the llnl_lc environments for ppc64le

### DIFF
--- a/spack_environments/llnl_lc/externals-linux-ppc64le.sh
+++ b/spack_environments/llnl_lc/externals-linux-ppc64le.sh
@@ -23,11 +23,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
     cmake::
       buildable: True
       variants: ~openssl ~ncurses
-      version: [3.18.0]
-      externals:
-      - spec: cmake@3.18.0 arch=${SPACK_ARCH}
-        modules:
-        - cmake/3.18.0
+      version: [3.18.2]
     cuda::
       buildable: False
       version: [11.0.2]


### PR DESCRIPTION
architectures to build CMake rather than find it as an external, since
the module doesn't exist on Ray.  Also bumped the version number of
CMake used to 3.18.2 for ppc64le systems to avoid a bug in CMake where
FindHDF5 doesn't work properly and impacts our inclusion of Conduit.