### PR TITLE
Fix path to Perl on LLNL x86 systems

### DIFF
--- a/spack_environments/llnl_lc/externals-linux-x86_64.sh
+++ b/spack_environments/llnl_lc/externals-linux-x86_64.sh
@@ -80,7 +80,7 @@ EXTERNAL_PACKAGES=$(cat <<EOF
         - 5.16.3
       externals:
       - spec: perl@5.16.3 arch=${SPACK_ARCH}
-        prefix: /usr/bin
+        prefix: /usr
     python::
       buildable: True
       variants: +shared ~readline ~zlib ~bz2 ~lzma ~pyexpat


### PR DESCRIPTION
I run into build errors on Pascal when I try to build Python with Spack. It looks like the search directory for Perl is different on x86 systems than on Power systems:
https://github.com/LLNL/lbann/blob/dec8dc599e4a9723bafa2d8176ec3a1be58dda4d/spack_environments/llnl_lc/externals-linux-ppc64le.sh#L70
Making x86 match Power fixed the issue for me.