### PR TITLE
Fix 403 error when downloading MNIST

### DIFF
--- a/applications/vision/data/mnist/__init__.py
+++ b/applications/vision/data/mnist/__init__.py
@@ -30,10 +30,16 @@ def download_data():
         data_file = os.path.join(data_dir, data_file)
         compressed_file = data_file + '.gz'
         if not os.path.isfile(data_file):
-            urllib.request.urlretrieve(url, filename=compressed_file)
-            with gzip.open(compressed_file, 'rb') as in_file:
-                with open(data_file, 'wb') as out_file:
-                    out_file.write(in_file.read())
+            request = urllib.request.Request(
+                url,
+                headers={'User-Agent': 'LBANN/vision-app'},
+            )
+            with urllib.request.urlopen(request) as response, \
+                 open(compressed_file, 'wb') as out_file:
+                out_file.write(response.read())
+            with gzip.open(compressed_file, 'rb') as in_file, \
+                 open(data_file, 'wb') as out_file:
+                out_file.write(in_file.read())
 
 def make_data_reader():
     """Make Protobuf message for MNIST data reader.


### PR DESCRIPTION
Our scripts to download MNIST fail with 403 errors (see https://github.com/pytorch/pytorch/issues/53267), likely due to some change in Yann LeCun's website. This PR copies the fix from torchvision (https://github.com/pytorch/vision/pull/3499). We don't need to change the MNIST data reader in Bamboo since it uses hard-coded paths in LC.