### PR TITLE
Debug node2vec to use double data type

### DIFF
--- a/applications/graph/node2vec/data/offline_walks.py
+++ b/applications/graph/node2vec/data/offline_walks.py
@@ -113,7 +113,7 @@ class SampleIterator:
         self.next_walk_batch_thread = None
 
         # Cache for batched sample generation
-        self.batch = np.zeros((self.batch_size, sample_dims()[0]), dtype=np.float32)
+        self.batch = np.zeros((self.batch_size, sample_dims()[0]), dtype=np.float64)
         self.batch_rows = []
 
         # Negative sampling distribution
@@ -176,7 +176,7 @@ class SampleIterator:
 
         Batch data is output to `out` and valid matrix rows are output
         to `rows`. `out` should be a `np.ndarray` with type
-        `np.float32` and dimensions `batch_size` x `sample_size`.
+        `np.float64` and dimensions `batch_size` x `sample_size`.
         `rows` should be a `list`.
 
         Walk data is read from the walk file in a background thread.

--- a/applications/graph/node2vec/main.py
+++ b/applications/graph/node2vec/main.py
@@ -222,6 +222,12 @@ obj.append(lbann.WeightedSum(negative_loss, scaling_factors='2'))
 metrics.append(lbann.Metric(positive_loss, name='positive loss'))
 metrics.append(lbann.Metric(negative_loss, name='negative loss'))
 
+# Perform computation at double precision
+for l in lbann.traverse_layer_graph(input_):
+    l.datatype = lbann.DataType.DOUBLE
+    for w in l.weights:
+        w.datatype = lbann.DataType.DOUBLE
+
 # ----------------------------------
 # Run LBANN
 # ----------------------------------

--- a/src/layers/activations/log_softmax.cu
+++ b/src/layers/activations/log_softmax.cu
@@ -74,7 +74,7 @@ __global__ void reduce_max_kernel(size_t height,
   for (size_t col = bidy; col < width; col += nblocksy) {
 
     // Find largest value for each thread
-    TensorDataType thread_max_val{-gpu_lib::infinity<DataType>()};
+    TensorDataType thread_max_val{-gpu_lib::infinity<TensorDataType>()};
     for (size_t row = gidx; row < height; row += nthreadsx) {
       const auto& val = values[row+col*values_ldim];
       thread_max_val = gpu_lib::max(thread_max_val, val);

--- a/src/layers/activations/softmax.cu
+++ b/src/layers/activations/softmax.cu
@@ -86,7 +86,7 @@ __global__ void reduce_max_kernel(size_t height,
   for (size_t col = bidy; col < width; col += nblocksy) {
 
     // Find largest value for each thread
-    TensorDataType thread_max_val{-gpu_lib::infinity<DataType>()};
+    TensorDataType thread_max_val{-gpu_lib::infinity<TensorDataType>()};
     for (size_t row = gidx; row < height; row += nthreadsx) {
       const auto& val = values[row+col*values_ldim];
       thread_max_val = gpu_lib::max(thread_max_val, val);


### PR DESCRIPTION
With very large graphs, the 24 bits in the mantissa of `float` is insufficient to represent all vertex indices (2^24= 1.7e7). Switching to `double` gives us a range up to 2^53=9.0e15.

[No new Bamboo errors](https://lc.llnl.gov/bamboo/browse/LBANN-TIM335-1).