### PR TITLE
Work toward bit-wise reproducibility in ATOM WAE test

### DIFF
--- a/src/layers/learning/embedding.cu
+++ b/src/layers/learning/embedding.cu
@@ -184,9 +184,13 @@ void embedding_layer<TensorDataType, T_layout, Dev>::bp_compute() {
     constexpr size_t block_size = 256;
     dim3 block_dims, grid_dims;
     block_dims.x = block_size;
+#ifdef LBANN_DETERMINISTIC
+    grid_dims.x = 1;
+#else
     grid_dims.x = (this->m_embedding_dim + block_size - 1) / block_size;
     grid_dims.y = input_size;
     grid_dims.z = local_mini_batch_size;
+#endif // LBANN_DETERMINISTIC
     hydrogen::gpu::LaunchKernel(
       bp_kernel<TensorDataType>,
       grid_dims, block_dims, 0, multisync,

--- a/src/layers/transform/tessellate.cu
+++ b/src/layers/transform/tessellate.cu
@@ -161,9 +161,14 @@ void tessellate_layer<TensorDataType, T_layout, Dev>
 
     const auto& local_height = local_gradient_wrt_output.Height();
     const auto& local_width = local_gradient_wrt_output.Width();
-    const auto& block_size = 256;
-    const auto& grid_size =
+#ifdef LBANN_DETERMINISTIC
+    const size_t block_size = 1;
+    const size_t grid_size = 1;
+#else
+    const size_t block_size = 256;
+    const size_t grid_size =
       (local_height * local_width + block_size - 1) / block_size;
+#endif // LBANN_DETERMINISTIC
     hydrogen::gpu::LaunchKernel(
       bp_gpu_3d_kernel<TensorDataType>,
       grid_size, block_size, 0, multisync,


### PR DESCRIPTION
This is an alternative approach from PR #1843. In a deterministic build, it achieves bit-wise reproducibility in the ATOM WAE test by removing the effect of atomics, e.g. by running with a single GPU thread. This comes at a massive cost to performance. When I run the ATOM WAE test (1 Lassen node, deterministic debug build, double-precision data), it is 43x slower than in `develop` and 9x slower than in #1843. I don't think this is worth it and would advise merging PR #1843 instead.