### PR TITLE
Move model checkpointing from end of training step to beginning

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -20,6 +20,12 @@ Internal features:
  - Elementary examples of using complex numbers
  - cuDNN handles are now wrapped in RAII management classes
  - Improved HWLOC compatility for v1.11 and v2.x
+ - Added an enum type of visitor hooks that will eventually be used to
+   allow callbacks or other visitors to operate at user defined hook
+   points
+ - Changed checkpoint logic to checkpoint at the start of epochs
+   and changed the naming scheme to use the callback phase (visitor
+   hook) in the name rather than the current execution context.
 
 I/O & data readers:
  - Experimental data reader that generates graph random walks with

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -31,6 +31,7 @@
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/training_algorithms/training_algorithm.hpp"
+#include "lbann/utils/visitor_hooks.hpp"
 
 namespace lbann {
 namespace callback {
@@ -88,9 +89,10 @@ public:
   void setup(model *m) override;
   void setup(trainer *t) override;
   void on_train_begin(model *m) override;
-  void on_epoch_end(model *m) override;
+  void on_train_end(model *m) override;
+  void on_epoch_begin(model *m) override;
   void on_batch_begin(model *m) override;
-  void on_validation_end(model *m) override;
+  void on_validation_begin(model *m) override;
 
   inline void set_checkpoint_dir(const std::string& dir){
     m_checkpoint_dir = dir;
@@ -181,7 +183,7 @@ public:
   std::string find_latest_checkpoint(lbann_comm& comm,
                                      const std::string& trainer_name,
                                      const std::string& alg_name,
-                                     execution_mode& mode,
+                                     visitor_hook& hook,
                                      size_t &epoch,
                                      size_t& step,
                                      bool& shared);
@@ -196,12 +198,12 @@ public:
   bool restart(model *m);
   std::string name() const override { return "checkpoint"; }
 private:
-  bool do_checkpoint(model *m);
+  bool do_checkpoint(model *m, visitor_hook hook);
   void do_distributed_checkpoint(
     lbann_comm& comm,
     trainer& t,
     model& m,
-    sgd_execution_context const& c,
+    visitor_hook hook,
     persist& p,
     size_t epoch,
     size_t step);
@@ -209,7 +211,7 @@ private:
     lbann_comm& comm,
     trainer& t,
     model& m,
-    sgd_execution_context const& c,
+    visitor_hook hook,
     persist& p,
     size_t epoch,
     size_t step);
@@ -232,7 +234,7 @@ private:
 
   template<size_t _max_dir_len>
   struct header_t {
-    execution_mode mode;
+    visitor_hook hook;
     int epoch;
     int step;
     int shared;
@@ -252,12 +254,12 @@ inline std::string get_last_shared_checkpoint_filename(const std::string& traine
   return get_last_shared_checkpoint_filename(alg_name, get_trainer_checkpoint_dirname(trainer_name, dir));
 }
 
-inline std::string get_shared_checkpoint_dirname(const std::string& alg_name, const std::string& dir, execution_mode mode, size_t epoch, size_t step) {
-  return build_string(dir, '/', alg_name, ".shared.", to_string(mode), ".epoch.", epoch, ".step.", step, '/');
+inline std::string get_shared_checkpoint_dirname(const std::string& alg_name, const std::string& dir, visitor_hook hook, size_t epoch, size_t step) {
+  return build_string(dir, '/', alg_name, ".shared.", to_string(hook), ".epoch.", epoch, ".step.", step, '/');
 }
 
-inline std::string get_shared_checkpoint_dirname(const std::string& trainer_name, const std::string& alg_name, const std::string& dir, execution_mode mode, size_t epoch, size_t step) {
-  return get_shared_checkpoint_dirname(alg_name, get_trainer_checkpoint_dirname(trainer_name, dir), mode, epoch, step);
+inline std::string get_shared_checkpoint_dirname(const std::string& trainer_name, const std::string& alg_name, const std::string& dir, visitor_hook hook, size_t epoch, size_t step) {
+  return get_shared_checkpoint_dirname(alg_name, get_trainer_checkpoint_dirname(trainer_name, dir), hook, epoch, step);
 }
 
 inline std::string get_last_distributed_checkpoint_filename(const std::string& alg_name, const std::string& dir) {
@@ -268,26 +270,26 @@ inline std::string get_last_distributed_checkpoint_filename(const std::string& t
   return get_last_distributed_checkpoint_filename(alg_name, get_trainer_checkpoint_dirname(trainer_name, dir));
 }
 
-inline std::string get_distributed_checkpoint_dirname(const std::string& alg_name, const int rank_in_trainer, const std::string& dir, execution_mode mode, size_t epoch, size_t step) {
+inline std::string get_distributed_checkpoint_dirname(const std::string& alg_name, const int rank_in_trainer, const std::string& dir, visitor_hook hook, size_t epoch, size_t step) {
   return build_string(dir, '/',
      alg_name,
     ".rank.", rank_in_trainer,
-    ".distributed.", to_string(mode),
+    ".distributed.", to_string(hook),
     ".epoch.", epoch,
     ".step.", step, '/');
 }
 
-inline std::string get_distributed_checkpoint_dirname(const std::string& trainer_name, const std::string& alg_name, const int rank_in_trainer, const std::string& dir, execution_mode mode, size_t epoch, size_t step) {
-  return get_distributed_checkpoint_dirname(alg_name, rank_in_trainer, get_trainer_checkpoint_dirname(trainer_name, dir), mode, epoch, step);
+inline std::string get_distributed_checkpoint_dirname(const std::string& trainer_name, const std::string& alg_name, const int rank_in_trainer, const std::string& dir, visitor_hook hook, size_t epoch, size_t step) {
+  return get_distributed_checkpoint_dirname(alg_name, rank_in_trainer, get_trainer_checkpoint_dirname(trainer_name, dir), hook, epoch, step);
 }
 
 // Print last checkpoint to file, used to determine which checkpoint to load from.
-inline bool write_latest(std::string filename, execution_mode mode, size_t epoch, size_t train) {
+inline bool write_latest(std::string filename, visitor_hook hook, size_t epoch, size_t train) {
   // open the file for writing
   int fd = openwrite(filename.c_str());
   if (fd != -1) {
     char field[256];
-    sprintf(field, "mode=%s epoch=%ld step=%ld\n", to_string(mode).c_str(), epoch, train);
+    sprintf(field, "hook=%s epoch=%ld step=%ld\n", to_string(hook).c_str(), epoch, train);
     write_string(fd, filename.c_str(), field, strlen(field));
     // close our file
     closewrite(fd, filename.c_str());
@@ -298,20 +300,20 @@ inline bool write_latest(std::string filename, execution_mode mode, size_t epoch
 /** \brief Reads the "latest" file and returns the epoch number and
  *        sample offset for most recent checkpoint
  */
-inline bool read_latest(std::string filename, execution_mode *mode, size_t *epochLast, size_t *trainLast) {
+inline bool read_latest(std::string filename, visitor_hook *hook, size_t *epochLast, size_t *trainLast) {
   // assume we don't have a file, we'll return -1 in that case
   *epochLast = -1;
   *trainLast = -1;
-  *mode = execution_mode::invalid;
+  *hook = visitor_hook::invalid;
   // open the file for reading
   int fd = openread(filename.c_str());
   if (fd != -1) {
     // read epoch from file
     char field[256];
     read_string(fd, filename.c_str(), field, sizeof(field));
-    char modeStr[64];
-    int ret = sscanf(field, "mode=%s epoch=%ld step=%ld\n", modeStr, epochLast, trainLast);
-    *mode = exec_mode_from_string(modeStr);
+    char hookStr[64];
+    int ret = sscanf(field, "hook=%s epoch=%ld step=%ld\n", hookStr, epochLast, trainLast);
+    *hook = visitor_hook_from_string(hookStr);
     // close our file
     closeread(fd, filename.c_str());
     if(ret != 3) { return false; }

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -309,6 +309,7 @@ inline bool read_latest(std::string filename, visitor_hook *hook, execution_mode
   // assume we don't have a file, we'll return -1 in that case
   *epochLast = -1;
   *trainLast = -1;
+  *mode = execution_mode::invalid;
   *hook = visitor_hook::invalid;
   // open the file for reading
   int fd = openread(filename.c_str());

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -89,7 +89,7 @@ public:
   void setup(trainer *t) override;
   void on_train_begin(model *m) override;
   void on_epoch_end(model *m) override;
-  void on_batch_end(model *m) override;
+  void on_batch_begin(model *m) override;
   void on_validation_end(model *m) override;
 
   inline void set_checkpoint_dir(const std::string& dir){

--- a/include/lbann/callbacks/dump_weights.hpp
+++ b/include/lbann/callbacks/dump_weights.hpp
@@ -32,6 +32,7 @@
 #include <utility>
 
 #include "lbann/callbacks/callback.hpp"
+#include "lbann/utils/visitor_hooks.hpp"
 
 namespace lbann {
 namespace callback {
@@ -87,7 +88,7 @@ class dump_weights : public callback_base {
   /** Interval at which to dump weights */
   El::Int m_epoch_interval;
   /// Dump weights from learning layers.
-  void do_dump_weights(const model& m, std::string s = "");
+  void do_dump_weights(const model& m, visitor_hook hook, std::string s = "");
 };
 
 // Builder function

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -40,6 +40,7 @@ set_full_path(THIS_DIR_HEADERS
   trainer_file_utils.hpp
   type_erased_matrix.hpp
   typename.hpp
+  visitor_hooks.hpp
   )
 
 if (LBANN_HAS_HALF)

--- a/include/lbann/utils/enum_iterator.hpp
+++ b/include/lbann/utils/enum_iterator.hpp
@@ -53,5 +53,5 @@ public:
   bool operator!=(const enum_iterator& i) { return val != i.val; }
 };
 
-}
+} // namespace lbann
 #endif // LBANN_ENUM_ITERATOR_H

--- a/include/lbann/utils/visitor_hooks.hpp
+++ b/include/lbann/utils/visitor_hooks.hpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////////xecu
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_VISITOR_HOOKS_HPP_INCLUDED
+#define LBANN_VISITOR_HOOKS_HPP_INCLUDED
+
+// #include "lbann_config.hpp"
+
+// #include "lbann/Elemental_extensions.hpp"
+// #include "lbann/utils/cyg_profile.hpp"
+// #include "lbann/utils/file_utils.hpp"
+#include "lbann/utils/enum_iterator.hpp"
+
+#include <iostream>
+#include <string>
+
+namespace lbann {
+
+/// Neural network execution mode
+enum class visitor_hook{setup_begin,
+    setup_end,
+    train_begin,
+    train_end,
+    phase_end,
+    epoch_begin,
+    epoch_end,
+    batch_begin,
+    batch_end,
+    test_begin,
+    test_end,
+    validation_begin,
+    validation_end,
+    forward_prop_begin,
+    forward_prop_end,
+    backward_prop_begin,
+    backward_prop_end,
+    optimize_begin,
+    optimize_end,
+    batch_evaluate_begin,
+    batch_evaluate_end,
+    evaluate_forward_prop_begin,
+    evaluate_forward_prop_end,
+    invalid};
+
+
+//enum class execution_mode {training, validation, testing, prediction, invalid};
+std::string to_string(visitor_hook hook);
+//using visitor_hook_iterator = enum_iterator<visitor_hook, visitor_hook::setup_begin, visitor_hook::invalid>;
+
+/** @brief Convert a string to an execution_mode. */
+visitor_hook visitor_hook_from_string(std::string const& str);
+/** @brief Extract an execution_mode from a stream. */
+std::istream& operator>>(std::istream& os, visitor_hook& e);
+
+} // namespace lbann
+
+#endif // LBANN_VISITOR_HOOKS_HPP_INCLUDED

--- a/include/lbann/utils/visitor_hooks.hpp
+++ b/include/lbann/utils/visitor_hooks.hpp
@@ -1,4 +1,4 @@
-////////////////////////////////////////////////////////////////////////////////xecu
+////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
@@ -27,6 +27,7 @@
 #ifndef LBANN_VISITOR_HOOKS_HPP_INCLUDED
 #define LBANN_VISITOR_HOOKS_HPP_INCLUDED
 
+#include "lbann/base.hpp"
 #include "lbann/utils/enum_iterator.hpp"
 
 #include <iostream>
@@ -37,36 +38,31 @@ namespace lbann {
 /// Neural network execution mode
 enum class visitor_hook{setup_begin,
     setup_end,
-    train_begin,
-    train_end,
     phase_end,
     epoch_begin,
     epoch_end,
-    batch_begin,
-    batch_end,
-    test_begin,
-    test_end,
-    validation_begin,
-    validation_end,
-    forward_prop_begin,
-    forward_prop_end,
-    backward_prop_begin,
-    backward_prop_end,
     optimize_begin,
     optimize_end,
-    batch_evaluate_begin,
-    batch_evaluate_end,
-    evaluate_forward_prop_begin,
-    evaluate_forward_prop_end,
+
+    /// Special visitor hooks that execute in conjunction with the execution mode
+    execution_mode_begin,
+    execution_mode_end,
+    execution_mode_batch_begin,
+    execution_mode_batch_end,
+    execution_mode_forward_prop_begin,
+    execution_mode_forward_prop_end,
+    execution_mode_backward_prop_begin,
+    execution_mode_backward_prop_end,
     invalid};
 
 
-//enum class execution_mode {training, validation, testing, prediction, invalid};
+bool is_execution_mode_hook(visitor_hook hook);
 std::string to_string(visitor_hook hook);
-//using visitor_hook_iterator = enum_iterator<visitor_hook, visitor_hook::setup_begin, visitor_hook::invalid>;
+std::string to_string(visitor_hook hook, execution_mode mode);
+using visitor_hook_iterator = enum_iterator<visitor_hook, visitor_hook::setup_begin, visitor_hook::invalid>;
 
 /** @brief Convert a string to an execution_mode. */
-visitor_hook visitor_hook_from_string(std::string const& str);
+void visitor_hook_from_string(std::string const& str, visitor_hook& hook, execution_mode& mode);
 /** @brief Extract an execution_mode from a stream. */
 std::istream& operator>>(std::istream& os, visitor_hook& e);
 

--- a/include/lbann/utils/visitor_hooks.hpp
+++ b/include/lbann/utils/visitor_hooks.hpp
@@ -27,11 +27,6 @@
 #ifndef LBANN_VISITOR_HOOKS_HPP_INCLUDED
 #define LBANN_VISITOR_HOOKS_HPP_INCLUDED
 
-// #include "lbann_config.hpp"
-
-// #include "lbann/Elemental_extensions.hpp"
-// #include "lbann/utils/cyg_profile.hpp"
-// #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/enum_iterator.hpp"
 
 #include <iostream>

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -77,7 +77,7 @@ void checkpoint::on_validation_end(model *m) {
   p.set_cb_type(callback_type::invalid);
 }
  // Interval defined with checkpoint_steps or ckpt_dist_steps
-void checkpoint::on_batch_end(model *m) {
+void checkpoint::on_batch_begin(model *m) {
   auto& p = get_active_trainer().get_persist_obj();
   p.set_cb_type(callback_type::full_checkpoint);
   if(need_checkpoint(m, callback_phase::batch)){

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -45,14 +45,14 @@ dump_weights::dump_weights()
 {}
 
 void dump_weights::on_train_begin(model *m) {
-  do_dump_weights(*m, "initial");
+  do_dump_weights(*m, visitor_hook::train_begin, "initial");
 }
 
 void dump_weights::on_epoch_end(model *m) {
-  do_dump_weights(*m);
+  do_dump_weights(*m, visitor_hook::epoch_end);
 }
 
-void dump_weights::do_dump_weights(const model& m, std::string s) {
+void dump_weights::do_dump_weights(const model& m, visitor_hook hook, std::string s) {
   const auto& c = static_cast<const sgd_execution_context&>(m.get_execution_context());
 
   if(c.get_epoch() % m_epoch_interval != 0)  return;
@@ -62,7 +62,7 @@ void dump_weights::do_dump_weights(const model& m, std::string s) {
   std::string epochdir = El::BuildString(get_shared_checkpoint_dirname(t.get_name(),
                                                                        c.get_training_algorithm().get_name(),
                                                                        m_directory.c_str(),
-                                                                       c.get_execution_mode(),
+                                                                       hook,
                                                                        c.get_epoch(),
                                                                        c.get_step()),
 
@@ -81,7 +81,7 @@ void dump_weights::do_dump_weights(const model& m, std::string s) {
     auto latest_file = get_last_shared_checkpoint_filename(t.get_name(),
                                                            c.get_training_algorithm().get_name(),
                                                            m_directory.c_str());
-    write_latest(latest_file, c.get_execution_mode(), c.get_epoch(), c.get_step());
+    write_latest(latest_file, hook, c.get_epoch(), c.get_step());
   }
 
 }

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -45,7 +45,7 @@ dump_weights::dump_weights()
 {}
 
 void dump_weights::on_train_begin(model *m) {
-  do_dump_weights(*m, visitor_hook::train_begin, "initial");
+  do_dump_weights(*m, visitor_hook::execution_mode_begin, "initial");
 }
 
 void dump_weights::on_epoch_end(model *m) {
@@ -63,6 +63,7 @@ void dump_weights::do_dump_weights(const model& m, visitor_hook hook, std::strin
                                                                        c.get_training_algorithm().get_name(),
                                                                        m_directory.c_str(),
                                                                        hook,
+                                                                       c.get_execution_mode(),
                                                                        c.get_epoch(),
                                                                        c.get_step()),
 
@@ -81,7 +82,7 @@ void dump_weights::do_dump_weights(const model& m, visitor_hook hook, std::strin
     auto latest_file = get_last_shared_checkpoint_filename(t.get_name(),
                                                            c.get_training_algorithm().get_name(),
                                                            m_directory.c_str());
-    write_latest(latest_file, hook, c.get_epoch(), c.get_step());
+    write_latest(latest_file, hook, c.get_execution_mode(), c.get_epoch(), c.get_step());
   }
 
 }

--- a/src/training_algorithms/sgd_training_algorithm.cpp
+++ b/src/training_algorithms/sgd_training_algorithm.cpp
@@ -96,6 +96,9 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
       evaluate(evaluation_context, model, dc, execution_mode::validation);
     }
   }
+  // Reset the model back to the training execution context prior to
+  // end of training callbacks
+  model.reset_mode(c, execution_mode::training);
   do_train_end_cbs(model);
 }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -28,6 +28,7 @@ set_full_path(THIS_DIR_SOURCES
   summary.cpp
   system_info.cpp
   trainer_file_utils.cpp
+  visitor_hooks.cpp
 )
 
 if (LBANN_HAS_CUDA)

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -384,16 +384,17 @@ std::unique_ptr<model> build_model_from_prototext(
     }else {
       size_t epochLast = std::numeric_limits<size_t>::max();;
       size_t stepLast = std::numeric_limits<size_t>::max();;
+      execution_mode mode = execution_mode::invalid;
       visitor_hook hook = visitor_hook::invalid;
       active_load_model_dir = callback::get_last_shared_checkpoint_filename("sgd", load_model_dir);
 
       // get last epoch and step saved.
-      int success = callback::read_latest(active_load_model_dir, &hook, &epochLast, &stepLast);
+      int success = callback::read_latest(active_load_model_dir, &hook, &mode, &epochLast, &stepLast);
       if(!success) {
         LBANN_ERROR("Unable to find the latest checkpoint ", active_load_model_dir);
         return nullptr;
       }
-      active_load_model_dir = callback::get_shared_checkpoint_dirname("sgd", load_model_dir, hook, epochLast, stepLast) + ret_model->get_name() + '/';
+      active_load_model_dir = callback::get_shared_checkpoint_dirname("sgd", load_model_dir, hook, mode, epochLast, stepLast) + ret_model->get_name() + '/';
     }
 
     if(cb == nullptr) {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -384,16 +384,16 @@ std::unique_ptr<model> build_model_from_prototext(
     }else {
       size_t epochLast = std::numeric_limits<size_t>::max();;
       size_t stepLast = std::numeric_limits<size_t>::max();;
-      execution_mode mode = execution_mode::invalid;
+      visitor_hook hook = visitor_hook::invalid;
       active_load_model_dir = callback::get_last_shared_checkpoint_filename("sgd", load_model_dir);
 
       // get last epoch and step saved.
-      int success = callback::read_latest(active_load_model_dir, &mode, &epochLast, &stepLast);
+      int success = callback::read_latest(active_load_model_dir, &hook, &epochLast, &stepLast);
       if(!success) {
         LBANN_ERROR("Unable to find the latest checkpoint ", active_load_model_dir);
         return nullptr;
       }
-      active_load_model_dir = callback::get_shared_checkpoint_dirname("sgd", load_model_dir, mode, epochLast, stepLast) + ret_model->get_name() + '/';
+      active_load_model_dir = callback::get_shared_checkpoint_dirname("sgd", load_model_dir, hook, epochLast, stepLast) + ret_model->get_name() + '/';
     }
 
     if(cb == nullptr) {

--- a/src/utils/visitor_hooks.cpp
+++ b/src/utils/visitor_hooks.cpp
@@ -29,119 +29,166 @@
 
 namespace lbann {
 
+bool is_execution_mode_hook(visitor_hook hook) {
+  switch(hook) {
+  case visitor_hook::setup_begin:
+  case visitor_hook::setup_end:
+  case visitor_hook::phase_end:
+  case visitor_hook::epoch_begin:
+  case visitor_hook::epoch_end:
+  case visitor_hook::optimize_begin:
+  case visitor_hook::optimize_end:
+  case visitor_hook::invalid:
+    return false;
+  case visitor_hook::execution_mode_begin:
+  case visitor_hook::execution_mode_end:
+  case visitor_hook::execution_mode_batch_begin:
+  case visitor_hook::execution_mode_batch_end:
+  case visitor_hook::execution_mode_forward_prop_begin:
+  case visitor_hook::execution_mode_forward_prop_end:
+  case visitor_hook::execution_mode_backward_prop_begin:
+  case visitor_hook::execution_mode_backward_prop_end:
+    return true;
+  default:
+    LBANN_ERROR("Invalid visitor hook specified");
+  }
+}
+
 std::string to_string(visitor_hook hook) {
   switch(hook) {
   case visitor_hook::setup_begin:
     return "setup_begin";
   case visitor_hook::setup_end:
     return "setup_end";
-  case visitor_hook::train_begin:
-    return "train_begin";
-  case visitor_hook::train_end:
-    return "train_end";
   case visitor_hook::phase_end:
     return "phase_end";
   case visitor_hook::epoch_begin:
     return "epoch_begin";
   case visitor_hook::epoch_end:
     return "epoch_end";
-  case visitor_hook::batch_begin:
-    return "batch_begin";
-  case visitor_hook::batch_end:
-    return "batch_end";
-  case visitor_hook::test_begin:
-    return "test_begin";
-  case visitor_hook::test_end:
-    return "test_end";
-  case visitor_hook::validation_begin:
-    return "validation_begin";
-  case visitor_hook::validation_end:
-    return "validation_end";
-  case visitor_hook::forward_prop_begin:
-    return "forward_prop_begin";
-  case visitor_hook::forward_prop_end:
-    return "forward_prop_end";
-  case visitor_hook::backward_prop_begin:
-    return "backward_prop_begin";
-  case visitor_hook::backward_prop_end:
-    return "backward_prop_end";
   case visitor_hook::optimize_begin:
     return "optimize_begin";
   case visitor_hook::optimize_end:
     return "optimize_end";
-  case visitor_hook::batch_evaluate_begin:
-    return "batch_evaluate_begin";
-  case visitor_hook::batch_evaluate_end:
-    return "batch_evaluate_end";
-  case visitor_hook::evaluate_forward_prop_begin:
-    return "evaluate_forward_prop_begin";
-  case visitor_hook::evaluate_forward_prop_end:
-    return "evaluate_forward_prop_end";
   case visitor_hook::invalid:
     return "invalid";
+  case visitor_hook::execution_mode_begin:
+  case visitor_hook::execution_mode_end:
+  case visitor_hook::execution_mode_batch_begin:
+  case visitor_hook::execution_mode_batch_end:
+  case visitor_hook::execution_mode_forward_prop_begin:
+  case visitor_hook::execution_mode_forward_prop_end:
+  case visitor_hook::execution_mode_backward_prop_begin:
+  case visitor_hook::execution_mode_backward_prop_end:
+    LBANN_ERROR("visitor_hook is execution_mode specific");
   default:
-      LBANN_ERROR("Invalid visitor hook specified");
+    LBANN_ERROR("Invalid visitor hook specified");
   }
 }
 
-visitor_hook visitor_hook_from_string(std::string const& str) {
+std::string to_string(visitor_hook hook, execution_mode mode) {
+  switch(hook) {
+  case visitor_hook::execution_mode_begin:
+    return to_string(mode) + "_begin";
+  case visitor_hook::execution_mode_end:
+    return to_string(mode) + "_end";
+  case visitor_hook::execution_mode_batch_begin:
+    return to_string(mode) + "_batch_begin";
+  case visitor_hook::execution_mode_batch_end:
+    return to_string(mode) + "_batch_end";
+  case visitor_hook::execution_mode_forward_prop_begin:
+    return to_string(mode) + "_forward_prop_begin";
+  case visitor_hook::execution_mode_forward_prop_end:
+    return to_string(mode) + "_forward_prop_end";
+  case visitor_hook::execution_mode_backward_prop_begin:
+    return to_string(mode) + "_backward_prop_begin";
+  case visitor_hook::execution_mode_backward_prop_end:
+    return to_string(mode) + "_backward_prop_end";
+  case visitor_hook::setup_begin:
+  case visitor_hook::setup_end:
+  case visitor_hook::epoch_begin:
+  case visitor_hook::epoch_end:
+  case visitor_hook::phase_end:
+  case visitor_hook::optimize_begin:
+  case visitor_hook::optimize_end:
+  case visitor_hook::invalid:
+    LBANN_ERROR("visitor_hook is not execution_mode specific");
+  default:
+    LBANN_ERROR("Invalid visitor hook specified");
+  }
+}
+
+void visitor_hook_from_string(std::string const& str, visitor_hook& hook, execution_mode& mode) {
+  mode = execution_mode::invalid;
+
   if(str == "setup_begin") {
-    return visitor_hook::setup_begin;
+    hook = visitor_hook::setup_begin;
+    return;
   }else if(str == "setup_end") {
-    return visitor_hook::setup_end;
-  }else if(str == "train_begin") {
-    return visitor_hook::train_begin;
-  }else if(str == "train_end") {
-    return visitor_hook::train_end;
+    hook = visitor_hook::setup_end;
+    return;
   }else if(str == "phase_end") {
-    return visitor_hook::phase_end;
+    hook = visitor_hook::phase_end;
+    return;
   }else if(str == "epoch_begin") {
-    return visitor_hook::epoch_begin;
+    hook = visitor_hook::epoch_begin;
+    return;
   }else if(str == "epoch_end") {
-    return  visitor_hook::epoch_end;
-  }else if(str == "batch_begin") {
-    return visitor_hook::batch_begin;
-  }else if(str == "batch_end") {
-    return visitor_hook::batch_end;
-  }else if(str == "test_begin") {
-    return  visitor_hook::test_begin;
-  }else if(str == "test_end") {
-    return visitor_hook::test_end;
-  }else if(str == "validation_begin") {
-    return visitor_hook::validation_begin;
-  }else if(str == "validation_end") {
-    return visitor_hook::validation_end;
-  }else if(str == "forward_prop_begin") {
-    return visitor_hook::forward_prop_begin;
-  }else if(str == "forward_prop_end") {
-    return visitor_hook::forward_prop_end;
-  }else if(str == "backward_prop_begin") {
-    return visitor_hook::backward_prop_begin;
-  }else if(str == "backward_prop_end") {
-    return visitor_hook::backward_prop_end;
+    hook =  visitor_hook::epoch_end;
+    return;
   }else if(str == "optimize_begin") {
-    return visitor_hook::optimize_begin;
+    hook = visitor_hook::optimize_begin;
+    return;
   }else if(str == "optimize_end") {
-    return visitor_hook::optimize_end;
-  }else if(str == "batch_evaluate_begin") {
-    return visitor_hook::batch_evaluate_begin;
-  }else if(str == "batch_evaluate_end") {
-    return visitor_hook::batch_evaluate_end;
-  }else if(str == "evaluate_forward_prop_begin") {
-    return visitor_hook::evaluate_forward_prop_begin;
-  }else if(str == "evaluate_forward_prop_end") {
-    return visitor_hook::evaluate_forward_prop_end;
+    hook = visitor_hook::optimize_end;
+    return;
   }else if(str == "invalid") {
-    return visitor_hook::invalid;
-  } else {
+    hook = visitor_hook::invalid;
+    return;
+  }else {
+    std::string delimiter = "_";
+    size_t pos = str.find(delimiter);
+    if(pos != std::string::npos) {
+      std::string mode_token = str.substr(0, pos);
+      mode = exec_mode_from_string(mode_token);
+      std::string visitor_token = str.substr(pos, str.length());
+      if(visitor_token == "_batch_begin") {
+        hook = visitor_hook::execution_mode_batch_begin;
+        return;
+      }else if(visitor_token == "_batch_end") {
+        hook = visitor_hook::execution_mode_batch_end;
+        return;
+      }else if(visitor_token == "_forward_prop_begin") {
+        hook = visitor_hook::execution_mode_forward_prop_begin;
+        return;
+      }else if(visitor_token == "_forward_prop_end") {
+        hook = visitor_hook::execution_mode_forward_prop_end;
+        return;
+      }else if(visitor_token == "_backward_prop_begin") {
+        hook = visitor_hook::execution_mode_backward_prop_begin;
+        return;
+      }else if(visitor_token == "_backward_prop_end") {
+        hook = visitor_hook::execution_mode_backward_prop_end;
+        return;
+      }else if(visitor_token == "_begin") { // Needs to be last to avoid substrings
+        hook = visitor_hook::execution_mode_begin;
+        return;
+      }else if(visitor_token == "_end") { // Needs to be last to avoid substrings
+        hook = visitor_hook::execution_mode_end;
+        return;
+      }
+      LBANN_ERROR("\"" + str + "\" is not a valid visitor hook.");
+    }
     LBANN_ERROR("\"" + str + "\" is not a valid visitor hook.");
   }
+  return;
 }
 
 std::istream& operator>>(std::istream& is, visitor_hook& hook) {
   std::string tmp;
   is >> tmp;
-  hook = visitor_hook_from_string(tmp);
+  execution_mode mode;
+  visitor_hook_from_string(tmp, hook, mode);
   return is;
 }
 

--- a/src/utils/visitor_hooks.cpp
+++ b/src/utils/visitor_hooks.cpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////////////////////////xecu
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/utils/visitor_hooks.hpp"
+#include "lbann/utils/exception.hpp"
+
+namespace lbann {
+
+std::string to_string(visitor_hook hook) {
+  switch(hook) {
+  case visitor_hook::setup_begin:
+    return "setup_begin";
+  case visitor_hook::setup_end:
+    return "setup_end";
+  case visitor_hook::train_begin:
+    return "train_begin";
+  case visitor_hook::train_end:
+    return "train_end";
+  case visitor_hook::phase_end:
+    return "phase_end";
+  case visitor_hook::epoch_begin:
+    return "epoch_begin";
+  case visitor_hook::epoch_end:
+    return "epoch_end";
+  case visitor_hook::batch_begin:
+    return "batch_begin";
+  case visitor_hook::batch_end:
+    return "batch_end";
+  case visitor_hook::test_begin:
+    return "test_begin";
+  case visitor_hook::test_end:
+    return "test_end";
+  case visitor_hook::validation_begin:
+    return "validation_begin";
+  case visitor_hook::validation_end:
+    return "validation_end";
+  case visitor_hook::forward_prop_begin:
+    return "forward_prop_begin";
+  case visitor_hook::forward_prop_end:
+    return "forward_prop_end";
+  case visitor_hook::backward_prop_begin:
+    return "backward_prop_begin";
+  case visitor_hook::backward_prop_end:
+    return "backward_prop_end";
+  case visitor_hook::optimize_begin:
+    return "optimize_begin";
+  case visitor_hook::optimize_end:
+    return "optimize_end";
+  case visitor_hook::batch_evaluate_begin:
+    return "batch_evaluate_begin";
+  case visitor_hook::batch_evaluate_end:
+    return "batch_evaluate_end";
+  case visitor_hook::evaluate_forward_prop_begin:
+    return "evaluate_forward_prop_begin";
+  case visitor_hook::evaluate_forward_prop_end:
+    return "evaluate_forward_prop_end";
+  case visitor_hook::invalid:
+    return "invalid";
+  default:
+      LBANN_ERROR("Invalid visitor hook specified");
+  }
+}
+
+visitor_hook visitor_hook_from_string(std::string const& str) {
+  if(str == "setup_begin") {
+    return visitor_hook::setup_begin;
+  }else if(str == "setup_end") {
+    return visitor_hook::setup_end;
+  }else if(str == "train_begin") {
+    return visitor_hook::train_begin;
+  }else if(str == "train_end") {
+    return visitor_hook::train_end;
+  }else if(str == "phase_end") {
+    return visitor_hook::phase_end;
+  }else if(str == "epoch_begin") {
+    return visitor_hook::epoch_begin;
+  }else if(str == "epoch_end") {
+    return  visitor_hook::epoch_end;
+  }else if(str == "batch_begin") {
+    return visitor_hook::batch_begin;
+  }else if(str == "batch_end") {
+    return visitor_hook::batch_end;
+  }else if(str == "test_begin") {
+    return  visitor_hook::test_begin;
+  }else if(str == "test_end") {
+    return visitor_hook::test_end;
+  }else if(str == "validation_begin") {
+    return visitor_hook::validation_begin;
+  }else if(str == "validation_end") {
+    return visitor_hook::validation_end;
+  }else if(str == "forward_prop_begin") {
+    return visitor_hook::forward_prop_begin;
+  }else if(str == "forward_prop_end") {
+    return visitor_hook::forward_prop_end;
+  }else if(str == "backward_prop_begin") {
+    return visitor_hook::backward_prop_begin;
+  }else if(str == "backward_prop_end") {
+    return visitor_hook::backward_prop_end;
+  }else if(str == "optimize_begin") {
+    return visitor_hook::optimize_begin;
+  }else if(str == "optimize_end") {
+    return visitor_hook::optimize_end;
+  }else if(str == "batch_evaluate_begin") {
+    return visitor_hook::batch_evaluate_begin;
+  }else if(str == "batch_evaluate_end") {
+    return visitor_hook::batch_evaluate_end;
+  }else if(str == "evaluate_forward_prop_begin") {
+    return visitor_hook::evaluate_forward_prop_begin;
+  }else if(str == "evaluate_forward_prop_end") {
+    return visitor_hook::evaluate_forward_prop_end;
+  }else if(str == "invalid") {
+    return visitor_hook::invalid;
+  } else {
+    LBANN_ERROR("\"" + str + "\" is not a valid visitor hook.");
+  }
+}
+
+std::istream& operator>>(std::istream& is, visitor_hook& hook) {
+  std::string tmp;
+  is >> tmp;
+  hook = visitor_hook_from_string(tmp);
+  return is;
+}
+
+} // namespace lbann


### PR DESCRIPTION
We have an off-by-one error for applications that require synchronized checkpointing and dumping weights/activations/metrics. Checkpointing happens at the end of the training step, after we apply the optimizer step, so the checkpointed model is one step later than the other dumped objects. We can fix this by checkpointing at the beginning of the training step.

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM327-1).