### PR TITLE
Perform extra synchronization in LTFB with checkpoint communication

### DIFF
--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -475,6 +475,9 @@ public:
       p.close_restart();
     }
 
+    /// @todo Should be unneeded, but we experience hangs without it
+    comm.trainer_barrier();
+
     restore_model_weights(m, restore_weights);
   }
 private:
@@ -576,6 +579,9 @@ public:
       RootedBinaryInputArchive ar(iss, comm.get_trainer_grid());
       ar(m);
     }
+
+    /// @todo Should be unneeded, but we experience hangs without it
+    comm.trainer_barrier();
 
     restore_model_weights(m, restore_weights);
   }


### PR DESCRIPTION
When performing LTFB with checkpoint communication (`checkpoint_file` and `checkpoint_binary`), we've sometimes observed non-deterministic hangs when loading a checkpoint.

<details> <summary> Details on the hang </summary>

I've been running on Lassen with variations on LeNet (different activations and learning rates on each trainer). With the models provided by @samadejacobs, I see problems when running with 2 procs/trainer and 16 or 32 trainers (8 or 16 nodes). Usually, one trainer hangs after a few LTFB rounds (usually the third or fourth), which causes other trainers to hang in subsequent LTFB rounds (eventually all trainers are stuck after ~`log2(num_trainers)` LTFB rounds). The trainer that hangs is non-deterministic and if all trainers survive the first few LTFB rounds, then training seems to run to completion. In the failing trainer, the hang appears to happen in a non-root proc when loading a checkpoint. The non-root proc is stuck in this `MPI_Bcast`: https://github.com/LLNL/lbann/blob/cca6f03dbceac68de236510a8e8569103713c280/include/lbann/utils/serialization/rooted_archive_adaptor.hpp#L334
The root proc has passed this point and is in the middle of the first evaluation mini-batch when it gets stuck. Looking at the non-root proc's stack, it appears to be deserializing a `std::weak_ptr<weights>` or `std::weak_ptr<Layer>` inside the `Layer` class. Maybe it's communicating the size of a layer's `std::vector<std::weak_ptr<weights>>`? Note that this is deferred to the end of deserialization:
https://github.com/LLNL/lbann/blob/42a7c5c2f4d46505aaeb1b6148281b1620b31d25/include/lbann/layers/layer.hpp#L470

I observe that the hang doesn't seem to happen if I disable CUDA with the `--disable_cuda` flag.

</details>

The non-determinism and CUDA-dependence makes me think this is some subtle bug in Spectrum MPI. I've been able to make the bug disappear with some extra synchronization after loading the checkpoint. It's not ideal, but it's not a terrible kludge since intra-trainer barriers should be fast and we already do a lot of intra-trainer communication when loading a checkpoint.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM334-1).