### PR TITLE
Actually-non-blocking allreduce without Aluminum

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -95,6 +95,7 @@ struct request
   mpi_req_type mpi_req = mpi_null_req;
   nccl_req_type nccl_req = nccl_null_req;
   mpicuda_req_type mpicuda_req = mpicuda_null_req;
+  MPI_Request raw_mpi_req = MPI_REQUEST_NULL;
 };
 
 } // namespace Al

--- a/include/lbann/comm_impl.hpp
+++ b/include/lbann/comm_impl.hpp
@@ -728,13 +728,13 @@ void lbann_comm::nb_allreduce(T* data,
     c.template GetComm<::Al::MPIBackend>(El::SyncInfo<El::Device::CPU>{}),
     req.mpi_req);
 #else
-  MPI_Iallreduce(data,
-                 MPI_IN_PLACE,
+  MPI_Iallreduce(MPI_IN_PLACE,
+                 data,
                  count,
                  El::mpi::TypeMap<T>(),
                  op.op,
-                 c.GetMPIComm()
-                 &req.raw_mpi_req);
+                 c.GetMPIComm(),
+                 &(req.raw_mpi_req));
 #endif // LBANN_HAS_ALUMINUM
   m_bytes_received += count * sizeof(T) * (El::mpi::Size(c) - 1);
 }

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -219,13 +219,25 @@ void allreduce_impl(El::Matrix<T, D>& m,
   return El::AllReduce(m, c, op);
 }
 
-template <typename T, El::Device D>
-void nb_allreduce_impl(El::Matrix<T, D>& m,
+template <typename T>
+void nb_allreduce_impl(El::Matrix<T, El::Device::CPU>& m,
                        const El::mpi::Comm& c,
-                       Al::request&,
+                       Al::request& req,
                        El::mpi::Op const& op)
 {
-  return El::AllReduce(m, c, op);
+  if (m.Height() == m.LDim() || m.Width() == 1) {
+    auto const count = m.Height() * m.Width();
+    MPI_Iallreduce(m.Buffer(),
+                   MPI_IN_PLACE,
+                   count,
+                   El::mpi::TypeMap<T>(),
+                   op.op,
+                   c.GetMPIComm(),
+                   &(req.raw_mpi_req));
+  }
+  else {
+    return El::AllReduce(m, c, op);
+  }
 }
 
 #if defined(LBANN_HAS_GPU) && defined(LBANN_HAS_ALUMINUM)
@@ -452,6 +464,9 @@ void lbann_comm::wait(Al::request& req) const
   }
 #endif // AL_HAS_MPI_CUDA
 #endif // LBANN_HAS_ALUMINUM
+  if (req.raw_mpi_req != MPI_REQUEST_NULL) {
+    MPI_Wait(&(req.raw_mpi_req), MPI_STATUS_IGNORE);;
+  }
 }
 
 bool lbann_comm::test(Al::request& req) const
@@ -472,6 +487,11 @@ bool lbann_comm::test(Al::request& req) const
   }
 #endif // AL_HAS_MPI_CUDA
 #endif // LBANN_HAS_ALUMINUM
+  if (req.raw_mpi_req != MPI_REQUEST_NULL) {
+    int flag = 0;
+    MPI_Test(&(req.raw_mpi_req), &flag, MPI_STATUS_IGNORE);
+    req_test = flag;
+  }
   return req_test;
 }
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -227,8 +227,8 @@ void nb_allreduce_impl(El::Matrix<T, El::Device::CPU>& m,
 {
   if (m.Height() == m.LDim() || m.Width() == 1) {
     auto const count = m.Height() * m.Width();
-    MPI_Iallreduce(m.Buffer(),
-                   MPI_IN_PLACE,
+    MPI_Iallreduce(MPI_IN_PLACE,
+                   m.Buffer(),
                    count,
                    El::mpi::TypeMap<T>(),
                    op.op,

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -232,6 +232,7 @@ template <typename TensorDataType>
 void abstract_evaluation_layer<TensorDataType>::fp_compute() {
   switch (this->get_device_allocation()) {
   case El::Device::CPU:
+    this->get_comm()->wait(m_allreduce_req);
     fp_cpu(*this->get_comm(),
            this->get_prev_activations(),
            m_value(0, 0),


### PR DESCRIPTION
This sort of punts on (a) noncontiguous matrices (but I don't see those showing up, at least not in the ATOM model I'm testing with) and (b) GPU matrices (but in this case one _should_ be using Aluminum or just accept bad performance).

I'm slightly torn: it makes some sense to migrate this code into Hydrogen so it's hidden a bit better and then all the actual MPI calls are coming from Hydrogen. On the other hand, `libHydrogen` doesn't need nonblocking collectives for its own purposes. Any thoughts?