### PR TITLE
Fix Clang compile error in row-wise weights norms layer

### DIFF
--- a/src/layers/misc/rowwise_weights_norms.cpp
+++ b/src/layers/misc/rowwise_weights_norms.cpp
@@ -65,7 +65,9 @@ void rowwise_weights_norms_layer<TensorDataType, Layout, Device>::row_sqsums(
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 void rowwise_weights_norms_layer<TensorDataType, Layout, Device>::sqrt(
   El::Matrix<TensorDataType, Device>& mat) {
-  El::EntrywiseMap(mat, El::Sqrt<TensorDataType>);
+  El::EntrywiseMap(
+    mat,
+    {[](TensorDataType const& a) -> TensorDataType { return El::Sqrt(a); }});
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>

--- a/src/layers/misc/rowwise_weights_norms.cpp
+++ b/src/layers/misc/rowwise_weights_norms.cpp
@@ -67,7 +67,7 @@ void rowwise_weights_norms_layer<TensorDataType, Layout, Device>::sqrt(
   El::Matrix<TensorDataType, Device>& mat) {
   El::EntrywiseMap(
     mat,
-    {[](TensorDataType const& a) -> TensorDataType { return El::Sqrt(a); }});
+    {[](TensorDataType const& a) { return El::Sqrt(a); }});
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>


### PR DESCRIPTION
The error seems to happen because we don't handle some metaprogramming template args for `El::Sqrt`. We don't see the error with GCC.

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM365-1).