### PR TITLE
Avoid GPU embedding and tessellate layers in ATOM WAE test

### DIFF
--- a/bamboo/integration_tests/test_integration_atom_wae.py
+++ b/bamboo/integration_tests/test_integration_atom_wae.py
@@ -103,6 +103,13 @@ def construct_model(lbann):
     wae_loss.append(recon)
 
     layers = list(lbann.traverse_layer_graph(input_))
+
+    # Hack to avoid non-deterministic floating-point errors in some
+    # GPU layers
+    for l in layers:
+        if isinstance(l, lbann.Embedding) or isinstance(l, lbann.Tessellate):
+            l.device = 'CPU'
+
     # Setup objective function
     weights = set()
     src_layers = []
@@ -111,7 +118,7 @@ def construct_model(lbann):
       if(l.weights and "disc0" in l.name and "instance1" in l.name):
         src_layers.append(l.name)
       #freeze weights in disc2
-      if(l.weights and "disc1" in l.name):
+      if(l.weights and "disc1" in l.name and "instance1" in l.name):
         dst_layers.append(l.name)
         for idx in range(len(l.weights)):
           l.weights[idx].optimizer = lbann.NoOptimizer()


### PR DESCRIPTION
These layers are correct, but have non-deterministic floating-point errors since they accumulate into atomics. The ATOM WAE test is incredibly sensitive, even when computing in double-precision, so bit-wise reproducbility is necessary. When I run the ATOM WAE test (1 Lassen node, deterministic debug build, double-precision data), I see a 5x slowdown relative to `develop`.