### PR TITLE
Fix issues of Distconv-enabled 3D CNN models

### DIFF
--- a/applications/physics/cosmology/cosmoflow/cosmoflow.py
+++ b/applications/physics/cosmology/cosmoflow/cosmoflow.py
@@ -1,4 +1,6 @@
 import argparse
+import math
+
 import numpy as np
 
 import lbann
@@ -311,8 +313,8 @@ if __name__ == "__main__":
         '--depth-groups', action='store', type=int, default=4,
         help='the number of processes for the depth dimension (default: 4)')
     parser.add_argument(
-        '--depth-splits-pooling-id', action='store', type=int, default=5,
-        help='the number of pooling layers from which depth_split is set (default: 5)')
+        '--depth-splits-pooling-id', action='store', type=int, default=None,
+        help='the number of pooling layers from which depth_split is set (default: None)')
     parser.add_argument(
         '--gather-dropout-id', action='store', type=int, default=1,
         help='the number of dropout layers from which the network is gathered (default: 1)')
@@ -360,7 +362,13 @@ if __name__ == "__main__":
         layer_name = layer.__class__.__name__
         if layer_name == 'Pooling':
             pooling_id += 1
-            if pooling_id == args.depth_splits_pooling_id:
+
+            depth_splits_pooling_id = args.depth_splits_pooling_id
+            if depth_splits_pooling_id is None:
+                assert 2**math.log2(args.depth_groups) == args.depth_groups
+                depth_splits_pooling_id = 5-(math.log2(args.depth_groups)-2)
+
+            if pooling_id == depth_splits_pooling_id:
                 parallel_strategy = dict(parallel_strategy.items())
                 parallel_strategy['depth_splits'] = 1
 

--- a/applications/physics/cosmology/cosmoflow/cosmoflow.py
+++ b/applications/physics/cosmology/cosmoflow/cosmoflow.py
@@ -337,8 +337,8 @@ if __name__ == "__main__":
     # Construct layer graph
     input = lbann.Input(
         target_mode='regression')
-    universes = lbann.Split(input)
-    secrets = lbann.Split(input)
+    universes = lbann.Identity(input)
+    secrets = lbann.Identity(input)
     statistics_group_size = 1 if args.local_batchnorm else -1
     preds = CosmoFlow(
         input_width=args.input_width,

--- a/applications/segmentation/unet3d/unet3d.py
+++ b/applications/segmentation/unet3d/unet3d.py
@@ -290,7 +290,6 @@ if __name__ == '__main__':
 
     # Construct layer graph
     input = lbann.Input(
-        io_buffer='partitioned',
         target_mode='label_reconstruction')
     volume = lbann.Split(input)
     output = UNet3D()(volume)

--- a/applications/segmentation/unet3d/unet3d.py
+++ b/applications/segmentation/unet3d/unet3d.py
@@ -291,9 +291,9 @@ if __name__ == '__main__':
     # Construct layer graph
     input = lbann.Input(
         target_mode='label_reconstruction')
-    volume = lbann.Split(input)
+    volume = lbann.Identity(input)
     output = UNet3D()(volume)
-    segmentation = lbann.Split(input)
+    segmentation = lbann.Identity(input)
     ce = lbann.CrossEntropy(
         [output, segmentation],
         use_labels=True)


### PR DESCRIPTION
This PR fixes some issues of the CosmoFlow network and the 3D U-Net which use Distconv.
* CosmoFlow uses appropriate depth-splits-pooling-id for given power of two-way partitioning if not specified.
* Fix 3D U-Net's input layer argument.