### PR TITLE
Update Python frontend to correctly specify procs_per_trainer

### DIFF
--- a/python/lbann/contrib/launcher.py
+++ b/python/lbann/contrib/launcher.py
@@ -81,6 +81,7 @@ def run(
     optimizer,
     lbann_exe=lbann.lbann_exe(),
     lbann_args=[],
+    procs_per_trainer=None,
     overwrite_script=False,
     setup_only=False,
     batch_job=False,
@@ -112,6 +113,8 @@ def run(
                                data_reader=data_reader,
                                optimizer=optimizer)
     lbann_command.append('--prototext={}'.format(prototext_file))
+    if procs_per_trainer is not None:
+        lbann_command.append(f'--procs_per_trainer={procs_per_trainer}')
     script.add_parallel_command(lbann_command)
     script.add_command('status=$?')
 

--- a/python/lbann/core/trainer.py
+++ b/python/lbann/core/trainer.py
@@ -8,13 +8,11 @@ class Trainer:
     def __init__(self,
                  mini_batch_size,
                  name=None,
-                 procs_per_trainer=None,
                  num_parallel_readers=None,
                  random_seed=None,
                  serialize_io=None,
                  callbacks=[]):
         self.name = name
-        self.procs_per_trainer = procs_per_trainer
         self.num_parallel_readers = num_parallel_readers
         self.random_seed = random_seed
         self.serialize_io = serialize_io
@@ -29,8 +27,6 @@ class Trainer:
         trainer = trainer_pb2.Trainer()
         if self.name is not None:
             trainer.name = self.name
-        if self.procs_per_trainer is not None:
-            trainer.procs_per_trainer = self.procs_per_trainer
         if self.num_parallel_readers is not None:
             trainer.num_parallel_readers = self.num_parallel_readers
         if self.random_seed is not None:

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -25,11 +25,13 @@ def run(trainer, model, data_reader, optimizer,
         launcher_args=[],
         lbann_exe=lbann.lbann_exe(),
         lbann_args=[],
+        procs_per_trainer=None,
         environment={},
         overwrite_script=False,
         setup_only=False,
         batch_job=False,
-        experiment_dir=None):
+        experiment_dir=None,
+):
     """Run LBANN.
 
     This is intended to interface with job schedulers on HPC
@@ -63,6 +65,8 @@ def run(trainer, model, data_reader, optimizer,
         lbann_exe (str, optional): LBANN executable.
         lbann_args (str, optional): Command-line arguments to LBANN
             executable.
+        procs_per_trainer (int, optional): Number of processes per
+            LBANN trainer. Default is all processes in one trainer.
         environment (dict of {str: str}, optional): Environment
             variables.
         overwrite_script (bool, optional): Whether to overwrite script
@@ -106,6 +110,9 @@ def run(trainer, model, data_reader, optimizer,
                                data_reader=data_reader,
                                optimizer=optimizer)
     lbann_command.append('--prototext={}'.format(prototext_file))
+    if procs_per_trainer is not None:
+        lbann_command.append(f'--procs_per_trainer={procs_per_trainer}')
+
     script.add_parallel_command(lbann_command)
     script.add_command('status=$?')
 


### PR DESCRIPTION
We've recently moved `procs_per_trainer` out of the trainer and required that it be passed directly into the LBANN driver. This PR updates the Python front-end to reflect this change, mainly by removing the option from the `Trainer` class. For convenience, I've also added a `procs_per_trainer` option to the run scripts.