### PR TITLE
Build OpenCV with imgcodecs module

### DIFF
--- a/spack_environments/llnl_lc/externals-linux-ppc64le.sh
+++ b/spack_environments/llnl_lc/externals-linux-ppc64le.sh
@@ -57,7 +57,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 0.3.10
     opencv::
       buildable: true
-      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png+powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab+vsx~vtk+zlib
+      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgcodecs+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png+powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab+vsx~vtk+zlib
       version:
       - 4.1.0
     perl::

--- a/spack_environments/llnl_lc/externals-linux-x86_64.sh
+++ b/spack_environments/llnl_lc/externals-linux-x86_64.sh
@@ -70,7 +70,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 0.3.10
     opencv::
       buildable: true
-      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
+      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgcodecs+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
       version:
       - 4.1.0
     perl::

--- a/spack_environments/nersc/externals-cray-cnl7-skylake_avx512.sh
+++ b/spack_environments/nersc/externals-cray-cnl7-skylake_avx512.sh
@@ -73,7 +73,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
       - 0.3.10
     opencv::
       buildable: true
-      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
+      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgcodecs+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
       version:
       - 4.1.0
     python::

--- a/spack_environments/olcf/externals-linux-rhel7-power9le.sh
+++ b/spack_environments/olcf/externals-linux-rhel7-power9le.sh
@@ -63,7 +63,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
         - 0.3.10
     opencv::
       buildable: true
-      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png+powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab+vsx~vtk+zlib
+      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgcodecs+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png+powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab+vsx~vtk+zlib
       version:
         - 4.1.0
     python::

--- a/spack_environments/osx/externals-darwin-x86_64.sh
+++ b/spack_environments/osx/externals-darwin-x86_64.sh
@@ -45,7 +45,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
         prefix: /usr/local/Cellar/llvm/10.0.1/
     opencv::
       buildable: true
-      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
+      variants: build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgcodecs+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
       version:
       - 4.1.0
     openmpi:


### PR DESCRIPTION
I encounter build problems when I build OpenCV with Spack, especially from this line:
https://github.com/LLNL/lbann/blob/42a7c5c2f4d46505aaeb1b6148281b1620b31d25/src/callbacks/save_images.cpp#L35
It is probably related to https://github.com/spack/spack/pull/20378, which added the `+imgcodecs` variant to the OpenCV package. Manually enabling with variant fixed the problem for me.