### PR TITLE
Batch-wise reduce-sum layer

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_batchwise_reduce_sum.py
+++ b/bamboo/unit_tests/test_unit_layer_batchwise_reduce_sum.py
@@ -1,0 +1,155 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20210301)
+_num_samples = 11
+_sample_size = 3
+_samples = np.random.normal(size=(_num_samples,_sample_size))
+_samples = _samples.astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index]
+def num_samples():
+    return _samples.shape[0]
+def sample_dims():
+    return (_samples.shape[1],)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples()
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    # Note: Multiply with a weights layer so that gradient checking
+    # will verify that error signals are correct. We multiply instead
+    # of adding so that each batch sample contributes a different
+    # gradient.
+    x_weights = lbann.Weights(
+        optimizer=lbann.SGD(),
+        initializer=lbann.ConstantInitializer(value=1.0),
+        name='input_weights'
+    )
+    x = lbann.Multiply(
+        lbann.Input(),
+        lbann.WeightsLayer(weights=x_weights, dims=tools.str_list(_sample_size)),
+    )
+
+    # Compute variance along batch dimension
+    sum_x = lbann.BatchwiseReduceSum(x)
+    sum_x2 = lbann.BatchwiseReduceSum(lbann.Square(x))
+    mini_batch_size = lbann.Tessellate(lbann.MiniBatchSize(), hint_layer=x)
+    mean_x = lbann.Divide(sum_x, mini_batch_size)
+    mean_x2 = lbann.Divide(sum_x2, mini_batch_size)
+    var = lbann.Subtract(mean_x2, lbann.Square(mean_x))
+    obj = lbann.L2Norm2(var)
+
+    # Objects for LBANN model
+    layers = list(lbann.traverse_layer_graph(x))
+    metric = lbann.Metric(obj, name='obj')
+    obj = lbann.ObjectiveFunction(obj)
+    callbacks = []
+
+    # Compute expected metric value
+    var = np.var(_samples, axis=0)
+    val = tools.numpy_l2norm2(var)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metric.name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # Gradient checking
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+
+    # Construct model
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=layers,
+                       objective_function=obj,
+                       metrics=[metric],
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for _test_func in tools.create_tests(setup_experiment, __file__):
+    globals()[_test_func.__name__] = _test_func

--- a/include/lbann/layers/transform/CMakeLists.txt
+++ b/include/lbann/layers/transform/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add the headers for this directory
 set_full_path(THIS_DIR_HEADERS
+  batchwise_reduce_sum.hpp
   concatenate.hpp
   pooling.hpp
   reshape.hpp

--- a/include/lbann/layers/transform/batchwise_reduce_sum.hpp
+++ b/include/lbann/layers/transform/batchwise_reduce_sum.hpp
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_TRANSFORM_BATCHWISE_REDUCE_SUM_HPP_INCLUDED
+#define LBANN_LAYERS_TRANSFORM_BATCHWISE_REDUCE_SUM_HPP_INCLUDED
+
+#include "lbann/layers/data_type_layer.hpp"
+
+namespace lbann {
+
+/** @brief Sum of tensor entries along batch dimension
+ *
+ *  Output tensor has same shape as input tensor.
+ */
+template <typename TensorDataType,
+          data_layout Layout = data_layout::DATA_PARALLEL,
+          El::Device Device = El::Device::CPU>
+class batchwise_reduce_sum_layer : public data_type_layer<TensorDataType> {
+public:
+
+  batchwise_reduce_sum_layer();
+  batchwise_reduce_sum_layer(const batchwise_reduce_sum_layer& other) = default;
+  batchwise_reduce_sum_layer& operator=(const batchwise_reduce_sum_layer& other) = default;
+
+  batchwise_reduce_sum_layer* copy() const override;
+
+  /** @name Serialization */
+  ///@{
+
+  template <typename ArchiveT>
+  void serialize(ArchiveT& ar);
+
+  ///@}
+
+  std::string get_type() const override;
+  data_layout get_data_layout() const override;
+  El::Device get_device_allocation() const override;
+
+protected:
+
+  void setup_dims(DataReaderMetaData& dr_metadata) override;
+
+  void fp_compute() override;
+  void bp_compute() override;
+
+};
+
+LBANN_DEFINE_LAYER_BUILDER(batchwise_reduce_sum);
+
+#ifndef LBANN_BATCHWISE_REDUCE_SUM_LAYER_INSTANTIATE
+#define PROTO_DEVICE(T, Device)                         \
+  extern template class batchwise_reduce_sum_layer<     \
+    T, data_layout::DATA_PARALLEL, Device>;             \
+  extern template class batchwise_reduce_sum_layer<     \
+    T, data_layout::MODEL_PARALLEL, Device>;
+#include "lbann/macros/instantiate_device.hpp"
+#undef PROTO_DEVICE
+#endif // LBANN_BATCHWISE_REDUCE_SUM_LAYER_INSTANTIATE
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_TRANSFORM_BATCHWISE_REDUCE_SUM_HPP_INCLUDED

--- a/src/layers/transform/CMakeLists.txt
+++ b/src/layers/transform/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  batchwise_reduce_sum.cpp
+  batchwise_reduce_sum_builder.cpp
   bernoulli.cpp
   categorical_random.cpp
   concatenate.cpp

--- a/src/layers/transform/batchwise_reduce_sum.cpp
+++ b/src/layers/transform/batchwise_reduce_sum.cpp
@@ -1,0 +1,164 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_BATCHWISE_REDUCE_SUM_LAYER_INSTANTIATE
+#include "lbann/layers/transform/batchwise_reduce_sum.hpp"
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::batchwise_reduce_sum_layer()
+  : data_type_layer<TensorDataType>(nullptr) {
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+batchwise_reduce_sum_layer<TensorDataType,Layout,Device>* batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::copy() const {
+  return new batchwise_reduce_sum_layer(*this);
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+std::string batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::get_type() const {
+  return "batch-wise reduce-sum";
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+data_layout batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::get_data_layout() const {
+  return Layout;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+El::Device batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::get_device_allocation() const {
+  return Device;
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::setup_dims(DataReaderMetaData& dr_metadata) {
+  data_type_layer<TensorDataType>::setup_dims(dr_metadata);
+  this->set_output_dims(this->get_input_dims());
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void batchwise_reduce_sum_layer<TensorDataType, Layout, Device>::fp_compute() {
+
+  // Data tensors
+  // Note: Assume input and output are aligned.
+  const auto& input = this->get_prev_activations();
+  const auto& local_input = input.LockedMatrix();
+  auto& local_output = this->get_local_activations();
+
+  // Temporary buffers
+  using LocalMat = El::Matrix<TensorDataType, Device>;
+  LocalMat sums, ones;
+  sums.Resize(local_input.Height(), 1);
+  El::Ones(ones, local_input.Width(), 1);
+
+  // Local sums
+  if (local_input.IsEmpty()) {
+    El::Zero(sums);
+  }
+  else {
+    El::Gemm(
+      El::NORMAL,
+      El::NORMAL,
+      El::TypeTraits<TensorDataType>::One(),
+      local_input,
+      ones,
+      El::TypeTraits<TensorDataType>::Zero(),
+      sums);
+  }
+
+  // Global sums
+  El::AllReduce(sums, input.RowComm(), El::mpi::SUM);
+
+  // Write to output tensor
+  if (!local_output.IsEmpty()) {
+    El::Gemm(
+      El::NORMAL,
+      El::TRANSPOSE,
+      El::TypeTraits<TensorDataType>::One(),
+      sums,
+      ones,
+      El::TypeTraits<TensorDataType>::Zero(),
+      local_output);
+  }
+
+}
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void batchwise_reduce_sum_layer<TensorDataType, Layout, Device>::bp_compute() {
+
+  // Data tensors
+  // Note: Assume input grad and output grad are aligned.
+  const auto& output_grad = this->get_prev_error_signals();
+  const auto& local_output_grad = output_grad.LockedMatrix();
+  auto& local_input_grad = this->get_local_error_signals();
+
+  // Temporary buffers
+  using LocalMat = El::Matrix<TensorDataType, Device>;
+  LocalMat sums, ones;
+  sums.Resize(local_output_grad.Height(), 1);
+  El::Ones(ones, local_output_grad.Width(), 1);
+
+  // Local sums
+  if (local_output_grad.IsEmpty()) {
+    El::Zero(sums);
+  }
+  else {
+    El::Gemm(
+      El::NORMAL,
+      El::NORMAL,
+      El::TypeTraits<TensorDataType>::One(),
+      local_output_grad,
+      ones,
+      El::TypeTraits<TensorDataType>::Zero(),
+      sums);
+  }
+
+  // Global sums
+  El::AllReduce(sums, output_grad.RowComm(), El::mpi::SUM);
+
+  // Write to output tensor
+  if (!local_input_grad.IsEmpty()) {
+    El::Gemm(
+      El::NORMAL,
+      El::TRANSPOSE,
+      El::TypeTraits<TensorDataType>::One(),
+      sums,
+      ones,
+      El::TypeTraits<TensorDataType>::Zero(),
+      local_input_grad);
+  }
+
+}
+
+#define PROTO_DEVICE(T, Device)                 \
+  template class batchwise_reduce_sum_layer<    \
+    T, data_layout::DATA_PARALLEL, Device>;     \
+  template class batchwise_reduce_sum_layer<    \
+    T, data_layout::MODEL_PARALLEL, Device>;
+#include "lbann/macros/instantiate_device.hpp"
+
+} // namespace lbann

--- a/src/layers/transform/batchwise_reduce_sum_builder.cpp
+++ b/src/layers/transform/batchwise_reduce_sum_builder.cpp
@@ -1,0 +1,51 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/transform/batchwise_reduce_sum.hpp"
+#include "lbann/proto/helpers.hpp"
+
+#include <lbann/proto/proto_common.hpp>
+#include <layers.pb.h>
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+std::unique_ptr<Layer> build_batchwise_reduce_sum_layer_from_pbuf(
+  lbann_comm* comm, lbann_data::Layer const& proto_layer)
+{
+  LBANN_ASSERT_MSG_HAS_FIELD(proto_layer, batchwise_reduce_sum);
+  using LayerType = batchwise_reduce_sum_layer<
+    TensorDataType,
+    data_layout::DATA_PARALLEL,
+    Device>;
+  return make_unique<LayerType>();
+}
+
+#define PROTO_DEVICE(T, Device) \
+  LBANN_LAYER_BUILDER_ETI(batchwise_reduce_sum, T, Device)
+#include "lbann/macros/instantiate_device.hpp"
+
+} // namespace lbann

--- a/src/layers/transform/cereal_registration/CMakeLists.txt
+++ b/src/layers/transform/cereal_registration/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Add the source files for this directory
 set_full_path(THIS_DIR_SOURCES
+  batchwise_reduce_sum.cpp
   bernoulli.cpp
   categorical_random.cpp
   concatenate.cpp

--- a/src/layers/transform/cereal_registration/batchwise_reduce_sum.cpp
+++ b/src/layers/transform/cereal_registration/batchwise_reduce_sum.cpp
@@ -1,0 +1,42 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#include "lbann/utils/serialize.hpp"
+#include <lbann/layers/transform/batchwise_reduce_sum.hpp>
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+template <typename ArchiveT>
+void batchwise_reduce_sum_layer<TensorDataType,Layout,Device>::serialize(ArchiveT& ar) {
+  using DataTypeLayer = data_type_layer<TensorDataType>;
+  ar(::cereal::make_nvp("DataTypeLayer",
+                        ::cereal::base_class<DataTypeLayer>(this)));
+}
+
+} // namespace lbann
+
+#define LBANN_LAYER_NAME batchwise_reduce_sum_layer
+#include <lbann/macros/register_layer_with_cereal.hpp>

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -76,6 +76,7 @@
 #include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 #include "lbann/layers/regularizers/layer_norm.hpp"
 #include "lbann/layers/regularizers/instance_norm.hpp"
+#include "lbann/layers/transform/batchwise_reduce_sum.hpp"
 #include "lbann/layers/transform/bernoulli.hpp"
 #include "lbann/layers/transform/categorical_random.hpp"
 #include "lbann/layers/transform/concatenate.hpp"
@@ -228,6 +229,7 @@ private:
     LBANN_REGISTER_BUILDER(Tanh, tanh);
 
     // Transform layers
+    LBANN_REGISTER_BUILDER(BatchwiseReduceSum, batchwise_reduce_sum);
     LBANN_REGISTER_BUILDER(Bernoulli, bernoulli);
     LBANN_REGISTER_BUILDER(CategoricalRandom, categorical_random);
     LBANN_REGISTER_BUILDER(Concatenation, concatenate);

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -92,6 +92,7 @@ message Layer {
     Tessellate tessellate = 327;
     Scatter scatter = 334;
     Gather gather = 335;
+    BatchwiseReduceSum batchwise_reduce_sum = 336;
 
     // Learning layers
     FullyConnected fully_connected = 11;
@@ -581,6 +582,12 @@ message Layer {
     *  gather along a specified dimension.
     */
   message Gather {}
+
+  /** @brief Sum of tensor entries along batch dimension
+    *
+    *  Output tensor has same shape as input tensor.
+    */
+  message BatchwiseReduceSum {}
 
   /////////////////////
   // Learning layers //


### PR DESCRIPTION
Some of our applications require batch-wise metrics, e.g. R2 over a mini-batch. In principle, we can implement a lot of these with a sum that goes over the batch dimension (e.g. `torch.sum(x, dim=0)` in PyTorch). For example, if we want to compute the (biased) variance of a scalar over a mini-batch, we can now do:
```
# var(x) = mean(x^2) - mean(x)^2
mini_batch_size = lbann.MiniBatchSize()
mean = lbann.Divide(lbann.BatchwiseReduceSum(x), mini_batch_size)
sqmean = lbann.Divide(lbann.BatchwiseReduceSum(lbann.Square(x)), mini_batch_size)
var = lbann.Subtract(sqmean, lbann.Square(mean))

# var(x) = mean( (x-mean(x))^2 )
# Note: This is better than the above for numerical accuracy
mini_batch_size = lbann.MiniBatchSize()
mean = lbann.Divide(lbann.BatchwiseReduceSum(x), mini_batch_size)
var = lbann.Divide(lbann.BatchwiseReduceSum(lbann.Square(lbann.Subtract(x, mean))), mini_batch_size)
```
Note that this layer requires blocking communication, so it will hurt performance.

[No new Bamboo errors](https://lc.llnl.gov/bamboo/browse/LBANN-TIM353-1).