### PR TITLE
Reformatting, documentation, and slight API tweaks

### DIFF
--- a/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
@@ -28,30 +28,33 @@
 #define LBANN_SGD_TRAINING_ALGORITHM_HPP
 
 #include "lbann/execution_algorithms/training_algorithm.hpp"
+#include "lbann/execution_contexts/execution_context.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
+#include "lbann/utils/cloneable.hpp"
 
 namespace lbann {
 
 /** @brief Base class for LBANN SGD-family training algorithms. */
-class sgd_training_algorithm : public training_algorithm {
-public:
+class sgd_training_algorithm
+  : public Cloneable<sgd_training_algorithm, training_algorithm>
+{
+  using BaseType = Cloneable<sgd_training_algorithm, training_algorithm>;
 
-  /** Constructor. */
-  sgd_training_algorithm() {};
-  /** Copy constructor. */
+public:
+  /** @brief Construct with a name. */
+  sgd_training_algorithm(std::string name) : BaseType{std::move(name)} {}
+
   sgd_training_algorithm(const sgd_training_algorithm& other) = default;
-  /** Copy assignment operator. */
-  sgd_training_algorithm& operator=(const sgd_training_algorithm& other) = default;
-  /** Move constructor. */
+  sgd_training_algorithm&
+  operator=(const sgd_training_algorithm& other) = default;
   sgd_training_algorithm(sgd_training_algorithm&& other) = default;
-  /** Move assignment operator. */
   sgd_training_algorithm& operator=(sgd_training_algorithm&& other) = default;
-  /** Destructor. */
+
   virtual ~sgd_training_algorithm() = default;
   /** Copy training_algorithm. */
   //  virtual sgd_training_algorithm* copy() const = default;
 
-  std::string get_name() const override { return "sgd"; }
+  std::string get_type() const override;
 
   // ===========================================
   // Execution
@@ -69,20 +72,27 @@ public:
   void train(sgd_execution_context& c,
              model& model,
              data_coordinator& dc,
-             size_t num_epochs, size_t num_batches=0);
+             size_t num_epochs,
+             size_t num_batches = 0);
 
   /** Evaluate a model using the forward pass of an SGD solver. */
   void evaluate(sgd_execution_context& c,
                 model& model,
                 data_coordinator& dc,
-                execution_mode mode, size_t num_batches=0);
+                execution_mode mode,
+                size_t num_batches = 0);
 
 protected:
   /** Train model on one step / mini-batch of an SGD forward pass */
-  virtual bool train_mini_batch(sgd_execution_context& c, model& model, data_coordinator& dc);
+  virtual bool train_mini_batch(sgd_execution_context& c,
+                                model& model,
+                                data_coordinator& dc);
 
   /** Evaluate model on one step / mini-batch of an SGD forward pass */
-  virtual bool evaluate_mini_batch(sgd_execution_context& c, model& model, data_coordinator& dc, execution_mode mode);
+  virtual bool evaluate_mini_batch(sgd_execution_context& c,
+                                   model& model,
+                                   data_coordinator& dc,
+                                   execution_mode mode);
 
   ////////////////////////////////////////////////////////////
   // Callbacks
@@ -106,6 +116,6 @@ protected:
   virtual void do_batch_end_cbs(model& model, execution_mode mode);
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_SGD_TRAINING_ALGORITHM_HPP
+#endif // LBANN_SGD_TRAINING_ALGORITHM_HPP

--- a/include/lbann/execution_algorithms/training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/training_algorithm.hpp
@@ -31,41 +31,109 @@
 #include "lbann/execution_contexts/execution_context.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/data_coordinator/data_coordinator.hpp"
+#include "lbann/utils/cloneable.hpp"
 
 namespace lbann {
 
 // Forward-declare this.
 class execution_context;
 
-/** Base class for LBANN training_algorithms. */
-class training_algorithm {
+/** @class training_algorithm
+ *  @brief Base class for LBANN training_algorithms.
+ *
+ *  A "training algorithm" is defined as a method for modifying one or
+ *  more models, where "model" is defined in the LBANN sense (that is,
+ *  a model object typically consists of a machine learning model plus
+ *  a "sub-DAG" for computing a training-specific objective
+ *  function). At this time, we only have support for training a
+ *  single model unit, though some ad hoc methods exist for training
+ *  multi-model scenarios such as GANs.
+ *
+ *  Logically, the inputs to a training algorithm are a model
+ *  architecture (encapsulated in a model object) and a data source,
+ *  and the output is a trained model (or, a set of parameters that
+ *  define the action of the model). Here, "trained" means that the
+ *  training algorithm has evolved the parameters until user-specified
+ *  stopping criteria have been met; it does necessarily imply that
+ *  any underlying optimization method has converged (or even exists)
+ *  or that such a convergence is even well-defined.
+ *
+ *  A key capability is that training algorithms should be
+ *  composable. This allows metaheuristic algorithms to simply be
+ *  implemented as training algorithms constructed from one or more
+ *  "inner" training algorithms.
+ *
+ *  @todo One component that we need to address yet is the issue of
+ *        logically encapsulating multiple models, as either inputs or
+ *        outputs to a training algorithm. Specifically, consider the
+ *        LTFB "meta-learning" method. Rather than producing the
+ *        single best model, a user might be interested in the K best
+ *        models. In this case, tournament-based evolution will begin
+ *        with a single model (per trainer) but could output several
+ *        models. Similarly, one might begin with an arbitrary
+ *        collection of models that are evolved until a single best
+ *        model emerges. This draws in other issues to be addressed
+ *        elsewhere in LBANN such as "How do we export models?"
+ *        Currently, this is done by writing to files on disk via
+ *        callbacks. However, one might imagine "in-core" interation
+ *        between training and inference, perhaps in an online
+ *        learning scenario, in which repeatedly writing to and
+ *        reading from disk is not sufficient.
+ */
+class training_algorithm
+  : public Cloneable<HasAbstractFunction<training_algorithm>>
+{
 public:
 
-  /** Constructor. */
-  training_algorithm() {};
-  /** Copy constructor. */
-  training_algorithm(const training_algorithm& other) = default;
-  /** Copy assignment operator. */
-  training_algorithm& operator=(const training_algorithm& other) = default;
-  /** Move constructor. */
-  training_algorithm(training_algorithm&& other) = default;
-  /** Move assignment operator. */
-  training_algorithm& operator=(training_algorithm&& other) = default;
-  /** Destructor. */
-  virtual ~training_algorithm() = default;
-  /** Copy training_algorithm. */
-  //  virtual training_algorithm* copy() const = default;
+  /** @name Lifecycle Management */
+  ///@{
+  /** @brief Constructor
+   *  @param[in] name The user-defined name of the algorithm.
+   */
+  training_algorithm(std::string name);
+  virtual ~training_algorithm() = 0;
+  ///@}
 
-  virtual std::string get_name() const = 0;
+  /** @name Queries */
+  ///@{
+  /** @brief A string identifying the type of the object. */
+  virtual std::string get_type() const = 0;
+  /** @brief A user-defined string identifying the algorithm object. */
+  std::string const& get_name() const noexcept;
+  ///@}
+  /** @name Execution interfaces */
+  ///@{
 
+  /** @brief Apply the algorithm to the given model.
+   *  @param[in,out] context The persistent state tracked by the model.
+   *  @param[in,out] model A model architecture with trainable
+   *                       weights. On exit, the weights will have
+   *                       been updated according to the algorithm.
+   *  @param[in,out] dc The data source for this round of training.
+   *  @param[in] mode IMO, superfluous. Will be removed.
+   *  @param[in] term_criteria A description of when to stop training.
+   */
   virtual void apply(execution_context& context,
                      model& model,
                      data_coordinator& dc,
                      execution_mode mode,
                      termination_criteria const& term_criteria) = 0;
 
-  void setup_models(std::vector<observer_ptr<model>> models, size_t max_mini_batch_size, DataReaderMetaData& dr_metadata);
+  void setup_models(std::vector<observer_ptr<model>>& models,
+                    size_t max_mini_batch_size,
+                    DataReaderMetaData& dr_metadata);
 
+protected:
+  /** @name In-hierarchy Lifecycle Management */
+  ///@{
+  training_algorithm(const training_algorithm& other) = default;
+  training_algorithm& operator=(const training_algorithm& other) = default;
+  training_algorithm(training_algorithm&& other) = default;
+  training_algorithm& operator=(training_algorithm&& other) = default;
+  ///@}
+private:
+  /** @brief The user-defined name of the algorithm. */
+  std::string m_name;
 };
 
 }  // namespace lbann

--- a/include/lbann/execution_algorithms/training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/training_algorithm.hpp
@@ -118,9 +118,18 @@ public:
                      execution_mode mode,
                      termination_criteria const& term_criteria) = 0;
 
+  /** @brief Setup a collection of models.
+   *  @param[in] models The collection of models to be setup.
+   *  @param[in] max_mini_batch_size The largest minibatch size
+   *             accepted by any model.
+   *  @param[in] dr_metadata The data reader metadata that might be
+   *             used when initializing certain model components.
+   *  @todo Remove the dr_metadata argument.
+   */
   void setup_models(std::vector<observer_ptr<model>> const& models,
                     size_t max_mini_batch_size,
                     DataReaderMetaData& dr_metadata);
+  ///@}
 
 protected:
   /** @name In-hierarchy Lifecycle Management */

--- a/include/lbann/execution_algorithms/training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/training_algorithm.hpp
@@ -90,7 +90,7 @@ public:
    *  @param[in] name The user-defined name of the algorithm.
    */
   training_algorithm(std::string name);
-  virtual ~training_algorithm() = 0;
+  virtual ~training_algorithm() = default;
   ///@}
 
   /** @name Queries */

--- a/include/lbann/execution_algorithms/training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/training_algorithm.hpp
@@ -28,9 +28,9 @@
 #define LBANN_TRAINING_ALGORITHM_HPP
 
 #include "lbann/base.hpp"
+#include "lbann/data_coordinator/data_coordinator.hpp"
 #include "lbann/execution_contexts/execution_context.hpp"
 #include "lbann/models/model.hpp"
-#include "lbann/data_coordinator/data_coordinator.hpp"
 #include "lbann/utils/cloneable.hpp"
 
 namespace lbann {
@@ -84,7 +84,6 @@ class training_algorithm
   : public Cloneable<HasAbstractFunction<training_algorithm>>
 {
 public:
-
   /** @name Lifecycle Management */
   ///@{
   /** @brief Constructor
@@ -119,7 +118,7 @@ public:
                      execution_mode mode,
                      termination_criteria const& term_criteria) = 0;
 
-  void setup_models(std::vector<observer_ptr<model>>& models,
+  void setup_models(std::vector<observer_ptr<model>> const& models,
                     size_t max_mini_batch_size,
                     DataReaderMetaData& dr_metadata);
 
@@ -136,6 +135,6 @@ private:
   std::string m_name;
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_TRAINING_ALGORITHM_HPP
+#endif // LBANN_TRAINING_ALGORITHM_HPP

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -45,6 +45,7 @@ class training_algorithm;
 
 class termination_criteria {
 public:
+  virtual ~termination_criteria() = default;
   size_t num_steps;
 };
 

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -43,13 +43,15 @@ namespace lbann {
 class trainer;
 class training_algorithm;
 
-class termination_criteria {
+class termination_criteria
+{
 public:
   virtual ~termination_criteria() = default;
   size_t num_steps;
 };
 
-class execution_context {
+class execution_context
+{
 public:
   /** Constructor. */
   execution_context(trainer& trainer,
@@ -59,79 +61,88 @@ public:
   virtual ~execution_context() = default;
 
   /** Copy execution_context. */
-  virtual std::unique_ptr<execution_context> copy_execution_context() const {
+  virtual std::unique_ptr<execution_context> copy_execution_context() const
+  {
     // Use explicit construction of unique pointer since copy
     // constructor is protected and cannot be accessed in make_unique
     return std::unique_ptr<execution_context>{new execution_context(*this)};
   }
 
   /** Archive for checkpoint and restart */
-  template <class Archive> void serialize( Archive & ar );
+  template <class Archive> void serialize(Archive& ar);
 
   /** @brief Return the state of the execution context as a string */
-  virtual std::string get_state_string() const noexcept {
-    return build_string("ec.", to_string(get_execution_mode()),
-                        ".step.", get_step());
+  virtual std::string get_state_string() const noexcept
+  {
+    return build_string("ec.",
+                        to_string(get_execution_mode()),
+                        ".step.",
+                        get_step());
   }
 
   /** @brief Current step in the training algorithm
-    *  @details Step counts the number of iterations in the training
-    *  algorithm's internal state
-    */
+   *  @details Step counts the number of iterations in the training
+   *  algorithm's internal state
+   */
   size_t get_step() const noexcept { return m_step; }
 
   /** @brief Increment the current step in the training algorithm
-    *  @details Increment the step count in the training
-    *  algorithm's internal state
-    */
+   *  @details Increment the step count in the training
+   *  algorithm's internal state
+   */
   void inc_step() noexcept { ++m_step; }
 
   /** Get the mode that the trainer is currenting executing. */
-  inline void set_execution_mode(execution_mode mode) noexcept {
+  inline void set_execution_mode(execution_mode mode) noexcept
+  {
     m_execution_mode = mode;
   }
 
   /** Get the mode that the trainer is currenting executing. */
-  inline execution_mode get_execution_mode() const noexcept {
+  inline execution_mode get_execution_mode() const noexcept
+  {
     return m_execution_mode;
   }
 
   /** Return true if the flag to stop training is set. */
-  bool get_terminate_training() const {
-    return m_terminate_training;
-  }
+  bool get_terminate_training() const { return m_terminate_training; }
   /** Set the terminate training flag (on or off). */
-  void set_terminate_training(bool f) {
-    m_terminate_training = f;
-  }
+  void set_terminate_training(bool f) { m_terminate_training = f; }
 
   /** Grab the trainer from the execution context */
-  const trainer& get_trainer() const {
-    return *m_trainer;
+  const trainer& get_trainer() const { return *m_trainer; }
+
+  trainer& get_trainer()
+  {
+    return const_cast<trainer&>(
+      static_cast<const execution_context&>(*this).get_trainer());
   }
 
-  trainer& get_trainer() {
-    return const_cast<trainer&>(static_cast<const execution_context&>(*this).get_trainer());
-  }
-
-  const training_algorithm& get_training_algorithm() const {
+  const training_algorithm& get_training_algorithm() const
+  {
     return *m_training_algorithm;
   }
 
-  training_algorithm& get_training_algorithm() {
-    return const_cast<training_algorithm&>(static_cast<const execution_context&>(*this).get_training_algorithm());
+  training_algorithm& get_training_algorithm()
+  {
+    return const_cast<training_algorithm&>(
+      static_cast<const execution_context&>(*this).get_training_algorithm());
   }
 
   thread_pool& get_io_thread_pool() const;
 
-  lbann_comm& get_comm() const {
-    if (!m_comm) { LBANN_ERROR("m_comm is null"); }
+  lbann_comm& get_comm() const
+  {
+    if (!m_comm) {
+      LBANN_ERROR("m_comm is null");
+    }
     return *m_comm;
   };
 
   /** Checkpoint training_algorithm to given file descriptor */
   virtual void save_to_checkpoint_shared(persist& p);
-  /** Restore training_algorithm by reading checkpoint from given file descriptor */
+  /** Restore training_algorithm by reading checkpoint from given file
+   * descriptor */
   virtual void load_from_checkpoint_shared(persist& p);
   virtual void save_to_checkpoint_distributed(persist& p);
   virtual void load_from_checkpoint_distributed(persist& p);
@@ -149,7 +160,8 @@ protected:
   execution_context& operator=(execution_context&& other) = default;
 
 private:
-  /** Pointer to the training context (execution environment) for the training algorithm */
+  /** Pointer to the training context (execution environment) for the training
+   * algorithm */
   trainer* m_trainer;
 
   training_algorithm* m_training_algorithm;
@@ -161,9 +173,9 @@ private:
   execution_mode m_execution_mode = execution_mode::training;
 
   /** @brief Current step in the training algorithm
-    *  @details Step counts the number of iterations in the training
-    *  algorithm's internal state
-    */
+   *  @details Step counts the number of iterations in the training
+   *  algorithm's internal state
+   */
   size_t m_step = 0;
 
   /** @brief Whether to terminate training.
@@ -173,6 +185,6 @@ private:
   bool m_terminate_training = false;
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_EXECUTION_CONTEXT_HPP
+#endif // LBANN_EXECUTION_CONTEXT_HPP

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -31,18 +31,19 @@
 
 namespace lbann {
 
-class sgd_termination_criteria : public termination_criteria {
+class sgd_termination_criteria : public termination_criteria
+{
 public:
   ~sgd_termination_criteria() = default;
   size_t num_epochs;
 };
 
-
 /** @brief SGD Uses the step to track the Current mini-batch step for
-  *  execution mode.
-  *  @details Step counts are not reset after each epoch.
-  */
-class sgd_execution_context final : public execution_context {
+ *  execution mode.
+ *  @details Step counts are not reset after each epoch.
+ */
+class sgd_execution_context final : public execution_context
+{
 public:
   /** Constructor. */
   sgd_execution_context(trainer& trainer,
@@ -55,54 +56,66 @@ public:
   /** Copy constructor. */
   sgd_execution_context(const sgd_execution_context& other) = default;
   /** Copy assignment operator. */
-  sgd_execution_context& operator=(const sgd_execution_context& other) = default;
+  sgd_execution_context&
+  operator=(const sgd_execution_context& other) = default;
   /** Move constructor. */
   sgd_execution_context(sgd_execution_context&& other) = default;
   /** Move assignment operator. */
   sgd_execution_context& operator=(sgd_execution_context&& other) = default;
   /** Copy sgd_execution_context. */
-  std::unique_ptr<execution_context> copy_execution_context() const override {
+  std::unique_ptr<execution_context> copy_execution_context() const override
+  {
     return make_unique<sgd_execution_context>(*this);
   }
 
   /** Archive for checkpoint and restart */
-  template <class Archive> void serialize( Archive & ar );
+  template <class Archive> void serialize(Archive& ar);
 
   /** @brief Return the state of the execution context as a string */
-  std::string get_state_string() const noexcept override {
-    return build_string("sgd.", to_string(get_execution_mode()),
-                        ".epoch.", get_epoch(), ".step.", get_step());
+  std::string get_state_string() const noexcept override
+  {
+    return build_string("sgd.",
+                        to_string(get_execution_mode()),
+                        ".epoch.",
+                        get_epoch(),
+                        ".step.",
+                        get_step());
   }
 
   /** Number of times the training set has been traversed. */
   inline size_t get_epoch() const noexcept { return m_epoch; }
 
   /** @brief Increment the current epoch in the execution context
-    *  @details Increment the counter tracking the number of times
-    *  that the data set has been traversed.
-    */
+   *  @details Increment the counter tracking the number of times
+   *  that the data set has been traversed.
+   */
   void inc_epoch() noexcept { ++m_epoch; }
 
   /** Set the trainer's current mini-batch size. */
-  inline void set_current_mini_batch_size(size_t mini_batch_size) {
+  inline void set_current_mini_batch_size(size_t mini_batch_size)
+  {
     m_current_mini_batch_size = mini_batch_size;
   }
   /** Get the trainer's current mini-batch size. */
-  inline size_t get_current_mini_batch_size() const {
+  inline size_t get_current_mini_batch_size() const
+  {
     return m_current_mini_batch_size;
   }
   /** Get the trainer's effective mini-batch size. */
-  inline size_t get_effective_mini_batch_size() const {
+  inline size_t get_effective_mini_batch_size() const
+  {
     return m_effective_mini_batch_size;
   }
   /** Set the trainer's effective mini-batch size. */
-  inline void set_effective_mini_batch_size(size_t mini_batch_size) {
+  inline void set_effective_mini_batch_size(size_t mini_batch_size)
+  {
     m_effective_mini_batch_size = mini_batch_size;
   }
 
   /** Checkpoint training_algorithm to given file descriptor  */
   void save_to_checkpoint_shared(persist& p) override;
-  /** Restore training_algorithm by reading checkpoint from given file descriptor */
+  /** Restore training_algorithm by reading checkpoint from given file
+   * descriptor */
   void load_from_checkpoint_shared(persist& p) override;
   void save_to_checkpoint_distributed(persist& p) override;
   void load_from_checkpoint_distributed(persist& p) override;
@@ -126,6 +139,6 @@ private:
   size_t m_effective_mini_batch_size;
 };
 
-}  // namespace lbann
+} // namespace lbann
 
-#endif  // LBANN_SGD_EXECUTION_CONTEXT_HPP
+#endif // LBANN_SGD_EXECUTION_CONTEXT_HPP

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -33,6 +33,7 @@ namespace lbann {
 
 class sgd_termination_criteria : public termination_criteria {
 public:
+  ~sgd_termination_criteria() = default;
   size_t num_epochs;
 };
 

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -272,7 +272,7 @@ void dump_weights::do_dump_weights(const model& m, visitor_hook hook) {
   std::string dir = El::BuildString(
     get_shared_checkpoint_dirname(
       t.get_name(),
-      context.get_training_algorithm().get_name(),
+      context.get_training_algorithm().get_type(),
       m_directory.c_str(),
       hook,
       context.get_execution_mode(),
@@ -290,7 +290,7 @@ void dump_weights::do_dump_weights(const model& m, visitor_hook hook) {
   if (m.get_comm()->am_trainer_master()) {
     auto latest_file = get_last_shared_checkpoint_filename(
       t.get_name(),
-      context.get_training_algorithm().get_name(),
+      context.get_training_algorithm().get_type(),
       m_directory.c_str());
     write_latest(
       latest_file,

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -25,8 +25,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
-#include "lbann/models/model.hpp"
 #include "lbann/callbacks/callback.hpp"
+#include "lbann/models/model.hpp"
 
 namespace lbann {
 
@@ -38,10 +38,13 @@ void sgd_training_algorithm::apply(execution_context& context,
                                    model& model,
                                    data_coordinator& dc,
                                    execution_mode mode,
-                                   termination_criteria const& term_criteria) {
-  sgd_execution_context& sgd_context = static_cast<sgd_execution_context&>(context);
-  const sgd_termination_criteria& sgd_term = static_cast<const sgd_termination_criteria&>(term_criteria);
-  switch(mode) {
+                                   termination_criteria const& term_criteria)
+{
+  sgd_execution_context& sgd_context =
+    static_cast<sgd_execution_context&>(context);
+  const sgd_termination_criteria& sgd_term =
+    static_cast<const sgd_termination_criteria&>(term_criteria);
+  switch (mode) {
   case execution_mode::training:
     train(sgd_context, model, dc, sgd_term.num_epochs, sgd_term.num_steps);
     break;
@@ -59,7 +62,8 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
                                    model& model,
                                    data_coordinator& dc,
                                    size_t num_epochs,
-                                   size_t num_batches) {
+                                   size_t num_batches)
+{
 
   // Initialize epoch
   model.reset_mode(c, execution_mode::training);
@@ -67,7 +71,9 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
 
   do_train_begin_cbs(model);
   for (size_t epoch = c.get_epoch(); epoch < num_epochs; ++epoch) {
-    if (c.get_terminate_training()) { break; }
+    if (c.get_terminate_training()) {
+      break;
+    }
 
     // Initialize epoch
     model.reset_mode(c, execution_mode::training);
@@ -77,9 +83,13 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
 
     // Training iterations
     if (num_batches > 0) {
-      for (size_t i = 0; i < num_batches; i++) { train_mini_batch(c, model, dc); }
-    } else {
-      while (!train_mini_batch(c, model, dc)) {}
+      for (size_t i = 0; i < num_batches; i++) {
+        train_mini_batch(c, model, dc);
+      }
+    }
+    else {
+      while (!train_mini_batch(c, model, dc)) {
+      }
     }
 
     // Finalize epoch
@@ -88,8 +98,12 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
     do_epoch_end_cbs(model);
 
     // Evaluate on validation set
-    auto key = c.get_trainer().check_and_build_execution_context(c, model, execution_mode::validation);
-    auto& evaluation_context = static_cast<sgd_execution_context&>(c.get_trainer().get_execution_context(key));
+    auto key = c.get_trainer().check_and_build_execution_context(
+      c,
+      model,
+      execution_mode::validation);
+    auto& evaluation_context = static_cast<sgd_execution_context&>(
+      c.get_trainer().get_execution_context(key));
     // Check to make sure that the model has a valid execution mode
     // before trying to do inference
     if (dc.is_execution_mode_valid(execution_mode::validation)) {
@@ -108,7 +122,8 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
 
 bool sgd_training_algorithm::train_mini_batch(sgd_execution_context& c,
                                               model& model,
-                                              data_coordinator& dc) {
+                                              data_coordinator& dc)
+{
   model.reset_mode(c, execution_mode::training);
   dc.reset_mode(c);
   do_batch_begin_cbs(model, execution_mode::training);
@@ -120,34 +135,36 @@ bool sgd_training_algorithm::train_mini_batch(sgd_execution_context& c,
 #if defined(LBANN_HAVE_OMP_TASKLOOP)
   LBANN_OMP_PARALLEL
   {
-    #pragma omp single
+#pragma omp single
     {
 #endif
-  // Forward prop step
-  model.clear_gradients();
-  model.forward_prop(execution_mode::training);
-  // check if the data coordinator has finished the epoch and kickoff
-  // background I/O
-  finished = dc.epoch_complete(execution_mode::training);
+      // Forward prop step
+      model.clear_gradients();
+      model.forward_prop(execution_mode::training);
+      // check if the data coordinator has finished the epoch and kickoff
+      // background I/O
+      finished = dc.epoch_complete(execution_mode::training);
 
-  // Result is not needed until the end of the mini-batch.
-  model.get_objective_function()->start_evaluation(execution_mode::training,
-                                                    c.get_current_mini_batch_size());
+      // Result is not needed until the end of the mini-batch.
+      model.get_objective_function()->start_evaluation(
+        execution_mode::training,
+        c.get_current_mini_batch_size());
 
-  // Backward prop step
-  model.get_objective_function()->differentiate();
-  model.backward_prop();
-  model.get_objective_function()->compute_weight_regularization();
+      // Backward prop step
+      model.get_objective_function()->differentiate();
+      model.backward_prop();
+      model.get_objective_function()->compute_weight_regularization();
 
-  // Finish evaluation.
-  model.get_objective_function()->finish_evaluation(execution_mode::training,
-                                                     c.get_current_mini_batch_size());
-  model.evaluate_metrics(execution_mode::training,
-                          c.get_current_mini_batch_size());
+      // Finish evaluation.
+      model.get_objective_function()->finish_evaluation(
+        execution_mode::training,
+        c.get_current_mini_batch_size());
+      model.evaluate_metrics(execution_mode::training,
+                             c.get_current_mini_batch_size());
 
-  // Update step
-  model.update_weights();
-  model.update_layers();
+      // Update step
+      model.update_weights();
+      model.update_layers();
 #if defined(LBANN_HAVE_OMP_TASKLOOP)
     }
   }
@@ -162,7 +179,8 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
                                       model& model,
                                       data_coordinator& dc,
                                       execution_mode mode,
-                                      size_t num_batches) {
+                                      size_t num_batches)
+{
   /// @todo BVE FIXME this state needs to be set for inference-only
   /// workflows -- however, if the model will bail due to a lack of a
   /// valid mode, the state of the data coordinator is not
@@ -173,10 +191,10 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
   // Ensure that the data coordinator has the right execution context
   dc.reset_mode(c);
   // Return early if execution mode is invalid
-  if (!dc.is_execution_mode_valid(mode)) return;
-  if (mode != execution_mode::validation
-      && mode != execution_mode::tournament
-      && mode != execution_mode::testing) {
+  if (!dc.is_execution_mode_valid(mode))
+    return;
+  if (mode != execution_mode::validation &&
+      mode != execution_mode::tournament && mode != execution_mode::testing) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
         << "invalid execution mode for evaluation";
@@ -186,9 +204,13 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
   // Evaluate on all mini-batches
   do_evaluate_begin_cbs(model, mode);
   if (num_batches > 0) {
-    for (size_t i = 0; i < num_batches; i++) { evaluate_mini_batch(c, model, dc, mode); }
-  } else {
-    while (!evaluate_mini_batch(c, model, dc, mode)) {}
+    for (size_t i = 0; i < num_batches; i++) {
+      evaluate_mini_batch(c, model, dc, mode);
+    }
+  }
+  else {
+    while (!evaluate_mini_batch(c, model, dc, mode)) {
+    }
   }
   c.inc_epoch();
   do_evaluate_end_cbs(model, mode);
@@ -197,7 +219,8 @@ void sgd_training_algorithm::evaluate(sgd_execution_context& c,
 bool sgd_training_algorithm::evaluate_mini_batch(sgd_execution_context& c,
                                                  model& model,
                                                  data_coordinator& dc,
-                                                 execution_mode mode) {
+                                                 execution_mode mode)
+{
   model.reset_mode(c, mode);
   dc.reset_mode(c);
   do_batch_begin_cbs(model, mode);
@@ -207,8 +230,12 @@ bool sgd_training_algorithm::evaluate_mini_batch(sgd_execution_context& c,
   // background I/O
   const bool finished = dc.epoch_complete(mode);
 
-  model.get_objective_function()->start_evaluation(mode, c.get_current_mini_batch_size());
-  model.get_objective_function()->finish_evaluation(mode, c.get_current_mini_batch_size());
+  model.get_objective_function()->start_evaluation(
+    mode,
+    c.get_current_mini_batch_size());
+  model.get_objective_function()->finish_evaluation(
+    mode,
+    c.get_current_mini_batch_size());
   model.evaluate_metrics(mode, c.get_current_mini_batch_size());
   model.update_layers();
   c.inc_step();
@@ -220,62 +247,79 @@ bool sgd_training_algorithm::evaluate_mini_batch(sgd_execution_context& c,
 // Callbacks
 ////////////////////////////////////////////////////////////
 
-void sgd_training_algorithm::do_train_begin_cbs(model& model) {
+void sgd_training_algorithm::do_train_begin_cbs(model& model)
+{
   for (const auto& cb : model.get_callbacks()) {
     cb->on_train_begin(&model);
   }
 }
 
-void sgd_training_algorithm::do_train_end_cbs(model& model) {
+void sgd_training_algorithm::do_train_end_cbs(model& model)
+{
   for (const auto& cb : model.get_callbacks()) {
     cb->on_train_end(&model);
   }
 }
 
-void sgd_training_algorithm::do_evaluate_begin_cbs(model& model, execution_mode mode) {
+void sgd_training_algorithm::do_evaluate_begin_cbs(model& model,
+                                                   execution_mode mode)
+{
   for (const auto& cb : model.get_callbacks()) {
     switch (mode) {
     case execution_mode::validation:
-      cb->on_validation_begin(&model); break;
+      cb->on_validation_begin(&model);
+      break;
     case execution_mode::tournament:
-      cb->on_validation_begin(&model); break;
+      cb->on_validation_begin(&model);
+      break;
     case execution_mode::testing:
-      cb->on_test_begin(&model); break;
+      cb->on_test_begin(&model);
+      break;
     default:
       LBANN_ERROR("invalid execution mode");
     }
   }
 }
 
-void sgd_training_algorithm::do_evaluate_end_cbs(model& model, execution_mode mode) {
+void sgd_training_algorithm::do_evaluate_end_cbs(model& model,
+                                                 execution_mode mode)
+{
   for (const auto& cb : model.get_callbacks()) {
     switch (mode) {
     case execution_mode::validation:
-      cb->on_validation_end(&model); break;
+      cb->on_validation_end(&model);
+      break;
     case execution_mode::tournament:
-      cb->on_validation_end(&model); break;
+      cb->on_validation_end(&model);
+      break;
     case execution_mode::testing:
-      cb->on_test_end(&model); break;
+      cb->on_test_end(&model);
+      break;
     default:
       LBANN_ERROR("invalid execution mode");
     }
   }
 }
 
-void sgd_training_algorithm::do_epoch_begin_cbs(model& model) {
+void sgd_training_algorithm::do_epoch_begin_cbs(model& model)
+{
   for (const auto& cb : model.get_callbacks()) {
     cb->on_epoch_begin(&model);
   }
 }
 
-void sgd_training_algorithm::do_epoch_end_cbs(model& model) {
+void sgd_training_algorithm::do_epoch_end_cbs(model& model)
+{
   for (const auto& cb : model.get_callbacks()) {
     cb->on_epoch_end(&model);
   }
 }
 
-void sgd_training_algorithm::do_batch_begin_cbs(model& model, execution_mode mode) {
-  sgd_execution_context& c = static_cast<sgd_execution_context&>(model.get_execution_context());
+void sgd_training_algorithm::do_batch_begin_cbs(model& model,
+                                                execution_mode mode)
+{
+  sgd_execution_context& c =
+    static_cast<sgd_execution_context&>(model.get_execution_context());
 
   for (const auto& cb : model.get_callbacks()) {
     switch (mode) {
@@ -295,8 +339,10 @@ void sgd_training_algorithm::do_batch_begin_cbs(model& model, execution_mode mod
   }
 }
 
-void sgd_training_algorithm::do_batch_end_cbs(model& model, execution_mode mode) {
-  sgd_execution_context& c = static_cast<sgd_execution_context&>(model.get_execution_context());
+void sgd_training_algorithm::do_batch_end_cbs(model& model, execution_mode mode)
+{
+  sgd_execution_context& c =
+    static_cast<sgd_execution_context&>(model.get_execution_context());
 
   for (const auto& cb : model.get_callbacks()) {
     switch (mode) {
@@ -316,4 +362,6 @@ void sgd_training_algorithm::do_batch_end_cbs(model& model, execution_mode mode)
   }
 }
 
-}  // namespace lbann
+std::string sgd_training_algorithm::get_type() const { return "sgd"; }
+
+} // namespace lbann

--- a/src/execution_algorithms/training_algorithm.cpp
+++ b/src/execution_algorithms/training_algorithm.cpp
@@ -30,8 +30,18 @@
 #include "lbann/callbacks/load_model.hpp"
 #include "lbann/callbacks/save_model.hpp"
 #include "lbann/models/model.hpp"
+#include <string>
 
 namespace lbann {
+
+training_algorithm::training_algorithm(std::string name)
+  : m_name{std::move(name)}
+{}
+
+std::string const& training_algorithm::get_name() const noexcept
+{
+  return m_name;
+}
 
 void training_algorithm::setup_models(
   std::vector<observer_ptr<model>> const& models,

--- a/src/execution_algorithms/training_algorithm.cpp
+++ b/src/execution_algorithms/training_algorithm.cpp
@@ -33,9 +33,10 @@
 
 namespace lbann {
 
-void training_algorithm::setup_models(std::vector<observer_ptr<model>>& models,
-                                      size_t max_mini_batch_size,
-                                      DataReaderMetaData& dr_metadata)
+void training_algorithm::setup_models(
+  std::vector<observer_ptr<model>> const& models,
+  size_t max_mini_batch_size,
+  DataReaderMetaData& dr_metadata)
 {
   for (observer_ptr<model> const& m : models) {
     // Set up callbacks

--- a/src/execution_algorithms/training_algorithm.cpp
+++ b/src/execution_algorithms/training_algorithm.cpp
@@ -25,21 +25,24 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/execution_algorithms/training_algorithm.hpp"
-#include "lbann/models/model.hpp"
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/callbacks/checkpoint.hpp"
-#include "lbann/callbacks/save_model.hpp"
 #include "lbann/callbacks/load_model.hpp"
+#include "lbann/callbacks/save_model.hpp"
+#include "lbann/models/model.hpp"
 
 namespace lbann {
 
-void training_algorithm::setup_models(std::vector<observer_ptr<model>> models, size_t max_mini_batch_size, DataReaderMetaData& dr_metadata) {
-  for (observer_ptr<model> m : models) {
+void training_algorithm::setup_models(std::vector<observer_ptr<model>>& models,
+                                      size_t max_mini_batch_size,
+                                      DataReaderMetaData& dr_metadata)
+{
+  for (observer_ptr<model> const& m : models) {
     // Set up callbacks
     for (auto* c : m->get_callbacks()) {
       {
         auto* cb = dynamic_cast<callback::checkpoint*>(c);
-        if(cb != nullptr) {
+        if (cb != nullptr) {
           cb->set_active_training_algorithm(this);
         }
       }
@@ -47,8 +50,6 @@ void training_algorithm::setup_models(std::vector<observer_ptr<model>> models, s
     // Setup models
     m->setup(max_mini_batch_size, dr_metadata);
   }
-  return;
 }
 
-
-}  // namespace lbann
+} // namespace lbann

--- a/src/execution_contexts/execution_context.cpp
+++ b/src/execution_contexts/execution_context.cpp
@@ -24,18 +24,18 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann/execution_algorithms/training_algorithm.hpp"
-#include "lbann/trainers/trainer.hpp"
 #include "lbann/callbacks/callback.hpp"
+#include "lbann/execution_algorithms/training_algorithm.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/io/persist_impl.hpp"
+#include "lbann/trainers/trainer.hpp"
 #include "lbann/utils/serialize.hpp"
+#include <iomanip>
+#include <lbann.pb.h>
+#include <queue>
 #include <string>
 #include <unistd.h>
-#include <iomanip>
-#include <queue>
 #include <unordered_set>
-#include <lbann.pb.h>
 
 namespace lbann {
 
@@ -46,14 +46,13 @@ namespace lbann {
 execution_context::execution_context(trainer& trainer,
                                      training_algorithm& training_algorithm,
                                      execution_mode mode)
-  : m_trainer(&trainer),
-    m_training_algorithm(&training_algorithm),
-    m_comm(trainer.get_comm()),
-    m_execution_mode(mode),
-    m_terminate_training(false) {}
+  : m_trainer(&trainer), m_training_algorithm(&training_algorithm),
+    m_comm(trainer.get_comm()), m_execution_mode(mode),
+    m_terminate_training(false)
+{}
 
-template <class Archive>
-void execution_context::serialize( Archive & ar ) {
+template <class Archive> void execution_context::serialize(Archive& ar)
+{
   ar(CEREAL_NVP(m_execution_mode),
      CEREAL_NVP(m_terminate_training),
      CEREAL_NVP(m_step));
@@ -67,7 +66,8 @@ void execution_context::serialize( Archive & ar ) {
 //   return m_trainer->get_io_thread_pool();
 // }
 
-thread_pool& execution_context::get_io_thread_pool() const {
+thread_pool& execution_context::get_io_thread_pool() const
+{
   return m_trainer->get_io_thread_pool();
 }
 
@@ -75,66 +75,66 @@ thread_pool& execution_context::get_io_thread_pool() const {
 // Checkpointing
 ////////////////////////////////////////////////////////////
 
-void execution_context::save_to_checkpoint_shared(persist& p) {
+void execution_context::save_to_checkpoint_shared(persist& p)
+{
   if (get_comm().am_trainer_master()) {
-    write_cereal_archive<execution_context>(
-      *this,
-      p,
-      get_execution_mode(),
+    write_cereal_archive<execution_context>(*this,
+                                            p,
+                                            get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-      "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-      "_ctx.bin"
+                                            "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                            "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-      );
+    );
   }
   return;
 }
 
-void execution_context::load_from_checkpoint_shared(persist& p) {
-  load_from_shared_cereal_archive<execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
-    get_comm(),
+void execution_context::load_from_checkpoint_shared(persist& p)
+{
+  load_from_shared_cereal_archive<execution_context>(*this,
+                                                     p,
+                                                     get_execution_mode(),
+                                                     get_comm(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                                     "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                                     "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-void execution_context::save_to_checkpoint_distributed(persist& p){
-  write_cereal_archive<execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
+void execution_context::save_to_checkpoint_distributed(persist& p)
+{
+  write_cereal_archive<execution_context>(*this,
+                                          p,
+                                          get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                          "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                          "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-void execution_context::load_from_checkpoint_distributed(persist& p){
-  read_cereal_archive<execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
+void execution_context::load_from_checkpoint_distributed(persist& p)
+{
+  read_cereal_archive<execution_context>(*this,
+                                         p,
+                                         get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                         "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                         "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-}  // namespace lbann
+} // namespace lbann
 
 #define LBANN_CLASS_NAME execution_context
 #include <lbann/macros/register_class_with_cereal.hpp>

--- a/src/execution_contexts/sgd_execution_context.cpp
+++ b/src/execution_contexts/sgd_execution_context.cpp
@@ -39,8 +39,8 @@ sgd_execution_context::sgd_execution_context(trainer& trainer,
     m_effective_mini_batch_size(mini_batch_size)
 {}
 
-template <class Archive>
-void sgd_execution_context::serialize(Archive & ar) {
+template <class Archive> void sgd_execution_context::serialize(Archive& ar)
+{
   ar(cereal::base_class<execution_context>(this),
      CEREAL_NVP(m_epoch),
      CEREAL_NVP(m_current_mini_batch_size),
@@ -51,66 +51,66 @@ void sgd_execution_context::serialize(Archive & ar) {
 // Checkpointing
 ////////////////////////////////////////////////////////////
 
-void sgd_execution_context::save_to_checkpoint_shared(persist& p) {
+void sgd_execution_context::save_to_checkpoint_shared(persist& p)
+{
   if (get_comm().am_trainer_master()) {
-    write_cereal_archive<sgd_execution_context>(
-      *this,
-      p,
-      get_execution_mode(),
+    write_cereal_archive<sgd_execution_context>(*this,
+                                                p,
+                                                get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-      "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-      "_ctx.bin"
+                                                "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                                "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-      );
+    );
   }
   return;
 }
 
-void sgd_execution_context::load_from_checkpoint_shared(persist& p) {
-  load_from_shared_cereal_archive<sgd_execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
-    get_comm(),
+void sgd_execution_context::load_from_checkpoint_shared(persist& p)
+{
+  load_from_shared_cereal_archive<sgd_execution_context>(*this,
+                                                         p,
+                                                         get_execution_mode(),
+                                                         get_comm(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                                         "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                                         "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-void sgd_execution_context::save_to_checkpoint_distributed(persist& p) {
-  write_cereal_archive<sgd_execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
+void sgd_execution_context::save_to_checkpoint_distributed(persist& p)
+{
+  write_cereal_archive<sgd_execution_context>(*this,
+                                              p,
+                                              get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                              "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                              "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-void sgd_execution_context::load_from_checkpoint_distributed(persist& p) {
-  read_cereal_archive<sgd_execution_context>(
-    *this,
-    p,
-    get_execution_mode(),
+void sgd_execution_context::load_from_checkpoint_distributed(persist& p)
+{
+  read_cereal_archive<sgd_execution_context>(*this,
+                                             p,
+                                             get_execution_mode(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-    "_ctx.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-    "_ctx.bin"
+                                             "_ctx.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                             "_ctx.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return;
 }
 
-}  // namespace lbann
+} // namespace lbann
 
 #define LBANN_CLASS_NAME sgd_execution_context
 #include <lbann/macros/register_class_with_cereal.hpp>

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -261,7 +261,7 @@ void trainer::apply(training_algorithm& alg,
 }
 
 void trainer::train(observer_ptr<model> model, El::Int num_epochs, El::Int num_batches) {
-  auto sgd = make_unique<sgd_training_algorithm>();
+  auto sgd = make_unique<sgd_training_algorithm>("sgd_train");
   auto key = check_and_build_execution_context(*sgd.get(), model, execution_mode::training);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
   sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);
@@ -270,7 +270,7 @@ void trainer::train(observer_ptr<model> model, El::Int num_epochs, El::Int num_b
 }
 
 void trainer::evaluate(observer_ptr<model> model, execution_mode mode, El::Int num_batches) {
-  auto sgd = make_unique<sgd_training_algorithm>();
+  auto sgd = make_unique<sgd_training_algorithm>("sgd_evaluate");
   auto key = check_and_build_execution_context(*sgd.get(), model, mode);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
   sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -28,6 +28,7 @@
 #include "lbann/trainers/trainer.hpp"
 
 // LBANN dependencies
+#include "lbann/base.hpp"
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
@@ -37,6 +38,7 @@
 #include "lbann/layers/transform/evaluation.hpp"
 #include "lbann/layers/transform/split.hpp"
 #include "lbann/metrics/layer_metric.hpp"
+#include "lbann/models/model.hpp"
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
 #include "lbann/utils/description.hpp"
@@ -58,6 +60,7 @@
 #include <queue>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace lbann {
 
@@ -249,33 +252,42 @@ void trainer::for_each_execution_context(
 // Evaluation and training
 ////////////////////////////////////////////////////////////
 void trainer::apply(training_algorithm& alg,
-                    observer_ptr<model> model,
+                    observer_ptr<model> mdl,
                     execution_mode mode,
                     termination_criteria const& term_criteria) {
 
-  auto key = check_and_build_execution_context(alg, model, mode);
+  auto key = check_and_build_execution_context(alg, mdl, mode);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
-  alg.setup_models({model}, get_max_mini_batch_size(), dr_metadata);
-  /// Apply the training algorithm to train the model
-  alg.apply(*(m_model_execution_context[key].get()), *model, get_data_coordinator(), mode, term_criteria);
+  {
+    std::vector<observer_ptr<model>> models = {mdl};
+    alg.setup_models(models, get_max_mini_batch_size(), dr_metadata);
+  }
+  // Apply the training algorithm to train the model
+  alg.apply(*(m_model_execution_context[key].get()), *mdl, get_data_coordinator(), mode, term_criteria);
 }
 
-void trainer::train(observer_ptr<model> model, El::Int num_epochs, El::Int num_batches) {
-  auto sgd = make_unique<sgd_training_algorithm>();
-  auto key = check_and_build_execution_context(*sgd.get(), model, execution_mode::training);
-  DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
-  sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);
-  /// Apply the training algorithm to train the model
-  sgd.get()->train(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *model, get_data_coordinator(), num_epochs, num_batches);
+void trainer::train(observer_ptr<model> mdl, El::Int num_epochs, El::Int num_batches) {
+  // FIXME (trb 03/11/21): This needs to be factory-ized.
+  auto sgd = make_unique<sgd_training_algorithm>("mysgd_train");
+  auto key = check_and_build_execution_context(*sgd.get(), mdl, execution_mode::training);
+  {
+    DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
+    std::vector<observer_ptr<model>> models = {mdl};
+    sgd.get()->setup_models(models, get_max_mini_batch_size(), dr_metadata);
+  }
+  // Apply the training algorithm to train the model
+  sgd.get()->train(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *mdl, get_data_coordinator(), num_epochs, num_batches);
 }
 
-void trainer::evaluate(observer_ptr<model> model, execution_mode mode, El::Int num_batches) {
-  auto sgd = make_unique<sgd_training_algorithm>();
-  auto key = check_and_build_execution_context(*sgd.get(), model, mode);
+void trainer::evaluate(observer_ptr<model> mdl, execution_mode mode, El::Int num_batches) {
+  // FIXME (trb 03/11/21): This needs to be factory-ized.
+  auto sgd = make_unique<sgd_training_algorithm>("mysgd_evaluate");
+  auto key = check_and_build_execution_context(*sgd.get(), mdl, mode);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
-  sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);
+  std::vector<observer_ptr<model>> models = {mdl};
+  sgd.get()->setup_models(models, get_max_mini_batch_size(), dr_metadata);
   /// Apply the training algorithm to evaluate the model
-  sgd.get()->evaluate(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *model, get_data_coordinator(), mode, num_batches);
+  sgd.get()->evaluate(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *mdl, get_data_coordinator(), mode, num_batches);
 }
 
 // =============================================


### PR DESCRIPTION
The API tweaks are:

- Made `execution_context` and `termination_criteria` polymorphically destructible.
- Modified the API of `training_algorithm` to have `get_type()`, which returns a string description of the algorithm's type ("sgd", etc.), and `get_name()`, which allows users to assign an identifier to the algorithm.
- Corrected the signature of `training_algorithm::setup_models(...)`.
- `training_algorithm`s are now `Cloneable`.

The rest is documentation and formatting.