### PR TITLE
Reformat trainer and frontend

### DIFF
--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -27,10 +27,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/lbann.hpp"
-#include "lbann/proto/proto_common.hpp"
-#include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
+#include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/protobuf_utils.hpp"
 #ifdef LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // LBANN_DNN_LIB
@@ -63,9 +63,10 @@ int guess_global_rank() noexcept
       return -1;
   }
 }
-}// namespace <anon>
+} // namespace
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[])
+{
   auto& arg_parser = global_argument_parser();
   construct_std_options();
   auto use_cudnn_tensor_ops =
@@ -89,8 +90,7 @@ int main(int argc, char *argv[]) {
       // Cannot call `El::ReportException` because MPI hasn't been
       // initialized yet.
       std::cerr << "Error during argument parsing:\n\ne.what():\n\n  "
-                << e.what() << "\n\nProcess terminating."
-                << std::endl;
+                << e.what() << "\n\nProcess terminating." << std::endl;
     std::terminate();
   }
 
@@ -98,9 +98,10 @@ int main(int argc, char *argv[]) {
   const bool master = comm->am_world_master();
 
   if (master) {
-    std::cout << "\n\n" << std::string(62,'=') << '\n'
+    std::cout << "\n\n"
+              << std::string(62, '=') << '\n'
               << "STARTING lbann with this command line:\n";
-    for (int j=0; j<argc; j++) {
+    for (int j = 0; j < argc; j++) {
       std::cout << argv[j] << " ";
     }
     std::cout << std::endl << std::endl;
@@ -108,7 +109,7 @@ int main(int argc, char *argv[]) {
 
   try {
     // Initialize options db (this parses the command line)
-    options *opts = options::get();
+    options* opts = options::get();
     opts->init(argc, argv);
     if (opts->has_string("h") or opts->has_string("help") or argc == 1) {
       if (master)
@@ -121,9 +122,11 @@ int main(int argc, char *argv[]) {
     if (master) {
       std::cout << "Default tensor core settings:\n"
                 << "   cuDNN: " << (use_cudnn_tensor_ops ? "" : "NOT ")
-                << "using tensor core math." << "\n"
+                << "using tensor core math."
+                << "\n"
                 << "  cuBLAS: " << (use_cublas_tensor_ops ? "" : "NOT ")
-                << "using tensor core math." << "\n"
+                << "using tensor core math."
+                << "\n"
                 << std::endl;
     }
 #ifdef LBANN_HAS_DNN_LIB
@@ -135,55 +138,63 @@ int main(int argc, char *argv[]) {
       El::gpu_blas::RequestTensorOperations();
 #endif // LBANN_HAS_CUDA
 
-    //this must be called after call to opts->init();
+    // this must be called after call to opts->init();
     if (!opts->get_bool("disable_signal_handler")) {
-      std::string file_base = (opts->get_bool("stack_trace_to_file") ?
-                               "stack_trace" : "");
+      std::string file_base =
+        (opts->get_bool("stack_trace_to_file") ? "stack_trace" : "");
       stack_trace::register_signal_handler(file_base);
     }
 
-    //to activate, must specify --st_on on cmd line
+    // to activate, must specify --st_on on cmd line
     stack_profiler::get()->activate(comm->get_rank_in_world());
 
     // Split MPI into trainers
     allocate_trainer_resources(comm.get());
 
     int trainer_rank = 0;
-    if(opts->get_bool("generate_multi_proto")) {
-        trainer_rank = comm->get_trainer_rank();
+    if (opts->get_bool("generate_multi_proto")) {
+      trainer_rank = comm->get_trainer_rank();
     }
     // Load the prototexts specificed on the command line
-    auto pbs = protobuf_utils::load_prototext(master, argc, argv,trainer_rank);
+    auto pbs = protobuf_utils::load_prototext(master, argc, argv, trainer_rank);
     // Optionally over-ride some values in the prototext for each model
-    for(size_t i = 0; i < pbs.size(); i++) {
+    for (size_t i = 0; i < pbs.size(); i++) {
       get_cmdline_overrides(*comm, *(pbs[i]));
     }
 
     lbann_data::LbannPB& pb = *(pbs[0]);
-    lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
+    lbann_data::Trainer* pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, pb, opts);
+    std::unique_ptr<trainer> trainer =
+      construct_trainer(comm.get(), pb_trainer, pb, opts);
 
     thread_pool& io_thread_pool = trainer->get_io_thread_pool();
 
     int training_dr_linearized_data_size = -1;
-    auto *dr = trainer->get_data_coordinator().get_data_reader(execution_mode::training);
-    if(dr != nullptr) {
+    auto* dr =
+      trainer->get_data_coordinator().get_data_reader(execution_mode::training);
+    if (dr != nullptr) {
       training_dr_linearized_data_size = dr->get_linearized_data_size();
     }
-    lbann_data::Model *pb_model = pb.mutable_model();
+    lbann_data::Model* pb_model = pb.mutable_model();
 
-    auto model = build_model_from_prototext(argc, argv, pb_trainer, pb,
-                                            comm.get(), opts, io_thread_pool,
-                                            trainer->get_callbacks_with_ownership(),
-                                            training_dr_linearized_data_size);
+    auto model =
+      build_model_from_prototext(argc,
+                                 argv,
+                                 pb_trainer,
+                                 pb,
+                                 comm.get(),
+                                 opts,
+                                 io_thread_pool,
+                                 trainer->get_callbacks_with_ownership(),
+                                 training_dr_linearized_data_size);
 
     if (opts->has_string("create_tarball")) {
       return EXIT_SUCCESS;
     }
 
-    if (! opts->get_bool("exit_after_setup")) {
+    if (!opts->get_bool("exit_after_setup")) {
 
       // Train model
       trainer->train(model.get(), pb_model->num_epochs());
@@ -191,23 +202,25 @@ int main(int argc, char *argv[]) {
       // Evaluate model on test set
       trainer->evaluate(model.get(), execution_mode::testing);
 
-      //has no affect unless option: --st_on was given
-      stack_profiler::get()->print();
-
-    } else {
-      if (comm->am_world_master()) {
-        std::cout <<
-          "--------------------------------------------------------------------------------\n"
-          "ALERT: model has been setup; we are now exiting due to command\n"
-          "       line option: --exit_after_setup\n"
-          "--------------------------------------------------------------------------------\n";
-      }
-
-      //has no affect unless option: --st_on was given
+      // has no affect unless option: --st_on was given
       stack_profiler::get()->print();
     }
+    else {
+      if (comm->am_world_master()) {
+        std::cout
+          << "-----------------------------------------------------------------"
+             "---------------\n"
+             "ALERT: model has been setup; we are now exiting due to command\n"
+             "       line option: --exit_after_setup\n"
+             "-----------------------------------------------------------------"
+             "---------------\n";
+      }
 
-  } catch (exception& e) {
+      // has no affect unless option: --st_on was given
+      stack_profiler::get()->print();
+    }
+  }
+  catch (exception& e) {
     if (options::get()->get_bool("stack_trace_to_file")) {
       std::ostringstream ss("stack_trace");
       const auto& rank = get_rank_in_world();
@@ -222,7 +235,8 @@ int main(int argc, char *argv[]) {
     // It's possible that a proper subset of ranks throw some
     // exception. But we want to tear down the whole world.
     El::mpi::Abort(El::mpi::COMM_WORLD, EXIT_FAILURE);
-  } catch (std::exception& e) {
+  }
+  catch (std::exception& e) {
     El::ReportException(e);
     // It's possible that a proper subset of ranks throw some
     // exception. But we want to tear down the whole world.

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -30,6 +30,7 @@
 // LBANN dependencies
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
+#include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/io/persist_impl.hpp"
@@ -38,7 +39,6 @@
 #include "lbann/layers/transform/split.hpp"
 #include "lbann/metrics/layer_metric.hpp"
 #include "lbann/objective_functions/layer_term.hpp"
-#include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
 #include "lbann/utils/description.hpp"
 #include "lbann/utils/omp_diagnostics.hpp"
 #include "lbann/utils/random.hpp"
@@ -65,13 +65,12 @@ namespace lbann {
 // Constructors and destructor
 ////////////////////////////////////////////////////////////
 
-trainer::trainer(lbann_comm *comm,
+trainer::trainer(lbann_comm* comm,
                  size_t mini_batch_size,
                  std::unique_ptr<data_coordinator> dc)
-  : m_comm(comm),
-    m_max_mini_batch_size(mini_batch_size),
-    m_io_thread_pool(),
-    m_background_io_allowed(true) {
+  : m_comm(comm), m_max_mini_batch_size(mini_batch_size), m_io_thread_pool(),
+    m_background_io_allowed(true)
+{
 
   // Default trainer name
   m_name = "trainer" + std::to_string(m_comm->get_trainer_rank());
@@ -79,10 +78,10 @@ trainer::trainer(lbann_comm *comm,
   m_data_coordinator->set_trainer(*this);
 }
 
-trainer::trainer(const trainer& other) :
-  m_comm(other.m_comm),
-  m_max_mini_batch_size(other.m_max_mini_batch_size),
-  m_background_io_allowed(other.m_background_io_allowed) {
+trainer::trainer(const trainer& other)
+  : m_comm(other.m_comm), m_max_mini_batch_size(other.m_max_mini_batch_size),
+    m_background_io_allowed(other.m_background_io_allowed)
+{
 
   //  m_data_coordinator = other.m_data_coordinator;
 
@@ -95,7 +94,8 @@ trainer::trainer(const trainer& other) :
   }
 }
 
-trainer& trainer::operator=(const trainer& other) {
+trainer& trainer::operator=(const trainer& other)
+{
 
   // Shallow copies
   m_comm = other.m_comm;
@@ -113,11 +113,10 @@ trainer& trainer::operator=(const trainer& other) {
   return *this;
 }
 
-trainer::~trainer() {
-}
+trainer::~trainer() {}
 
-template <class Archive>
-void trainer::serialize(Archive & ar) {
+template <class Archive> void trainer::serialize(Archive& ar)
+{
   ar(CEREAL_NVP(m_persist),
      CEREAL_NVP(m_max_mini_batch_size),
      CEREAL_NVP(m_root_random_seed),
@@ -129,14 +128,18 @@ void trainer::serialize(Archive & ar) {
 // Trainer specification
 ////////////////////////////////////////////////////////////
 
-void trainer::set_name(std::string const& name) {
+void trainer::set_name(std::string const& name)
+{
   if (name.empty()) {
-    LBANN_ERROR("attempted to rename trainer \"", get_name(), "\" with empty string");
+    LBANN_ERROR("attempted to rename trainer \"",
+                get_name(),
+                "\" with empty string");
   }
   m_name = name;
 }
 
-description trainer::get_description() const {
+description trainer::get_description() const
+{
 
   // Construct description object
   description desc(get_name());
@@ -144,14 +147,15 @@ description trainer::get_description() const {
 
   // Result
   return desc;
-
 }
 
 ////////////////////////////////////////////////////////////
 // Setup
 ////////////////////////////////////////////////////////////
 
-void trainer::setup(std::unique_ptr<thread_pool> io_thread_pool, std::map<execution_mode, generic_data_reader *> data_readers) {
+void trainer::setup(std::unique_ptr<thread_pool> io_thread_pool,
+                    std::map<execution_mode, generic_data_reader*> data_readers)
+{
   // Setup I/O threads - set up before setting up the layers (input
   // layer depends on having a properly initialized thread pool)
   m_io_thread_pool = std::move(io_thread_pool);
@@ -159,7 +163,9 @@ void trainer::setup(std::unique_ptr<thread_pool> io_thread_pool, std::map<execut
   for (auto d : data_readers) {
     d.second->set_trainer(this);
   }
-  m_data_coordinator.get()->setup(*m_io_thread_pool.get(), get_max_mini_batch_size(), data_readers);
+  m_data_coordinator.get()->setup(*m_io_thread_pool.get(),
+                                  get_max_mini_batch_size(),
+                                  data_readers);
 
   // Set up callbacks first - allow checkpoint / restart to reload state
   for (auto& cb : m_callbacks) {
@@ -167,76 +173,93 @@ void trainer::setup(std::unique_ptr<thread_pool> io_thread_pool, std::map<execut
   }
 }
 
-/// Check if there is already an execution context for the model in this mode, if not create one
-trainer::execution_context_key_pair_t trainer::check_and_build_execution_context(training_algorithm& alg,
-                                                                                 observer_ptr<model> model,
-                                                                                 execution_mode mode) {
-  auto key = std::make_pair(model,mode);
-  if(m_model_execution_context.count(key) == 0) {
+/// Check if there is already an execution context for the model in this mode,
+/// if not create one
+trainer::execution_context_key_pair_t
+trainer::check_and_build_execution_context(training_algorithm& alg,
+                                           observer_ptr<model> model,
+                                           execution_mode mode)
+{
+  auto key = std::make_pair(model, mode);
+  if (m_model_execution_context.count(key) == 0) {
     /// Create a execution context for each model and execution mode
     std::unique_ptr<execution_context> context;
-    if(dynamic_cast<observer_ptr<sgd_training_algorithm>>(&alg) != nullptr) {
+    if (dynamic_cast<observer_ptr<sgd_training_algorithm>>(&alg) != nullptr) {
       /// @todo BVE FIXME Figure out how to get a good mini-batch size
       /// in here
-      context = make_unique<sgd_execution_context>(*this, alg, mode, get_max_mini_batch_size());
-    }else {
+      context = make_unique<sgd_execution_context>(*this,
+                                                   alg,
+                                                   mode,
+                                                   get_max_mini_batch_size());
+    }
+    else {
       context = make_unique<execution_context>(*this, alg, mode);
     }
-    m_model_execution_context.emplace(key,std::move(context));
+    m_model_execution_context.emplace(key, std::move(context));
   }
   return key;
 }
 
-/// Check if there is already an execution context for the model in this mode, if not create one
-trainer::execution_context_key_pair_t trainer::check_and_build_execution_context(execution_context& c,
-                                                                                 model& model,
-                                                                                 execution_mode mode) {
+/// Check if there is already an execution context for the model in this mode,
+/// if not create one
+trainer::execution_context_key_pair_t
+trainer::check_and_build_execution_context(execution_context& c,
+                                           model& model,
+                                           execution_mode mode)
+{
   auto key = std::make_pair(&model, mode);
-  if(m_model_execution_context.count(key) == 0) {
+  if (m_model_execution_context.count(key) == 0) {
     std::unique_ptr<execution_context> context;
     //    observer_ptr<training_algorithm> alg = const_cast
-    if(dynamic_cast<observer_ptr</*const */sgd_execution_context>>(&c) != nullptr) {
+    if (dynamic_cast<observer_ptr</*const */ sgd_execution_context>>(&c) !=
+        nullptr) {
       context = make_unique<sgd_execution_context>(*this,
                                                    c.get_training_algorithm(),
                                                    mode,
                                                    get_max_mini_batch_size());
-    }else {
-      context = make_unique<execution_context>(*this,
-                                               c.get_training_algorithm(),
-                                               mode);
     }
-    m_model_execution_context.emplace(key,std::move(context));
+    else {
+      context =
+        make_unique<execution_context>(*this, c.get_training_algorithm(), mode);
+    }
+    m_model_execution_context.emplace(key, std::move(context));
   }
   return key;
 }
 
 execution_context& trainer::get_execution_context(observer_ptr<model> model,
-                                                  execution_mode mode) {
-  auto key = std::make_pair(model,mode);
+                                                  execution_mode mode)
+{
+  auto key = std::make_pair(model, mode);
   return get_execution_context(key);
 }
 
-execution_context& trainer::get_execution_context(execution_context_key_pair_t key) {
-  if(m_model_execution_context.count(key) == 0) {
+execution_context&
+trainer::get_execution_context(execution_context_key_pair_t key)
+{
+  if (m_model_execution_context.count(key) == 0) {
     LBANN_ERROR("No execution context for this model / mode pair");
   }
-  return static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get()));
+  return static_cast<sgd_execution_context&>(
+    *(m_model_execution_context[key].get()));
 }
 
-void trainer::delete_execution_context(execution_context_key_pair_t key) {
-  if(m_model_execution_context.count(key) == 0) {
-    LBANN_WARNING("Attempting to delete an invalid execution context for model="
-                  + (key.first)->get_name() + " / " + to_string(key.second));
+void trainer::delete_execution_context(execution_context_key_pair_t key)
+{
+  if (m_model_execution_context.count(key) == 0) {
+    LBANN_WARNING(
+      "Attempting to delete an invalid execution context for model=" +
+      (key.first)->get_name() + " / " + to_string(key.second));
   }
   m_model_execution_context.erase(key);
 }
 
-  /// @todo BVE FIXME seems like there is a bug here about mapping
-  /// execution contexts to the right model
+/// @todo BVE FIXME seems like there is a bug here about mapping
+/// execution contexts to the right model
 void trainer::for_each_execution_context(
-  std::function<void(observer_ptr<execution_context>)>fn)
+  std::function<void(observer_ptr<execution_context>)> fn)
 {
-  for(auto&& c : m_model_execution_context) {
+  for (auto&& c : m_model_execution_context) {
     // auto&& model = c.first.first;
     // auto&& mode = c.first.second;
     auto&& context = c.second;
@@ -244,79 +267,101 @@ void trainer::for_each_execution_context(
   }
 }
 
-
 ////////////////////////////////////////////////////////////
 // Evaluation and training
 ////////////////////////////////////////////////////////////
 void trainer::apply(training_algorithm& alg,
                     observer_ptr<model> model,
                     execution_mode mode,
-                    termination_criteria const& term_criteria) {
+                    termination_criteria const& term_criteria)
+{
 
   auto key = check_and_build_execution_context(alg, model, mode);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
   alg.setup_models({model}, get_max_mini_batch_size(), dr_metadata);
   /// Apply the training algorithm to train the model
-  alg.apply(*(m_model_execution_context[key].get()), *model, get_data_coordinator(), mode, term_criteria);
+  alg.apply(*(m_model_execution_context[key].get()),
+            *model,
+            get_data_coordinator(),
+            mode,
+            term_criteria);
 }
 
-void trainer::train(observer_ptr<model> model, El::Int num_epochs, El::Int num_batches) {
+void trainer::train(observer_ptr<model> model,
+                    El::Int num_epochs,
+                    El::Int num_batches)
+{
   auto sgd = make_unique<sgd_training_algorithm>("sgd_train");
-  auto key = check_and_build_execution_context(*sgd.get(), model, execution_mode::training);
+  auto key = check_and_build_execution_context(*sgd.get(),
+                                               model,
+                                               execution_mode::training);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
   sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);
   /// Apply the training algorithm to train the model
-  sgd.get()->train(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *model, get_data_coordinator(), num_epochs, num_batches);
+  sgd.get()->train(static_cast<sgd_execution_context&>(
+                     *(m_model_execution_context[key].get())),
+                   *model,
+                   get_data_coordinator(),
+                   num_epochs,
+                   num_batches);
 }
 
-void trainer::evaluate(observer_ptr<model> model, execution_mode mode, El::Int num_batches) {
+void trainer::evaluate(observer_ptr<model> model,
+                       execution_mode mode,
+                       El::Int num_batches)
+{
   auto sgd = make_unique<sgd_training_algorithm>("sgd_evaluate");
   auto key = check_and_build_execution_context(*sgd.get(), model, mode);
   DataReaderMetaData dr_metadata = get_data_coordinator().get_dr_metadata();
   sgd.get()->setup_models({model}, get_max_mini_batch_size(), dr_metadata);
   /// Apply the training algorithm to evaluate the model
-  sgd.get()->evaluate(static_cast<sgd_execution_context&>(*(m_model_execution_context[key].get())), *model, get_data_coordinator(), mode, num_batches);
+  sgd.get()->evaluate(static_cast<sgd_execution_context&>(
+                        *(m_model_execution_context[key].get())),
+                      *model,
+                      get_data_coordinator(),
+                      mode,
+                      num_batches);
 }
 
 // =============================================
 // Checkpointing
 // =============================================
 
-bool trainer::save_to_checkpoint_shared() {
-  for_each_execution_context(
-    [this](observer_ptr<execution_context> ctx) {
-      ctx->save_to_checkpoint_shared(this->get_persist_obj());
-    });
+bool trainer::save_to_checkpoint_shared()
+{
+  for_each_execution_context([this](observer_ptr<execution_context> ctx) {
+    ctx->save_to_checkpoint_shared(this->get_persist_obj());
+  });
   save_rng_to_checkpoint_shared(get_persist_obj(), m_comm);
 
   if (m_comm->am_trainer_master()) {
-    write_cereal_archive(
-      *this,
-      get_persist_obj(),
+    write_cereal_archive(*this,
+                         get_persist_obj(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-      "trainer.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-      "trainer.bin"
+                         "trainer.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                         "trainer.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-      );
+    );
   }
 
   return get_data_coordinator().save_to_checkpoint_shared(get_persist_obj());
 }
 
-bool trainer::load_from_checkpoint_shared(persist& p) {
+bool trainer::load_from_checkpoint_shared(persist& p)
+{
   try {
-    load_from_shared_cereal_archive(
-      *this,
-      p,
-      *get_comm(),
+    load_from_shared_cereal_archive(*this,
+                                    p,
+                                    *get_comm(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-      "trainer.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-      "trainer.bin"
+                                    "trainer.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                                    "trainer.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-      );
-  } catch (NonexistentArchiveFile const& e) {
+    );
+  }
+  catch (NonexistentArchiveFile const& e) {
     LBANN_MSG(e.what());
     return false;
   }
@@ -324,20 +369,24 @@ bool trainer::load_from_checkpoint_shared(persist& p) {
   return get_data_coordinator().load_from_checkpoint_shared(p);
 }
 
-bool trainer::load_from_checkpoint_shared(model& m, execution_context& c) {
+bool trainer::load_from_checkpoint_shared(model& m, execution_context& c)
+{
   // Reload the RNG once the trainer and all of the  models are setup
   // to avoid spurious turns of the RNGs
   load_rng_from_checkpoint(get_persist_obj(), m_comm);
 
   execution_mode current_mode = c.get_execution_mode();
 
-  for(execution_mode mode : execution_mode_iterator()) {
+  for (execution_mode mode : execution_mode_iterator()) {
     /// Restart should optionally load any other valid contexts
-    if(mode == execution_mode::invalid) { continue; }
+    if (mode == execution_mode::invalid) {
+      continue;
+    }
     trainer::execution_context_key_pair_t key;
     try {
-      if(current_mode == mode) {
-        /// Restart has to be able to load the currently running execution context
+      if (current_mode == mode) {
+        /// Restart has to be able to load the currently running execution
+        /// context
         c.load_from_checkpoint_shared(get_persist_obj());
       }
       else {
@@ -349,10 +398,12 @@ bool trainer::load_from_checkpoint_shared(model& m, execution_context& c) {
     }
     catch (NonexistentArchiveFile const& e) {
       // Ignore the exception if the file is not for the current execution mode
-      if(current_mode == mode) {
+      if (current_mode == mode) {
         LBANN_ERROR("Failed to restart model, invalid execution mode: ",
                     to_string(current_mode),
-                    "\n\n  e.what(): ", e.what(), "\n");
+                    "\n\n  e.what(): ",
+                    e.what(),
+                    "\n");
       }
       else {
         delete_execution_context(key);
@@ -363,63 +414,74 @@ bool trainer::load_from_checkpoint_shared(model& m, execution_context& c) {
   return get_data_coordinator().load_from_checkpoint_shared(get_persist_obj());
 }
 
-bool trainer::save_to_checkpoint_distributed(){
-  for_each_execution_context(
-    [this](observer_ptr<execution_context> ctx) {
-      ctx->save_to_checkpoint_distributed(this->get_persist_obj());
-    });
+bool trainer::save_to_checkpoint_distributed()
+{
+  for_each_execution_context([this](observer_ptr<execution_context> ctx) {
+    ctx->save_to_checkpoint_distributed(this->get_persist_obj());
+  });
   save_rng_to_checkpoint_distributed(get_persist_obj(), m_comm);
   return get_data_coordinator().save_to_checkpoint_shared(get_persist_obj());
 }
 
-bool trainer::load_from_checkpoint_distributed(persist& p){
-  read_cereal_archive(
-    *this,
-    p,
+bool trainer::load_from_checkpoint_distributed(persist& p)
+{
+  read_cereal_archive(*this,
+                      p,
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-      "trainer.xml"
-#else // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-      "trainer.bin"
+                      "trainer.xml"
+#else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
+                      "trainer.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
-    );
+  );
   return get_data_coordinator().load_from_checkpoint_distributed(p);
 }
 
-bool trainer::load_from_checkpoint_distributed(model& m, execution_context& c){
+bool trainer::load_from_checkpoint_distributed(model& m, execution_context& c)
+{
   load_rng_from_checkpoint(get_persist_obj(), m_comm);
 
   execution_mode current_mode = c.get_execution_mode();
 
-  for(execution_mode mode : execution_mode_iterator()) {
+  for (execution_mode mode : execution_mode_iterator()) {
     /// Restart should optionally load any other valid contexts
-    if(mode == execution_mode::invalid) { continue; }
+    if (mode == execution_mode::invalid) {
+      continue;
+    }
     trainer::execution_context_key_pair_t key;
     try {
-      if(current_mode == mode) {
-        /// Restart has to be able to load the currently running  execution context
+      if (current_mode == mode) {
+        /// Restart has to be able to load the currently running  execution
+        /// context
         c.load_from_checkpoint_distributed(get_persist_obj());
-      }else {
+      }
+      else {
         key = check_and_build_execution_context(c, m, mode);
-        auto& evaluation_context = static_cast<sgd_execution_context&>(get_execution_context(key));
+        auto& evaluation_context =
+          static_cast<sgd_execution_context&>(get_execution_context(key));
         evaluation_context.load_from_checkpoint_distributed(get_persist_obj());
       }
-    }catch (NonexistentArchiveFile const&) {
+    }
+    catch (NonexistentArchiveFile const&) {
       // Ignore the exception if the file is not for the current execution mode
-      if(current_mode == mode) {
-        LBANN_ERROR("Failed to restart model, invalid execution mode: " + to_string(current_mode));
-      }else {
+      if (current_mode == mode) {
+        LBANN_ERROR("Failed to restart model, invalid execution mode: " +
+                    to_string(current_mode));
+      }
+      else {
         delete_execution_context(key);
       }
     }
   }
-  return get_data_coordinator().load_from_checkpoint_distributed(get_persist_obj());
+  return get_data_coordinator().load_from_checkpoint_distributed(
+    get_persist_obj());
 }
 
-void trainer::write_proto(lbann_data::Trainer* proto) {
+void trainer::write_proto(lbann_data::Trainer* proto)
+{
   proto->Clear();
   if (m_comm->am_world_master()) {
     proto->set_mini_batch_size(m_max_mini_batch_size);
   }
 }
 
-}  // namespace lbann
+} // namespace lbann


### PR DESCRIPTION
This applies clang-format to the `trainer` class and the `lbann` frontend. There are no non-formatting changes; as such, I am not running Bamboo on this branch.

Depends on #1827.