### PR TITLE
Clean up handling of GPU errors

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn.hpp
@@ -38,10 +38,9 @@
   do {                                                          \
     const cudnnStatus_t status_CHECK_CUDNN = (cudnn_call);      \
     if (status_CHECK_CUDNN != CUDNN_STATUS_SUCCESS) {           \
-      cudaDeviceReset();                                        \
-      LBANN_ERROR(std::string("cuDNN error (")                  \
-                  + cudnnGetErrorString(status_CHECK_CUDNN)     \
-                  + std::string(")"));                          \
+      LBANN_ERROR("cuDNN error (",                              \
+                  cudnnGetErrorString(status_CHECK_CUDNN),      \
+                  ")");                                         \
     }                                                           \
   } while (0)
 #define CHECK_CUDNN_DEBUG(cudnn_call)                           \

--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -37,11 +37,10 @@
 #define CHECK_MIOPEN_NODEBUG(miopen_call)                         \
   do {                                                            \
     const miopenStatus_t status_CHECK_MIOPEN = (miopen_call);     \
-    if (status_CHECK_MIOPEN != miopenStatusSuccess) {           \
-      hipDeviceReset();                                           \
-      LBANN_ERROR(std::string("MIOpen error (")                   \
-                  + miopenGetErrorString(status_CHECK_MIOPEN)     \
-                  + std::string(")"));                            \
+    if (status_CHECK_MIOPEN != miopenStatusSuccess) {             \
+      LBANN_ERROR("MIOpen error (",                               \
+                  miopenGetErrorString(status_CHECK_MIOPEN),      \
+                  ")");                                           \
     }                                                             \
   } while (0)
 #define CHECK_MIOPEN_DEBUG(miopen_call)                           \

--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -49,27 +49,22 @@
     if (status_CUDA_SYNC == cudaSuccess)                        \
       status_CUDA_SYNC = cudaGetLastError();                    \
     if (status_CUDA_SYNC != cudaSuccess) {                      \
-      cudaDeviceReset();                                        \
-      std::stringstream err_CUDA_SYNC;                          \
-      if (async) { err_CUDA_SYNC << "Asynchronous "; }          \
-      err_CUDA_SYNC << "CUDA error ("                           \
-                    << cudaGetErrorString(status_CUDA_SYNC)     \
-                    << ")";                                     \
+      LBANN_ERROR((async ? "Asynchronous " : ""),               \
+                  "CUDA error (",                               \
+                  cudaGetErrorString(status_CUDA_SYNC),         \
+                  ")");                                         \
       LBANN_ERROR(err_CUDA_SYNC.str());                         \
     }                                                           \
   } while (0)
-#define LBANN_CUDA_CHECK_LAST_ERROR(async)                              \
-  do {                                                                  \
-    cudaError_t status = cudaGetLastError();                            \
-    if (status != cudaSuccess) {                                        \
-      cudaDeviceReset();                                                \
-      std::stringstream err_CUDA_CHECK_LAST_ERROR;                      \
-      if (async) { err_CUDA_CHECK_LAST_ERROR << "Asynchronous "; }      \
-      err_CUDA_CHECK_LAST_ERROR << "CUDA error ("                       \
-                                << cudaGetErrorString(status)           \
-                                << ")";                                 \
-      LBANN_ERROR(err_CUDA_CHECK_LAST_ERROR.str());                     \
-    }                                                                   \
+#define LBANN_CUDA_CHECK_LAST_ERROR(async)                      \
+  do {                                                          \
+    cudaError_t status = cudaGetLastError();                    \
+    if (status != cudaSuccess) {                                \
+      LBANN_ERROR((async ? "Asynchronous " : ""),               \
+                  "CUDA error (",                               \
+                  cudaGetErrorString(status),                   \
+                  ")");                                         \
+    }                                                           \
   } while (0)
 #define FORCE_CHECK_CUDA(cuda_call)                             \
   do {                                                          \
@@ -78,9 +73,9 @@
     LBANN_CUDA_SYNC(true);                                      \
     cudaError_t status_CHECK_CUDA = (cuda_call);                \
     if (status_CHECK_CUDA != cudaSuccess) {                     \
-      LBANN_ERROR(std::string("CUDA error (")                   \
-                  + cudaGetErrorString(status_CHECK_CUDA)       \
-                  + std::string(")"));                          \
+      LBANN_ERROR("CUDA error (",                               \
+                  cudaGetErrorString(status_CHECK_CUDA),        \
+                  ")");                                         \
     }                                                           \
     LBANN_CUDA_SYNC(false);                                     \
   } while (0)
@@ -88,9 +83,9 @@
   do {                                                          \
     cudaError_t status_CHECK_CUDA = (cuda_call);                \
     if (status_CHECK_CUDA != cudaSuccess) {                     \
-      LBANN_ERROR(std::string("CUDA error (")                   \
-                  + cudaGetErrorString(status_CHECK_CUDA)       \
-                  + std::string(")"));                          \
+      LBANN_ERROR("CUDA error (",                               \
+                  cudaGetErrorString(status_CHECK_CUDA),        \
+                  ")");                                         \
     }                                                           \
   } while (0)
 #ifdef LBANN_DEBUG

--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -53,7 +53,6 @@
                   "CUDA error (",                               \
                   cudaGetErrorString(status_CUDA_SYNC),         \
                   ")");                                         \
-      LBANN_ERROR(err_CUDA_SYNC.str());                         \
     }                                                           \
   } while (0)
 #define LBANN_CUDA_CHECK_LAST_ERROR(async)                      \

--- a/include/lbann/utils/gpu/rocm.hpp
+++ b/include/lbann/utils/gpu/rocm.hpp
@@ -49,27 +49,21 @@
     if (status_ROCM_SYNC == hipSuccess)                         \
       status_ROCM_SYNC = hipGetLastError();                     \
     if (status_ROCM_SYNC != hipSuccess) {                       \
-      hipDeviceReset();                                         \
-      std::stringstream err_ROCM_SYNC;                          \
-      if (async) { err_ROCM_SYNC << "Asynchronous "; }          \
-      err_ROCM_SYNC << "ROCm error ("                           \
-                    << hipGetErrorString(status_ROCM_SYNC)      \
-                    << ")";                                     \
-      LBANN_ERROR(err_ROCM_SYNC.str());                         \
+      LBANN_ERROR((async ? "Asynchronous " : ""),               \
+                  "ROCm error (",                               \
+                  hipGetErrorString(status_ROCM_SYNC),          \
+                  ")");                                         \
     }                                                           \
   } while (0)
-#define LBANN_ROCM_CHECK_LAST_ERROR(async)                              \
-  do {                                                                  \
-    hipError_t status = hipGetLastError();                              \
-    if (status != hipSuccess) {                                         \
-      hipDeviceReset();                                                 \
-      std::stringstream err_ROCM_CHECK_LAST_ERROR;                      \
-      if (async) { err_ROCM_CHECK_LAST_ERROR << "Asynchronous "; }      \
-      err_ROCM_CHECK_LAST_ERROR << "ROCm error ("                       \
-                                << hipGetErrorString(status)            \
-                                << ")";                                 \
-      LBANN_ERROR(err_ROCM_CHECK_LAST_ERROR.str());                     \
-    }                                                                   \
+#define LBANN_ROCM_CHECK_LAST_ERROR(async)                      \
+  do {                                                          \
+    hipError_t status = hipGetLastError();                      \
+    if (status != hipSuccess) {                                 \
+      LBANN_ERROR((async ? "Asynchronous " : ""),               \
+                  "ROCm error (",                               \
+                  hipGetErrorString(status),                    \
+                  ")");                                         \
+    }                                                           \
   } while (0)
 #define FORCE_CHECK_ROCM(rocm_call)                             \
   do {                                                          \
@@ -78,9 +72,9 @@
     LBANN_ROCM_SYNC(true);                                      \
     hipError_t status_CHECK_ROCM = (rocm_call);                 \
     if (status_CHECK_ROCM != hipSuccess) {                      \
-      LBANN_ERROR(std::string("ROCm error (")                   \
-                  + hipGetErrorString(status_CHECK_ROCM)        \
-                  + std::string(")"));                          \
+      LBANN_ERROR("ROCm error (",                               \
+                  hipGetErrorString(status_CHECK_ROCM),         \
+                  ")");                                         \
     }                                                           \
     LBANN_ROCM_SYNC(false);                                     \
   } while (0)
@@ -88,9 +82,9 @@
   do {                                                          \
     hipError_t status_CHECK_ROCM = (rocm_call);                 \
     if (status_CHECK_ROCM != hipSuccess) {                      \
-      LBANN_ERROR(std::string("ROCm error (")                   \
-                  + hipGetErrorString(status_CHECK_ROCM)        \
-                  + std::string(")"));                          \
+      LBANN_ERROR("ROCm error (",                               \
+                  hipGetErrorString(status_CHECK_ROCM),         \
+                  ")");                                         \
     }                                                           \
   } while (0)
 #ifdef LBANN_DEBUG


### PR DESCRIPTION
This is the LBANN part of a cleanup that will also occur in Hydrogen and Aluminum.

The primary change is to remove `cudaDeviceReset()` from the error handling macros. Since I was there, I cleaned up the messy error string building code, too.

[cudaDeviceReset](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__DEVICE.html#group__CUDART__DEVICE_1gef69dd5c6d0206c2b8d099abac61f217) is a very big hammer, causing all allocations to be destroyed and cleans up "all resources". Our error checking macros will call this, but then they will throw an exception. This has a few issues:

1. Since all allocations are destroyed, any attempt to recover from this error would be futile. If a fatal error occurs (i.e., one from which recovery is not meant to be possible), throwing an exception is not the correct behavior (maybe: print error message, print stack, `MPI_Abort`/`std::abort`).
2. While the exception is finding its way up the stack, there will still be runtime calls, say, in destructors that will try to deallocate an objects internal (GPU) memory buffers. But these have already been deleted, so it's likely that a user will get a cryptic error message similar to:
```cpp
{
    File: /path/to/hydrogen/include/El/core/Memory/impl.hpp
    Line: 177
    Mesg: CUDA error detected in command: "hydrogen::cub::MemoryPool().DeviceFree(ptr)"

    Error Code: 400
    Error Name: cudaErrorInvalidResourceHandle
    Error Mesg: invalid resource handle
}
```
This looks very bad and very scary, and it is, but it's also highly likely that it is not the "real" error. Moreover, the initial error that triggered this whole chain of events may never be reported anyway, rendering the entire reporting infrastructure essentially moot. To get any real information, a user would have to run through a debugger with breakpoints set correctly, and we may has well have printed "An error occurred. Ask GDB about it."

Anyway, this just removes the `cudaDeviceReset()` so the "real" error has a chance to make it to the `catch` clause (or to make its way out of `main()`, where it will likely be reported by the runtime).