### PR TITLE
Make OpenCV optional when building Catch2 tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,7 +577,9 @@ if (LBANN_WITH_UNIT_TESTING)
   add_subdirectory(src/utils/unit_test)
   add_subdirectory(src/weights/unit_test)
   add_subdirectory(src/transforms/unit_test)
-  add_subdirectory(src/transforms/vision/unit_test)
+  if (LBANN_HAS_OPENCV)
+    add_subdirectory(src/transforms/vision/unit_test)
+  endif ()
 
   # Add this one last
   add_subdirectory(unit_test)


### PR DESCRIPTION
I run into build errors when I disable OpenCV and enable Catch2. A minor tweak to the CMake gets it to work for me.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM340-1).