### PR TITLE
Implement ATOM WAE reconstruction loss with gather layer

### DIFF
--- a/applications/ATOM/eval_atom_wae.py
+++ b/applications/ATOM/eval_atom_wae.py
@@ -150,7 +150,8 @@ def construct_model(run_args):
         for idx in range(len(l.weights)):
           l.weights[idx].optimizer = lbann.NoOptimizer()
       weights.update(l.weights)
-    l2_reg = lbann.L2WeightRegularization(weights=weights, scale=1e-4)
+    l2_weights = [w for w in weights if not isinstance(w.optimizer, lbann.NoOptimizer)]
+    l2_reg = lbann.L2WeightRegularization(weights=l2_weights, scale=1e-4)
 
     wae_loss.append(d1_real_bce)
     wae_loss.append(d_adv_bce)

--- a/applications/ATOM/models/vae.py
+++ b/applications/ATOM/models/vae.py
@@ -299,8 +299,7 @@ class MolVAE(lbann.modules.Module):
         )
         x = lbann.Identity(x)
 
-        # Convert indices in x to one-hot representation
-        # Note: Ignored indices result in zero vectors
+        # Figure out entries in x to ignore
         ignore_mask = lbann.Equal(
             x,
             self.constant(self.label_to_ignore, hint_layer=x),
@@ -308,22 +307,38 @@ class MolVAE(lbann.modules.Module):
         keep_mask = lbann.LogicalNot(ignore_mask)
         length = lbann.Reduction(keep_mask, mode='sum')
         length = lbann.Max(length, self.constant(1, [1]))
-        x = lbann.Add(
-            lbann.Multiply(keep_mask, x),
-            lbann.Multiply(ignore_mask, self.constant(-1, hint_layer=x)),
+
+        # Convert entries in x to indices in y
+        # Note: Ignored entries correspond to an index of -1.
+        offsets = [
+            row*self.dictionary_size
+            for row in range(self.input_feature_dims-1)
+        ]
+        offsets = lbann.Weights(
+            initializer=lbann.ValueInitializer(values=str_list(offsets)),
+            optimizer=lbann.NoOptimizer(),
         )
-        x = lbann.Slice(x, slice_points=str_list(range(self.input_feature_dims)))
-        x = [lbann.Identity(x) for _ in range(self.input_feature_dims-1)]
-        x = [lbann.OneHot(xi, size=self.dictionary_size) for xi in x]
-        x = [lbann.Reshape(xi, dims=str_list([1, self.dictionary_size])) for xi in x]
-        x = lbann.Concatenation(x, axis=0)
+        offsets = lbann.WeightsLayer(
+            dims=str_list([self.input_feature_dims-1]),
+            weights=offsets,
+        )
+        y_inds = lbann.Add(x, offsets)
+        y_inds = lbann.Add(
+            lbann.Multiply(keep_mask, y_inds),
+            lbann.Multiply(
+                ignore_mask,
+                self.constant(-1, hint_layer=y_inds),
+            ),
+        )
 
         # recon_loss = F.cross_entropy(
         #     y[:, :-1].contiguous().view(-1, y.size(-1)),
         #     x[:, 1:].contiguous().view(-1),
         #     ignore_index=self.pad
         # )
-        # Note: Ideally we'd shift y by y.max(-1) for numerical stability
+
+        # Shift y for numerical stability
+        # Note: We'd prefer to shift by y.max(-1)
         shifts = lbann.MatMul(
             lbann.Max(y, self.constant(0, hint_layer=y)),
             self.constant(
@@ -332,6 +347,8 @@ class MolVAE(lbann.modules.Module):
             ),
         )
         y = lbann.Subtract(y, shifts)
+
+        # Compute log of softmax denominator and sum
         z = lbann.MatMul(
             lbann.Exp(y),
             self.constant(1, [self.dictionary_size, 1]),
@@ -341,13 +358,15 @@ class MolVAE(lbann.modules.Module):
             lbann.Reshape(keep_mask, dims=str_list([1, -1])),
             z,
         )
-        recon_loss = lbann.MatMul(
-            lbann.Reshape(y, dims=str_list([1, -1])),
-            lbann.Reshape(x, dims=str_list([1, -1])),
-            transpose_b=True,
+        z = lbann.Reshape(z, dims=str_list([1]))
+
+        # Compute cross entropy
+        recon_loss = lbann.Gather(
+            lbann.Reshape(y, dims=str_list([-1])),
+            y_inds,
         )
+        recon_loss = lbann.Reduction(recon_loss, mode='sum')
         recon_loss = lbann.Subtract(z, recon_loss)
-        recon_loss = lbann.Reshape(recon_loss, dims=str_list([1]))
         recon_loss = lbann.Divide(recon_loss, length)
 
         return recon_loss

--- a/applications/ATOM/train_atom_vae.py
+++ b/applications/ATOM/train_atom_vae.py
@@ -127,7 +127,8 @@ def construct_model(run_args):
     weights = set()
     for l in layers:
       weights.update(l.weights)
-    l2_reg = lbann.L2WeightRegularization(weights=weights, scale=5e-4)
+    l2_weights = [w for w in weights if not isinstance(w.optimizer, lbann.NoOptimizer)]
+    l2_reg = lbann.L2WeightRegularization(weights=l2_weights, scale=5e-4)
     obj = lbann.ObjectiveFunction(vae_loss)
 
     # Initialize check metric callback

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -146,7 +146,8 @@ def construct_model(run_args):
         for idx in range(len(l.weights)):
           l.weights[idx].optimizer = lbann.NoOptimizer()
       weights.update(l.weights)
-    l2_reg = lbann.L2WeightRegularization(weights=weights, scale=1e-4)
+    l2_weights = [w for w in weights if not isinstance(w.optimizer, lbann.NoOptimizer)]
+    l2_reg = lbann.L2WeightRegularization(weights=l2_weights, scale=1e-4)
 
     d_adv_bce = lbann.LayerTerm(d_adv_bce,scale=0.01)
 

--- a/applications/ATOM/train_atom_wae.py
+++ b/applications/ATOM/train_atom_wae.py
@@ -116,10 +116,12 @@ def construct_model(run_args):
 
     print("save output? ", save_output, "out dir ",  run_args.dump_outputs_dir)
     z = lbann.Gaussian(mean=0.0,stdev=1.0, neuron_dims="128")
-    recon, d1_real, d1_fake, d_adv, arg_max  = molwae.MolWAE(input_feature_dims,
-                                                           dictionary_size,
-                                                           embedding_size,
-                                                           pad_index,save_output)(input_,z)
+    recon, d1_real, d1_fake, d_adv, arg_max  = molwae.MolWAE(
+        input_feature_dims,
+        dictionary_size,
+        embedding_size,
+        pad_index,
+        save_output=save_output)(input_,z)
 
 
 


### PR DESCRIPTION
When training the ATOM WAE model, we compute the cross entropy loss for each character in the output sequence. Our old approach involved computing the log-softmax and applying a mask that was built out of one-hot vectors (one per sequence position). This incurred the overhead of launching many small kernels to construct the one-hot vectors. Since we have implemented a gather layer (PR #1766), we can replace all of the one-hot vectors with a single gather layer. Note that this is mathematically equivalent.

Running with synthetic data on a Lassen node, per-step time drops from 0.021 sec to 0.018 sec (1.14x speedup). Running a CPU build on a Pascal node (using PR #1797), there is not a significant change in per-step time (1.5 sec). The reconstruction losses are similar between the new and old implementations (except on GPU after it goes below the eps for half-precision).