### PR TITLE
Perform LTFB model exchanges with temporary models

### DIFF
--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -89,7 +89,11 @@ def construct_model(lbann):
     ]
     callbacks = [
         lbann.CallbackPrint(),
-        lbann.CallbackLTFB(batch_interval=1, metric='random'),
+        lbann.CallbackLTFB(
+            batch_interval=1,
+            metric='random',
+            communication_algorithm='checkpoint_file',
+        ),
     ]
 
     # Construct model

--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -40,7 +40,7 @@ def initialize_rng():
 
 # Sample access functions
 _mini_batch_size = 2
-_num_epochs = 3
+_num_epochs = 5
 def get_sample(index):
     initialize_rng()
     return (random.gauss(0,1),)

--- a/include/lbann/callbacks/ltfb.hpp
+++ b/include/lbann/callbacks/ltfb.hpp
@@ -55,8 +55,6 @@ namespace callback {
  *      or a subset of the weights? Hyperparameters?
  *    - Can this be used to explore model architectures?
  *
- *  @todo Exchange optimizer state.
- *  @todo Support heterogeneous models.
  */
 class ltfb : public callback_base {
 public:
@@ -89,13 +87,8 @@ public:
 
     /** Save and load model data with checkpoint files.
      *
-     *  @todo Implement.
-     *
      *  Notes:
      *    - Supports hyperparameter exploration.
-     *    - Checkpoint files currently do not store model architecture
-     *      information, so this is not suitable for model
-     *      architecture exploraiton.
      *    - This approach is temporary and experimental, since going
      *      through the file system is very suboptimal. When a wire
      *      format for model checkpoints is developed, it should be
@@ -128,11 +121,10 @@ public:
   ltfb* copy() const override { return new ltfb(*this); }
   std::string name() const override { return "LTFB"; }
 
-  void setup(model *m) override;
   void on_train_begin(model *m) override;
   void on_batch_begin(model *m) override;
 
-  /** Convert string to LTFB communication algorithm.
+  /** @brief Convert string to LTFB communication algorithm.
    *
    *  If an empty string is provided, returns @c
    *  communication_algorithm::sendrecv_weights.
@@ -144,34 +136,29 @@ public:
 
 private:
 
-  /** Metric for tournament evaluation. */
+  /** @brief Metric for tournament evaluation. */
   std::string m_metric_name;
 
-  /** List of weights to exchange with partner.
+  /** @brief List of weights to exchange with partner.
    *
    *  If empty, then all weights are exchanged.
    */
   std::set<std::string> m_weights_names;
 
-  /** Whether low-scoring or high-scoring models survive a
+  /** @brief Whether low-scoring or high-scoring models survive a
    *  tournament. */
   bool m_low_score_wins;
 
-  /** Inter-trainer communication scheme. */
+  /** @brief Inter-trainer communication scheme. */
   communication_algorithm m_comm_algo;
 
-  /** Base directory of the checkpoint state */
+  /** @brief Base directory of the checkpoint state */
   std::string m_ckpt_basedir;
 
   /** Whether to exchange training hyperparameters between trainers
   */
   bool m_exchange_hyperparameters;
 
-  /** Workspace weights.
-   *
-   *  Used to temporarily store local weights during a tournament.
-   */
-  std::vector<std::unique_ptr<weights>> m_workspace_weights;
 };
 
 // Builder function

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -240,13 +240,21 @@ public:
   /** @brief Are background I/O activities enabled by the input layers */
   bool background_io_activity_allowed() { return m_background_io_allowed; }
 
+  void swap_layers(model& other);
+  void swap_weights(model& other);
+  void swap_metrics(model& other);
+  void swap_objective_function(model& other);
+
   // ===========================================
   // Setup
   // ===========================================
 
   /** @details Must be called after model specification and before
    *  execution. */
-  virtual void setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata);
+  virtual void setup(
+    size_t max_mini_batch_size,
+    DataReaderMetaData& dr_metadata,
+    bool force=false);
 
   virtual void make_data_store_preloaded(execution_mode mode);
 

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -27,6 +27,7 @@
 #include "lbann/callbacks/ltfb.hpp"
 #include "lbann/callbacks/imcomm.hpp"
 #include "lbann/utils/random_number_generators.hpp"
+#include "lbann/models/directed_acyclic_graph.hpp"
 #include "lbann/optimizers/sgd.hpp"
 #include "lbann/optimizers/adam.hpp"
 #include "lbann/proto/proto_common.hpp"
@@ -97,13 +98,11 @@ namespace sendrecv_weights {
  *  @param send_weights     Weights values sent to partner.
  *  @param recv_weights     Weights values recieved from partner.
  */
-template <typename TensorDataType>
 void exchange_models(lbann_comm& comm,
                      El::Int partner_trainer,
                      const std::set<std::string>& weights_names,
-                     const std::vector<data_type_weights<TensorDataType>*>& send_weights,
-                     std::vector<data_type_weights<TensorDataType>*>& recv_weights,
-                     bool exchange_hyperparameters) {
+                     bool exchange_hyperparameters,
+                     model& m) {
 
   // Get partner process
   const El::Int rank_in_trainer = comm.get_rank_in_trainer();
@@ -112,86 +111,103 @@ void exchange_models(lbann_comm& comm,
                                          + rank_in_trainer);
 
   // Exchange weights with partner
-  for (size_t i = 0; i < send_weights.size(); ++i) {
-    const auto& send = *send_weights[i];
-    auto& recv = *recv_weights[i];
-    if (weights_names.empty()
-        || (std::find(weights_names.begin(), weights_names.end(),
-                      send.get_name())
-            != weights_names.end())) {
+  for (auto&& w_ptr : m.get_weights()) {
 
-      // Exchange weights values
-      El::SendRecv(send.get_values().LockedMatrix(),
-                   recv.get_values().Matrix(),
-                   comm.get_world_comm(),
-                   partner_rank_in_world,
-                   partner_rank_in_world);
-
-      // Exchange optimizer state
-      const auto* send_opt = send.get_optimizer();
-      auto* recv_opt = recv.get_optimizer();
-      const auto* send_sgd = dynamic_cast<const sgd<TensorDataType>*>(send_opt);
-      auto* recv_sgd = dynamic_cast<sgd<TensorDataType>*>(recv_opt);
-      if (send_sgd != nullptr && recv_sgd != nullptr) {
-        if(exchange_hyperparameters) {
-          using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, bool>;
-          hyperparameters_type hyperparameters(send_sgd->get_learning_rate(),
-                                               send_sgd->get_momentum(),
-                                               send_sgd->using_nesterov());
-          El::mpi::SendRecv(reinterpret_cast<El::byte*>(&hyperparameters),
-                            sizeof(hyperparameters_type),
-                            partner_rank_in_world,
-                            partner_rank_in_world,
-                            comm.get_world_comm(),
-                            El::SyncInfo<El::Device::CPU>{});
-          recv_sgd->set_learning_rate(std::get<0>(hyperparameters));
-          recv_sgd->set_momentum(std::get<1>(hyperparameters));
-          recv_sgd->set_nesterov(std::get<2>(hyperparameters));
-        }
-        El::SendRecv(send_sgd->get_velocity().LockedMatrix(),
-                     recv_sgd->get_velocity().Matrix(),
-                     comm.get_world_comm(),
-                     partner_rank_in_world,
-                     partner_rank_in_world);
-      }
-      const auto* send_adam = dynamic_cast<const adam<TensorDataType>*>(send_opt);
-      auto* recv_adam = dynamic_cast<adam<TensorDataType>*>(recv_opt);
-      if (send_adam != nullptr && recv_adam != nullptr) {
-        if(exchange_hyperparameters) {
-          using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, TensorDataType,
-                                                  TensorDataType, TensorDataType, TensorDataType>;
-          hyperparameters_type hyperparameters(send_adam->get_learning_rate(),
-                                               send_adam->get_beta1(),
-                                               send_adam->get_beta2(),
-                                               send_adam->get_eps(),
-                                               send_adam->get_current_beta1(),
-                                               send_adam->get_current_beta2());
-          El::mpi::SendRecv(reinterpret_cast<El::byte*>(&hyperparameters),
-                            sizeof(hyperparameters_type),
-                            partner_rank_in_world,
-                            partner_rank_in_world,
-                            comm.get_world_comm(),
-                            El::SyncInfo<El::Device::CPU>{});
-          recv_adam->set_learning_rate(std::get<0>(hyperparameters));
-          recv_adam->set_beta1(std::get<1>(hyperparameters));
-          recv_adam->set_beta2(std::get<2>(hyperparameters));
-          recv_adam->set_eps(std::get<3>(hyperparameters));
-          recv_adam->set_current_beta1(std::get<4>(hyperparameters));
-          recv_adam->set_current_beta2(std::get<5>(hyperparameters));
-        }
-        El::SendRecv(send_adam->get_moment1().LockedMatrix(),
-                     recv_adam->get_moment1().Matrix(),
-                     comm.get_world_comm(),
-                     partner_rank_in_world,
-                     partner_rank_in_world);
-        El::SendRecv(send_adam->get_moment2().LockedMatrix(),
-                     recv_adam->get_moment2().Matrix(),
-                     comm.get_world_comm(),
-                     partner_rank_in_world,
-                     partner_rank_in_world);
-      }
-
+    // Skip weights if name isn't in list
+    if (!weights_names.empty()
+        && (std::find(
+              weights_names.begin(),
+              weights_names.end(),
+              w_ptr->get_name())
+            == weights_names.end())) {
+      continue;
     }
+
+    // Exchange weights values
+    using TensorDataType = DataType;
+    using WeightsType = data_type_weights<TensorDataType>;
+    auto& recv_weights = dynamic_cast<WeightsType&>(*w_ptr);
+    auto send_weights = recv_weights;
+    El::SendRecv(
+      send_weights.get_values().LockedMatrix(),
+      recv_weights.get_values().Matrix(),
+      comm.get_world_comm(),
+      partner_rank_in_world,
+      partner_rank_in_world);
+
+    // Exchange SGD optimizer state
+    using SGDType = sgd<TensorDataType>;
+    auto* send_sgd = dynamic_cast<SGDType*>(send_weights.get_optimizer());
+    auto* recv_sgd = dynamic_cast<SGDType*>(recv_weights.get_optimizer());
+    if (send_sgd != nullptr && recv_sgd != nullptr) {
+      if (exchange_hyperparameters) {
+        using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, bool>;
+        hyperparameters_type hyperparameters(
+          send_sgd->get_learning_rate(),
+          send_sgd->get_momentum(),
+          send_sgd->using_nesterov());
+        El::mpi::SendRecv(
+          reinterpret_cast<El::byte*>(&hyperparameters),
+          sizeof(hyperparameters_type),
+          partner_rank_in_world,
+          partner_rank_in_world,
+          comm.get_world_comm(),
+          El::SyncInfo<El::Device::CPU>{});
+        recv_sgd->set_learning_rate(std::get<0>(hyperparameters));
+        recv_sgd->set_momentum(std::get<1>(hyperparameters));
+        recv_sgd->set_nesterov(std::get<2>(hyperparameters));
+      }
+      El::SendRecv(
+        send_sgd->get_velocity().LockedMatrix(),
+        recv_sgd->get_velocity().Matrix(),
+        comm.get_world_comm(),
+        partner_rank_in_world,
+        partner_rank_in_world);
+    }
+
+    // Exchange Adam optimizer state
+    using AdamType = adam<TensorDataType>;
+    auto* send_adam = dynamic_cast<AdamType*>(send_weights.get_optimizer());
+    auto* recv_adam = dynamic_cast<AdamType*>(recv_weights.get_optimizer());
+    if (send_adam != nullptr && recv_adam != nullptr) {
+      if (exchange_hyperparameters) {
+        using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, TensorDataType,
+                                                TensorDataType, TensorDataType, TensorDataType>;
+        hyperparameters_type hyperparameters(
+          send_adam->get_learning_rate(),
+          send_adam->get_beta1(),
+          send_adam->get_beta2(),
+          send_adam->get_eps(),
+          send_adam->get_current_beta1(),
+          send_adam->get_current_beta2());
+        El::mpi::SendRecv(
+          reinterpret_cast<El::byte*>(&hyperparameters),
+          sizeof(hyperparameters_type),
+          partner_rank_in_world,
+          partner_rank_in_world,
+          comm.get_world_comm(),
+          El::SyncInfo<El::Device::CPU>{});
+        recv_adam->set_learning_rate(std::get<0>(hyperparameters));
+        recv_adam->set_beta1(std::get<1>(hyperparameters));
+        recv_adam->set_beta2(std::get<2>(hyperparameters));
+        recv_adam->set_eps(std::get<3>(hyperparameters));
+        recv_adam->set_current_beta1(std::get<4>(hyperparameters));
+        recv_adam->set_current_beta2(std::get<5>(hyperparameters));
+      }
+      El::SendRecv(
+        send_adam->get_moment1().LockedMatrix(),
+        recv_adam->get_moment1().Matrix(),
+        comm.get_world_comm(),
+        partner_rank_in_world,
+        partner_rank_in_world);
+      El::SendRecv(
+        send_adam->get_moment2().LockedMatrix(),
+        recv_adam->get_moment2().Matrix(),
+        comm.get_world_comm(),
+        partner_rank_in_world,
+        partner_rank_in_world);
+    }
+
   }
 
 }
@@ -431,18 +447,19 @@ void ltfb::on_train_begin(model *m) {
   }
 }
 
-void ltfb::on_batch_begin(model *m) {
-  const auto& c = m->get_execution_context();
-  auto&& comm = *m->get_comm();
+void ltfb::on_batch_begin(model* m) {
+  auto& local_model = *m;
+  auto& context = local_model.get_execution_context();
+  auto&& comm = *local_model.get_comm();
 
   // Check whether to start LTFB round
-  const auto mode = c.get_execution_mode();
-  const auto step = c.get_step();
+  const auto mode = context.get_execution_mode();
+  const auto step = context.get_step();
   if (mode != execution_mode::training || step == 0) { return; }
 
   // Print message
   const auto message_prefix = (std::string{} + "LTFB ("
-                               + "model \"" + m->get_name() + "\", "
+                               + "model \"" + local_model.get_name() + "\", "
                                + "step " + std::to_string(step)
                                + "): ");
   if (comm.am_world_master()) {
@@ -457,48 +474,34 @@ void ltfb::on_batch_begin(model *m) {
   if (comm.am_world_master()) {
     std::cout << message_prefix + "evaluating local model...\n";
   }
-  auto local_score = evaluate(*m, m_metric_name);
-  if (std::isinf(local_score)) { local_score = std::nan(""); }
+  auto local_score = evaluate(local_model, m_metric_name);
 
-  // Store local model data
-  auto&& model_weights_tmp = m->get_weights();
-  std::vector<data_type_weights<DataType>*> local_weights, model_weights;
-  local_weights.reserve(model_weights_tmp.size());
-  model_weights.reserve(model_weights_tmp.size());
-  for (size_t i = 0; i < model_weights_tmp.size(); ++i) {
-    auto* wsp = dynamic_cast<data_type_weights<DataType>*>(
-      m_workspace_weights[i].get());
-    auto* mlw = dynamic_cast<data_type_weights<DataType>*>(
-      model_weights_tmp[i]);
-    if (!wsp || !mlw)
-      LBANN_ERROR("Detected bad weights");
-    local_weights.push_back(wsp);
-    model_weights.push_back(mlw);
-    *local_weights.back() = *model_weights.back();
-  }
-
-  // Exchange model data with partner trainer
+  // Get model from partner trainer
   if (comm.am_world_master()) {
     std::cout << message_prefix + "exchanging model data...\n";
   }
+  using ModelType = directed_acyclic_graph_model;
+  ModelType partner_model(dynamic_cast<ModelType&>(local_model));
   switch (m_comm_algo) {
   case communication_algorithm::sendrecv_weights:
-    sendrecv_weights::exchange_models(comm,
-                                      partner_trainer,
-                                      m_weights_names,
-                                      local_weights,
-                                      model_weights,
-                                      m_exchange_hyperparameters);
+    sendrecv_weights::exchange_models(
+      comm,
+      partner_trainer,
+      m_weights_names,
+      m_exchange_hyperparameters,
+      partner_model);
     break;
+#if 0
   case communication_algorithm::checkpoint_file:
     checkpoint_file::exchange_models(comm,
                                      partner_trainer,
-                                     *m,
+                                     partner_model,
                                      step,
                                      m_weights_names,
                                      local_weights,
                                      m_ckpt_basedir);
     break;
+#endif
   default:
     LBANN_ERROR("invalid LTFB communication algorithm");
   }
@@ -507,29 +510,28 @@ void ltfb::on_batch_begin(model *m) {
   if (comm.am_world_master()) {
     std::cout << message_prefix + "evaluating partner model...\n";
   }
-  auto partner_score = evaluate(*m, m_metric_name);
-  if (std::isinf(partner_score)) { partner_score = std::nan(""); }
+  auto partner_score = evaluate(partner_model, m_metric_name);
 
   // Choose tournament winner
   // Note: restore local model data if it got a better score.
-  El::Int tournament_winner = partner_trainer;
-  if ((m_low_score_wins && local_score <= partner_score)
-      || (!m_low_score_wins && local_score >= partner_score)
-      || (!std::isnan(local_score) && std::isnan(partner_score))) {
+  El::Int tournament_winner = local_trainer;
+  if ((m_low_score_wins && partner_score <= local_score)
+      || (!m_low_score_wins && partner_score >= local_score)
+      || (!std::isfinite(local_score) && std::isfinite(partner_score))) {
+    tournament_winner = partner_trainer;
 
-    tournament_winner = local_trainer;
-    switch (m_comm_algo) {
-    case communication_algorithm::sendrecv_weights:
-      for (size_t i = 0; i < model_weights.size(); ++i) {
-        *model_weights[i] = *local_weights[i];
-      }
-      break;
-    case communication_algorithm::checkpoint_file:
-      checkpoint_file::restore_local_model(comm, *m, step, m_ckpt_basedir);
-      break;
-    default:
-      LBANN_ERROR("invalid LTFB communication algorithm");
-    }
+    /// @todo Use move assignment operator once LTFB is moved into a
+    /// training algorithm
+    local_model.swap_layers(partner_model);
+    local_model.swap_weights(partner_model);
+    local_model.swap_metrics(partner_model);
+    local_model.swap_objective_function(partner_model);
+    auto& trainer_ = context.get_trainer();
+    auto&& metadata = trainer_.get_data_coordinator().get_dr_metadata();
+    local_model.setup(
+      trainer_.get_max_mini_batch_size(),
+      metadata,
+      true);
   }
 
   // Report tournament winner
@@ -544,6 +546,7 @@ void ltfb::on_batch_begin(model *m) {
         << "= " << partner_score << ")" << "\n";
     std::cout << msg.str() << std::flush;
   }
+
 }
 
 typename ltfb::communication_algorithm

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -132,7 +132,7 @@ model::model(const model& other) :
 model& model::operator=(const model& other) {
 
   // Delete objects
-  if (m_execution_context  != nullptr) { delete m_execution_context; } /// @todo BVE FIXME what do we do with smart pointers here
+  // if (m_execution_context  != nullptr) { delete m_execution_context; } /// @todo BVE FIXME what do we do with smart pointers here
 
   // Shallow copies
   m_comm = other.m_comm;
@@ -450,6 +450,22 @@ void model::copy_trained_weights_from(std::vector<weights*>& new_weights) {
    }
 }
 
+void model::swap_layers(model& other) {
+  std::swap(m_layers, other.m_layers);
+}
+
+void model::swap_weights(model& other) {
+  std::swap(m_weights, other.m_weights);
+}
+
+void model::swap_metrics(model& other) {
+  std::swap(m_metrics, other.m_metrics);
+}
+
+void model::swap_objective_function(model& other) {
+  std::swap(m_objective_function, other.m_objective_function);
+}
+
 void model::reorder_layers(const std::vector<El::Int>& gather_indices) {
   std::stringstream err;
 
@@ -546,10 +562,10 @@ void model::remap_pointers(
 // Setup
 // =============================================
 
-void model::setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata) {
+void model::setup(size_t max_mini_batch_size, DataReaderMetaData& dr_metadata, bool force) {
 
   // Bail out if the model is already setup
-  if(m_model_is_setup) { return; }
+  if(m_model_is_setup && !force) { return; }
 
   for (const auto& cb : m_callbacks) {
     if (dynamic_cast<callback::checkpoint const*>(cb.get()))


### PR DESCRIPTION
This is some refactoring I've done in preparation for LTFB with heterogeneous architectures. In particular, we have problems because the LTFB callback is owned by a model. What happens when LTFB loads a checkpoint and replaces all the callbacks? The "right answer"® is to make LTFB a training algorithm, but even so I think this PR makes LTFB slightly easier to reason about.

Instead of reloading checkpoints into the active model, I figure it will be easier to load into a temporary model. If the remote model is better than the local model, then we swap their data (everything except callbacks). This adds the overhead of creating the temporary model at every LTFB round and doubles the memory footprint, but also reduces the number of times we need to load checkpoints (previously, we needed to load a checkpoint to restore the local model if it is better than the remote model). I've also done some refactoring to concentrate the differences between the "sendrecv weights" and "checkpoint file" communication algorithms, so they only differ in a single function call.

LTFB with "checkpoint file" communication runs and appears _mostly_ correct (checkpointing doesn't handle multiple metrics correctly, but that will be moot when #1709 is merged and we get full model serialization with Cereal). Once we have checkpoints that store model topology, it will just be a matter of making sure that LTFB is calling the correct checkpointing API in the "checkpoint file" communication algorithm, and then heterogeneous LTFB should just work.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM325-2).