### PR TITLE
Use size_t for weights positions

### DIFF
--- a/include/lbann/weights/data_type_weights.hpp
+++ b/include/lbann/weights/data_type_weights.hpp
@@ -135,11 +135,11 @@ public:
   void set_values(const AbsDistMatrixType& values);
 
   /** Set a weight value. */
-  void set_value(TensorDataType value, int index);
+  void set_value(TensorDataType value, size_t index);
   /** Set an entry in the weight tensor. */
-  void set_value(TensorDataType value, std::vector<int> pos);
+  void set_value(TensorDataType value, std::vector<size_t> pos);
   /** Set an entry in the weight matrix. */
-  void set_value(TensorDataType value, int row, int col);
+  void set_value(TensorDataType value, size_t row, size_t col);
 
   /** Reconcile weight values.
    *  If weight values are duplicated across multiple processes, they

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -271,7 +271,7 @@ void data_type_weights<TensorDataType>::set_values(const AbsDistMatrixType& valu
 }
 
 template <typename TensorDataType>
-void data_type_weights<TensorDataType>::set_value(TensorDataType value, int index) {
+void data_type_weights<TensorDataType>::set_value(TensorDataType value, size_t index) {
 
 #ifdef LBANN_DEBUG
   // Check that tensor position is valid
@@ -291,7 +291,7 @@ void data_type_weights<TensorDataType>::set_value(TensorDataType value, int inde
 }
 
 template <typename TensorDataType>
-void data_type_weights<TensorDataType>::set_value(TensorDataType value, std::vector<int> pos) {
+void data_type_weights<TensorDataType>::set_value(TensorDataType value, std::vector<size_t> pos) {
 
   // Get tensor dimensions
   const auto& dims = this->get_dims();
@@ -311,7 +311,7 @@ void data_type_weights<TensorDataType>::set_value(TensorDataType value, std::vec
 #endif // LBANN_DEBUG
 
   // Get index of weight value and set
-  int index = 0;
+  size_t index = 0;
   for (size_t i = 0; i < dims.size(); ++i) {
     index = index * dims[i] + pos[i];
   }
@@ -319,7 +319,7 @@ void data_type_weights<TensorDataType>::set_value(TensorDataType value, std::vec
 }
 
 template <typename TensorDataType>
-void data_type_weights<TensorDataType>::set_value(TensorDataType value, int row, int col) {
+void data_type_weights<TensorDataType>::set_value(TensorDataType value, size_t row, size_t col) {
 
 #ifdef LBANN_DEBUG
   // Check that matrix entry is valid


### PR DESCRIPTION
PR #1819 introduced some compile errors in the debug build since the weights positions (in `int`) don't match the dimensions (in `size_t`).

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM357-1). Pinging @davidHysom.