### PR TITLE
Fix bug in cuDNN filter desc wrapper copy constructor

### DIFF
--- a/bamboo/unit_tests/test_unit_callback_ltfb.py
+++ b/bamboo/unit_tests/test_unit_callback_ltfb.py
@@ -113,6 +113,8 @@ def construct_data_reader(lbann):
 
     """
 
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
     message = lbann.reader_pb2.DataReader()
     message.reader.extend([
         tools.create_python_data_reader(
@@ -191,7 +193,8 @@ def augment_test_func(test_func):
                         continue
                     ltfb_partners = [[] for _ in range(num_trainers)]
                     ltfb_winners = [[] for _ in range(num_trainers)]
-                    metric_values = [[] for _ in range(num_trainers)]
+                    tournament_metrics = [[] for _ in range(num_trainers)]
+                    validation_metrics = [[] for _ in range(num_trainers)]
 
                 # LTFB tournament winners
                 match = re.search(
@@ -213,7 +216,7 @@ def augment_test_func(test_func):
                     line)
                 if match:
                     trainer = int(match.group(1))
-                    metric_values[trainer].append(float(match.group(2)))
+                    tournament_metrics[trainer].append(float(match.group(2)))
 
                 # Metric value on validation set
                 match = re.search(
@@ -222,7 +225,7 @@ def augment_test_func(test_func):
                     line)
                 if match:
                     trainer = int(match.group(1))
-                    metric_values[trainer].append(float(match.group(2)))
+                    validation_metrics[trainer].append(float(match.group(2)))
 
         # Make sure file has been parsed correctly
         assert num_trainers, \
@@ -237,18 +240,23 @@ def augment_test_func(test_func):
                 f'Error parsing {log_file} ' \
                 f'(expected {_num_epochs-1} LTFB rounds, ' \
                 f'but found {len(winners)} for trainer {trainer})'
-        for trainer, vals in enumerate(metric_values):
-            assert len(vals) == _num_epochs+2*(_num_epochs-1), \
+        for trainer, vals in enumerate(validation_metrics):
+            assert len(vals) == _num_epochs, \
                 f'Error parsing {log_file} ' \
-                f'(expected {_num_epochs+2*(_num_epochs-1)} validation metric values, ' \
+                f'(expected {_num_epochs} validation metric values, ' \
+                f'but found {len(val)} for trainer {trainer})'
+        for trainer, vals in enumerate(tournament_metrics):
+            assert len(vals) == 2*(_num_epochs-1), \
+                f'Error parsing {log_file} ' \
+                f'(expected {_num_epochs} validation metric values, ' \
                 f'but found {len(val)} for trainer {trainer})'
 
         # Make sure metric values match expected values
         # Note: An LTFB round occurs once per training epoch
         # (excluding the first epoch). Each LTFB round involves two
-        # evaluations on the validation set: once on the local model
+        # evaluations on the tournament set: once on the local model
         # and once on a model from a partner trainer. At the end of
-        # each training epoch, we perform another evalutation on the
+        # each training epoch, we perform an evalutation on the
         # validation set. By inspecting the metric values
         # (corresponding to the model weight), we can make sure that
         # LTFB is evaluating on the correct models.
@@ -257,12 +265,12 @@ def augment_test_func(test_func):
             for trainer in range(num_trainers):
                 partner = ltfb_partners[trainer][step]
                 winner = ltfb_winners[trainer][step]
-                local_val = metric_values[trainer][3*step+1]
-                partner_val = metric_values[trainer][3*step+2]
-                winner_val = metric_values[trainer][3*step+3]
-                true_local_val = metric_values[trainer][3*step]
-                true_partner_val = metric_values[partner][3*step]
-                true_winner_val = metric_values[winner][3*step]
+                local_val = tournament_metrics[trainer][2*step]
+                partner_val = tournament_metrics[trainer][2*step+1]
+                winner_val = validation_metrics[trainer][step+1]
+                true_local_val = validation_metrics[trainer][step]
+                true_partner_val = validation_metrics[partner][step]
+                true_winner_val = validation_metrics[winner][step]
                 assert true_local_val-tol < local_val < true_local_val+tol, \
                     'Incorrect metric value for LTFB local model'
                 assert true_partner_val-tol < partner_val < true_partner_val+tol, \

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -252,19 +252,20 @@ FilterDescriptor::FilterDescriptor(const FilterDescriptor& other) {
     int num_dims;
     cudnnDataType_t data_type;
     cudnnTensorFormat_t format;
+    std::vector<int> dims(1);
     CHECK_CUDNN(
       cudnnGetFilterNdDescriptor(
         other.desc_,
-        0,          // nbDimsRequested
+        dims.size(),
         &data_type,
         &format,
         &num_dims,
-        nullptr));  // filterDimA
-    std::vector<int> dims(num_dims);
+        dims.data()));
+    dims.resize(num_dims);
     CHECK_CUDNN(
       cudnnGetFilterNdDescriptor(
         other.desc_,
-        num_dims,
+        dims.size(),
         &data_type,
         &format,
         &num_dims,


### PR DESCRIPTION
I've found that [`cuDNNGetFilterNdDescriptor`](https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnGetFilterNdDescriptor) will return `CUDNN_BAD_PARAM` if we pass in `nbDimsRequested=0`. I've modified the copy constructor for `lbann::dnn_lib::cudnn::FilterDescriptor` to handle this. We may want to make a similar change to other cuDNN objects, e.g. `TensorDescriptor`.

This bugfix emerged out a bug @samadejacobs noticed in LTFB, so I've also updated the unit test to handle the recent PR that added a "tournament" execution mode.