### PR TITLE
Force model to setup after a copy constructor or copy assignment

### DIFF
--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -596,6 +596,9 @@ EvalType evaluate(model& m, const std::string& metric_name)
   data_coordinator& dc = m.get_execution_context().get_trainer().get_data_coordinator();
   dc.collect_background_data_fetch(original_mode);
 
+  if(!dc.is_execution_mode_valid(execution_mode::tournament)) {
+    LBANN_ERROR("LTFB requires ", to_string(execution_mode::tournament), " execution mode");
+  }
   // Mark the data store as loading - Note that this is a temporary fix
   // for the current use of the tournament
   m.mark_data_store_explicitly_loading(execution_mode::tournament);

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -82,7 +82,7 @@ model::model(const model& other) :
   m_execution_context(other.m_execution_context),
   m_comm(other.m_comm),
   m_name(other.m_name),
-  m_model_is_setup(other.m_model_is_setup) {
+  m_model_is_setup(false) {
 
   // Deep copies
   m_default_optimizer_msg = (other.m_default_optimizer_msg
@@ -137,7 +137,7 @@ model& model::operator=(const model& other) {
   // Shallow copies
   m_comm = other.m_comm;
   m_name = other.m_name;
-  m_model_is_setup = other.m_model_is_setup;
+  m_model_is_setup = false;
 
   // Deep copies
   m_execution_context  = other.m_execution_context;


### PR DESCRIPTION
We recently ran into weird runtime errors in the GRU layer during LTFB with the "sendrecv_weights" communication algorithm. The explanation:
1. Before an LTFB model exchange, LTFB copy-constructs a new model to hold data from the other trainer.
2. The GRU layer copy constructor doesn't attempt to copy cuDNN objects. It assumes everything will be reinitialized during setup.
3. The model copy constructor naively copies `m_model_is_setup` from the original model.
4. When the copy model attempts to setup, it sees `m_model_is_setup==true` and gives up.
5. During forward prop, the GRU layer passes uninitialized cuDNN objects to cuDNN and fails.

The fix is to force models to setup after a copy constructor or copy-assignment operator.

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM343-1).