### PR TITLE
Fix bug in MIOpen dropout

### DIFF
--- a/include/lbann/utils/dnn_lib/miopen/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/dropout.hpp
@@ -68,7 +68,7 @@ void dropout_forward(DropoutDescriptor const& dropoutDesc,
   CHECK_MIOPEN(
     miopenDropoutForward(handle_manager.get(),
                          dropoutDesc,
-                         /*noise_shape=*/nullptr, // placeholder, unused.
+                         /*noise_shape=*/xDesc, // placeholder, unused.
                          xDesc,
                          x.LockedBuffer(),
                          yDesc,
@@ -104,7 +104,7 @@ void dropout_backward(DropoutDescriptor const& dropoutDesc,
   CHECK_MIOPEN(
     miopenDropoutBackward(handle_manager.get(),
                           dropoutDesc,
-                          /*noise_shape=*/nullptr, // placeholder, unused.
+                          /*noise_shape=*/dyDesc, // placeholder, unused.
                           dyDesc,
                           dy.LockedBuffer(),
                           dxDesc,


### PR DESCRIPTION
The `noise_shape` tensor descriptor passed to the MIOpen `dropout{Forward,Backward}` was causing a nullptr dereference error.  The `noise_shape` input is not used according to MIOpen docs: https://rocmsoftwareplatform.github.io/MIOpen/doc/html/dropout.html#miopendropoutforward

I replaced the `nullptr` with the input tensor descriptor for `noise_shape` to fix this bug.