### PR TITLE
Refactor iwyu

### DIFF
--- a/include/lbann/Elemental_extensions.hpp
+++ b/include/lbann/Elemental_extensions.hpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 
 namespace El {
 

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -27,10 +27,10 @@
 #ifndef LBANN_BASE_HPP_INCLUDED
 #define LBANN_BASE_HPP_INCLUDED
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 // Defines, among other things, DataType.
-#include "lbann_config.hpp"
+#include "lbann_config.hpp" // IWYU pragma: export
 
 #include "lbann/Elemental_extensions.hpp"
 #include "lbann/utils/cyg_profile.hpp"

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -40,10 +40,10 @@
 // Support for OpenMP macros
 #include "lbann/utils/omp_pragma.hpp"
 
-#include <functional>
-#include <iostream>
-#include <memory>
-#include <string>
+#include <functional> // IWYU pragma: export
+#include <iostream> // IWYU pragma: export
+#include <memory> // IWYU pragma: export
+#include <string> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/data_coordinator/data_coordinator_metadata.hpp
+++ b/include/lbann/data_coordinator/data_coordinator_metadata.hpp
@@ -27,7 +27,7 @@
 #ifndef LBANN_DATA_COORDINATOR_METADATA_HPP
 #define LBANN_DATA_COORDINATOR_METADATA_HPP
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 #include "lbann/utils/enum_iterator.hpp"
 #include "lbann/utils/distconv.hpp"

--- a/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
+++ b/include/lbann/data_readers/sample_list_conduit_io_handle.hpp
@@ -1,7 +1,7 @@
 #ifndef __SAMPLE_LIST_CONDUIT_IO_HANDLE_HPP__
 #define __SAMPLE_LIST_CONDUIT_IO_HANDLE_HPP__
 
-#include "sample_list_open_files.hpp"
+#include "lbann/data_readers/sample_list_open_files.hpp"
 #include "conduit/conduit.hpp"
 #include "conduit/conduit_relay.hpp"
 #include "conduit/conduit_relay_io_handle.hpp"

--- a/include/lbann/data_readers/sample_list_hdf5.hpp
+++ b/include/lbann/data_readers/sample_list_hdf5.hpp
@@ -1,7 +1,7 @@
 #ifndef __SAMPLE_LIST_HDF5_HPP__
 #define __SAMPLE_LIST_HDF5_HPP__
 
-#include "sample_list_open_files.hpp"
+#include "lbann/data_readers/sample_list_open_files.hpp"
 #include "hdf5.h"
 #include "conduit/conduit.hpp"
 #include "conduit/conduit_relay.hpp"
@@ -35,7 +35,7 @@ class sample_list_hdf5 : public sample_list_open_files<sample_name_t, hid_t> {
 
 template <typename sample_name_t>
 inline sample_list_hdf5<sample_name_t>::sample_list_hdf5()
-: sample_list_open_files<sample_name_t, hid_t>() {} 
+: sample_list_open_files<sample_name_t, hid_t>() {}
 
 template <typename sample_name_t>
 inline sample_list_hdf5<sample_name_t>::~sample_list_hdf5() {

--- a/include/lbann/data_readers/sample_list_impl.hpp
+++ b/include/lbann/data_readers/sample_list_impl.hpp
@@ -1,3 +1,6 @@
+#ifndef __SAMPLE_LIST_IMPL_HPP__
+#define __SAMPLE_LIST_IMPL_HPP__
+
 #include <iostream>
 #include <fstream>
 #include <string>
@@ -945,3 +948,5 @@ inline void sample_list<sample_name_t>
 }
 
 } // end of namespace lbann
+
+#endif // __SAMPLE_LIST_IMPL_HPP__

--- a/include/lbann/data_readers/sample_list_open_files_impl.hpp
+++ b/include/lbann/data_readers/sample_list_open_files_impl.hpp
@@ -1,3 +1,6 @@
+#ifndef __SAMPLE_LIST_OPEN_FILES_IMPL_HPP__
+#define __SAMPLE_LIST_OPEN_FILES_IMPL_HPP__
+
 namespace lbann {
 
 template <typename sample_name_t, typename file_handle_t>
@@ -723,3 +726,5 @@ inline void sample_list_open_files<sample_name_t, file_handle_t>
 }
 
 } // end of namespace lbann
+
+#endif // __SAMPLE_LIST_OPEN_FILES_IMPL_HPP__

--- a/include/lbann/io/persist.hpp
+++ b/include/lbann/io/persist.hpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/enum_iterator.hpp"
 #include "lbann/utils/serialize.hpp"
-#include "El.hpp"
+#include "El.hpp"  // IWYU pragma: export
 #include <sstream>
 
 namespace lbann {

--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/distconv.hpp"
 
 #include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/models/directed_acyclic_graph.hpp
+++ b/include/lbann/models/directed_acyclic_graph.hpp
@@ -30,7 +30,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/layers/layer.hpp"
 
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -49,7 +49,7 @@
 // complete type. Sigh. (The greater implication of this is that you
 // cannot have `unique_ptr<IncompleteType>` as a drop-in for
 // `IncompleteType*`, which is annoying.
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 #include <vector>
 #include <string>

--- a/include/lbann/optimizers/adagrad.hpp
+++ b/include/lbann/optimizers/adagrad.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/optimizers/adam.hpp
+++ b/include/lbann/optimizers/adam.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 #include <cereal/types/base_class.hpp>
 //#include <cereal/types/utility.hpp>
 

--- a/include/lbann/optimizers/hypergradient_adam.hpp
+++ b/include/lbann/optimizers/hypergradient_adam.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/optimizers/rmsprop.hpp
+++ b/include/lbann/optimizers/rmsprop.hpp
@@ -30,7 +30,7 @@
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include <sys/stat.h>
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/optimizers/sgd.hpp
+++ b/include/lbann/optimizers/sgd.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include <optimizers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/include/lbann/proto/datatype_helpers.hpp
+++ b/include/lbann/proto/datatype_helpers.hpp
@@ -27,7 +27,7 @@
 #ifndef LBANN_PROTO_DATATYPE_HELPERS_HPP_INCLUDED
 #define LBANN_PROTO_DATATYPE_HELPERS_HPP_INCLUDED
 
-#include <model.pb.h>
+#include <model.pb.h> // IWYU pragma: export
 
 namespace lbann
 {

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -35,7 +35,7 @@
 #include "lbann/io/persist.hpp"
 #include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/utils/hash.hpp"
-#include <lbann.pb.h>
+#include <lbann.pb.h> // IWYU pragma: export
 #include <vector>
 #include <string>
 #include <unordered_map>

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_UTILS_DISTCONV_HPP
 #define LBANN_UTILS_DISTCONV_HPP
 
+// IWYU pragma: begin_exports
 #include "lbann_config.hpp"
 
 #ifdef LBANN_HAS_DISTCONV
@@ -255,4 +256,5 @@ int get_num_spatial_dims(const Layer &layer);
 } // namespace lbann
 
 #endif // LBANN_HAS_DISTCONV
+// IWYU pragma: end_exports
 #endif // LBANN_UTILS_DISTCONV_HPP

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -31,7 +31,7 @@
 
 #ifdef LBANN_HAS_DISTCONV
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 #include "lbann/comm.hpp"
 #include <vector>
 

--- a/include/lbann/utils/dnn_lib/dnn_lib.hpp
+++ b/include/lbann/utils/dnn_lib/dnn_lib.hpp
@@ -34,7 +34,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include <vector>
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #ifdef LBANN_HAS_DNN_LIB
 
@@ -775,4 +775,3 @@ dnnMathType_t convert_to_dnn_math_type(ProtoTensorOpEnumType mt);
 } // namespace lbann
 #endif // LBANN_HAS_DNN_LIB
 #endif // LBANN_UTILS_DNN_LIB_DNN_LIB_HPP
-

--- a/include/lbann/utils/gpu/sync_info_helpers.hpp
+++ b/include/lbann/utils/gpu/sync_info_helpers.hpp
@@ -27,7 +27,7 @@
 #ifndef LBANN_UTILS_GPU_SYNC_INFO_HELPERS_HPP_INCLUDED
 #define LBANN_UTILS_GPU_SYNC_INFO_HELPERS_HPP_INCLUDED
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 namespace lbann {
 namespace gpu {

--- a/include/lbann/utils/h2_tmp.hpp
+++ b/include/lbann/utils/h2_tmp.hpp
@@ -29,6 +29,7 @@
 
 #include <lbann_config.hpp>
 
+// IWYU pragma: begin_exports
 #ifdef LBANN_HAS_DIHYDROGEN
 
 #include <h2/meta/Core.hpp>
@@ -900,4 +901,5 @@ public:
 #endif // H2_MULTIMETHODS_SWITCHDISPATCHER_HPP_
 
 #endif // LBANN_HAS_DIHYDROGEN
+// IWYU pragma: end_exports
 #endif // LBANN_UTILS_H2_TMP_HPP_

--- a/include/lbann/utils/hydrogen_utils.hpp
+++ b/include/lbann/utils/hydrogen_utils.hpp
@@ -26,7 +26,7 @@
 
 namespace lbann {
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 #include <lbann/utils/memory.hpp>
 
 template <typename TensorDataType, typename EvalDataType>

--- a/include/lbann/utils/serialization/cereal_utils.hpp
+++ b/include/lbann/utils/serialization/cereal_utils.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_UTILS_SERIALIZATION_CEREAL_UTILS_HPP_
 #define LBANN_UTILS_SERIALIZATION_CEREAL_UTILS_HPP_
 
+// IWYU pragma: begin_exports
 #include <cereal/cereal.hpp>
 
 #include <cereal/archives/binary.hpp>
@@ -40,6 +41,7 @@
 #include <cereal/types/unordered_map.hpp>
 #include <cereal/types/utility.hpp>
 #include <cereal/types/vector.hpp>
+// IWYU pragma: end_exports
 
 #include <lbann/utils/h2_tmp.hpp>
 

--- a/include/lbann/utils/serialization/rooted_archive_adaptor.hpp
+++ b/include/lbann/utils/serialization/rooted_archive_adaptor.hpp
@@ -31,7 +31,7 @@
 
 #include "cereal_utils.hpp"
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 #include <optional>
 #include <string>

--- a/include/lbann/utils/serialization/serialize_half.hpp
+++ b/include/lbann/utils/serialization/serialize_half.hpp
@@ -36,7 +36,7 @@
 #include "lbann_config.hpp"
 
 // Half-precision support comes from here:
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 #include "cereal_utils.hpp"
 

--- a/include/lbann/utils/serialization/serialize_matrices.hpp
+++ b/include/lbann/utils/serialization/serialize_matrices.hpp
@@ -32,7 +32,7 @@
 
 #include <lbann/utils/exception.hpp>
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 #include <stdexcept>
 
 // These really belong in Elemental; let's just extend that.

--- a/include/lbann/utils/serialize.hpp
+++ b/include/lbann/utils/serialize.hpp
@@ -26,7 +26,7 @@
 #pragma once
 #ifndef LBANN_UTILS_SERIALIZE_HPP_
 #define LBANN_UTILS_SERIALIZE_HPP_
-
+// IWYU pragma: begin_exports
 #include "serialization/cereal_utils.hpp"
 
 // Serialization code is only valid in C++ code.
@@ -38,4 +38,5 @@
 #include "serialization/serialize_matrices.hpp"
 
 #endif // !(defined __CUDACC__ || defined __HIPCC__)
+// IWYU pragma: end_exports
 #endif // LBANN_UTILS_SERIALIZE_HPP_

--- a/include/lbann/utils/type_erased_matrix.hpp
+++ b/include/lbann/utils/type_erased_matrix.hpp
@@ -4,7 +4,7 @@
 #include <lbann/utils/any.hpp>
 #include <lbann/utils/memory.hpp>
 
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 namespace lbann
 {

--- a/lbann_iwyu_mapping.imp
+++ b/lbann_iwyu_mapping.imp
@@ -1,0 +1,6 @@
+[
+{ include: ["@<hydrogen/.*>", "private", "<El.hpp>", "public"] },
+{ include: ["@<h2/.*>", "private", "\"lbann/utils/h2_tmp.hpp\"", "public"] },
+{ include: ["@<cereal/types/.*>", "private", "\"lbann/utils/serialization/cereal_utils.hpp\"", "public"] },
+{ include: ["@<El/.*>", "private", "<El.hpp>", "public"] },
+]

--- a/src/Elemental_extensions.cpp
+++ b/src/Elemental_extensions.cpp
@@ -26,7 +26,7 @@
 // This file is an extension of several Elemental functions
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 
 #include <lbann_config.hpp>
 #include "lbann/Elemental_extensions.hpp"

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -32,7 +32,7 @@
 
 #include "lbann/utils/h2_tmp.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <cmath>
 #include <iostream>

--- a/src/callbacks/check_metric.cpp
+++ b/src/callbacks/check_metric.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <set>
 #include <string>

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -31,7 +31,7 @@
 
 #include "lbann/models/model.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <memory>
 #include <string>

--- a/src/callbacks/confusion_matrix.cpp
+++ b/src/callbacks/confusion_matrix.cpp
@@ -27,7 +27,7 @@
 #include "lbann/callbacks/confusion_matrix.hpp"
 #include "lbann/layers/data_type_layer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <fstream>
 #include <memory>

--- a/src/callbacks/debug_io.cpp
+++ b/src/callbacks/debug_io.cpp
@@ -31,7 +31,7 @@
 #include "lbann/base.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 #include <iostream>
 #include <memory>
 

--- a/src/callbacks/dump_error_signals.cpp
+++ b/src/callbacks/dump_error_signals.cpp
@@ -27,7 +27,7 @@
 #include "lbann/callbacks/dump_error_signals.hpp"
 #include "lbann/layers/data_type_layer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/dump_gradients.cpp
+++ b/src/callbacks/dump_gradients.cpp
@@ -29,7 +29,7 @@
 #include "lbann/callbacks/dump_gradients.hpp"
 #include "lbann/optimizers/data_type_optimizer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <vector>
 

--- a/src/callbacks/dump_minibatch_sample_indices.cpp
+++ b/src/callbacks/dump_minibatch_sample_indices.cpp
@@ -31,7 +31,7 @@
 #include "lbann/callbacks/dump_minibatch_sample_indices.hpp"
 #include "lbann/data_coordinator/data_coordinator.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <iomanip>
 #include <cstdlib>

--- a/src/callbacks/dump_outputs.cpp
+++ b/src/callbacks/dump_outputs.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/trainer_file_utils.hpp"
 #include "lbann/layers/data_type_layer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #ifdef LBANN_HAS_CNPY
 #include <cnpy.h>

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/trainer_file_utils.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <string>
 

--- a/src/callbacks/early_stopping.cpp
+++ b/src/callbacks/early_stopping.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/callbacks/early_stopping.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <iostream>
 

--- a/src/callbacks/hang.cpp
+++ b/src/callbacks/hang.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/callbacks/hang.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/imcomm.cpp
+++ b/src/callbacks/imcomm.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/timer.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <typeinfo>
 #include <typeindex>

--- a/src/callbacks/learning_rate.cpp
+++ b/src/callbacks/learning_rate.cpp
@@ -33,7 +33,7 @@
 
 #include "callback_helpers.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <cmath> // std::pow

--- a/src/callbacks/load_model.cpp
+++ b/src/callbacks/load_model.cpp
@@ -33,8 +33,8 @@
 #include "lbann/models/directed_acyclic_graph.hpp"
 #include "lbann/utils/file_utils.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
+#include <model.pb.h> // IWYU pragma: export
 
 #include <cstdlib>
 #include <fstream>

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -36,7 +36,7 @@
 #include <lbann/utils/cloneable.hpp>
 #include <lbann/utils/memory.hpp>
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <numeric>

--- a/src/callbacks/mixup.cpp
+++ b/src/callbacks/mixup.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/beta.hpp"
 #include "lbann/utils/exception.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <unordered_set>
 

--- a/src/callbacks/monitor_io.cpp
+++ b/src/callbacks/monitor_io.cpp
@@ -32,7 +32,7 @@
 #include "lbann/data_coordinator/data_coordinator.hpp"
 #include "lbann/proto/proto_common.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/perturb_adam.cpp
+++ b/src/callbacks/perturb_adam.cpp
@@ -28,7 +28,7 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/random_number_generators.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <cmath>

--- a/src/callbacks/perturb_dropout.cpp
+++ b/src/callbacks/perturb_dropout.cpp
@@ -28,7 +28,7 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/random_number_generators.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/print_model_description.cpp
+++ b/src/callbacks/print_model_description.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/callbacks/print_model_description.hpp"
 #include "lbann/models/model.hpp"
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/print_statistics.cpp
+++ b/src/callbacks/print_statistics.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/lbann_library.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <iomanip>

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -29,7 +29,7 @@
 #include "lbann/callbacks/profiler.hpp"
 #include "lbann/utils/profiling.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #ifdef LBANN_NVPROF
 #include "nvToolsExt.h"

--- a/src/callbacks/replace_weights.cpp
+++ b/src/callbacks/replace_weights.cpp
@@ -30,7 +30,7 @@
 
 #include "callback_helpers.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <string>
 #include <vector>

--- a/src/callbacks/save_images.cpp
+++ b/src/callbacks/save_images.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/proto/proto_common.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #ifdef LBANN_HAS_OPENCV
 #include <opencv2/imgcodecs.hpp>

--- a/src/callbacks/save_model.cpp
+++ b/src/callbacks/save_model.cpp
@@ -31,12 +31,12 @@
 #include "lbann/training_algorithms/training_algorithm.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
+#include <model.pb.h> // IWYU pragma: export
 
-#include <google/protobuf/text_format.h>
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h> // IWYU pragma: export
+#include <google/protobuf/io/coded_stream.h> // IWYU pragma: export
+#include <google/protobuf/io/zero_copy_stream_impl.h> // IWYU pragma: export
 
 #include <unistd.h>
 #include <dirent.h>

--- a/src/callbacks/save_topk_models.cpp
+++ b/src/callbacks/save_topk_models.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/callbacks/save_topk_models.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <functional>

--- a/src/callbacks/set_weights_value.cpp
+++ b/src/callbacks/set_weights_value.cpp
@@ -27,7 +27,7 @@
 #include "lbann/callbacks/set_weights_value.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 
 namespace lbann {

--- a/src/callbacks/summarize_images.cpp
+++ b/src/callbacks/summarize_images.cpp
@@ -35,7 +35,7 @@
 #include <lbann/utils/factory.hpp>
 #include <lbann/utils/summary.hpp>
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <iostream>
 

--- a/src/callbacks/summary.cpp
+++ b/src/callbacks/summary.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/profiling.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <string>

--- a/src/callbacks/sync_layers.cpp
+++ b/src/callbacks/sync_layers.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/timeline.cpp
+++ b/src/callbacks/timeline.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <fstream>
 #include <string>

--- a/src/callbacks/variable_minibatch.cpp
+++ b/src/callbacks/variable_minibatch.cpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/io/input_layer.hpp"
 #include "lbann/utils/exception.hpp"
 
-#include <callbacks.pb.h>
+#include <callbacks.pb.h> // IWYU pragma: export
 
 #include <iostream>
 #include <utility>

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -48,6 +48,10 @@
 
 #include <cstdlib>
 
+#include <hdf5.h>
+#include "conduit/conduit_relay.hpp"
+#include "conduit/conduit_relay_io_hdf5.hpp"
+
 namespace lbann {
 
 data_store_conduit::data_store_conduit(

--- a/src/execution_contexts/execution_context.cpp
+++ b/src/execution_contexts/execution_context.cpp
@@ -33,7 +33,7 @@
 #include <iomanip>
 #include <queue>
 #include <unordered_set>
-#include <lbann.pb.h>
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/io/persist.cpp
+++ b/src/io/persist.cpp
@@ -41,7 +41,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 #include "mpi.h"
 
 /****************************************************

--- a/src/layers/activations/softmax_builder.cpp
+++ b/src/layers/activations/softmax_builder.cpp
@@ -26,8 +26,8 @@
 
 #include "lbann/layers/activations/softmax.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -31,7 +31,7 @@
 #include "lbann/io/persist.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -29,7 +29,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/weights/initializer.hpp"
 #include "lbann/weights/variance_scaling_initializers.hpp"
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann
 {

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -30,7 +30,7 @@
 
 #include "lbann/proto/proto_common.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/learning/embedding_builder.cpp
+++ b/src/layers/learning/embedding_builder.cpp
@@ -26,8 +26,8 @@
 
 #include "lbann/layers/learning/embedding.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -30,7 +30,7 @@
 #include "lbann/weights/initializer.hpp"
 #include "lbann/weights/variance_scaling_initializers.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #include <string>
 #include <sstream>

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -30,7 +30,7 @@
 #include "lbann/weights/initializer.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/hash.hpp"
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/math/math_builders.cpp
+++ b/src/layers/math/math_builders.cpp
@@ -30,8 +30,8 @@
 #include <lbann/layers/math/matmul.hpp>
 #include <lbann/layers/math/unary.hpp>
 
-#include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann
 {

--- a/src/layers/misc/dft_abs.cu
+++ b/src/layers/misc/dft_abs.cu
@@ -1,4 +1,4 @@
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 namespace lbann
 {

--- a/src/layers/misc/dist_embedding.cpp
+++ b/src/layers/misc/dist_embedding.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/weights/weights_helpers.hpp"
 #include "lbann/proto/proto_common.hpp"
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 // =========================================================
 // CPU layer implementation

--- a/src/layers/transform/bernoulli.cpp
+++ b/src/layers/transform/bernoulli.cpp
@@ -27,8 +27,8 @@
 #define LBANN_BERNOULLI_LAYER_INSTANTIATE
 #include "lbann/layers/transform/bernoulli.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/concatenate_builder.cpp
+++ b/src/layers/transform/concatenate_builder.cpp
@@ -26,8 +26,8 @@
 
 #include "lbann/layers/transform/concatenate.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <layers.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/constant.cpp
+++ b/src/layers/transform/constant.cpp
@@ -27,8 +27,8 @@
 #define LBANN_CONSTANT_LAYER_INSTANTIATE
 #include "lbann/layers/transform/constant.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/crop_builder.cpp
+++ b/src/layers/transform/crop_builder.cpp
@@ -26,8 +26,8 @@
 
 #include "lbann/layers/transform/crop.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace {

--- a/src/layers/transform/hadamard.cpp
+++ b/src/layers/transform/hadamard.cpp
@@ -27,8 +27,8 @@
 #define LBANN_HADAMARD_LAYER_INSTANTIATE
 #include "lbann/layers/transform/hadamard.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/pooling.cpp
+++ b/src/layers/transform/pooling.cpp
@@ -27,8 +27,8 @@
 #define LBANN_POOLING_LAYER_INSTANTIATE
 #include "lbann/layers/transform/pooling.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace {

--- a/src/layers/transform/split.cpp
+++ b/src/layers/transform/split.cpp
@@ -27,8 +27,8 @@
 #define LBANN_SPLIT_LAYER_INSTANTIATE
 #include "lbann/layers/transform/split.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/stop_gradient.cpp
+++ b/src/layers/transform/stop_gradient.cpp
@@ -27,8 +27,8 @@
 #define LBANN_STOP_GRADIENT_LAYER_INSTANTIATE
 #include "lbann/layers/transform/stop_gradient.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/sum.cpp
+++ b/src/layers/transform/sum.cpp
@@ -27,8 +27,8 @@
 #define LBANN_SUM_LAYER_INSTANTIATE
 #include "lbann/layers/transform/sum.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/weighted_sum.cpp
+++ b/src/layers/transform/weighted_sum.cpp
@@ -27,8 +27,8 @@
 #define LBANN_WEIGHTED_SUM_LAYER_INSTANTIATE
 #include "lbann/layers/transform/weighted_sum.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/layers/transform/weights.cpp
+++ b/src/layers/transform/weights.cpp
@@ -27,8 +27,8 @@
 #define LBANN_WEIGHTS_LAYER_INSTANTIATE
 #include "lbann/layers/transform/weights.hpp"
 
-#include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
+#include <lbann.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -43,8 +43,8 @@
 #include <cereal/types/base_class.hpp>
 #include <cereal/types/polymorphic.hpp>
 
-#include <model.pb.h>
-#include <optimizers.pb.h>
+#include <model.pb.h> // IWYU pragma: export
+#include <optimizers.pb.h> // IWYU pragma: export
 
 #include <mpi.h>
 

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -37,8 +37,8 @@
 #include <lbann/utils/serialize.hpp>
 #include <lbann/proto/factories.hpp>
 
-#include <lbann.pb.h>
-#include <google/protobuf/text_format.h>
+#include <lbann.pb.h> // IWYU pragma: export
+#include <google/protobuf/text_format.h> // IWYU pragma: export
 
 namespace pb = ::google::protobuf;
 

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -74,8 +74,8 @@
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include <callbacks.pb.h>  // IWYU pragma: export
+#include <model.pb.h> // IWYU pragma: export
 
 #include <google/protobuf/message.h>
 

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -104,7 +104,7 @@
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
 #include "lbann/utils/peek_map.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #ifdef LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/helpers.hpp"

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -29,8 +29,8 @@
 
 #include "lbann/layers/learning/fully_connected.hpp"
 
-#include <model.pb.h>
-#include <trainer.pb.h>
+#include <model.pb.h> // IWYU pragma: export
+#include <trainer.pb.h> // IWYU pragma: export
 
 #include <string>
 #include <unordered_map>

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -34,8 +34,8 @@
 #include "lbann/objective_functions/weight_regularization/l2.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <model.pb.h>
-#include <objective_functions.pb.h>
+#include <model.pb.h> // IWYU pragma: export
+#include <objective_functions.pb.h> // IWYU pragma: export
 
 #include <iostream>
 #include <map>

--- a/src/proto/factories/objective_function_factory.cpp
+++ b/src/proto/factories/objective_function_factory.cpp
@@ -31,7 +31,7 @@
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/objective_functions/weight_regularization/l2.hpp"
 
-#include <objective_functions.pb.h>
+#include <objective_functions.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace proto {

--- a/src/proto/factories/trainer_factory.cpp
+++ b/src/proto/factories/trainer_factory.cpp
@@ -30,7 +30,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/data_coordinator/buffered_data_coordinator.hpp"
 
-#include <trainer.pb.h>
+#include <trainer.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace proto {

--- a/src/proto/factories/transform_factory.cpp
+++ b/src/proto/factories/transform_factory.cpp
@@ -52,8 +52,8 @@
 #include "lbann/utils/factory.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <reader.pb.h>
-#include <transforms.pb.h>
+#include <reader.pb.h> // IWYU pragma: export
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace proto {

--- a/src/proto/helpers.cpp
+++ b/src/proto/helpers.cpp
@@ -27,8 +27,8 @@
 #include "lbann/proto/helpers.hpp"
 #include "lbann/utils/exception.hpp"
 
-#include <google/protobuf/message.h>
-#include <google/protobuf/text_format.h>
+#include <google/protobuf/message.h> // IWYU pragma: export
+#include <google/protobuf/text_format.h> // IWYU pragma: export
 
 #include <string>
 

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -36,11 +36,11 @@
 #endif // LBANN_HAS_OPENCV
 #include "lbann/data_readers/data_reader_mnist.hpp"
 
-#include <reader.pb.h>
+#include <reader.pb.h> // IWYU pragma: export
 
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/coded_stream.h> // IWYU pragma: export
+#include <google/protobuf/io/zero_copy_stream_impl.h> // IWYU pragma: export
+#include <google/protobuf/text_format.h> // IWYU pragma: export
 
 #include <memory>
 #include <string>

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -34,12 +34,12 @@
 #include "lbann/utils/file_utils.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <reader.pb.h>
+#include <lbann.pb.h> // IWYU pragma: export
+#include <reader.pb.h> // IWYU pragma: export
 
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/zero_copy_stream_impl.h>
-#include <google/protobuf/text_format.h>
+#include <google/protobuf/io/coded_stream.h> // IWYU pragma: export
+#include <google/protobuf/io/zero_copy_stream_impl.h> // IWYU pragma: export
+#include <google/protobuf/text_format.h> // IWYU pragma: export
 
 #include <functional>
 #include <memory>

--- a/src/proto/unit_test/parse_list_test.cpp
+++ b/src/proto/unit_test/parse_list_test.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include <lbann/base.hpp>
-#include <lbann/proto/proto_common.hpp>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
 
 #include <string>
 #include <vector>

--- a/src/proto/unit_test/parse_set_test.cpp
+++ b/src/proto/unit_test/parse_set_test.cpp
@@ -1,7 +1,7 @@
 #include <catch2/catch.hpp>
 
 #include <lbann/base.hpp>
-#include <lbann/proto/proto_common.hpp>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
 
 #include <string>
 #include <set>

--- a/src/proto/unit_test/trim_test.cpp
+++ b/src/proto/unit_test/trim_test.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch.hpp>
 
-#include <lbann/proto/proto_common.hpp>
+#include <lbann/proto/proto_common.hpp> // IWYU pragma: export
 
 #include <string>
 

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -44,7 +44,7 @@
 #include <iomanip>
 #include <queue>
 #include <unordered_set>
-#include <lbann.pb.h>
+#include <lbann.pb.h> // IWYU pragma: export
 
 #include "mpi.h"
 

--- a/src/transforms/normalize.cpp
+++ b/src/transforms/normalize.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/proto/proto_common.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/scale.cpp
+++ b/src/transforms/scale.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/transforms/scale.hpp"
 #include "lbann/utils/memory.hpp"
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/adjust_brightness.cpp
+++ b/src/transforms/vision/adjust_brightness.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/adjust_contrast.cpp
+++ b/src/transforms/vision/adjust_contrast.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/adjust_saturation.cpp
+++ b/src/transforms/vision/adjust_saturation.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/center_crop.cpp
+++ b/src/transforms/vision/center_crop.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <cmath>
 

--- a/src/transforms/vision/color_jitter.cpp
+++ b/src/transforms/vision/color_jitter.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/horizontal_flip.cpp
+++ b/src/transforms/vision/horizontal_flip.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/normalize_to_lbann_layout.cpp
+++ b/src/transforms/vision/normalize_to_lbann_layout.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/random_affine.cpp
+++ b/src/transforms/vision/random_affine.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/random_crop.cpp
+++ b/src/transforms/vision/random_crop.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/random_resized_crop.cpp
+++ b/src/transforms/vision/random_resized_crop.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.cpp
+++ b/src/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/resize.cpp
+++ b/src/transforms/vision/resize.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/resized_center_crop.cpp
+++ b/src/transforms/vision/resized_center_crop.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/vertical_flip.cpp
+++ b/src/transforms/vision/vertical_flip.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include <transforms.pb.h> // IWYU pragma: export
 
 namespace lbann {
 namespace transform {

--- a/src/utils/cudnn.cpp
+++ b/src/utils/cudnn.cpp
@@ -31,7 +31,7 @@
 #endif // LBANN_HAS_CUDNN
 #include "lbann/utils/number_theory.hpp"
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 #include <iostream>
 #include <map>
 #include <unordered_map>

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -36,8 +36,8 @@
 #include "lbann/callbacks/load_model.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include <lbann.pb.h> // IWYU pragma: export
+#include <model.pb.h> // IWYU pragma: export
 
 namespace lbann {
 

--- a/src/utils/miopen.cpp
+++ b/src/utils/miopen.cpp
@@ -31,7 +31,7 @@
 #endif // LBANN_HAS_MIOPEN
 #include "lbann/utils/number_theory.hpp"
 
-#include "El.hpp"
+#include "El.hpp" // IWYU pragma: export
 #include <iostream>
 #include <map>
 #include <unordered_map>

--- a/src/utils/unit_test/type_erased_matrix_test.cpp
+++ b/src/utils/unit_test/type_erased_matrix_test.cpp
@@ -5,7 +5,7 @@
 #include <lbann/utils/type_erased_matrix.hpp>
 
 // Other includes
-#include <El.hpp>
+#include <El.hpp> // IWYU pragma: export
 
 namespace
 {

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/io/file_io.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <sstream>

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/io/file_io.hpp"
 
-#include <layers.pb.h>
+#include <layers.pb.h> // IWYU pragma: export
 
 #include <algorithm>
 #include <sstream>


### PR DESCRIPTION
Rework the way that we include the headers across the project to use the include-what-you-use methodology.  This should help us drive down compile time by reducing header dependencies and scope.  Additionally, this will be done in conjunction with pre-compiling headers for external headers.