### PR TITLE
Add command-line arg to set trainer grid height

### DIFF
--- a/include/lbann/comm.hpp
+++ b/include/lbann/comm.hpp
@@ -157,12 +157,17 @@ public:
   lbann_comm& operator=(const lbann_comm&) = delete;
   ~lbann_comm();
 
-  /**
-   * Split communicators so each trainer has procs_per_trainer processes.
-   * If you call this multiple times, it will invalidate existing grids
-   * and communicators.
+  /** @brief Construct communicators for trainers
+   *
+   *  Invalidates any existing trainer communicators.
+   *
+   *  @param procs_per_trainer Number of MPI ranks in a trainer.
+   *  Default is size of world communicator.
+   *  @param trainer_grid_height Height of 2D process grid for each
+   *  trainer. Must divide @c procs_per_trainer. Default grid is
+   *  approximately square.
    */
-  void split_trainers(int procs_per_trainer);
+  void split_trainers(int procs_per_trainer=-1, int trainer_grid_height=-1);
 
   /** Get which trainer this process is in. */
   inline int get_trainer_rank() const noexcept { return m_trainer_rank; }

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -41,6 +41,7 @@ const int lbann_default_random_seed = 42;
 #define NUM_TEST_SAMPLES "Num test samples"
 #define ALLOW_GLOBAL_STATISTICS "LTFB Allow global statistics"
 #define PROCS_PER_TRAINER "Processes per trainer"
+#define TRAINER_GRID_HEIGHT "Height of 2D process grid for each trainer"
 
 void construct_std_options();
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -92,11 +92,13 @@ lbann_comm::~lbann_comm()
 #endif
 }
 
-void lbann_comm::split_trainers(const int ppm)
+void lbann_comm::split_trainers(
+  int procs_per_trainer,
+  int trainer_grid_height)
 {
-  int world_size = El::mpi::Size(get_world_comm());
-  m_procs_per_trainer = ppm;
-  if (ppm == 0) {
+  const int world_size = El::mpi::Size(get_world_comm());
+  m_procs_per_trainer = procs_per_trainer;
+  if (m_procs_per_trainer <= 0) {
     m_procs_per_trainer = world_size;
   }
   // Check if parameters are valid
@@ -130,16 +132,9 @@ void lbann_comm::split_trainers(const int ppm)
                  m_intertrainer_comm);
 
   // Initialize Elemental grid for trainer
-  if (const auto& trainer_grid_height
-      = std::getenv("LBANN_TRAINER_GRID_HEIGHT")) {
-    m_grid = make_unique<El::Grid>(
-      m_trainer_comm.GetMPIComm(),
-      std::stoi(trainer_grid_height));
-  }
-  else {
-    m_grid = make_unique<El::Grid>(
-      m_trainer_comm.GetMPIComm());
-  }
+  m_grid = make_unique<El::Grid>(
+    m_trainer_comm.GetMPIComm(),
+    trainer_grid_height);
 
 }
 

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -87,6 +87,12 @@ void construct_std_options() {
                         " The number of resulting trainers is "
                         " num_procs / procs_per_trainer.",
                         0);
+  arg_parser.add_option(TRAINER_GRID_HEIGHT,
+                        {"--trainer_grid_height"},
+                        utils::ENV("LBANN_TRAINER_GRID_HEIGHT"),
+                        "Height of 2D process grid for each trainer. "
+                        "Default grid is approximately square.",
+                        -1);
 }
 
 /// Split the MPI communicator into trainers
@@ -94,6 +100,7 @@ void construct_std_options() {
 int allocate_trainer_resources(lbann_comm *comm) {
   auto& arg_parser = global_argument_parser();
   int procs_per_trainer = arg_parser.get<int>(PROCS_PER_TRAINER);
+  int trainer_grid_height = arg_parser.get<int>(TRAINER_GRID_HEIGHT);
 
   if (procs_per_trainer == 0) {
     procs_per_trainer = comm->get_procs_in_world();
@@ -102,8 +109,9 @@ int allocate_trainer_resources(lbann_comm *comm) {
   // Set up the communicator and get the grid based on the commandline spec.
   // We do not currently support splitting different trainers in different ways,
   // as this implies different grids.
-  if (procs_per_trainer != comm->get_procs_per_trainer()) {
-    comm->split_trainers(procs_per_trainer);
+  if (procs_per_trainer != comm->get_procs_per_trainer()
+      || trainer_grid_height != comm->get_trainer_grid().Height()) {
+    comm->split_trainers(procs_per_trainer, trainer_grid_height);
   }
 
   return procs_per_trainer;


### PR DESCRIPTION
This is a followup to suggestions from PR #1834. It adds a command-line argument `--trainer_grid_height` to set the trainer grid height.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM363-1).