### PR TITLE
Add clang-format specification

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,165 @@
+###############################################################################
+# Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+###############################################################################
+
+# Basic clang-format specification for LBANN.
+# Based on clang-10 for LC compatibility.
+
+---
+Language: Cpp
+BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(catch|gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        c++17
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...

--- a/.clang-format
+++ b/.clang-format
@@ -38,9 +38,9 @@ AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands:   true
 AlignTrailingComments: true
-AllowAllArgumentsOnNextLine: true
+AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
@@ -51,8 +51,8 @@ AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
-BinPackArguments: true
-BinPackParameters: true
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
   AfterCaseLabel:  false
   AfterClass:      true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,6 +795,12 @@ configure_package_config_file(cmake/configure_files/LBANNConfig.cmake.in
   INSTALL_DESTINATION "${CMAKE_INSTALL_DIR}"
   PATH_VARS INCLUDE_INSTALL_DIRS LIB_INSTALL_DIR)
 
+# Clang format
+include(LBANNClangFormat)
+if (CLANG_FORMAT_AVAILABLE)
+  add_clang_format(lbann)
+endif ()
+
 # Install library
 install(
   TARGETS lbann

--- a/cmake/modules/LBANNClangFormat.cmake
+++ b/cmake/modules/LBANNClangFormat.cmake
@@ -1,0 +1,152 @@
+################################################################################
+## Copyright 2019-2020 Lawrence Livermore National Security, LLC and other
+## DiHydrogen Project Developers. See the top-level LICENSE file for details.
+##
+## SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+get_filename_component(COMPILER_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+get_filename_component(COMPILER_PREFIX "${COMPILER_BIN_DIR}" DIRECTORY)
+
+# Let the user override clang-format with its own variable. This would
+# help if building with an older LLVM installation.
+find_program(CLANG_FORMAT_PROGRAM clang-format
+  HINTS ${CLANG_FORMAT_DIR} $ENV{CLANG_FORMAT_DIR}
+  PATH_SUFFIXES bin
+  DOC "The clang-format executable."
+  NO_DEFAULT_PATH)
+
+# Normal search inspired by the compiler choice. If the compiler
+# happens to be, GCC, for example, users can also use LLVM_DIR. If all
+# else fails, this falls back on default CMake searching.
+find_program(CLANG_FORMAT_PROGRAM clang-format
+  HINTS
+  ${COMPILER_BIN_DIR}
+  ${COMPILER_PREFIX}
+  ${LLVM_DIR} $ENV{LLVM_DIR}
+  PATH_SUFFIXES bin
+  DOC "The clang-format executable."
+  NO_DEFAULT_PATH)
+
+# Default CMake searching.
+find_program(CLANG_FORMAT_PROGRAM clang-format)
+
+if (CLANG_FORMAT_PROGRAM)
+  execute_process(COMMAND ${CLANG_FORMAT_PROGRAM} --version
+    OUTPUT_VARIABLE CLANG_FORMAT_VERSION_STRING
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  string(REGEX MATCH "[0-9]+\.[0-9]+\.[0-9]+"
+    CLANG_FORMAT_VERSION
+    "${CLANG_FORMAT_VERSION_STRING}")
+
+  if (CLANG_FORMAT_VERSION VERSION_GREATER_EQUAL "10.0.0")
+    set(CLANG_FORMAT_VERSION_OK TRUE)
+  else ()
+    set(CLANG_FORMAT_VERSION_OK FALSE)
+  endif ()
+endif ()
+
+set(CLANG_FORMAT_AVAILABLE)
+if (CLANG_FORMAT_PROGRAM AND CLANG_FORMAT_VERSION_OK)
+  set(CLANG_FORMAT_AVAILABLE TRUE)
+  add_custom_target(
+    clang-format
+    COMMAND ${CLANG_FORMAT_PROGRAM} -i
+    $<TARGET_PROPERTY:clang-format,FORMAT_SOURCES>
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    COMMENT "Applying clang-format."
+    COMMAND_EXPAND_LISTS
+    VERBATIM)
+  define_property(TARGET PROPERTY FORMAT_SOURCES
+    BRIEF_DOCS "Sources for clang-format."
+    FULL_DOCS "Sources for clang-format.")
+
+  # Add the sources from the given target to the "clang-format"
+  # target.
+  macro (add_clang_format IN_TARGET)
+
+    get_target_property(TGT_TYPE ${IN_TARGET} TYPE)
+
+    if ((TGT_TYPE MATCHES "(STATIC|SHARED|OBJECT|MODULE)_LIBRARY")
+        OR (TGT_TYPE MATCHES "EXECUTABLE"))
+
+      unset(TGT_SOURCES_FULL_PATH)
+      get_target_property(TGT_SOURCES ${IN_TARGET} SOURCES)
+      get_target_property(TGT_SRC_DIR ${IN_TARGET} SOURCE_DIR)
+
+      foreach (src IN LISTS TGT_SOURCES)
+        get_filename_component(SRC_NAME "${src}" NAME)
+        if (src STREQUAL SRC_NAME)
+          list(APPEND TGT_SOURCES_FULL_PATH "${TGT_SRC_DIR}/${src}")
+        else ()
+          list(APPEND TGT_SOURCES_FULL_PATH "${src}")
+        endif ()
+      endforeach ()
+
+      set_property(TARGET clang-format APPEND
+        PROPERTY FORMAT_SOURCES "${TGT_SOURCES_FULL_PATH}")
+    elseif (TGT_TYPE MATCHES "INTERFACE_LIBRARY")
+      get_target_property(TGT_SOURCES ${IN_TARGET} INTERFACE_SOURCES)
+
+      if (TGT_SOURCES)
+        # Sources might be in generator expressions! :/ We want to only
+        # change the BUILD_INTERFACE objects with absolute paths.
+        foreach (src IN LISTS TGT_SOURCES)
+          # Skip install files
+          if (src MATCHES ".*INSTALL_INTERFACE.*")
+            continue()
+          endif ()
+
+          if (src MATCHES ".*BUILD_INTERFACE:(.*)>")
+            set(my_src "${CMAKE_MATCH_1}")
+          else ()
+            set(my_src "${src}")
+          endif ()
+          get_filename_component(SRC_NAME "${my_src}" NAME)
+          # Assume a relative path is
+          if (my_src STREQUAL SRC_NAME)
+            message(FATAL_ERROR "Not expecting relative path: ${my_src}")
+            list(APPEND TGT_SOURCES_FULL_PATH "${TGT_SRC_DIR}/${my_src}")
+          else ()
+            list(APPEND TGT_SOURCES_FULL_PATH "${my_src}")
+          endif ()
+        endforeach ()
+
+        set_property(TARGET clang-format APPEND
+          PROPERTY FORMAT_SOURCES "${TGT_SOURCES_FULL_PATH}")
+      endif (TGT_SOURCES)
+    endif ()
+  endmacro ()
+
+  function (add_cf_to_tgts_in_dir IN_DIR)
+
+    # Handle this directory
+    get_property(_targets
+      DIRECTORY "${IN_DIR}"
+      PROPERTY BUILDSYSTEM_TARGETS)
+
+    foreach (tgt IN LISTS _targets)
+      add_clang_format(${tgt})
+    endforeach ()
+
+    # Recursive call.
+    get_property(_subdirs
+      DIRECTORY "${IN_DIR}"
+      PROPERTY SUBDIRECTORIES)
+
+    foreach (dir IN LISTS _subdirs)
+      add_cf_to_tgts_in_dir("${dir}")
+    endforeach ()
+  endfunction ()
+
+  function (add_clang_format_to_all_targets)
+    add_cf_to_tgts_in_dir("${CMAKE_SOURCE_DIR}")
+  endfunction ()
+
+  message(STATUS "Found clang-format: ${CLANG_FORMAT_PROGRAM}")
+  message(STATUS "Clang-format Version: ${CLANG_FORMAT_VERSION})")
+  message(STATUS
+    "Added target \"clang-format\" "
+    "for applying clang-format to source.")
+endif ()


### PR DESCRIPTION
A good time to merge this sort of PR will be at the release of v1.0.

This will automatically add a target to the build system called `clang-format`. This will call `clang-format` on every file that's registered as a source file of the `lbann` target.

I recommend that we add a hook to run `clang-format` as a part of the commit process for `develop`.

The style is sort of a mixture of the base LLVM style with 2-space indents with a few aspects of Allman-style bracing. I will argue for class and function breaks before braces:
```cpp
class foo
{
...
};

void bar()
{
}
```
but I don't care as much about nested blocks such as conditionals or for loops (I still prefer the break, but I think this is a reasonable compromise):
```cpp
// This is fine
if (whatever) {
}

// As is this
for (auto x : y) {
}
```
Most of the other main changes it makes is a consistent formatting style for arguments, initializers, and inheritance, as well as a consistent ordering of `#include` statements.

See [the clang10 docs](https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormatStyleOptions.html) for info about what each key in `.clang-format` means.