### PR TITLE
Manually set Spack spec for OpenBLAS on LC x86 systems

### DIFF
--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -143,7 +143,7 @@ set_center_specific_spack_dependencies()
                 ;;
             "broadwell" | "haswell" | "sandybridge" | "ivybridge") # Pascal, RZHasGPU, Surface, Catalyst
                 # On LC the mvapich2 being used is built against HWLOC v1
-                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13"
+                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^openblas@0.3.12 threads=openmp"
                 ;;
             "zen" | "zen2") # Corona
                 # On LC the mvapich2 being used is built against HWLOC v1


### PR DESCRIPTION
This matches how we handle Power systems. See PRs #1792 and #1800.