### PR TITLE
More LTFB refactoring

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -26,6 +26,7 @@ Internal features:
  - Changed checkpoint logic to checkpoint at the start of epochs
    and changed the naming scheme to use the callback phase (visitor
    hook) in the name rather than the current execution context.
+ - Added in-memory binary model exchange for LTFB.
 
 I/O & data readers:
  - Experimental data reader that generates graph random walks with

--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -92,7 +92,7 @@ def construct_model(lbann):
         lbann.CallbackLTFB(
             batch_interval=1,
             metric='random',
-            communication_algorithm='checkpoint_file',
+            communication_algorithm='checkpoint_binary',
         ),
     ]
 

--- a/include/lbann/callbacks/ltfb.hpp
+++ b/include/lbann/callbacks/ltfb.hpp
@@ -36,7 +36,7 @@ namespace lbann {
 namespace callback {
 
 // Forward declaration
-class CommunicationAlgorithm;
+class LTFBCommunicationAlgorithm;
 
 /** @brief Tournament training.
  *
@@ -75,7 +75,7 @@ public:
    */
   ltfb(El::Int batch_interval,
        std::string metric_name,
-       std::unique_ptr<CommunicationAlgorithm> comm_algo,
+       std::unique_ptr<LTFBCommunicationAlgorithm> comm_algo,
        bool exchange_hyperparameters = false);
   ltfb(const ltfb& other);
   ltfb& operator=(const ltfb& other);
@@ -91,7 +91,7 @@ private:
   std::string m_metric_name;
 
   /** @brief Communication algorithm for exchanging models */
-  std::unique_ptr<CommunicationAlgorithm> comm_algo_;
+  std::unique_ptr<LTFBCommunicationAlgorithm> comm_algo_;
 
   /** @brief Whether low-scoring or high-scoring models survive a
    *  tournament. */

--- a/include/lbann/callbacks/ltfb.hpp
+++ b/include/lbann/callbacks/ltfb.hpp
@@ -35,6 +35,9 @@
 namespace lbann {
 namespace callback {
 
+// Forward declaration
+class CommunicationAlgorithm;
+
 /** @brief Tournament training.
  *
  *  This is intended to support research into the LTFB algorithm. An
@@ -59,44 +62,6 @@ namespace callback {
 class ltfb : public callback_base {
 public:
 
-  /** Inter-trainer communication scheme for LTFB.
-   *
-   *  The specifics of these algorithms are experimental and will be
-   *  in flux.
-   */
-  enum class communication_algorithm {
-    /** Directly exchange weights values with sendrecv.
-     *
-     *  Corresponding ranks in partner trainers will iterate through
-     *  their weights and exchange values with sendrecvs.
-     *
-     *  Notes:
-     *    - Requires all models to be identical aside from their
-     *      weights values, so this is not suitable for hyperparameter
-     *      or model architecture exploration.
-     *    - Optimizer state is not exchanged, so there may be wonky
-     *      learning behavior immediately after a tournament.
-     *    - Optimal if communication performance between ranks is
-     *      uniform and independent. If intra-trainer communication is
-     *      fast or if communication performance is sensitive to
-     *      network traffic, it may be advantageous to gather model
-     *      data on the trainer master ranks and only perform
-     *      inter-trainer communication between them.
-     */
-    sendrecv_weights,
-
-    /** Save and load model data with checkpoint files.
-     *
-     *  Notes:
-     *    - Supports hyperparameter exploration.
-     *    - This approach is temporary and experimental, since going
-     *      through the file system is very suboptimal. When a wire
-     *      format for model checkpoints is developed, it should be
-     *      used instead.
-     */
-    checkpoint_file
-  };
-
   /** @brief Construct the LTFB callback
    *  @param batch_interval Number of training mini-batch steps between
    *                        tournaments.
@@ -108,14 +73,10 @@ public:
    *  @param comm_algo      Inter-trainer communication scheme.
    *  @param summarizer     The summarizer to use for this callback
    */
-  ltfb(
-    El::Int batch_interval,
-    std::string metric_name,
-    std::set<std::string> weights_names = std::set<std::string>(),
-    bool low_score_wins = false,
-    communication_algorithm comm_algo = communication_algorithm::sendrecv_weights,
-    const std::string& ckptdir = "",
-    bool exchange_hyperparameters = false);
+  ltfb(El::Int batch_interval,
+       std::string metric_name,
+       std::unique_ptr<CommunicationAlgorithm> comm_algo,
+       bool exchange_hyperparameters = false);
   ltfb(const ltfb& other);
   ltfb& operator=(const ltfb& other);
   ltfb* copy() const override { return new ltfb(*this); }
@@ -124,41 +85,17 @@ public:
   void on_train_begin(model *m) override;
   void on_batch_begin(model *m) override;
 
-  /** @brief Convert string to LTFB communication algorithm.
-   *
-   *  If an empty string is provided, returns @c
-   *  communication_algorithm::sendrecv_weights.
-   */
-  static communication_algorithm string_to_comm_algo(const std::string& str);
-
-  void set_ckpt_basedir(const std::string& dir);
-  std::string get_ckpt_basedir() const;
-
 private:
 
   /** @brief Metric for tournament evaluation. */
   std::string m_metric_name;
 
-  /** @brief List of weights to exchange with partner.
-   *
-   *  If empty, then all weights are exchanged.
-   */
-  std::set<std::string> m_weights_names;
+  /** @brief Communication algorithm for exchanging models */
+  std::unique_ptr<CommunicationAlgorithm> comm_algo_;
 
   /** @brief Whether low-scoring or high-scoring models survive a
    *  tournament. */
   bool m_low_score_wins;
-
-  /** @brief Inter-trainer communication scheme. */
-  communication_algorithm m_comm_algo;
-
-  /** @brief Base directory of the checkpoint state */
-  std::string m_ckpt_basedir;
-
-  /** Whether to exchange training hyperparameters between trainers
-  */
-  bool m_exchange_hyperparameters;
-
 };
 
 // Builder function

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -103,6 +103,10 @@ public:
       );
 
     ar.serializeDeferments();
+#ifndef __CUDACC__
+    if constexpr (utils::IsInputArchive<Archive>)
+      m_model_is_setup = false;
+#endif // __CUDACC__
   }
 
   // ===========================================

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -51,24 +51,24 @@
 namespace lbann {
 namespace callback {
 
-/** @class CommunicationAlgorithm
+/** @class LTFBCommunicationAlgorithm
  *  @brief Exchange model information with partners.
  */
-class CommunicationAlgorithm
-  : public Cloneable<HasAbstractFunction<CommunicationAlgorithm>>
+class LTFBCommunicationAlgorithm
+  : public Cloneable<HasAbstractFunction<LTFBCommunicationAlgorithm>>
 {
 public:
   /** @brief Default constructor.
    *
    *  All weights within a model are exchanged.
    */
-  CommunicationAlgorithm() = default;
+  LTFBCommunicationAlgorithm() = default;
 
   /** @brief Construct with names of weights
    *  @param[in] weights_names Names of weights to exchange. If empty,
    *                           then all weights are exchanged.
    */
-  CommunicationAlgorithm(std::set<std::string> const& weights_names)
+  LTFBCommunicationAlgorithm(std::set<std::string> const& weights_names)
     : weights_names_{weights_names}
   {}
 
@@ -76,11 +76,11 @@ public:
    *  @param[in] weights_names Names of weights to exchange. If empty,
    *                           then all weights are exchanged.
    */
-  CommunicationAlgorithm(std::set<std::string>&& weights_names)
+  LTFBCommunicationAlgorithm(std::set<std::string>&& weights_names)
     : weights_names_{std::move(weights_names)}
   {}
 
-  virtual ~CommunicationAlgorithm() noexcept = default;
+  virtual ~LTFBCommunicationAlgorithm() noexcept = default;
 
   /** @brief Exchange data in model with a partner.
    *
@@ -95,8 +95,8 @@ public:
                                El::Int partner_trainer,
                                El::Int step) const = 0;
 protected:
-  CommunicationAlgorithm(CommunicationAlgorithm const&) = default;
-  CommunicationAlgorithm(CommunicationAlgorithm&&) = default;
+  LTFBCommunicationAlgorithm(LTFBCommunicationAlgorithm const&) = default;
+  LTFBCommunicationAlgorithm(LTFBCommunicationAlgorithm&&) = default;
   /** @name Data access and query */
   ///@{
   auto weights_names() const noexcept
@@ -106,7 +106,7 @@ protected:
   ///@}
 private:
   std::set<std::string> weights_names_;
-};// class CommunicationAlgorithm
+};// class LTFBCommunicationAlgorithm
 
 namespace {
 
@@ -226,9 +226,9 @@ El::Int get_partner_trainer(lbann_comm& comm,
  *  only SGD and Adam are supported.
  */
 class SendRecvWeights final
-  : public Cloneable<SendRecvWeights, CommunicationAlgorithm>
+  : public Cloneable<SendRecvWeights, LTFBCommunicationAlgorithm>
 {
-  using BaseType = Cloneable<SendRecvWeights, CommunicationAlgorithm>;
+  using BaseType = Cloneable<SendRecvWeights, LTFBCommunicationAlgorithm>;
 public:
   /** @brief Construct from weights names
    *  @param[in] weights_names Names of weights to exchange. If empty,
@@ -376,9 +376,9 @@ private:
 
 /// See @c lbann::callbacks::ltfb::communication_algorithm::checkpoint_file
 class CheckpointFile final
-  : public Cloneable<CheckpointFile, CommunicationAlgorithm>
+  : public Cloneable<CheckpointFile, LTFBCommunicationAlgorithm>
 {
-  using BaseType = Cloneable<CheckpointFile, CommunicationAlgorithm>;
+  using BaseType = Cloneable<CheckpointFile, LTFBCommunicationAlgorithm>;
 public:
 
   CheckpointFile(std::set<std::string> const& weights_names,
@@ -473,9 +473,9 @@ private:
 };// class CheckpointFile
 
 class CheckpointBlob final
-  : public Cloneable<CheckpointBlob, CommunicationAlgorithm>
+  : public Cloneable<CheckpointBlob, LTFBCommunicationAlgorithm>
 {
-  using BaseType = Cloneable<CheckpointBlob, CommunicationAlgorithm>;
+  using BaseType = Cloneable<CheckpointBlob, LTFBCommunicationAlgorithm>;
 public:
   CheckpointBlob(std::set<std::string> const& weights_names)
     : BaseType(weights_names)
@@ -602,7 +602,7 @@ EvalType evaluate(model& m, const std::string& metric_name)
 
 ltfb::ltfb(El::Int batch_interval,
            std::string metric_name,
-           std::unique_ptr<CommunicationAlgorithm> algo,
+           std::unique_ptr<LTFBCommunicationAlgorithm> algo,
            bool low_score_wins)
   : callback_base(batch_interval),
     m_metric_name{std::move(metric_name)},
@@ -732,7 +732,7 @@ build_ltfb_callback_from_pbuf(
   const auto& params =
     dynamic_cast<const lbann_data::Callback::CallbackLTFB&>(proto_msg);
   auto weights_list = parse_set<std::string>(params.weights());
-  std::unique_ptr<CommunicationAlgorithm> algo;
+  std::unique_ptr<LTFBCommunicationAlgorithm> algo;
   switch (string_to_comm_algo(params.communication_algorithm()))
   {
   case comm_algorithm::sendrecv_weights:

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -533,7 +533,7 @@ public:
                     El::SyncInfo<El::Device::CPU>{});
       load_model_ckpt.resize(load_size);
 
-      while (save_size && load_size)
+      while (save_size || load_size)
       {
         // Get the max blk size
         auto constexpr max_blk_size = std::numeric_limits<int>::max();

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -25,7 +25,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/ltfb.hpp"
-#include "lbann/callbacks/imcomm.hpp"
 #include "lbann/utils/random_number_generators.hpp"
 #include "lbann/models/directed_acyclic_graph.hpp"
 #include "lbann/optimizers/sgd.hpp"
@@ -34,16 +33,146 @@
 #include "lbann/weights/data_type_weights.hpp"
 #include "lbann/data_coordinator/data_coordinator.hpp"
 
+#include <lbann/utils/cloneable.hpp>
+#include <lbann/utils/memory.hpp>
+
 #include <callbacks.pb.h>
 
+#include <algorithm>
+#include <numeric>
+#include <set>
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace lbann {
 namespace callback {
 
+/** @class CommunicationAlgorithm
+ *  @brief Exchange model information with partners.
+ */
+class CommunicationAlgorithm
+  : public Cloneable<HasAbstractFunction<CommunicationAlgorithm>>
+{
+public:
+  /** @brief Default constructor.
+   *
+   *  All weights within a model are exchanged.
+   */
+  CommunicationAlgorithm() = default;
+
+  /** @brief Construct with names of weights
+   *  @param[in] weights_names Names of weights to exchange. If empty,
+   *                           then all weights are exchanged.
+   */
+  CommunicationAlgorithm(std::set<std::string> const& weights_names)
+    : weights_names_{weights_names}
+  {}
+
+  /** @brief Construct with names of weights
+   *  @param[in] weights_names Names of weights to exchange. If empty,
+   *                           then all weights are exchanged.
+   */
+  CommunicationAlgorithm(std::set<std::string>&& weights_names)
+    : weights_names_{std::move(weights_names)}
+  {}
+
+  virtual ~CommunicationAlgorithm() noexcept = default;
+
+  /** @brief Exchange data in model with a partner.
+   *
+   *  @param[in,out] m Model to send to partner trainer. On output it
+   *                   will be overwritten with model recieved from
+   *                   partner trainer.
+   *  @param[in] partner_trainer Index of the partner trainer with
+   *                             which to exchange models.
+   *  @param[in] step The step ID at which the exchange occurs.
+   */
+  virtual void exchange_models(model& m,
+                               El::Int partner_trainer,
+                               El::Int step) const = 0;
+protected:
+  CommunicationAlgorithm(CommunicationAlgorithm const&) = default;
+  CommunicationAlgorithm(CommunicationAlgorithm&&) = default;
+  /** @name Data access and query */
+  ///@{
+  auto weights_names() const noexcept
+    -> std::set<std::string> const&
+  { return weights_names_; }
+  bool has_weights_names() const noexcept { return !weights_names_.empty(); }
+  ///@}
+private:
+  std::set<std::string> weights_names_;
+};// class CommunicationAlgorithm
+
 namespace {
+
+/** @brief Inter-trainer communication scheme for LTFB.
+ *
+ *  The specifics of these algorithms are experimental and will be
+ *  in flux.
+ */
+enum class comm_algorithm {
+  /** @brief Directly exchange weights values with sendrecv.
+   *
+   *  Corresponding ranks in partner trainers will iterate through
+   *  their weights and exchange values with sendrecvs.
+   *
+   *  Notes:
+   *    - Requires all models to be identical aside from their
+   *      weights values, so this is not suitable for hyperparameter
+   *      or model architecture exploration.
+   *    - Optimizer state is not exchanged, so there may be wonky
+   *      learning behavior immediately after a tournament.
+   *    - Optimal if communication performance between ranks is
+   *      uniform and independent. If intra-trainer communication is
+   *      fast or if communication performance is sensitive to
+   *      network traffic, it may be advantageous to gather model
+   *      data on the trainer master ranks and only perform
+   *      inter-trainer communication between them.
+   */
+  sendrecv_weights,
+
+  /** @brief Save and load model data with checkpoint files.
+   *
+   *  Notes:
+   *    - Supports hyperparameter exploration.
+   *    - This approach is temporary and experimental, since going
+   *      through the file system is very suboptimal. When a wire
+   *      format for model checkpoints is developed, it should be
+   *      used instead.
+   */
+  checkpoint_file,
+
+  /** @brief Transfer model on the wire.
+   *
+   *  The entire model is saved, as though doing a
+   *  checkpoint. Instead of writing to disk, a binary stream is
+   *  used. After gathering the binary stream, it is
+   *  exchanged. There is an implicit assumption that the
+   *  participating processes are binary-compatible (e.g., for
+   *  issues like endianness).
+   */
+  checkpoint_binary,
+};// enum comm_algorithm
+comm_algorithm string_to_comm_algo(const std::string& str)
+{
+  if (str.empty() || str == "sendrecv_weights") {
+    return comm_algorithm::sendrecv_weights;
+  }
+  else if (str == "checkpoint_file") {
+    return comm_algorithm::checkpoint_file;
+  }
+  else if (str == "checkpoint_binary") {
+    return comm_algorithm::checkpoint_binary;
+  }
+  // Invalid LTFB communication algorithm
+  LBANN_ERROR("invalid LTFB communication algorithm (",str,")");
+  return comm_algorithm::sendrecv_weights;
+}
 
 /** @brief Generate partner trainer assignments.
  *
@@ -51,266 +180,386 @@ namespace {
  *  odd number of trainers, one of them is partnered with itself.
  */
 El::Int get_partner_trainer(lbann_comm& comm,
-                            const std::string& message_prefix) {
-    // Assign partner trainers
-    // Note: The first trainer in 'trainers' is paired with the
-    // second, the third with the fourth, and so on. If there are an
-    // odd number of trainers, the last one is partnered with itself.
-    const El::Int num_trainers = comm.get_num_trainers();
-    std::vector<El::Int> trainers(num_trainers);
-    std::iota(trainers.begin(), trainers.end(), 0);
-    // Everyone use a special RNG that is only for LTFB so that they
-    // can all communicate the same pairs without communication
-    std::shuffle(trainers.begin(), trainers.end(), get_ltfb_generator());
+                            const std::string& message_prefix)
+{
+  // Assign partner trainers
+  // Note: The first trainer in 'trainers' is paired with the
+  // second, the third with the fourth, and so on. If there are an
+  // odd number of trainers, the last one is partnered with itself.
+  const El::Int num_trainers = comm.get_num_trainers();
+  std::vector<El::Int> trainers(num_trainers);
+  std::iota(trainers.begin(), trainers.end(), 0);
+  // Everyone use a special RNG that is only for LTFB so that they
+  // can all communicate the same pairs without communication
+  std::shuffle(trainers.begin(), trainers.end(), get_ltfb_generator());
 
-    if (comm.am_world_master()) { // Root process
-      // Print partner assignments to standard output
-      std::stringstream msg;
-      msg << message_prefix << "tournament partners -";
-      for (El::Int i = 0; i < num_trainers; i += 2) {
-        msg << (i > 0 ? "," : "")
-            << " {" << trainers[i];
-        if (i+1 < num_trainers) {
-          msg << "," << trainers[i+1];
-        }
-        msg << "}";
-      }
-      msg << "\n";
-      std::cout << msg.str() << std::endl << std::flush;
-    }
-
-    // Setup partner assignments for all processes
-    std::vector<El::Int> send_buffer(num_trainers);
+  if (comm.am_world_master()) { // Root process
+    // Print partner assignments to standard output
+    std::stringstream msg;
+    msg << message_prefix << "tournament partners -";
     for (El::Int i = 0; i < num_trainers; i += 2) {
-      const auto& trainer1 = trainers[i];
-      const auto& trainer2 = (i+1 < num_trainers) ? trainers[i+1] : trainer1;
-      send_buffer[trainer1] = trainer2;
-      send_buffer[trainer2] = trainer1;
+      msg << (i > 0 ? "," : "")
+          << " {" << trainers[i];
+      if (i+1 < num_trainers) {
+        msg << "," << trainers[i+1];
+      }
+      msg << "}";
     }
-    return send_buffer[comm.get_trainer_rank()];
+    msg << "\n";
+    std::cout << msg.str() << std::endl << std::flush;
+  }
+
+  // Setup partner assignments for all processes
+  std::vector<El::Int> send_buffer(num_trainers);
+  for (El::Int i = 0; i < num_trainers; i += 2) {
+    const auto& trainer1 = trainers[i];
+    const auto& trainer2 = (i+1 < num_trainers) ? trainers[i+1] : trainer1;
+    send_buffer[trainer1] = trainer2;
+    send_buffer[trainer2] = trainer1;
+  }
+  return send_buffer[comm.get_trainer_rank()];
 }
 
-/// See @c lbann::callbacks::ltfb::communication_algorithm::sendrecv_weights
-namespace sendrecv_weights {
-
-/** @param weights_names    Names of weights to exchange. If empty,
- *                          then all weights are exchanged.
- *  @param exchange_hyperparameters Exchange optimizer
- *                                  hyperparameters.
- *  @param m                Model to send to partner trainer. On
- *                          output it will be overwritten with model
- *                          recieved from partner trainer.
- *
+/** @class SendRecvWeights
+ *  @brief Exchange model weights directly using sendrecvs.
  *  @todo More general approach to exchange optimizer state. Currently
  *  only SGD and Adam are supported.
  */
-void exchange_models(lbann_comm& comm,
-                     El::Int partner_trainer,
-                     const std::set<std::string>& weights_names,
-                     bool exchange_hyperparameters,
-                     model& m) {
+class SendRecvWeights final
+  : public Cloneable<SendRecvWeights, CommunicationAlgorithm>
+{
+  using BaseType = Cloneable<SendRecvWeights, CommunicationAlgorithm>;
+public:
+  /** @brief Construct from weights names
+   *  @param[in] weights_names Names of weights to exchange. If empty,
+   *                           then all weights are exchanged.
+   *  @param[in] exchange_hyperparameters Exchange optimizer
+   *                                      hyperparameters.
+   */
+  SendRecvWeights(std::set<std::string> const& weights_names,
+                  bool exchange_hyperparameters)
+    : BaseType(weights_names),
+      exchange_hyperparams_{exchange_hyperparameters}
+  {}
 
-  // Get partner process
-  const El::Int rank_in_trainer = comm.get_rank_in_trainer();
-  const El::Int procs_per_trainer = comm.get_procs_per_trainer();
-  const El::Int partner_rank_in_world = (partner_trainer * procs_per_trainer
-                                         + rank_in_trainer);
+  /** @brief Construct from weights names
+   *  @param[in] weights_names Names of weights to exchange. If empty,
+   *                           then all weights are exchanged.
+   *  @param[in] exchange_hyperparameters Exchange optimizer
+   *                                      hyperparameters.
+   */
+  SendRecvWeights(std::set<std::string>&& weights_names,
+                  bool exchange_hyperparameters)
+    : BaseType(std::move(weights_names)),
+      exchange_hyperparams_{exchange_hyperparameters}
+  {}
 
-  // Exchange weights with partner
-  for (auto&& w_ptr : m.get_weights()) {
+  SendRecvWeights(SendRecvWeights const&) = default;
+  SendRecvWeights(SendRecvWeights&&) = default;
 
-    // Skip weights if name isn't in list
-    if (!weights_names.empty()
-        && (std::find(
-              weights_names.begin(),
-              weights_names.end(),
-              w_ptr->get_name())
-            == weights_names.end())) {
-      continue;
-    }
+  /** @todo This function is way too long. */
+  void exchange_models(model& m,
+                       El::Int partner_trainer,
+                       El::Int /*step*/) const final
+  {
+    auto&& comm = *m.get_comm();
 
-    // Exchange weights values
-    using TensorDataType = DataType;
-    using WeightsType = data_type_weights<TensorDataType>;
-    auto& recv_weights = dynamic_cast<WeightsType&>(*w_ptr);
-    auto send_weights = recv_weights;
-    El::SendRecv(
-      send_weights.get_values().LockedMatrix(),
-      recv_weights.get_values().Matrix(),
-      comm.get_world_comm(),
-      partner_rank_in_world,
-      partner_rank_in_world);
+    // Get partner process
+    const El::Int rank_in_trainer = comm.get_rank_in_trainer();
+    const El::Int procs_per_trainer = comm.get_procs_per_trainer();
+    const El::Int partner_rank_in_world =
+      (partner_trainer * procs_per_trainer + rank_in_trainer);
 
-    // Exchange SGD optimizer state
-    using SGDType = sgd<TensorDataType>;
-    auto* send_sgd = dynamic_cast<SGDType*>(send_weights.get_optimizer());
-    auto* recv_sgd = dynamic_cast<SGDType*>(recv_weights.get_optimizer());
-    if (send_sgd != nullptr && recv_sgd != nullptr) {
-      if (exchange_hyperparameters) {
-        using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, bool>;
-        hyperparameters_type hyperparameters(
-          send_sgd->get_learning_rate(),
-          send_sgd->get_momentum(),
-          send_sgd->using_nesterov());
-        El::mpi::SendRecv(
-          reinterpret_cast<El::byte*>(&hyperparameters),
-          sizeof(hyperparameters_type),
-          partner_rank_in_world,
-          partner_rank_in_world,
-          comm.get_world_comm(),
-          El::SyncInfo<El::Device::CPU>{});
-        recv_sgd->set_learning_rate(std::get<0>(hyperparameters));
-        recv_sgd->set_momentum(std::get<1>(hyperparameters));
-        recv_sgd->set_nesterov(std::get<2>(hyperparameters));
+    // Exchange weights with partner
+    for (auto&& w_ptr : m.get_weights()) {
+
+      // Skip weights if name isn't in list
+      auto const& weights_names = this->weights_names();
+      if (this->has_weights_names()
+          && (weights_names.find(w_ptr->get_name()) == weights_names.cend()))
+      {
+        continue;
       }
+
+      // Exchange weights values
+      using TensorDataType = DataType;
+      using WeightsType = data_type_weights<TensorDataType>;
+      auto& recv_weights = dynamic_cast<WeightsType&>(*w_ptr);
+      auto send_weights = recv_weights;
       El::SendRecv(
-        send_sgd->get_velocity().LockedMatrix(),
-        recv_sgd->get_velocity().Matrix(),
+        send_weights.get_values().LockedMatrix(),
+        recv_weights.get_values().Matrix(),
         comm.get_world_comm(),
         partner_rank_in_world,
         partner_rank_in_world);
-    }
 
-    // Exchange Adam optimizer state
-    using AdamType = adam<TensorDataType>;
-    auto* send_adam = dynamic_cast<AdamType*>(send_weights.get_optimizer());
-    auto* recv_adam = dynamic_cast<AdamType*>(recv_weights.get_optimizer());
-    if (send_adam != nullptr && recv_adam != nullptr) {
-      if (exchange_hyperparameters) {
-        using hyperparameters_type = std::tuple<TensorDataType, TensorDataType, TensorDataType,
-                                                TensorDataType, TensorDataType, TensorDataType>;
-        hyperparameters_type hyperparameters(
-          send_adam->get_learning_rate(),
-          send_adam->get_beta1(),
-          send_adam->get_beta2(),
-          send_adam->get_eps(),
-          send_adam->get_current_beta1(),
-          send_adam->get_current_beta2());
-        El::mpi::SendRecv(
-          reinterpret_cast<El::byte*>(&hyperparameters),
-          sizeof(hyperparameters_type),
-          partner_rank_in_world,
-          partner_rank_in_world,
+      // Exchange SGD optimizer state
+      using SGDType = sgd<TensorDataType>;
+      auto* send_sgd = dynamic_cast<SGDType*>(send_weights.get_optimizer());
+      auto* recv_sgd = dynamic_cast<SGDType*>(recv_weights.get_optimizer());
+      if (send_sgd != nullptr && recv_sgd != nullptr) {
+        if (exchange_hyperparams_) {
+          using hyperparameters_type = std::tuple<TensorDataType,
+                                                  TensorDataType,
+                                                  bool>;
+          hyperparameters_type hyperparameters(
+            send_sgd->get_learning_rate(),
+            send_sgd->get_momentum(),
+            send_sgd->using_nesterov());
+          El::mpi::SendRecv(
+            reinterpret_cast<El::byte*>(&hyperparameters),
+            sizeof(hyperparameters_type),
+            partner_rank_in_world,
+            partner_rank_in_world,
+            comm.get_world_comm(),
+            El::SyncInfo<El::Device::CPU>{});
+          recv_sgd->set_learning_rate(std::get<0>(hyperparameters));
+          recv_sgd->set_momentum(std::get<1>(hyperparameters));
+          recv_sgd->set_nesterov(std::get<2>(hyperparameters));
+        }
+        El::SendRecv(
+          send_sgd->get_velocity().LockedMatrix(),
+          recv_sgd->get_velocity().Matrix(),
           comm.get_world_comm(),
-          El::SyncInfo<El::Device::CPU>{});
-        recv_adam->set_learning_rate(std::get<0>(hyperparameters));
-        recv_adam->set_beta1(std::get<1>(hyperparameters));
-        recv_adam->set_beta2(std::get<2>(hyperparameters));
-        recv_adam->set_eps(std::get<3>(hyperparameters));
-        recv_adam->set_current_beta1(std::get<4>(hyperparameters));
-        recv_adam->set_current_beta2(std::get<5>(hyperparameters));
+          partner_rank_in_world,
+          partner_rank_in_world);
       }
-      El::SendRecv(
-        send_adam->get_moment1().LockedMatrix(),
-        recv_adam->get_moment1().Matrix(),
-        comm.get_world_comm(),
-        partner_rank_in_world,
-        partner_rank_in_world);
-      El::SendRecv(
-        send_adam->get_moment2().LockedMatrix(),
-        recv_adam->get_moment2().Matrix(),
-        comm.get_world_comm(),
-        partner_rank_in_world,
-        partner_rank_in_world);
-    }
 
+      // Exchange Adam optimizer state
+      using AdamType = adam<TensorDataType>;
+      auto* send_adam = dynamic_cast<AdamType*>(send_weights.get_optimizer());
+      auto* recv_adam = dynamic_cast<AdamType*>(recv_weights.get_optimizer());
+      if (send_adam != nullptr && recv_adam != nullptr) {
+        if (exchange_hyperparams_) {
+          using hyperparameters_type =
+            std::tuple<TensorDataType, TensorDataType, TensorDataType,
+                       TensorDataType, TensorDataType, TensorDataType>;
+          hyperparameters_type hyperparameters(
+            send_adam->get_learning_rate(),
+            send_adam->get_beta1(),
+            send_adam->get_beta2(),
+            send_adam->get_eps(),
+            send_adam->get_current_beta1(),
+            send_adam->get_current_beta2());
+          El::mpi::SendRecv(
+            reinterpret_cast<El::byte*>(&hyperparameters),
+            sizeof(hyperparameters_type),
+            partner_rank_in_world,
+            partner_rank_in_world,
+            comm.get_world_comm(),
+            El::SyncInfo<El::Device::CPU>{});
+          recv_adam->set_learning_rate(std::get<0>(hyperparameters));
+          recv_adam->set_beta1(std::get<1>(hyperparameters));
+          recv_adam->set_beta2(std::get<2>(hyperparameters));
+          recv_adam->set_eps(std::get<3>(hyperparameters));
+          recv_adam->set_current_beta1(std::get<4>(hyperparameters));
+          recv_adam->set_current_beta2(std::get<5>(hyperparameters));
+        }
+        El::SendRecv(
+          send_adam->get_moment1().LockedMatrix(),
+          recv_adam->get_moment1().Matrix(),
+          comm.get_world_comm(),
+          partner_rank_in_world,
+          partner_rank_in_world);
+        El::SendRecv(
+          send_adam->get_moment2().LockedMatrix(),
+          recv_adam->get_moment2().Matrix(),
+          comm.get_world_comm(),
+          partner_rank_in_world,
+          partner_rank_in_world);
+      }
+    }
   }
-
-}
-
-} // namespace sendrecv_weights
+private:
+  bool exchange_hyperparams_;
+};// class SendRecvWeights
 
 /// See @c lbann::callbacks::ltfb::communication_algorithm::checkpoint_file
-namespace checkpoint_file {
+class CheckpointFile final
+  : public Cloneable<CheckpointFile, CommunicationAlgorithm>
+{
+  using BaseType = Cloneable<CheckpointFile, CommunicationAlgorithm>;
+public:
 
-/** @param weights_names    Names of weights to exchange. If empty,
- *                          then all weights are exchanged.
- *  @param m                Model to send to partner trainer. On
- *                          output it will be overwritten with model
- *                          recieved from partner trainer.
- */
-void exchange_models(lbann_comm& comm,
-                     El::Int partner_trainer,
-                     const std::set<std::string>& weights_names,
-                     const std::string& ckpt_basedir,
-                     El::Int step,
-                     model& m) {
+  CheckpointFile(std::set<std::string> const& weights_names,
+                 std::string const& ckpt_basedir)
+    : BaseType(weights_names),
+      ckpt_basedir_{ckpt_basedir}
+  {}
 
-  // Keep track of weights that shouldn't be exchanged
-  std::unordered_map<std::string, std::unique_ptr<weights>> restore_weights;
-  if (!weights_names.empty()) {
-    for (auto w : m.get_weights()) {
-      if (std::find(weights_names.begin(), weights_names.end(), w->get_name())
-          == weights_names.end()) {
-        using TensorDataType = DataType;
-        using WeightsType = data_type_weights<TensorDataType>;
-        restore_weights[w->get_name()]
-          = make_unique<WeightsType>(dynamic_cast<WeightsType&>(*w));
+  CheckpointFile(std::set<std::string>&& weights_names,
+                 std::string const& ckpt_basedir)
+    : BaseType(std::move(weights_names)),
+      ckpt_basedir_{ckpt_basedir}
+  {}
+
+  void exchange_models(model& m,
+                       El::Int partner_trainer,
+                       El::Int step) const final
+  {
+    auto&& comm = *m.get_comm();
+    // Keep track of weights that shouldn't be exchanged
+    std::unordered_map<std::string, std::unique_ptr<weights>> restore_weights;
+    if (this->has_weights_names()) {
+      auto const& weights_names = this->weights_names();
+      for (auto w : m.get_weights()) {
+        if (weights_names.find(w->get_name()) == weights_names.cend())
+        {
+          using TensorDataType = DataType;
+          using WeightsType = data_type_weights<TensorDataType>;
+          restore_weights[w->get_name()]
+            = make_unique<WeightsType>(dynamic_cast<WeightsType&>(*w));
+        }
       }
     }
-  }
 
-  // Checkpoint directories
-  const auto basedir = (ckpt_basedir.empty()
-                        ? std::string("")
-                        : add_delimiter(ckpt_basedir));
-  const auto local_trainer = comm.get_trainer_rank();
-  const std::string send_dir = (basedir
-                                + m.get_name()
-                                + "_trainer" + std::to_string(local_trainer)
-                                + "_step" + std::to_string(step));
-  const std::string recv_dir = (basedir
-                                + m.get_name()
-                                + "_trainer" + std::to_string(partner_trainer)
-                                + "_step" + std::to_string(step));
+    // Checkpoint directories
+    const auto basedir = (ckpt_basedir_.empty()
+                          ? std::string("")
+                          : add_delimiter(ckpt_basedir_));
+    const auto local_trainer = comm.get_trainer_rank();
+    const std::string send_dir = (basedir
+                                  + m.get_name()
+                                  + "_trainer" + std::to_string(local_trainer)
+                                  + "_step" + std::to_string(step));
+    const std::string recv_dir = (basedir
+                                  + m.get_name()
+                                  + "_trainer" + std::to_string(partner_trainer)
+                                  + "_step" + std::to_string(step));
 
-  // Save model checkpoint
-  {
-    persist p;
-    p.set_cb_type(callback_type::model_only);
-    p.open_checkpoint(send_dir, comm.am_trainer_master());
+    // Save model checkpoint
+    {
+      persist p;
+      p.set_cb_type(callback_type::model_only);
+      p.open_checkpoint(send_dir, comm.am_trainer_master());
+      comm.trainer_barrier();
+      m.save_to_checkpoint_shared(p);
+      p.close_checkpoint();
+    }
+
+    // Synchronize with partner trainer
     comm.trainer_barrier();
-    m.save_to_checkpoint_shared(p);
-    p.close_checkpoint();
-  }
+    if (comm.am_trainer_master()) {
+      int send{0}, recv{0};
+      comm.sendrecv(&send, 1, partner_trainer, 0,
+                    &recv, 1, partner_trainer, 0,
+                    El::SyncInfo<El::Device::CPU>{});
+    }
+    comm.trainer_barrier();
 
-  // Synchronize with partner trainer
-  comm.trainer_barrier();
-  if (comm.am_trainer_master()) {
-    int send{0}, recv{0};
-    comm.sendrecv(&send, 1, partner_trainer, 0,
-                  &recv, 1, partner_trainer, 0,
-                  El::SyncInfo<El::Device::CPU>{});
-  }
-  comm.trainer_barrier();
+    // Load model checkpoint from partner trainer
+    {
+      persist p;
+      p.set_cb_type(callback_type::model_only);
+      p.open_restart(recv_dir);
+      m.load_from_checkpoint_shared(p);
+      p.close_restart();
+    }
 
-  // Load model checkpoint from partner trainer
-  {
-    persist p;
-    p.set_cb_type(callback_type::model_only);
-    p.open_restart(recv_dir);
-    m.load_from_checkpoint_shared(p);
-    p.close_restart();
-  }
-
-  // Restore weights that shouldn't be exchanged
-  if (!restore_weights.empty()) {
-    for (auto w : m.get_weights()) {
-      if (restore_weights.count(w->get_name()) > 0) {
-        using TensorDataType = DataType;
-        using WeightsType = data_type_weights<TensorDataType>;
-        dynamic_cast<WeightsType&>(*w)
-          = dynamic_cast<WeightsType&>(*restore_weights[w->get_name()]);
+    // Restore weights that shouldn't be exchanged
+    if (!restore_weights.empty()) {
+      for (auto w : m.get_weights()) {
+        if (restore_weights.count(w->get_name()) > 0) {
+          using TensorDataType = DataType;
+          using WeightsType = data_type_weights<TensorDataType>;
+          dynamic_cast<WeightsType&>(*w)
+            = dynamic_cast<WeightsType&>(*restore_weights[w->get_name()]);
+        }
       }
     }
   }
+private:
+  std::string ckpt_basedir_;
+};// class CheckpointFile
 
-}
+class CheckpointBlob final
+  : public Cloneable<CheckpointBlob, CommunicationAlgorithm>
+{
+  using BaseType = Cloneable<CheckpointBlob, CommunicationAlgorithm>;
+public:
+  CheckpointBlob(std::set<std::string> const& weights_names)
+    : BaseType(weights_names)
+  {}
+  CheckpointBlob(std::set<std::string>&& weights_names)
+    : BaseType(std::move(weights_names))
+  {}
+  void exchange_models(model& m,
+                       El::Int partner_trainer,
+                       El::Int /*step*/) const final
+  {
+    auto&& comm = *m.get_comm();
+    // Keep track of weights that shouldn't be exchanged
+    std::unordered_map<std::string, std::unique_ptr<weights>> restore_weights;
+    if (this->has_weights_names()) {
+      auto const& weights_names = this->weights_names();
+      for (auto w : m.get_weights()) {
+        if (weights_names.find(w->get_name()) == weights_names.cend())
+        {
+          using TensorDataType = DataType;
+          using WeightsType = data_type_weights<TensorDataType>;
+          restore_weights[w->get_name()]
+            = make_unique<WeightsType>(dynamic_cast<WeightsType&>(*w));
+        }
+      }
+    }
 
-} // namespace checkpoint_file
+    // Save model checkpoint
+    std::ostringstream oss;
+    {
+      RootedBinaryOutputArchive ar(oss, comm.get_trainer_grid());
+      comm.trainer_barrier();
+      ar(m);
+    }
+
+    // sure, why not
+    comm.trainer_barrier();
+
+    // Synchronize with partner trainer
+    std::string save_model_ckpt = oss.str(), load_model_ckpt;
+    if (comm.am_trainer_master())
+    {
+      std::size_t save_size=save_model_ckpt.size(), load_size=0;
+      comm.sendrecv(&save_size, 1, partner_trainer, 0,
+                    &load_size, 1, partner_trainer, 0,
+                    El::SyncInfo<El::Device::CPU>{});
+      load_model_ckpt.resize(load_size);
+      comm.sendrecv(
+        reinterpret_cast<El::byte const*>(save_model_ckpt.data()),
+        save_size*sizeof(typename std::string::value_type)/sizeof(El::byte),
+        partner_trainer, 0,
+        reinterpret_cast<El::byte*>(load_model_ckpt.data()),
+        load_size*sizeof(typename std::string::value_type)/sizeof(El::byte),
+        partner_trainer, 0,
+        El::SyncInfo<El::Device::CPU>{});
+    }
+
+    // sure, why not
+    comm.trainer_barrier();
+
+    // Load model checkpoint from partner trainer
+    {
+      std::istringstream iss{std::move(load_model_ckpt)};
+      RootedBinaryInputArchive ar(iss, comm.get_trainer_grid());
+      ar(m);
+    }
+
+    // Restore weights that shouldn't be exchanged
+    if (!restore_weights.empty()) {
+      for (auto w : m.get_weights()) {
+        if (restore_weights.count(w->get_name()) > 0) {
+          using TensorDataType = DataType;
+          using WeightsType = data_type_weights<TensorDataType>;
+          dynamic_cast<WeightsType&>(*w)
+            = dynamic_cast<WeightsType&>(*restore_weights[w->get_name()]);
+        }
+      }
+    }
+  }
+};// class CheckpointBlob
 
 /** Get mean metric value with validation set. */
-EvalType evaluate(model& m, const std::string& metric_name) {
+EvalType evaluate(model& m, const std::string& metric_name)
+{
   auto& c = m.get_execution_context();
   // Make sure data readers finish asynchronous work
   const auto original_mode = c.get_execution_mode();
@@ -347,48 +596,38 @@ EvalType evaluate(model& m, const std::string& metric_name) {
   m.reset_mode(c, original_mode);
   c.get_trainer().get_data_coordinator().reset_mode(c);
   return metric_value;
-
 }
 
 } // namespace <anon>
 
 ltfb::ltfb(El::Int batch_interval,
            std::string metric_name,
-           std::set<std::string> weights_names,
-           bool low_score_wins,
-           communication_algorithm comm_algo,
-           const std::string& ckpt_basedir,
-           bool exchange_hyperparameters)
+           std::unique_ptr<CommunicationAlgorithm> algo,
+           bool low_score_wins)
   : callback_base(batch_interval),
-    m_metric_name(std::move(metric_name)),
-    m_weights_names(std::move(weights_names)),
-    m_low_score_wins(low_score_wins),
-    m_comm_algo(comm_algo),
-    m_ckpt_basedir(ckpt_basedir),
-    m_exchange_hyperparameters(exchange_hyperparameters) {}
+    m_metric_name{std::move(metric_name)},
+    comm_algo_{std::move(algo)},
+    m_low_score_wins{low_score_wins}
+{}
 
 ltfb::ltfb(const ltfb& other) :
   callback_base(other),
   m_metric_name(other.m_metric_name),
-  m_weights_names(other.m_weights_names),
-  m_low_score_wins(other.m_low_score_wins),
-  m_comm_algo(other.m_comm_algo),
-  m_ckpt_basedir(other.m_ckpt_basedir),
-  m_exchange_hyperparameters(other.m_exchange_hyperparameters)
+  comm_algo_(other.comm_algo_->clone()),
+  m_low_score_wins(other.m_low_score_wins)
 {}
 
-ltfb& ltfb::operator=(const ltfb& other) {
+ltfb& ltfb::operator=(const ltfb& other)
+{
   callback_base::operator=(other);
   m_metric_name = other.m_metric_name;
-  m_weights_names = other.m_weights_names;
+  comm_algo_ = other.comm_algo_->clone();
   m_low_score_wins = other.m_low_score_wins;
-  m_comm_algo = other.m_comm_algo;
-  m_ckpt_basedir = other.m_ckpt_basedir;
-  m_exchange_hyperparameters = other.m_exchange_hyperparameters;
   return *this;
 }
 
-void ltfb::on_train_begin(model *m) {
+void ltfb::on_train_begin(model *m)
+{
   auto&& comm = *m->get_comm();
 
   if (comm.am_world_master()) {
@@ -403,7 +642,8 @@ void ltfb::on_train_begin(model *m) {
   }
 }
 
-void ltfb::on_batch_begin(model* m) {
+void ltfb::on_batch_begin(model* m)
+{
   auto& local_model = *m;
   auto& context = local_model.get_execution_context();
   auto&& comm = *local_model.get_comm();
@@ -438,27 +678,10 @@ void ltfb::on_batch_begin(model* m) {
   }
   using ModelType = directed_acyclic_graph_model;
   ModelType partner_model(dynamic_cast<ModelType&>(local_model));
-  switch (m_comm_algo) {
-  case communication_algorithm::sendrecv_weights:
-    sendrecv_weights::exchange_models(
-      comm,
-      partner_trainer,
-      m_weights_names,
-      m_exchange_hyperparameters,
-      partner_model);
-    break;
-  case communication_algorithm::checkpoint_file:
-    checkpoint_file::exchange_models(
-      comm,
-      partner_trainer,
-      m_weights_names,
-      m_ckpt_basedir,
-      step,
-      partner_model);
-    break;
-  default:
-    LBANN_ERROR("invalid LTFB communication algorithm");
-  }
+  if (comm_algo_)
+    comm_algo_->exchange_models(partner_model, partner_trainer, step);
+  else
+    LBANN_ERROR("No communication algorithm.");
 
   // Evaluate partner model
   if (comm.am_world_master()) {
@@ -490,7 +713,7 @@ void ltfb::on_batch_begin(model* m) {
 
   // Report tournament winner
   if (comm.am_trainer_master()) {
-    std::stringstream msg;
+    std::ostringstream msg;
     msg << message_prefix
         << "trainer " << local_trainer << " "
         << "selected model from trainer " << tournament_winner
@@ -500,30 +723,6 @@ void ltfb::on_batch_begin(model* m) {
         << "= " << partner_score << ")" << "\n";
     std::cout << msg.str() << std::flush;
   }
-
-}
-
-typename ltfb::communication_algorithm
-ltfb::string_to_comm_algo(const std::string& str) {
-  if (str.empty() || str == "sendrecv_weights") {
-    return communication_algorithm::sendrecv_weights;
-  }
-  if (str == "checkpoint_file") {
-    return communication_algorithm::checkpoint_file;
-  }
-
-  // Invalid LTFB communication algorithm
-  LBANN_ERROR("invalid LTFB communication algorithm (",str,")");
-  return communication_algorithm::sendrecv_weights;
-
-}
-
-void ltfb::set_ckpt_basedir(const std::string& dir) {
-  m_ckpt_basedir = dir;
-}
-
-std::string ltfb::get_ckpt_basedir() const {
-  return m_ckpt_basedir;
 }
 
 std::unique_ptr<callback_base>
@@ -532,14 +731,29 @@ build_ltfb_callback_from_pbuf(
   const std::shared_ptr<lbann_summary>&) {
   const auto& params =
     dynamic_cast<const lbann_data::Callback::CallbackLTFB&>(proto_msg);
+  auto weights_list = parse_set<std::string>(params.weights());
+  std::unique_ptr<CommunicationAlgorithm> algo;
+  switch (string_to_comm_algo(params.communication_algorithm()))
+  {
+  case comm_algorithm::sendrecv_weights:
+    algo = make_unique<SendRecvWeights>(
+      std::move(weights_list),
+      params.exchange_hyperparameters());
+    break;
+  case comm_algorithm::checkpoint_file:
+    algo = make_unique<CheckpointFile>(
+      std::move(weights_list),
+      params.checkpoint_basedir());
+    break;
+  case comm_algorithm::checkpoint_binary:
+    algo = make_unique<CheckpointBlob>(std::move(weights_list));
+    break;
+  }
   return make_unique<ltfb>(
     params.batch_interval(),
     params.metric(),
-    parse_set<std::string>(params.weights()),
-    params.low_score_wins(),
-    ltfb::string_to_comm_algo(params.communication_algorithm()),
-    params.checkpoint_basedir(),
-    params.exchange_hyperparameters());
+    std::move(algo),
+    params.low_score_wins());
 }
 
 } // namespace callback


### PR DESCRIPTION
1. Adds a new "checkpoint_binary" approach to LTFB model exchange.
2. Refactor the LTFB implementation into a strategy-based approach. The strategies are private for now.

~~The tests still pass for `checkpoint_file`; however, I'm still debugging some setup issues for the `checkpoint_binary` approach.~~ The LTFB tests appear to pass. I have updated `test_unit_callback_ltfb.py` to use `checkpoint_binary` instead of `checkpoint_file`.

~~Bamboo is running now.~~ Bamboo failures match `develop`.


