### PR TITLE
Handle weights with dims >2.1B

### DIFF
--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -178,7 +178,7 @@ void channelwise_scale_bias_layer<TensorDataType, Layout, Dev>
   auto dist = this->get_prev_activations().DistData();
   dist.colDist = El::STAR;
   dist.rowDist = El::STAR;
-  this->get_weights(0).set_dims({static_cast<int>(num_channels)}, {2});
+  this->get_weights(0).set_dims({static_cast<size_t>(num_channels)}, {2});
   this->get_weights(0).set_matrix_distribution(dist);
 
   // Setup gradient w.r.t. weights

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -239,8 +239,7 @@ void embedding_layer<TensorDataType,Layout,Device>::setup_data(size_t max_mini_b
   auto matrix_dist = this->get_prev_activations().DistData();
   matrix_dist.colDist = El::STAR;
   matrix_dist.rowDist = El::STAR;
-  embeddings.set_dims({static_cast<int>(m_embedding_dim)},
-                      {static_cast<int>(m_num_embeddings)});
+  embeddings.set_dims({m_embedding_dim}, {m_num_embeddings});
   embeddings.set_matrix_distribution(matrix_dist);
   embeddings.setup();
 

--- a/include/lbann/layers/learning/entrywise_scale_bias.hpp
+++ b/include/lbann/layers/learning/entrywise_scale_bias.hpp
@@ -153,8 +153,9 @@ entrywise_scale_bias_layer<TensorDataType, Layout, Dev>
 
     // Initialize output dimensions
     this->set_output_dims(this->get_input_dims());
-    const auto output_dims = this->get_output_dims();
-    const El::Int output_size = this->get_output_size();
+    const auto& output_dims_ = this->get_output_dims();
+    std::vector<size_t> output_dims(output_dims_.begin(), output_dims_.end());
+    const auto output_size = this->get_output_size();
 
     // Construct default weights if needed
     // Note: Scale is initialized to 1 and bias to 0
@@ -183,7 +184,7 @@ entrywise_scale_bias_layer<TensorDataType, Layout, Dev>
     auto dist = this->get_prev_activations().DistData();
     dist.rowDist = El::STAR;
     this->get_weights(0).set_dims(output_dims,
-                                     {static_cast<int>(2)});
+                                  {static_cast<int>(2)});
     this->get_weights(0).set_matrix_distribution(dist);
 
     // Setup gradient w.r.t. weights

--- a/include/lbann/layers/misc/dist_embedding.hpp
+++ b/include/lbann/layers/misc/dist_embedding.hpp
@@ -322,9 +322,7 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::setup_data(size_t max_m
     auto dist = this->get_prev_activations().DistData();
     dist.colDist = El::STAR;
     dist.rowDist = El::VC;
-    embeddings.set_dims(
-      {static_cast<int>(m_embedding_dim)},
-      {static_cast<int>(m_num_embeddings)});
+    embeddings.set_dims({m_embedding_dim}, {m_num_embeddings});
     embeddings.set_matrix_distribution(dist);
   }
 

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -132,7 +132,8 @@ protected:
 
     // Initialize output dimensions
     this->set_output_dims(this->get_input_dims());
-    const auto output_dims = this->get_output_dims();
+    const auto output_dims_ = this->get_output_dims();
+    std::vector<size_t> output_dims(output_dims_.begin(), output_dims_.end());
     const auto output_size = this->get_output_size();
 
     // Initialize default weights if none are provided

--- a/include/lbann/layers/transform/weights.hpp
+++ b/include/lbann/layers/transform/weights.hpp
@@ -146,9 +146,11 @@ public:
     }
 
     // Setup weights and weights gradient
+    const auto& output_dims_ = this->get_output_dims();
+    std::vector<size_t> output_dims(output_dims_.begin(), output_dims_.end());
     m_gradient->AlignWith(this->get_activations());
     m_gradient->Resize(this->get_output_size(), 1);
-    this->get_weights(0).set_dims(this->get_output_dims());
+    this->get_weights(0).set_dims(output_dims);
     this->get_weights(0).set_matrix_distribution(m_gradient->DistData());
 
     // Initialize freeze state

--- a/include/lbann/weights/data_type_weights.hpp
+++ b/include/lbann/weights/data_type_weights.hpp
@@ -177,8 +177,8 @@ private:
 
   void do_augment_description_(description&) const override;
   void do_setup_() override;
-  void do_set_dims_(std::vector<int> const& matrix_height_dims,
-                    std::vector<int> const& matrix_width_dims) override;
+  void do_set_dims_(std::vector<size_t> const& matrix_height_dims,
+                    std::vector<size_t> const& matrix_width_dims) override;
   void do_move_values_(data_type_weights& other);
   void do_steal_values_(weights& other) override;
 private:

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -135,34 +135,34 @@ public:
    *  height dimensions. If the local matrices are also fully packed,
    *  the tensor data is fully packed.
    */
-  std::vector<int> get_dims() const;
+  std::vector<size_t> get_dims() const;
   /** Get number of entries in weight tensor. */
-  int get_size() const;
+  size_t get_size() const;
   /** Get tensor dimensions corresponding to weight matrix height.
    *  The dimensions are sorted in decreasing order of strides. Matrix
    *  rows are fully-packed w.r.t. the matrix height dimensions.
    */
-  std::vector<int> get_matrix_height_dims() const;
+  std::vector<size_t> get_matrix_height_dims() const;
   /** Get tensor dimensions corresponding to weight matrix width.
    *  The dimensions are sorted in decreasing order of strides. Matrix
    *  columns are fully-packed w.r.t. the matrix width dimensions.
    */
-  std::vector<int> get_matrix_width_dims() const;
+  std::vector<size_t> get_matrix_width_dims() const;
   /** Get weight matrix height.
    *  If there are no matrix height dimensions, the height is one.
    */
-  int get_matrix_height() const;
+  size_t get_matrix_height() const;
   /** Get weight matrix width.
    *  If there are no matrix width dimensions, the width is one.
    */
-  int get_matrix_width() const;
+  size_t get_matrix_width() const;
   /** Set weight tensor dimensions.
    *  See the 'get_dims' function for an explanation of the notation.
    */
-  void set_dims(std::vector<int> matrix_height_dims,
-                std::vector<int> matrix_width_dims = std::vector<int>());
+  void set_dims(std::vector<size_t> matrix_height_dims,
+                std::vector<size_t> matrix_width_dims = {});
   /** Set weight tensor dimensions as a 1D tensor. */
-  void set_dims(int size) { set_dims({size}, {}); }
+  void set_dims(size_t size) { set_dims({size}, {}); }
 
   // -----------------------------------------------
   // Matrix distribution accessors
@@ -296,8 +296,8 @@ protected:
 private:
   virtual void do_augment_description_(description&) const = 0;
   virtual void do_setup_() = 0;
-  virtual void do_set_dims_(std::vector<int> const& matrix_height_dims,
-                            std::vector<int> const& matrix_width_dims) = 0;
+  virtual void do_set_dims_(std::vector<size_t> const& matrix_height_dims,
+                            std::vector<size_t> const& matrix_width_dims) = 0;
   virtual void do_steal_values_(weights& other) = 0;
 private:
 
@@ -313,11 +313,11 @@ private:
   /** Tensor dimensions corresponding to matrix height.
    *  See the 'get_matrix_height_dims' function.
    */
-  std::vector<int> m_matrix_height_dims;
+  std::vector<size_t> m_matrix_height_dims;
   /** Tensor dimensions corresponding to matrix width.
    *  See the 'get_matrix_width_dims' function.
    */
-  std::vector<int> m_matrix_width_dims;
+  std::vector<size_t> m_matrix_width_dims;
   /** Distribution of weights matrix. */
   El::DistData m_matrix_dist;
 

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -302,7 +302,8 @@ base_convolution_layer<TensorDataType,Device>
   // Tensor dimensions
   const auto& input_dims = this->get_input_dims();
   const auto& output_dims = this->get_output_dims();
-  const auto& kernel_dims = this->get_kernel_dims();
+  const auto& kernel_dims_ = this->get_kernel_dims();
+  std::vector<size_t> kernel_dims(kernel_dims_.begin(), kernel_dims_.end());
   const auto& kernel_size = std::accumulate(kernel_dims.begin(),
                                             kernel_dims.end(),
                                             1, std::multiplies<int>());

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -152,9 +152,9 @@ channelwise_fully_connected_layer<TensorDataType,Layout,Device>
   // Tensor dimensions
   const auto& input_dims = this->get_input_dims();
   const auto& output_dims = this->get_output_dims();
-  const std::vector<int> input_channel_dims(
+  const std::vector<size_t> input_channel_dims(
     input_dims.begin()+1, input_dims.end());
-  const std::vector<int> output_channel_dims(
+  const std::vector<size_t> output_channel_dims(
     output_dims.begin()+1, output_dims.end());
   const auto& input_channel_size = std::accumulate(
     input_channel_dims.begin(), input_channel_dims.end(),

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -164,6 +164,12 @@ void fully_connected_layer<TensorDataType, T_layout, Dev>
     set_fan_out(*initializer, this->get_output_size());
   }
 
+  // Input and output dimensions
+  const auto& input_dims_ = this->get_input_dims();
+  const auto& output_dims_ = this->get_output_dims();
+  std::vector<size_t> input_dims(input_dims_.begin(), input_dims_.end());
+  std::vector<size_t> output_dims(output_dims_.begin(), output_dims_.end());
+
   // Setup linearity weights
   auto linearity_dist = this->get_prev_activations().DistData();
   if (linearity_dist.colDist != El::MC
@@ -172,9 +178,9 @@ void fully_connected_layer<TensorDataType, T_layout, Dev>
     linearity_dist.rowDist = El::STAR;
   }
   if (m_transpose) {
-    linearity_weights.set_dims(this->get_input_dims(), this->get_output_dims());
+    linearity_weights.set_dims(input_dims, output_dims);
   } else {
-    linearity_weights.set_dims(this->get_output_dims(), this->get_input_dims());
+    linearity_weights.set_dims(output_dims, input_dims);
   }
   linearity_weights.set_matrix_distribution(linearity_dist);
 
@@ -192,7 +198,7 @@ void fully_connected_layer<TensorDataType, T_layout, Dev>
     // Setup bias weights
     auto bias_dist = this->get_activations().DistData();
     bias_dist.rowDist = El::STAR;
-    bias_weights.set_dims(this->get_output_dims());
+    bias_weights.set_dims(output_dims);
     bias_weights.set_matrix_distribution(bias_dist);
     if (this->m_bias_gradient != nullptr) {
       El::Zeros(*this->m_bias_gradient,

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -225,13 +225,11 @@ void gru_layer<TensorDataType, Layout, Device>
     auto& hh_bias = this->get_weights(4*i+3);
 
     ih_matrix.set_dims(
-      {static_cast<int>(3*m_hidden_size)},
-      {static_cast<int>(i == 0 ? input_size : m_hidden_size)});
-    hh_matrix.set_dims(
-      {static_cast<int>(3*m_hidden_size)},
-      {static_cast<int>(m_hidden_size)});
-    ih_bias.set_dims({static_cast<int>(3*m_hidden_size)});
-    hh_bias.set_dims({static_cast<int>(3*m_hidden_size)});
+      {3*m_hidden_size},
+      {i == 0 ? input_size : m_hidden_size});
+    hh_matrix.set_dims({3*m_hidden_size}, {m_hidden_size});
+    ih_bias.set_dims({3*m_hidden_size});
+    hh_bias.set_dims({3*m_hidden_size});
     auto dist = this->get_prev_activations().DistData();
     dist.colDist = El::STAR;
     dist.rowDist = El::STAR;

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -129,8 +129,8 @@ void data_type_weights<TensorDataType>::do_set_dims_(
   std::vector<size_t> const& matrix_height_dims,
   std::vector<size_t> const& matrix_width_dims) {
   if (m_values != nullptr) {
-    const auto& height = this->get_matrix_height();
-    const auto& width = this->get_matrix_width();
+    const El::Int height = this->get_matrix_height();
+    const El::Int width = this->get_matrix_width();
     if (m_values->Height() != height || m_values->Width() != width) {
       LBANN_ERROR("attempted to set weights \"", this->get_name(), "\" "
                   "with dimensions ",

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -44,7 +44,7 @@
 namespace {
 
 /** @brief Get a string version of tensor dimensions */
-std::string stringify_dims(const std::vector<int>& dims)
+std::string stringify_dims(const std::vector<size_t>& dims)
 {
   std::ostringstream oss;
   oss << dims.front();
@@ -57,8 +57,8 @@ std::string stringify_dims(const std::vector<int>& dims)
  *  The tensor is stored in a matrix, although there may be multiple
  *  dimensions corresponding to the matrix height and width.
  */
-std::string get_dims_string(const std::vector<int>& matrix_height_dims,
-                            const std::vector<int>& matrix_width_dims) {
+std::string get_dims_string(const std::vector<size_t>& matrix_height_dims,
+                            const std::vector<size_t>& matrix_width_dims) {
   std::ostringstream oss;
   oss << "(" << stringify_dims(matrix_height_dims) << ")x"
       << "(" << stringify_dims(matrix_width_dims) << ")";
@@ -126,8 +126,8 @@ void data_type_weights<TensorDataType>::do_augment_description_(description& des
 // -----------------------------------------------
 template <typename TensorDataType>
 void data_type_weights<TensorDataType>::do_set_dims_(
-  std::vector<int> const& matrix_height_dims,
-  std::vector<int> const& matrix_width_dims) {
+  std::vector<size_t> const& matrix_height_dims,
+  std::vector<size_t> const& matrix_width_dims) {
   if (m_values != nullptr) {
     const auto& height = this->get_matrix_height();
     const auto& width = this->get_matrix_width();

--- a/src/weights/unit_test/weights_proxy_test.cpp
+++ b/src/weights/unit_test/weights_proxy_test.cpp
@@ -93,13 +93,13 @@ TEST_CASE("Basic weights tests", "[mpi][weights]")
   using DataType = float;
 
   auto& world_comm = unit_test::utilities::current_world_comm();
-  int const size_of_world = world_comm.get_procs_in_world();
+  size_t const size_of_world = world_comm.get_procs_in_world();
 
   // Setup the weights object -- let's hope I do this right. It's not
   // like it's documented anywhere.
 
-  int const weights_height = 3 * size_of_world;
-  int const weights_width = 2 * size_of_world;
+  size_t const weights_height = 3 * size_of_world;
+  size_t const weights_width = 2 * size_of_world;
 
   // Create the object
   DataTypeWeights<DataType> dtw(world_comm);
@@ -123,8 +123,10 @@ TEST_CASE("Basic weights tests", "[mpi][weights]")
     REQUIRE_NOTHROW(dtw.setup());
     CHECK(count_differing_values(value, get_local_values(dtw)) == 0UL);
 
-    CHECK(dtw.get_values().Height() == dtw.get_matrix_height());
-    CHECK(dtw.get_values().Width() == dtw.get_matrix_width());
+    CHECK(dtw.get_values().Height()
+          == El::To<El::Int>(dtw.get_matrix_height()));
+    CHECK(dtw.get_values().Width()
+          == El::To<El::Int>(dtw.get_matrix_width()));
   }
 }
 
@@ -176,11 +178,11 @@ TEMPLATE_TEST_CASE("Weights proxy tests.", "[mpi][weights][proxy]",
   using DataType = ProxyType<TestType>;
 
   auto& world_comm = unit_test::utilities::current_world_comm();
-  int const size_of_world = world_comm.get_procs_in_world();
+  size_t const size_of_world = world_comm.get_procs_in_world();
 
   // Setup the weights object
-  int const weights_height = 3 * size_of_world;
-  int const weights_width = 2 * size_of_world;
+  size_t const weights_height = 3 * size_of_world;
+  size_t const weights_width = 2 * size_of_world;
 
   // Create the master weights object.
   auto dtw = std::make_shared<DataTypeWeights<MasterDataType>>(world_comm);
@@ -207,8 +209,10 @@ TEMPLATE_TEST_CASE("Weights proxy tests.", "[mpi][weights][proxy]",
     REQUIRE(!proxy.empty());
 
     // At this point, the proxy should have the right size.
-    CHECK(proxy.values().Height() == dtw->get_matrix_height());
-    CHECK(proxy.values().Width() == dtw->get_matrix_width());
+    CHECK(proxy.values().Height()
+          == El::To<El::Int>(dtw->get_matrix_height()));
+    CHECK(proxy.values().Width()
+          == El::To<El::Int>(dtw->get_matrix_width()));
 
     REQUIRE_NOTHROW(proxy.synchronize_with_master());
 
@@ -293,7 +297,9 @@ TEMPLATE_TEST_CASE("Weights proxy tests.", "[mpi][weights][proxy]",
     CHECK(&proxy_default.master_weights() == dtw.get());
 
     // At this point, the proxy_default should have the right size.
-    CHECK(proxy_default.values().Height() == dtw->get_matrix_height());
-    CHECK(proxy_default.values().Width() == dtw->get_matrix_width());
+    CHECK(proxy_default.values().Height()
+          == El::To<El::Int>(dtw->get_matrix_height()));
+    CHECK(proxy_default.values().Width()
+          == El::To<El::Int>(dtw->get_matrix_width()));
   }
 }

--- a/src/weights/unit_test/weights_test.cpp
+++ b/src/weights/unit_test/weights_test.cpp
@@ -56,7 +56,7 @@ auto make_weights(lbann::lbann_comm& comm)
 }
 
 template <typename T>
-auto make_weights(lbann::lbann_comm& comm, int height, int width)
+auto make_weights(lbann::lbann_comm& comm, size_t height, size_t width)
 {
   T const value = El::To<T>(1.3);
   DataTypeWeights<T> out(comm);
@@ -68,7 +68,7 @@ auto make_weights(lbann::lbann_comm& comm, int height, int width)
 }// namespace <>
 
 template <typename T>
-auto make_weights_ptr(lbann::lbann_comm& comm, int height, int width)
+auto make_weights_ptr(lbann::lbann_comm& comm, size_t height, size_t width)
 {
   T const value = El::To<T>(1.3);
   auto out = std::make_unique<DataTypeWeights<T>>(comm);
@@ -84,7 +84,7 @@ TEST_CASE("Serializing weights", "[mpi][weights][serialize]")
   using DataType = float;
 
   auto& world_comm = unit_test::utilities::current_world_comm();
-  int const size_of_world = world_comm.get_procs_in_world();
+  size_t const size_of_world = world_comm.get_procs_in_world();
 
   auto const& g = world_comm.get_trainer_grid();
   lbann::utils::grid_manager mgr(g);
@@ -92,8 +92,8 @@ TEST_CASE("Serializing weights", "[mpi][weights][serialize]")
   std::stringstream ss;
 
   // Create the objects
-  int const weights_height = 3 * size_of_world;
-  int const weights_width = 2 * size_of_world;
+  size_t const weights_height = 3 * size_of_world;
+  size_t const weights_width = 2 * size_of_world;
 
   auto dtw_src = make_weights<DataType>(world_comm,
                                         weights_height,

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -45,8 +45,8 @@ namespace {
  *  The tensor is stored in a matrix, although there may be multiple
  *  dimensions corresponding to the matrix height and width.
  */
-std::string get_dims_string(const std::vector<int>& matrix_height_dims,
-                            const std::vector<int>& matrix_width_dims) {
+std::string get_dims_string(const std::vector<size_t>& matrix_height_dims,
+                            const std::vector<size_t>& matrix_width_dims) {
   std::stringstream ss;
   ss << "(";
   for (size_t i = 0; i < matrix_height_dims.size(); ++i) {
@@ -122,35 +122,35 @@ description weights::get_description() const {
 // Dimension accessors
 // -----------------------------------------------
 
-std::vector<int> weights::get_dims() const {
-  std::vector<int> dims;
+std::vector<size_t> weights::get_dims() const {
+  std::vector<size_t> dims;
   for (const auto& d : get_matrix_width_dims())  { dims.push_back(d); }
   for (const auto& d : get_matrix_height_dims()) { dims.push_back(d); }
   return dims;
 }
-int weights::get_size() const {
+size_t weights::get_size() const {
   const auto& dims = get_dims();
   return std::accumulate(dims.begin(), dims.end(),
-                         1, std::multiplies<int>());
+                         1, std::multiplies<size_t>());
 }
-std::vector<int> weights::get_matrix_height_dims() const {
+std::vector<size_t> weights::get_matrix_height_dims() const {
   return m_matrix_height_dims;
 }
-std::vector<int> weights::get_matrix_width_dims() const {
+std::vector<size_t> weights::get_matrix_width_dims() const {
   return m_matrix_width_dims;
 }
-int weights::get_matrix_height() const {
+size_t weights::get_matrix_height() const {
   const auto& dims = get_matrix_height_dims();
   return std::accumulate(dims.begin(), dims.end(),
-                         1, std::multiplies<int>());
+                         1, std::multiplies<size_t>());
 }
-int weights::get_matrix_width() const {
+size_t weights::get_matrix_width() const {
   const auto& dims = get_matrix_width_dims();
   return std::accumulate(dims.begin(), dims.end(),
-                         1, std::multiplies<int>());
+                         1, std::multiplies<size_t>());
 }
-void weights::set_dims(std::vector<int> matrix_height_dims,
-                       std::vector<int> matrix_width_dims) {
+void weights::set_dims(std::vector<size_t> matrix_height_dims,
+                       std::vector<size_t> matrix_width_dims) {
   m_matrix_height_dims = std::move(matrix_height_dims);
   m_matrix_width_dims = std::move(matrix_width_dims);
   do_set_dims_(matrix_height_dims, matrix_width_dims);
@@ -204,7 +204,7 @@ void weights::setup_default_matrix_distribution() {
 void weights::setup() {
 
   // Check that tensor dimensions are valid
-  const auto& is_nonpositive = [] (int d) { return d <= 0; };
+  const auto& is_nonpositive = [] (size_t d) { return d <= 0; };
   if (std::any_of(m_matrix_height_dims.begin(),
                   m_matrix_height_dims.end(),
                   is_nonpositive)


### PR DESCRIPTION
@KIwabuchi has observed integer overflow errors when running node2vec on very large graphs. The fix is to store weight dims in `size_t` instead of `int`. With this change, I've been able to run on Lassen with 5B embeddings and synthetic data. The GPU implementation runs without problem, but the CPU implementation fails with an OpenSHMEM error. I don't see anything substantially different between the CPU and GPU implementations, so maybe it's something in OpenMPI OpenSHMEM?

This is making progress toward #91. [Bamboo is failing](https://lc.llnl.gov/bamboo/browse/LBANN-TIM355-1/artifact) because I forgot the unit tests, but the main code should be ready for review.