### PR TITLE
Specify correct OpenBLAS Spack variant when building on Lassen

### DIFF
--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -129,7 +129,7 @@ set_center_specific_spack_dependencies()
     if [[ ${center} = "llnl_lc" ]]; then
         case ${spack_arch_target} in
             "power9le" | "power8le")
-                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12"
+                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp"
                 ;;
             "broadwell" | "haswell")
                 # On LC the mvapich2 being used is built against HWLOC v1


### PR DESCRIPTION
Spack behaves incorrectly if you do:
```
spack add lbann ^openblas
spack add openblas
spack install
```
The problem is that the concretizer doesn't handle the OpenBLAS variants correctly: LBANN depends on `openblas threads=openmp`, while `spack add openblas` resolves to `openblas threads=none`.