### PR TITLE
Fixed bug with MIOpen convolution algorithm selection

### DIFF
--- a/src/utils/miopen.cpp
+++ b/src/utils/miopen.cpp
@@ -1192,6 +1192,7 @@ miopenConvFwdAlgorithm_t get_fwd_algo_heuristic(
                 perf_results.data(),
                 ws, ws_size,
                 true));
+  perf_results.resize(num_tested_algos);
   return find_best_heuristic_algorithm(perf_results, nondet_fwd_algos,
                                        deterministic, ws_size);
 }
@@ -1220,6 +1221,7 @@ miopenConvBwdDataAlgorithm_t get_bwd_data_algo_heuristic(
                 perf_results.data(),
                 ws, ws_size,
                 true));
+  perf_results.resize(num_tested_algos);
   return find_best_heuristic_algorithm(perf_results, nondet_bwd_data_algos,
                                        deterministic, ws_size);
 }
@@ -1248,6 +1250,7 @@ miopenConvBwdWeightsAlgorithm_t get_bwd_filter_algo_heuristic(
                 perf_results.data(),
                 ws, ws_size,
                 true));
+  perf_results.resize(num_tested_algos);
   return find_best_heuristic_algorithm(perf_results, nondet_bwd_filter_algos,
                                        deterministic, ws_size);
 }
@@ -1263,30 +1266,21 @@ miopenConvFwdAlgorithm_t get_fwd_algo_autotune(
   void* output,
   size_t ws_size,
   void* ws) {
-  constexpr int num_trials = 3;
-  constexpr int num_skip = 1;
   int num_algos = ConvolutionFwdAlgoCount();
-  std::vector<miopenConvAlgoPerf_t> perf_results_all;
   std::vector<miopenConvAlgoPerf_t> perf_results(num_algos);
-  for (int trial = 0; trial < num_trials + num_skip; ++trial) {
-    int num_tested_algos;
-    CHECK_MIOPEN(miopenFindConvolutionForwardAlgorithm(
-                  get_handle(),
-                  input_desc, input,
-                  kernel_desc, kernel,
-                  conv_desc,
-                  output_desc, output,
-                  num_algos, &num_tested_algos,
-                  perf_results.data(),
-                  ws, ws_size,
-                  false));
-    if (trial > num_skip) {
-      for (const auto& p : perf_results) {
-        perf_results_all.push_back(p);
-      }
-    }
-  }
-  return find_best_algorithm(perf_results_all, nondet_fwd_algos,
+  int num_tested_algos;
+  CHECK_MIOPEN(miopenFindConvolutionForwardAlgorithm(
+                get_handle(),
+                input_desc, input,
+                kernel_desc, kernel,
+                conv_desc,
+                output_desc, output,
+                num_algos, &num_tested_algos,
+                perf_results.data(),
+                ws, ws_size,
+                false));
+  perf_results.resize(num_tested_algos);
+  return find_best_algorithm(perf_results, nondet_fwd_algos,
                              deterministic, ws_size);
 }
 
@@ -1301,30 +1295,21 @@ miopenConvBwdDataAlgorithm_t get_bwd_data_algo_autotune(
   void* error_signal,
   size_t ws_size,
   void* ws) {
-  constexpr int num_trials = 3;
-  constexpr int num_skip = 1;
   int num_algos = ConvolutionBwdDataAlgoCount();
-  std::vector<miopenConvAlgoPerf_t> perf_results_all;
   std::vector<miopenConvAlgoPerf_t> perf_results(num_algos);
-  for (int trial = 0; trial < num_trials + num_skip; ++trial) {
-    int num_tested_algos;
-    CHECK_MIOPEN(miopenFindConvolutionBackwardDataAlgorithm(
-                  get_handle(),
-                  prev_error_signal_desc, prev_error_signal,
-                  kernel_desc, kernel,
-                  conv_desc,
-                  error_signal_desc, error_signal,
-                  num_algos, &num_tested_algos,
-                  perf_results.data(),
-                  ws, ws_size,
-                  false));
-    if (trial > num_skip) {
-      for (const auto& p : perf_results) {
-        perf_results_all.push_back(p);
-      }
-    }
-  }
-  return find_best_algorithm(perf_results_all, nondet_bwd_data_algos,
+  int num_tested_algos;
+  CHECK_MIOPEN(miopenFindConvolutionBackwardDataAlgorithm(
+                get_handle(),
+                prev_error_signal_desc, prev_error_signal,
+                kernel_desc, kernel,
+                conv_desc,
+                error_signal_desc, error_signal,
+                num_algos, &num_tested_algos,
+                perf_results.data(),
+                ws, ws_size,
+                false));
+  perf_results.resize(num_tested_algos);
+  return find_best_algorithm(perf_results, nondet_bwd_data_algos,
                              deterministic, ws_size);
 }
 
@@ -1339,30 +1324,21 @@ miopenConvBwdWeightsAlgorithm_t get_bwd_filter_algo_autotune(
   void* kernel_gradient,
   size_t ws_size,
   void* ws) {
-  constexpr int num_trials = 3;
-  constexpr int num_skip = 1;
   int num_algos = ConvolutionBwdFilterAlgoCount();
-  std::vector<miopenConvAlgoPerf_t> perf_results_all;
   std::vector<miopenConvAlgoPerf_t> perf_results(num_algos);
-  for (int trial = 0; trial < num_trials + num_skip; ++trial) {
-    int num_tested_algos;
-    CHECK_MIOPEN(miopenFindConvolutionBackwardWeightsAlgorithm(
-                  get_handle(),
-                  prev_error_signal_desc, prev_error_signal,
-                  input_desc, input,
-                  conv_desc,
-                  kernel_gradient_desc, kernel_gradient,
-                  num_algos, &num_tested_algos,
-                  perf_results.data(),
-                  ws, ws_size,
-                  false));
-    if (trial > num_skip) {
-      for (const auto& p : perf_results) {
-        perf_results_all.push_back(p);
-      }
-    }
-  }
-  return find_best_algorithm(perf_results_all, nondet_bwd_filter_algos,
+  int num_tested_algos;
+  CHECK_MIOPEN(miopenFindConvolutionBackwardWeightsAlgorithm(
+                get_handle(),
+                prev_error_signal_desc, prev_error_signal,
+                input_desc, input,
+                conv_desc,
+                kernel_gradient_desc, kernel_gradient,
+                num_algos, &num_tested_algos,
+                perf_results.data(),
+                ws, ws_size,
+                false));
+  perf_results.resize(num_tested_algos);
+  return find_best_algorithm(perf_results, nondet_bwd_filter_algos,
                              deterministic, ws_size);
 }
 


### PR DESCRIPTION
Initial implementation of the miopen algorithm selection treated the `miopenFindConvolution*Algorithm` functions the same as their cuDNN equivalents, causing an issue with algorithm selection.  Specifically, the `GEMM` convolution algorithms were always being selected, showing a measured performance time of "0", despite those being the worst performing algorithms.  Changes include:

- Remove the for loop of trials which repeatedly calls `miopenFindConvolution*Algorithm`.  This was done because repeated calls to the functions returned the same exact results.  Even with `MIOPEN_FIND_ENFORCE=3` (https://rocmsoftwareplatform.github.io/MIOpen/doc/html/perfdatabase.html#miopen-find-enforce) the exact same performance results are returned after the first call.
- Resize `perf_results` vector based on the number of algorithms tested.  The number of algorithms _tested_ is not guaranteed to be the number of algorithms _requested_ and sometimes the vector will contain `miopenConvAlgoPerf_t` structs with default values (e.g., GEMM with time "0").  Pruning the results to the number of algorithms tested fixes this problem.
- Added convolution algorithm selection to the `dnn_lib` unit test

A few more things to document/note:
- It seems that the MIOpen performance database should occasionally or always be forced to update by setting `MIOPEN_FIND_ENFORCE=4`.  Otherwise, the algorithm selection will pull from pre-calculated performance data in the DB
- It's unclear if `find_best_algorithm` and `find_best_heuristic_algorithm` are necessary.  The MIOpen functions return sorted vectors (based on time only) and selecting the first algorithm may be sufficient to replace those functions.