### PR TITLE
Build script uses clingo

### DIFF
--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -49,13 +49,7 @@ Setup Spack (One-time setup)
        spack compiler add        # Make Spack aware of the new compiler
        spack solve zlib          # Force Spack to bootstrap clingo
 
-    Then open the `config.yaml` file:
-
-    .. code-block:: bash
-
-       emacs -nw <path to installation>/spack.git/etc/spack/config.yaml
-
-    Ensure the `config.yaml` file contains the following lines:
+    Create the file `${SPACK_ROOT}/etc/spack/config.yaml` if it doesn't exist. Verify that this file contains the following lines, adding them if necessary:
 
     .. code-block:: bash
 

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -24,6 +24,8 @@ Building with `Spack <https://github.com/llnl/spack>`_
           different compiler than the default OSX command line tools
           and an MPI library.
 
+.. _setup_spack:
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Setup Spack (One-time setup)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,24 +41,7 @@ Setup Spack (One-time setup)
         export SPACK_ROOT=<path to installation>/spack.git
         source ${SPACK_ROOT}/share/spack/setup-env.sh
 
-2.  Update spack to use the new clingo concretizer.  There are two
-    steps to this: bootstrapping clingo and modifying the repositories
-    configuration file.
-
-    .. code-block:: bash
-
-       module load gcc/8.3.1     # Load a compiler with C++17 support
-       spack compiler add        # Make Spack aware of the new compiler
-       spack solve zlib          # Force Spack to bootstrap clingo
-
-    Create the file `${SPACK_ROOT}/etc/spack/config.yaml` if it doesn't exist. Verify that this file contains the following lines, adding them if necessary:
-
-    .. code-block:: bash
-
-       config:
-         concretizer: clingo
-
-3.  LBANN will use `Spack environments
+2.  LBANN will use `Spack environments
     <https://spack.readthedocs.io/en/latest/environments.html>`_ to
     specify and manage both compilers and versions of dependent
     libraries.  Go to the install instructions for :ref:`users
@@ -89,11 +74,34 @@ that want to train new or existing models using the Python front-end.
 
 .. note:: Users should make themselves comfortable with Spack and `its
           idioms for installing packages
-          <https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html>`_
-          and experts can `customizations to their Spack ecosystem
+          <https://spack-tutorial.readthedocs.io/en/latest/tutorial_basics.html>`_,
+          and experts can add `customizations to their Spack ecosystem
           <https://spack.readthedocs.io/en/latest/configuration.html>`_
           (and modify these instructions) to ensure that they get the
           compilers and externals that they want.
+
+.. _setting_up_clingo:
+
+.. note:: LBANN works best with Spack's new concretizer clingo.
+          Please enable it by performing the following steps.  This
+          only needs to be done once per spack repository.
+
+          To update spack to use the new clingo concretizer.  There are two
+          steps to this: bootstrapping clingo and modifying the repositories
+          configuration file.
+
+          .. code-block:: bash
+
+             module load gcc/8.3.1     # Load a compiler with C++17 support
+             spack compiler add        # Make Spack aware of the new compiler
+             spack solve zlib          # Force Spack to bootstrap clingo
+
+          Create the file `${SPACK_ROOT}/etc/spack/config.yaml` if it doesn't exist. Verify that this file contains the following lines, adding them if necessary:
+
+          .. code-block:: bash
+
+             config:
+               concretizer: clingo
 
 .. note:: If your model requires custom layers or data readers, you
           may need to install LBANN as a developer, which would allow
@@ -140,10 +148,10 @@ software.
       spack load lbann@develop
 
 Please note that when getting LBANN to build as a user will encounter
-some issues with the Spack legacy concretizer.  It will require
-getting just the "right" invocation and we are working on making it
-smoother.  For the time being, it may be easier to use the developer
-build instructions.
+some issues with the Spack legacy concretizer and use of the new
+clingo concreizer is highly recommended :ref:`(see above)
+<setuping_up_clingo>`.  Using the legacy concretizer will require getting
+just the "right" invocation and we suggest using clingo.
 
 .. _build_lbann_from_source:
 
@@ -189,6 +197,14 @@ platform and the nominal options in the CMake build environment.
    .. warning:: Depending on the completeness of the externals
                 specification, the initial build of all of the
                 standard packages in Spack can take a long time.
+
+   .. note:: The build script will automatically update your Spack
+             repository to use clingo.  The manual instructions for
+             doing this are detailed in the :ref:`user instructions
+             <setuping_up_clingo>`.  Note that if Spack's
+             bootstrapping fails due to not finding a valid compiler,
+             please refer to the explicit user instructions on how to
+             have spack find a modern enough C++ compiler.
 
 2.  Once the installation has completed, to run LBANN you will want to
     load the spack module for LBANN with one of the following

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -92,7 +92,7 @@ that want to train new or existing models using the Python front-end.
 
           .. code-block:: bash
 
-             module load gcc/8.3.1     # Load a compiler with C++17 support
+             module load gcc/8.3.1     # Load a compiler with C++14 support
              spack compiler add        # Make Spack aware of the new compiler
              spack solve zlib          # Force Spack to bootstrap clingo
 

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -175,7 +175,7 @@ platform and the nominal options in the CMake build environment.
 
     .. code-block:: bash
 
-        <path to lbann repo>/scripts/build_lbann.sh -d -- +dihydrogen +cuda +half
+        <path to lbann repo>/scripts/build_lbann.sh -d -- +cuda +half
 
     Note that the named version and resulting environment can be
     controlled via the :code:`-l` flag. A full list of options can be
@@ -256,7 +256,6 @@ build from local repositories:
                     --hydrogen-repo <path>/Hydrogen.git
                     --aluminum-repo <path>/Aluminum.git
                     --dihydrogen-repo <path>/DiHydrogen.git
-                    -- +dihydrogen
 
 .. toctree::
    :maxdepth: 1

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -25,7 +25,7 @@ Building with `Spack <https://github.com/llnl/spack>`_
           and an MPI library.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Setup Spack
+Setup Spack (One-time setup)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1.  Download and install `Spack <https://github.com/llnl/spack>`_
@@ -39,8 +39,30 @@ Setup Spack
         export SPACK_ROOT=<path to installation>/spack.git
         source ${SPACK_ROOT}/share/spack/setup-env.sh
 
+2.  Update spack to use the new clingo concretizer.  There are two
+    steps to this: bootstrapping clingo and modifying the repositories
+    configuration file.
 
-2.  LBANN will use `Spack environments
+    .. code-block:: bash
+
+       module load gcc/8.3.1     # Load a compiler with C++17 support
+       spack compiler add        # Make Spack aware of the new compiler
+       spack solve zlib          # Force Spack to bootstrap clingo
+
+    Then open the `config.yaml` file:
+
+    .. code-block:: bash
+
+       emacs -nw <path to installation>/spack.git/etc/spack/config.yaml
+
+    Ensure the `config.yaml` file contains the following lines:
+
+    .. code-block:: bash
+
+       config:
+         concretizer: clingo
+
+3.  LBANN will use `Spack environments
     <https://spack.readthedocs.io/en/latest/environments.html>`_ to
     specify and manage both compilers and versions of dependent
     libraries.  Go to the install instructions for :ref:`users

--- a/docs/building_lbann.rst
+++ b/docs/building_lbann.rst
@@ -1,4 +1,4 @@
-.. role:: bash(code)
+ .. role:: bash(code)
           :language: bash
 
 ====================
@@ -96,7 +96,9 @@ that want to train new or existing models using the Python front-end.
              spack compiler add        # Make Spack aware of the new compiler
              spack solve zlib          # Force Spack to bootstrap clingo
 
-          Create the file `${SPACK_ROOT}/etc/spack/config.yaml` if it doesn't exist. Verify that this file contains the following lines, adding them if necessary:
+          Create the file :code:`${SPACK_ROOT}/etc/spack/config.yaml`
+          if it doesn't exist. Verify that this file contains the
+          following lines, adding them if necessary:
 
           .. code-block:: bash
 
@@ -109,10 +111,10 @@ that want to train new or existing models using the Python front-end.
 
 The best practices are to create a Spack environment (similar to a
 Python virtual environment) and to use something like your compute
-center's `modules` packages to provide paths to system installed
+center's :code:`modules` packages to provide paths to system installed
 software.
 
-1. Create and activate spack environment called (replace <env name>):
+1. Create and activate spack environment called (replace :code:`<env name>`):
 
 .. code-block:: bash
 
@@ -134,8 +136,10 @@ software.
    spack install lbann <variants and dependencies>
    spack load lbann@develop
 
-.. note:: Here is an example of a set of commands that works on an
-          x86_64 architecture with Nvidia P100 GPUs:
+.. note::
+
+   Here is an example of a set of commands that works on an x86_64
+   architecture with Nvidia P100 GPUs:
 
    .. code-block:: bash
 
@@ -149,8 +153,8 @@ software.
 
 Please note that when getting LBANN to build as a user will encounter
 some issues with the Spack legacy concretizer and use of the new
-clingo concreizer is highly recommended :ref:`(see above)
-<setuping_up_clingo>`.  Using the legacy concretizer will require getting
+clingo concretizer is highly recommended :ref:`(see above)
+<setting_up_clingo>`. Using the legacy concretizer will require getting
 just the "right" invocation and we suggest using clingo.
 
 .. _build_lbann_from_source:
@@ -201,7 +205,7 @@ platform and the nominal options in the CMake build environment.
    .. note:: The build script will automatically update your Spack
              repository to use clingo.  The manual instructions for
              doing this are detailed in the :ref:`user instructions
-             <setuping_up_clingo>`.  Note that if Spack's
+             <setting_up_clingo>`.  Note that if Spack's
              bootstrapping fails due to not finding a valid compiler,
              please refer to the explicit user instructions on how to
              have spack find a modern enough C++ compiler.
@@ -234,15 +238,15 @@ For more control over the LBANN build, please see :ref:`the complete
 documentation for building LBANN directly with CMake
 <build-with-cmake>`.
 
-------------------------------------------
+--------------------------------------------
 Debugging some common Spack related issues
-------------------------------------------
+--------------------------------------------
 
 One common issue that can occur is that the modules can get out of
 sync between what the LBANN environment does and the Spack defaults.
 As a result the generated module files can get out of whack.  LBANN
 uses a module hierarchy naming scheme that is compatible with other
-modules, provides for name collision, and reduces the cluttter in the
+modules, provides for name collision, and reduces the clutter in the
 module name.  If your modules are not working you can regenerate them
 in a LBANN Spack environment compatible approach:
 

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -174,13 +174,6 @@ while :; do
     shift
 done
 
-function exit_on_failure()
-{
-    local cmd="$1"
-    echo "FAILED: ${cmd}"
-    exit 1
-}
-
 function uninstall_specific_versions()
 {
     local package="$1"
@@ -248,6 +241,23 @@ if [[ -f ${LOG} ]]; then
     echo ${CMD}
     [[ -z "${DRY_RUN:-}" ]] && ${CMD}
 fi
+
+function exit_on_failure()
+{
+    local cmd="$1"
+    echo "FAILED: ${cmd}"
+    echo "##########################################################################################" | tee -a ${LOG}
+    echo "LBANN is being installed in a spack environment named ${LBANN_ENV} but an error occured, access it via:" | tee -a ${LOG}
+    echo "  spack env activate -p ${LBANN_ENV}" | tee -a ${LOG}
+    echo "To rebuild LBANN from source drop into a shell with the spack build environment setup (requires active environment):" | tee -a ${LOG}
+    echo "  spack build-env lbann -- bash" | tee -a ${LOG}
+    echo "  cd spack-build-${LBANN_SPEC_HASH}" | tee -a ${LOG}
+    echo "  ninja install" | tee -a ${LOG}
+    echo "##########################################################################################" | tee -a ${LOG}
+    echo "All details of the run are logged to ${LOG}"
+    echo "##########################################################################################"
+    exit 1
+}
 
 if [[ ! "${LBANN_VARIANTS}" =~ .*"^hydrogen".* ]]; then
     # If the user didn't supply a specific version of Hydrogen on the command line add one

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -432,12 +432,13 @@ fi
 
 # Figure out if there is a default MPI library for the center
 CENTER_DEPENDENCIES=
+CENTER_FLAGS=
 set_center_specific_spack_dependencies ${CENTER} ${SPACK_ARCH_TARGET}
 
 ##########################################################################################
 # Establish the spec for LBANN
-LBANN_SPEC="lbann@${LBANN_LABEL} ${LBANN_VARIANTS} ${HYDROGEN} ${DIHYDROGEN} ${ALUMINUM} ${CENTER_DEPENDENCIES}"
-LBANN_DEV_PATH_SPEC="lbann@${LBANN_LABEL} dev_path=${LBANN_HOME} ${LBANN_VARIANTS} ${HYDROGEN} ${DIHYDROGEN} ${ALUMINUM} ${CENTER_DEPENDENCIES}"
+LBANN_SPEC="lbann@${LBANN_LABEL} ${CENTER_FLAGS} ${LBANN_VARIANTS} ${HYDROGEN} ${DIHYDROGEN} ${ALUMINUM} ${CENTER_DEPENDENCIES}"
+LBANN_DEV_PATH_SPEC="lbann@${LBANN_LABEL} ${CENTER_FLAGS} dev_path=${LBANN_HOME} ${LBANN_VARIANTS} ${HYDROGEN} ${DIHYDROGEN} ${ALUMINUM} ${CENTER_DEPENDENCIES}"
 ##########################################################################################
 
 if [[ -n "${INSTALL_DEPS:-}" ]]; then

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -320,7 +320,7 @@ fi
 function exit_on_failure()
 {
     local cmd="$1"
-    echo "FAILED: ${cmd}"
+    echo -e "FAILED: ${cmd}"
     echo "##########################################################################################" | tee -a ${LOG}
     echo "LBANN is being installed in a spack environment named ${LBANN_ENV} but an error occured, access it via:" | tee -a ${LOG}
     echo "  spack env activate -p ${LBANN_ENV}" | tee -a ${LOG}
@@ -484,7 +484,7 @@ fi
 CMD="spack solve -l ${LBANN_DEV_PATH_SPEC}"
 echo ${CMD} | tee -a ${LOG}
 if [[ -z "${DRY_RUN:-}" ]]; then
-    eval ${CMD} || exit_on_failure "${CMD}"
+    eval ${CMD} || exit_on_failure "${CMD}\nIf the error is that boostrapping failed try something like 'module load gcc/8.3.1; spack compiler add' and then rerunning"
 fi
 # Get the spack hash before dev-build is called
 LBANN_SPEC_HASH=$(spack spec -l ${LBANN_DEV_PATH_SPEC} | grep lbann | grep arch=${SPACK_ARCH_PLATFORM} | awk '{print $1}')

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -460,7 +460,6 @@ fi
 ##########################################################################################
 # Actually install LBANN from local source
 CMD="spack install"
-#CMD="spack dev-build --source-path ${LBANN_HOME} ${DEV_BUILD_FLAGS} ${INSTALL_DEV_BUILD_EXTRAS} ${LBANN_SPEC}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -140,14 +140,18 @@ set_center_specific_spack_dependencies()
         case ${spack_arch_target} in
             "power9le" | "power8le") # Lassen, Ray
                 CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp"
+                CENTER_FLAGS="ldflags=\"-fuse-ld=gold\""
                 ;;
             "broadwell" | "haswell" | "sandybridge" | "ivybridge") # Pascal, RZHasGPU, Surface, Catalyst
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13"
+                CENTER_FLAGS="ldflags=\"-fuse-ld=gold\""
                 ;;
             "zen" | "zen2") # Corona
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_DEPENDENCIES="^openmpi ^hwloc@2.3.0"
+                # Don't overwrite the flag here since we set compiler specific flags
+                # CENTER_FLAGS="ldflags=\"-fuse-ld=lld\""
                 ;;
             *)
                 echo "No center-specified CENTER_DEPENDENCIES."
@@ -197,9 +201,6 @@ set_center_specific_externals()
     echo "Updating Clang compiler's to see the gfortran compiler."
 
     if [[ ${center} = "llnl_lc" ]]; then
-        # LC uses a old default gcc and clang needs a newer default gcc toolchain
-        perl -i.perl_bak -0pe 's/(- compiler:.*?spec: clang.*?flags:) (\{\})/$1 \{cflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc\-8\.1\.0, cxxflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0\}/smg' ${yaml}
-
         case ${spack_arch_target} in
             "broadwell" | "haswell" | "sandybridge" | "power9le" | "power8le")
 cat <<EOF  >> ${yaml}
@@ -378,6 +379,7 @@ cleanup_clang_compilers()
 
     if [[ ${center} = "llnl_lc" ]]; then
         # LC uses a old default gcc and clang needs a newer default gcc toolchain
-        perl -i.perl_bak -0pe 's/(- compiler:.*?spec: clang.*?flags:) (\{\})/$1 \{cflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc\-8\.1\.0, cxxflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0\}/smg' ${yaml}
+        # Also set LC clang compilers to use lld for faster linking
+        perl -i.perl_bak -0pe 's/(- compiler:.*?spec: clang.*?flags:) (\{\})/$1 \{cflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0, cxxflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0, ldflags: -fuse-ld=lld\}/smg' ${yaml}
     fi
 }


### PR DESCRIPTION
This PR simplifies the build script and gives directions on how the user needs to setup the clingo concretizer.  Using the clingo concretizer greatly simplifies what information the user has to specify to get spack to find a valid solution.