### PR TITLE
Move data store exchange to primary thread

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -304,6 +304,9 @@ class generic_data_reader {
   /// Fetch this mini-batch's responses into Y.
   virtual int fetch_responses(CPUMat& Y);
 
+  void start_data_store_mini_batch_exchange();
+  void finish_data_store_mini_batch_exchange();
+
   virtual bool has_labels() const { return m_supported_input_types.at(input_data_type::LABELS); }
   virtual bool has_responses() const { return m_supported_input_types.at(input_data_type::RESPONSES); }
 

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -233,7 +233,8 @@ class data_store_conduit {
    */
   void preload_local_cache();
 
-  void exchange_mini_batch_data(size_t current_pos, size_t mb_size);
+  void start_exchange_mini_batch_data(size_t current_pos, size_t mb_size);
+  void finish_exchange_mini_batch_data();
 
   void set_node_sizes_vary() { m_node_sizes_vary = true; }
 
@@ -440,6 +441,9 @@ private :
   int  m_np_in_trainer;
   int  m_num_partitions_in_trainer;
 
+  /// Flag to indicate if a data exchange has started
+  bool m_mini_batch_data_exchange_started = false;
+
   /** @brief Maps an index to the processor that owns the associated data
    * First value of index is the sample ID and second value is the partiton ID
    *
@@ -508,7 +512,8 @@ private :
   // methods follow
   //=========================================================================
 
-  void exchange_data_by_sample(size_t current_pos, size_t mb_size);
+  void start_exchange_data_by_sample(size_t current_pos, size_t mb_size);
+  void finish_exchange_data_by_sample();
 
   void setup_data_store_buffers();
 

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -165,6 +165,11 @@ void buffered_data_coordinator<TensorDataType>::fetch_data(execution_mode mode) 
   // If there is no valid data and there is not already a background
   // thread to fetch the data, queue up the background thread
   if(active_buffer.num_samples_ready() == 0 && !active_buffer.is_data_fetched_in_background()) {
+    // Start data store exchange if necessary (this should be move
+    // earlier as a future optimization)
+    get_data_reader(mode)->start_data_store_mini_batch_exchange();
+    // Finish data store exchange before accessing samples
+    get_data_reader(mode)->finish_data_store_mini_batch_exchange();
     std::future<void> background_fetch_done = get_io_thread_pool().submit_job(
       std::bind(&buffered_data_coordinator::fetch_data_in_background, this, this->get_active_buffer_idx(mode), mode));
     active_buffer.set_data_fetch_future(std::move(background_fetch_done));
@@ -198,6 +203,11 @@ bool buffered_data_coordinator<TensorDataType>::epoch_complete(execution_mode mo
   // in epoch.  In a future PR this state should be moved to the data coordinator
   if(!m_data_set_processed && m_trainer->background_io_activity_allowed()) {
     int next_active_buffer = this->get_active_buffer_idx(mode) + 1;
+    // Start data store exchange if necessary (this should be move
+    // earlier as a future optimization)
+    get_data_reader(mode)->start_data_store_mini_batch_exchange();
+    // Finish data store exchange before accessing samples
+    get_data_reader(mode)->finish_data_store_mini_batch_exchange();
     std::future<void> background_fetch_done = get_io_thread_pool().submit_job(
       std::bind(&buffered_data_coordinator::fetch_data_in_background, this, next_active_buffer, mode));
     data_buffer_map_t& next_io_buffer_map = m_data_buffers[next_active_buffer % m_data_buffers.size()];


### PR DESCRIPTION
Moved the data store exchange out of the fetch_data call to allow it
to start and finish in the primary thread.  This should alleviate
issues with MPI_THREAD_MULTIPLE and background I/O.  Furthermore,
there should be no loss in performance since it is being executed in
the same sequence as before.  Additionally, split the data store calls
into two phases that are split between initiating the non-blocking
sends and receives and the subsequent wait statements.  Currently,
these calls are still executed back-to-back to provide equivalent
semantics as the prior implementation.