### PR TITLE
Configure trainer grid dims with environment variable

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -205,9 +205,9 @@ public:
     return get_rank_in_world() == get_world_master();
   }
   /** Return a grid to use for this trainer. */
-  inline El::Grid& get_trainer_grid() noexcept { return *m_grid; }
+  inline El::Grid& get_trainer_grid() { return *m_grid; }
   /** Return a read-only grid to use for this trainer. */
-  inline const El::Grid& get_trainer_grid() const noexcept { return *m_grid; }
+  inline const El::Grid& get_trainer_grid() const { return *m_grid; }
   /** Return the total number of trainers. */
   inline int get_num_trainers() const noexcept { return m_num_trainers; }
   /* Return the number of processes in a trainer. */
@@ -904,7 +904,7 @@ private:
   /** Packed group communicators. */
   mutable std::unordered_map<int, El::mpi::Comm> m_group_communicators;
   /** Grid for this trainer. */
-  Grid* m_grid;
+  std::unique_ptr<El::Grid> m_grid;
   /** Number of trainers. */
   int m_num_trainers;
   /** Number of processors per trainer. */

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -30,6 +30,7 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer.hpp"
 #include "mpi.h"
 #include "omp.h"
@@ -58,7 +59,7 @@ namespace lbann {
 #endif // #ifdef LBANN_DEBUG
 
 lbann_comm::lbann_comm(int ppm, El::mpi::Comm world)
-  : m_world_comm(std::move(world)), m_grid(nullptr), m_procs_per_trainer(ppm),
+  : m_world_comm(std::move(world)), m_procs_per_trainer(ppm),
     m_num_trainer_barriers(0), m_num_intertrainer_barriers(0),
     m_num_global_barriers(0), m_bytes_sent(0), m_bytes_received(0)
 {
@@ -82,7 +83,7 @@ lbann_comm::lbann_comm(int ppm, El::mpi::Comm world)
 
 lbann_comm::~lbann_comm()
 {
-  delete m_grid;
+  m_grid.reset();
   El::mpi::Free(m_trainer_comm);
   El::mpi::Free(m_intertrainer_comm);
   El::mpi::Free(m_node_comm);
@@ -128,11 +129,18 @@ void lbann_comm::split_trainers(const int ppm)
                  m_trainer_rank,
                  m_intertrainer_comm);
 
-  // Initialize Elemental grid
-  if (m_grid != nullptr) {
-    delete m_grid;
+  // Initialize Elemental grid for trainer
+  if (const auto& trainer_grid_height
+      = std::getenv("LBANN_TRAINER_GRID_HEIGHT")) {
+    m_grid = make_unique<El::Grid>(
+      m_trainer_comm.GetMPIComm(),
+      std::stoi(trainer_grid_height));
   }
-  m_grid = new Grid(m_trainer_comm.GetMPIComm());
+  else {
+    m_grid = make_unique<El::Grid>(
+      m_trainer_comm.GetMPIComm());
+  }
+
 }
 
 void lbann_comm::intertrainer_sum_matrix(AbsMat& mat) const


### PR DESCRIPTION
By default, Hydrogen initializes process grids to be as square as possible. However, we have some applications with very tall-skinny matrices that would benefit from making the process grid 1D. This PR adds the option to configure the grid height with the `LBANN_TRAINER_GRID_HEIGHT` environment variable.

@benson31 and I have talked about exposing this more visibly, perhaps in the Protobuf and Python interfaces. It's not a bad idea, although I'm not sure how to do it right yet. I think the future is moving toward per-layer, multi-dimensional process grids with user-specified or introspected dimensions, e.g. for distconv or sub-graph parallelism, so this will come up again.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM360-1).