### PR TITLE
Bug fix for ROCm spack install

### DIFF
--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -93,7 +93,7 @@ set_center_specific_modules()
                 ;;
             "zen" | "zen2") # Corona
                 # Don't load OpenMPI get the HIP Clang to build it
-                MODULE_CMD="module --force unload StdEnv; module load clang/11.0.0 python/3.7.2 opt rocm/4.0.0"
+                MODULE_CMD="module --force unload StdEnv; module load clang/11.0.0 python/3.7.2 opt rocm/4.0.0 openmpi-gnu/4.0"
                 ;;
             *)
                 echo "No pre-specified modules found for this system. Make sure to setup your own"
@@ -282,6 +282,13 @@ cat <<EOF  >> ${yaml}
       externals:
       - spec: rdma-core@20 arch=${spack_arch}
         prefix: /usr
+    openmpi:
+      buildable: False
+      version:
+      - 4.0
+      externals:
+      - spec: openmpi@4.0.0 arch=${spack_arch}
+        prefix: /opt/openmpi/4.0/gnu
 EOF
                 ;;
             *)

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -92,7 +92,6 @@ set_center_specific_modules()
                 MODULE_CMD="module --force unload StdEnv; module load gcc/8.3.1 mvapich2/2.3 python/3.7.2"
                 ;;
             "zen" | "zen2") # Corona
-                # Don't load OpenMPI get the HIP Clang to build it
                 MODULE_CMD="module --force unload StdEnv; module load clang/11.0.0 python/3.7.2 opt rocm/4.0.0 openmpi-gnu/4.0"
                 ;;
             *)


### PR DESCRIPTION
This PR loads the system OpenMPI on Corona and makes Spack use that (rather than build its own OpenMPI).  This fixes an error where launching the `lbann` executable with `srun` gave an error (`OMPI was not built with SLURM support`).  We also see a performance improvement using the system OpenMPI.