### PR TITLE
Support DiHydrogen's mean squared error layers

### DIFF
--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -28,8 +28,26 @@
 #define LBANN_LAYERS_LOSS_MEAN_SQUARED_ERROR_HPP_INCLUDED
 
 #include "lbann/layers/data_type_layer.hpp"
+#include "lbann/utils/distconv.hpp"
 
 namespace lbann {
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+class mean_squared_error_distconv_adapter: public data_type_distconv_adapter<TensorDataType> {
+ public:
+  using TensorDevType = typename data_type_distconv_adapter<TensorDataType>::TensorDevType;
+  mean_squared_error_distconv_adapter(Layer& layer)
+      : data_type_distconv_adapter<TensorDataType>(layer) {}
+  virtual ~mean_squared_error_distconv_adapter() = default;
+  void setup_distributions(tensor_overlap_constraints &constraints) override;
+  dc::Shape get_prev_activations_shape(int index) const override;
+  dc::Shape get_activations_shape(int index) const override;
+  dc::Shape get_activations_local_shape(int index) const override;
+  void setup_layer(size_t workspace_capacity) override;
+  std::unique_ptr<dc::MeanSquaredError> m_mean_squared_error;
+};
+#endif // LBANN_HAS_DISTCONV
 
 /** @brief
  *
@@ -80,6 +98,19 @@ public:
     data_type_layer<TensorDataType>::setup_dims(dr_metadata);
     this->set_output_dims({1});
 
+#ifdef LBANN_HAS_DISTCONV
+    // In the current implementation of mean squared error in Distconv, we
+    // do not use the reshape layer and just assumes both inputs have
+    // the matching shape. Therefore, the following check on the input
+    // dimensions would fail. We could address this by either 1)
+    // implementing the reshape layer, or 2) giving a proper shape to
+    // the ground-truth data.
+    //
+    if (this->distconv_enabled()) {
+      return;
+    }
+#endif
+
     // Check that input dimensions match
     if (this->get_input_dims(0) != this->get_input_dims(1)) {
       const auto& parents = this->get_parent_layers();
@@ -123,6 +154,13 @@ public:
 
   void fp_compute() override {
 
+#ifdef LBANN_HAS_DISTCONV
+    if (this->distconv_enabled()) {
+      fp_compute_distconv();
+      return;
+    }
+#endif // LBANN_HAS_DISTCONV
+
     // Initialize workspace
     m_workspace->Empty();
     m_workspace->AlignWith(this->get_prev_activations());
@@ -140,6 +178,13 @@ public:
   }
 
   void bp_compute() override {
+
+#ifdef LBANN_HAS_DISTCONV
+    if (this->distconv_enabled()) {
+      bp_compute_distconv();
+      return;
+    }
+#endif // LBANN_HAS_DISTCONV
 
     // Initialize workspace
     m_workspace->Empty();
@@ -164,7 +209,132 @@ private:
   /** Workspace matrix. */
   std::unique_ptr<AbsDistMatrixType> m_workspace;
 
+#ifdef LBANN_HAS_DISTCONV
+  friend class mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>;
+ protected:
+  bool is_distconv_supported() const override {
+    return Dev == El::Device::GPU && T_layout == data_layout::DATA_PARALLEL;
+  }
+
+  void setup_distconv_adapter(const DataReaderMetaData& dr_metadata) override {
+    this->get_distconv_adapter_ptr() = make_unique<
+      mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>>(*this);
+  }
+
+  mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() override;
+  const mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>& get_distconv_adapter() const override;
+
+  void fp_compute_distconv() {
+    assert_always(this->distconv_enabled());
+    get_distconv_adapter().m_mean_squared_error->forward(this->get_distconv_adapter().get_prev_activations(0),
+                                                         this->get_distconv_adapter().get_prev_activations(1),
+                                                         this->get_distconv_adapter().get_activations());
+  }
+
+  void bp_compute_distconv() {
+    assert_always(this->distconv_enabled());
+    get_distconv_adapter().m_mean_squared_error->backward(this->get_distconv_adapter().get_prev_activations(0),
+                                                          this->get_distconv_adapter().get_prev_activations(1),
+                                                          this->get_distconv_adapter().get_prev_error_signals(0),
+                                                          this->get_distconv_adapter().get_error_signals(0),
+                                                          this->get_distconv_adapter().get_error_signals(1));
+  }
+#endif // LBANN_HAS_DISTCONV
+
 };
+
+#ifdef LBANN_HAS_DISTCONV
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+const mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>&
+mean_squared_error_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() const {
+  return dynamic_cast<const mean_squared_error_distconv_adapter<
+    TensorDataType, T_layout, Dev>&>(data_type_layer<TensorDataType>::get_distconv_adapter());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>&
+mean_squared_error_layer<TensorDataType, T_layout, Dev>::get_distconv_adapter() {
+  return const_cast<mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>&>(
+      static_cast<const mean_squared_error_layer<TensorDataType, T_layout, Dev>&>(*this).get_distconv_adapter());
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+dc::Shape mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>::
+get_prev_activations_shape(int index) const {
+  // Assumes both of the two input tensors have the equal shape.
+  return data_type_distconv_adapter<TensorDataType>::get_prev_activations_shape(0);
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+dc::Shape mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>::
+get_activations_shape(int output_index) const {
+  // NOTE: LBANN matrix is a 2-D matrix, while Distconv keeps the
+  // original spatial and channel dimensions, so
+  // get_output_tensor_shape() doesn't work here.
+  dc::Shape shape = this->get_prev_activations_shape(0);
+  for (int i = 0; i < shape.num_dims() - 1; ++i) {
+    shape[i] = 1;
+  }
+  return shape;
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+dc::Shape mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>::
+get_activations_local_shape(int index) const {
+  assert_eq(index, 0);
+  auto input_shape = this->get_prev_activations().get_local_shape();
+  for (int i = 0; i < input_shape.length() - 1; ++i) {
+    input_shape[i] = 1;
+  }
+  return input_shape;
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>::
+setup_distributions(tensor_overlap_constraints &constraints) {
+  data_type_distconv_adapter<TensorDataType>::setup_distributions(
+      constraints);
+  // Output tensors share all dimensions except for the sample dimension
+  auto activations_split = this->get_activations_dist().get_split_shape();
+  auto prev_error_signals_split = this->get_prev_error_signals_dist().get_split_shape();
+  for (int i = 0; i < activations_split.length() - 1; ++i) {
+    activations_split[i] = 1;
+    prev_error_signals_split[i] = 1;
+  }
+  this->get_activations_dist().set_split_shape(activations_split);
+  this->get_prev_error_signals_dist().set_split_shape(prev_error_signals_split);
+
+  for (auto &d: this->m_prev_activations_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_activations_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_prev_error_signals_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+  for (auto &d: this->m_error_signals_dists) {
+    d.clear_overlap();
+    constraints.mark_updated(d);
+    constraints.mark_invariant(d);
+  }
+}
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void mean_squared_error_distconv_adapter<TensorDataType, T_layout, Dev>::setup_layer(
+    size_t workspace_capacity) {
+  m_mean_squared_error = make_unique<dc::MeanSquaredError>(dc::get_backend());
+  m_mean_squared_error->setup(this->get_prev_activations(0),
+                         this->get_prev_activations(1),
+                         this->get_activations(0));
+}
+#endif // LBANN_HAS_DISTCONV
 
 #ifndef LBANN_MEAN_SQUARED_ERROR_LAYER_INSTANTIATE
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -119,6 +119,7 @@ template <typename TensorDataType>
 using BatchNormalization = ::distconv::BatchNormalization<Backend, TensorDataType>;
 using Softmax = ::distconv::Softmax<Backend>;
 using CrossEntropy = ::distconv::CrossEntropy<Backend>;
+using MeanSquaredError = ::distconv::MeanSquaredError<Backend>;
 
 using ::distconv::get_sample_dim;
 using ::distconv::get_channel_dim;

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -378,7 +378,9 @@ get_activations_shape(int index) const {
     auto shape = this->get_activations_shape(0);
     auto label_size = data_type_distconv_adapter<TensorDataType>::
         get_activations_shape(1).reduce_prod();
-    auto num_channels = label_size / shape.reduce_prod();
+    const std::string env = std::getenv("DISTCONV_LABEL_NUM_CHANNELS");
+    auto num_channels = env != ""
+        ? std::stoi(env) : label_size / shape.reduce_prod();
     shape[-2] = num_channels;
     return shape;
   }


### PR DESCRIPTION
This PR makes mean squared error layers available for Distconv-enabled networks (https://github.com/LLNL/DiHydrogen/pull/45). The architectural requirements of mean squared error layers are the same as those of cross-entropy loss layers.

This PR also allows users to specify the number of channels of the "label" tensors by setting `DISTCONV_LABEL_NUM_CHANNELS`. In previous implementations, this number of channels was calculated as one, assuming a segmentation task, but this feature is necessary when it is not true, such as in reconstruction tasks.
