### PR TITLE
Parallelize computation of Gaussian random numbers

### DIFF
--- a/include/lbann/utils/random.hpp
+++ b/include/lbann/utils/random.hpp
@@ -169,6 +169,20 @@ template <typename TensorDataType>
 void uniform_fill_procdet(El::AbstractDistMatrix<TensorDataType>& mat, El::Int m, El::Int n,
                           TensorDataType center = 0.0, TensorDataType radius = 1.0);
 
+/**
+ * Make mat into an m x n matrix where each entry is independently
+ * drawn from a Gaussian distribution with given mean and standard
+ * deviation. Entries are generated in parallel, so there are no
+ * guarantees of thread/process indendence.
+ */
+template <typename TensorDataType>
+void gaussian_fill_parallel(
+  El::AbstractDistMatrix<TensorDataType>& mat,
+  El::Int m,
+  El::Int n,
+  TensorDataType mean = 0.0,
+  TensorDataType stddev = 1.0);
+
 bool save_rng_to_checkpoint_shared(persist& p, lbann_comm* comm);
 bool save_rng_to_checkpoint_distributed(persist& p, lbann_comm* comm);
 bool load_rng_from_checkpoint(persist& p, const lbann_comm* comm);
@@ -216,7 +230,8 @@ void rng_bernoulli(const float p, DistMat *m) {
   extern template void uniform_fill<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T center, T radius);        \
   extern template void gaussian_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T mean, T stddev); \
   extern template void bernoulli_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, double p);        \
-  extern template void uniform_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T center, T radius)
+  extern template void uniform_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T center, T radius); \
+  extern template void gaussian_fill_parallel<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T mean, T stddev)
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -374,10 +374,12 @@ void gaussian_fill_parallel(
   if (mat.RedundantRank() == 0) {
 
     // Local buffer to hold random variables
-    El::Matrix<RandDataType, El::Device::CPU> local_vals;
-    if (std::is_same<TensorDataType,RandDataType>::value
-        && mat.GetLocalDevice() == El::Device::CPU) {
-      El::View(local_vals, mat.Matrix());
+    using LocalMatType = El::Matrix<RandDataType, El::Device::CPU>;
+    LocalMatType local_vals;
+    if constexpr (std::is_same<TensorDataType,RandDataType>::value) {
+      if (mat.GetLocalDevice() == El::Device::CPU) {
+        El::View(local_vals, mat.Matrix());
+      }
     }
     else {
       local_vals.Resize(mat.LocalHeight(), mat.LocalWidth());

--- a/src/utils/random.cpp
+++ b/src/utils/random.cpp
@@ -430,7 +430,7 @@ void gaussian_fill_parallel(
   template void gaussian_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T mean, T stddev); \
   template void bernoulli_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, double p);        \
   template void uniform_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T center, T radius); \
-  template void gaussian_fill_procdet<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T mean, T stddev)
+  template void gaussian_fill_parallel<T>(El::AbstractDistMatrix<T>& mat, El::Int m, El::Int n, T mean, T stddev)
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -19,6 +19,7 @@ set_full_path(THIS_DIR_SEQ_CATCH2_TEST_FILES
   )
 
 set_full_path(THIS_DIR_MPI_CATCH2_TEST_FILES
+  random_fill_test.cpp
   rooted_archive_test.cpp
   serialize_distmatrix_test.cpp
   serialize_enum_test.cpp

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -239,15 +239,16 @@ TEMPLATE_LIST_TEST_CASE(
       // Fill matrix with random values
       DistMatType mat(2*height, width, comm.get_trainer_grid());
       DistMatType mat_view = El::View(mat, El::IR(height/2,height+height/2), El::ALL);
+      const auto* buffer = mat_view.LockedBuffer();
       REQUIRE_NOTHROW(lbann::gaussian_fill(mat_view, height, width, mean, stddev));
 
-      // Check matrix dimensions
+      // Check matrix
       REQUIRE(mat_view.Height() == height);
       REQUIRE(mat_view.Width() == width);
       REQUIRE(mat_view.Viewing());
       if (!mat_view.LockedMatrix().IsEmpty())
       {
-        REQUIRE_FALSE(mat_view.Contiguous());
+        REQUIRE(mat_view.LockedBuffer() == buffer);
       }
 
       // Check that values are normally distributed

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -189,7 +189,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     // Attempt Anderson-Darling test several times
     bool passed_test = false;
-    for (int iter=0; iter<3; iter)
+    for (int iter=0; iter<3; ++iter)
     {
 
       // Fill matrix with random values
@@ -233,7 +233,7 @@ TEMPLATE_LIST_TEST_CASE(
 
     // Attempt Anderson-Darling test several times
     bool passed_test = false;
-    for (int iter=0; iter<3; iter)
+    for (int iter=0; iter<3; ++iter)
     {
 
       // Fill matrix with random values

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -1,0 +1,281 @@
+#include <catch2/catch.hpp>
+#include <lbann/base.hpp>
+
+#include <lbann/utils/random.hpp>
+#include <h2/patterns/multimethods/SwitchDispatcher.hpp>
+
+#include "MPITestHelpers.hpp"
+
+/** @brief Statistic for Anderson-Darling normality test
+ *
+ *  A higher statistic implies greater confidence in non-normality.
+ *
+ *  See:
+ *
+ *  George Marsaglia and John Marsaglia. "Evaluating the
+ *  Anderson-Darling distribution." Journal of statistical software 9,
+ *  no. 2 (2004): 1-5.
+ *
+ *  @todo Implement as uniformity test and apply to @c uniform_fill.
+ */
+double anderson_darling_test(
+  std::vector<double>& values,
+  double mean,
+  double stddev)
+{
+
+  // Convert values to CDF form
+  std::sort(values.begin(), values.end());
+  std::for_each(
+    values.begin(),
+    values.end(),
+    [mean, stddev] (double& x)
+    {
+      x = (x-mean) / stddev;              // z-score
+      x = std::erfc(-x/std::sqrt(2)) / 2; // Normal CDF
+    });
+
+  // Perform Anderson-Darling test
+  const int N = values.size();
+  double sum = 0;
+  for (int i=0; i<N; ++i)
+  {
+    sum += (2*i+1) * ( std::log(values[i]) + std::log(1-values[N-1-i]) );
+  }
+  return -N - sum/N;
+
+}
+
+/** @brief Critical value for Anderson-Darling normality test
+ *
+ *  A statistic of 1.9329578327415937304 corresponds to a significance
+ *  of 0.1, 2.4923671600494096176 to 0.05, and 3.8781250216053948842
+ *  to 0.01.
+ */
+constexpr double anderson_darling_critical_value = 2.4923671600494096176;
+
+TEST_CASE("Anderson-Darling normality test", "[random][utilities]")
+{
+
+  // Parameters
+  const double mean = 12.25;
+  const double stddev = 07.04;
+
+  // Applied inverse of normal CDF to uniform range in [0,1)
+  const std::vector<double> normal_z_scores = {
+    -2.24140273, -1.78046434, -1.53412054, -1.35631175, -1.21333962,
+    -1.09162037, -0.98423496, -0.88714656, -0.79777685, -0.71436744,
+    -0.63565701, -0.56070303, -0.48877641, -0.41929575, -0.35178434,
+    -0.28584087, -0.22111871, -0.15731068, -0.09413741, -0.03133798,
+    0.03133798,  0.09413741,  0.15731068,  0.22111871,  0.28584087,
+    0.35178434,  0.41929575,  0.48877641,  0.56070303,  0.63565701,
+    0.71436744,  0.79777685,  0.88714656,  0.98423496,  1.09162037,
+    1.21333962,  1.35631175,  1.53412054,  1.78046434,  2.24140273};
+
+  SECTION("Normal distribution")
+  {
+    std::vector<double> values = normal_z_scores;
+    std::for_each(
+      values.begin(),
+      values.end(),
+      [mean, stddev] (double& x) { x = x*stddev + mean; });
+    REQUIRE(
+      anderson_darling_test(values, mean, stddev)
+      < anderson_darling_critical_value);
+  }
+
+  SECTION("Shifted normal distribution")
+  {
+    std::vector<double> values = normal_z_scores;
+    std::for_each(
+      values.begin(),
+      values.end(),
+      [mean, stddev] (double& x) { x = x*stddev + mean; });
+    REQUIRE_FALSE(
+      anderson_darling_test(values, mean+3, stddev)
+      < anderson_darling_critical_value);
+  }
+
+  SECTION("Uniform distribution")
+  {
+    const int N = 654;
+    std::vector<double> values;
+    for (int i=0; i<N; ++i)
+    {
+      double x = (i+0.5)/N;       // Uniform in [0,1)
+      x = 2*std::sqrt(3)*(x-0.5); // z-score
+      values.push_back(x*stddev + mean);
+    }
+    REQUIRE_FALSE(
+      anderson_darling_test(values, mean, stddev)
+      < anderson_darling_critical_value);
+  }
+
+}
+
+// Enumerate all DistMatrix types. Start by getting all the
+// distributions.
+template <typename T, El::Device D>
+using DistMatrixTypesWithDevice = h2::meta::TL<
+  // There is currently a known bug where copying
+  // (CIRC,CIRC,CPU)->(CIRC,CIRC,GPU) results in an infinite recursion
+  // in Hydrogen. Since we don't actually use this in our code, ignore
+  // this case for now.
+  //
+  // El::DistMatrix<T, El::CIRC, El::CIRC, El::ELEMENT, D>,
+  El::DistMatrix<T, El::MC  , El::MR  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::MC  , El::STAR, El::ELEMENT, D>,
+  El::DistMatrix<T, El::MD  , El::STAR, El::ELEMENT, D>,
+  El::DistMatrix<T, El::MR  , El::MC  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::MR  , El::STAR, El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::MC  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::MD  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::MR  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::STAR, El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::VC  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::STAR, El::VR  , El::ELEMENT, D>,
+  El::DistMatrix<T, El::VC  , El::STAR, El::ELEMENT, D>,
+  El::DistMatrix<T, El::VR  , El::STAR, El::ELEMENT, D>>;
+
+// Enumerate valid combinations of data types and devices
+using AllDistMatrixTypes = h2::meta::tlist::Append<
+  DistMatrixTypesWithDevice<float, El::Device::CPU>
+  , DistMatrixTypesWithDevice<double, El::Device::CPU>
+#if defined LBANN_HAS_GPU
+  , DistMatrixTypesWithDevice<float, El::Device::GPU>
+  , DistMatrixTypesWithDevice<double, El::Device::GPU>
+#endif // defined LBANN_HAS_GPU
+#if defined LBANN_HAS_CPU_FP16
+  , DistMatrixTypesWithDevice<lbann::cpu_fp16, El::Device::CPU>
+#endif // defined LBANN_HAS_CPU_FP16
+#if defined LBANN_HAS_GPU_FP16
+  , DistMatrixTypesWithDevice<lbann::fp16, El::Device::GPU>
+#endif // defined LBANN_HAS_GPU_FP16
+  >;
+
+// Meta-programming to get data type from matrix
+template <typename DistMat>
+struct TensorDataTypeStruct;
+template <typename T, El::Dist ColDist, El::Dist RowDist, El::DistWrap Wrap, El::Device D>
+struct TensorDataTypeStruct<El::DistMatrix<T,ColDist,RowDist,Wrap,D>>
+{
+  using type = T;
+};
+template <typename DistMat>
+using TensorDataType = typename TensorDataTypeStruct<DistMat>::type;
+
+TEMPLATE_LIST_TEST_CASE(
+  "Testing gaussian_fill",
+  "[random][utilities][mpi]",
+  AllDistMatrixTypes)
+{
+
+  // Typedefs
+  using DistMatType = TestType;
+  using StarMatType = El::DistMatrix<double, El::STAR, El::STAR, El::ELEMENT, El::Device::CPU>;
+
+  // Parameters
+  const TensorDataType<DistMatType> mean = 12.3f;
+  const TensorDataType<DistMatType> stddev = 4.56f;
+  const El::Int height = 53;
+  const El::Int width = 41;
+
+  // Initialization
+  auto& comm = ::unit_test::utilities::current_world_comm();
+  lbann::init_random(-1, 0, &comm);
+
+  SECTION("Contiguous matrix")
+  {
+
+    // Attempt Anderson-Darling test several times
+    bool passed_test = false;
+    for (int iter=0; iter<3; iter)
+    {
+
+      // Fill matrix with random values
+      DistMatType mat(comm.get_trainer_grid());
+      REQUIRE_NOTHROW(lbann::gaussian_fill(mat, height, width, mean, stddev));
+
+      // Check matrix dimensions
+      REQUIRE(mat.Height() == height);
+      REQUIRE(mat.Width() == width);
+
+      // Check that values are normally distributed
+      StarMatType mat_copy(mat.Grid());
+      El::Copy(mat, mat_copy);
+      std::vector<double> values;
+      for (El::Int col = 0; col < width; ++col)
+      {
+        for (El::Int row = 0; row < height; ++row)
+        {
+          values.push_back(mat_copy.Get(row, col));
+        }
+      }
+      if (anderson_darling_test(
+            values,
+            static_cast<double>(mean),
+            static_cast<double>(stddev))
+          < anderson_darling_critical_value)
+      {
+        passed_test = true;
+        break;
+      }
+
+    }
+
+    // Make sure Anderson-Darling test has succeeded at least once
+    REQUIRE(passed_test);
+
+  }
+
+  SECTION("Non-contiguous matrix")
+  {
+
+    // Attempt Anderson-Darling test several times
+    bool passed_test = false;
+    for (int iter=0; iter<3; iter)
+    {
+
+      // Fill matrix with random values
+      DistMatType mat(2*height, width, comm.get_trainer_grid());
+      DistMatType mat_view = El::View(mat, El::IR(height/2,height+height/2), El::ALL);
+      REQUIRE_NOTHROW(lbann::gaussian_fill(mat_view, height, width, mean, stddev));
+
+      // Check matrix dimensions
+      REQUIRE(mat_view.Height() == height);
+      REQUIRE(mat_view.Width() == width);
+      REQUIRE(mat_view.Viewing());
+      if (!mat_view.LockedMatrix().IsEmpty())
+      {
+        REQUIRE_FALSE(mat_view.Contiguous());
+      }
+
+      // Check that values are normally distributed
+      StarMatType mat_copy(mat_view.Grid());
+      El::Copy(mat_view, mat_copy);
+      std::vector<double> values;
+      for (El::Int col = 0; col < width; ++col)
+      {
+        for (El::Int row = 0; row < height; ++row)
+        {
+          values.push_back(mat_copy.Get(row, col));
+        }
+      }
+      if (anderson_darling_test(
+            values,
+            static_cast<double>(mean),
+            static_cast<double>(stddev))
+          < anderson_darling_critical_value)
+      {
+        passed_test = true;
+        break;
+      }
+
+    }
+
+    // Make sure Anderson-Darling test has succeeded at least once
+    REQUIRE(passed_test);
+
+  }
+
+}

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -5,7 +5,7 @@
 
 #include "MPITestHelpers.hpp"
 
-/** @brief Statistic for Anderson-Darling normality test
+/*  @brief Statistic for Anderson-Darling normality test
  *
  *  A higher statistic implies greater confidence in non-normality.
  *
@@ -45,7 +45,7 @@ double anderson_darling_test(
 
 }
 
-/** @brief Critical value for Anderson-Darling normality test
+/*  @brief Critical value for Anderson-Darling normality test
  *
  *  A statistic of 1.9329578327415937304 corresponds to a significance
  *  of 0.1, 2.4923671600494096176 to 0.05, and 3.8781250216053948842
@@ -185,7 +185,7 @@ TEMPLATE_LIST_TEST_CASE(
   const auto& grid = comm.get_trainer_grid();
   lbann::init_random(20200319, 0, &comm);
 
-  SECTION("Contiguous matrix (parallel implementation)")
+  SECTION("Contiguous matrix")
   {
 
     // Attempt Anderson-Darling test several times
@@ -195,7 +195,7 @@ TEMPLATE_LIST_TEST_CASE(
 
       // Fill matrix with random values
       DistMatType mat(grid);
-      REQUIRE_NOTHROW(lbann::gaussian_fill_parallel(mat, height, width, mean, stddev));
+      REQUIRE_NOTHROW(lbann::gaussian_fill(mat, height, width, mean, stddev));
 
       // Check matrix dimensions
       REQUIRE(mat.Height() == height);
@@ -229,7 +229,7 @@ TEMPLATE_LIST_TEST_CASE(
 
   }
 
-  SECTION("Non-contiguous matrix (parallel implementation)")
+  SECTION("Non-contiguous matrix")
   {
 
     // Attempt Anderson-Darling test several times
@@ -247,7 +247,7 @@ TEMPLATE_LIST_TEST_CASE(
         El::IR(owner_offset,height+owner_offset),
         El::ALL);
       const auto* buffer = mat.LockedBuffer();
-      REQUIRE_NOTHROW(lbann::gaussian_fill_parallel(mat, height, width, mean, stddev));
+      REQUIRE_NOTHROW(lbann::gaussian_fill(mat, height, width, mean, stddev));
 
       // Check matrix
       REQUIRE(mat.Height() == height);

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -5,7 +5,7 @@
 
 #include "MPITestHelpers.hpp"
 
-/*  @brief Statistic for Anderson-Darling normality test
+/** @brief Statistic for Anderson-Darling normality test
  *
  *  A higher statistic implies greater confidence in non-normality.
  *
@@ -45,7 +45,7 @@ double anderson_darling_test(
 
 }
 
-/*  @brief Critical value for Anderson-Darling normality test
+/** @brief Critical value for Anderson-Darling normality test
  *
  *  A statistic of 1.9329578327415937304 corresponds to a significance
  *  of 0.1, 2.4923671600494096176 to 0.05, and 3.8781250216053948842


### PR DESCRIPTION
This replaces calls to `El::Gaussian` with an OpenMP-parallelized loop. Running the ATOM WAE on a Pascal node, I see a 3.6x speedup in the Gaussian layers.

I haven't properly tested this yet and I'd like to implement some basic normality tests in Catch. But deadlines being what they are, we can merge this in if we're willing to accept the risk of a bug.