### PR TITLE
Cleanup execution context

### DIFF
--- a/include/lbann/callbacks/callback.hpp
+++ b/include/lbann/callbacks/callback.hpp
@@ -207,9 +207,8 @@ public:
     if (dir.empty()) { dir = "./"; }
     if (dir.back() != '/') { dir += "/"; }
 
-    const auto& c = static_cast<const sgd_execution_context&>(m.get_execution_context());
     return build_string(dir,
-                        c.get_trainer().get_name(), '/');
+                        get_const_trainer().get_name(), '/');
   }
 
   /** @brief Build a standard directory hierachy including trainer,

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -192,8 +192,8 @@ public:
                               const std::string& task_label,
                               const std::string& trainer_name,
                               const std::string& alg_name,
-                              std::function<bool(/*const */persist&)> reload_shared_ckpt,
-                              std::function<bool(/*const */persist&)> reload_distributed_ckpt);
+                              std::function<void(/*const */persist&)> reload_shared_ckpt,
+                              std::function<void(/*const */persist&)> reload_distributed_ckpt);
   bool reload_model(model *m);
   bool reload_trainer(trainer *t);
   bool restart(model *m);

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -192,8 +192,8 @@ public:
                               const std::string& task_label,
                               const std::string& trainer_name,
                               const std::string& alg_name,
-                              std::function<void(/*const */persist&)> reload_shared_ckpt,
-                              std::function<void(/*const */persist&)> reload_distributed_ckpt);
+                              std::function<bool(/*const */persist&)> reload_shared_ckpt,
+                              std::function<bool(/*const */persist&)> reload_distributed_ckpt);
   bool reload_model(model *m);
   bool reload_trainer(trainer *t);
   bool restart(model *m);

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -30,7 +30,6 @@
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/io/persist.hpp"
-#include "lbann/utils/cloneable.hpp"
 #include "lbann/utils/threads/thread_pool.hpp"
 
 // Forward declaration
@@ -127,7 +126,7 @@ private:
    *  @details Step counts the number of iterations in the training
    *  algorithm's internal state
    */
-  size_t m_step = 0;
+  size_t m_step = 0UL;
 
   /** @brief Whether to terminate training.
    *  @details If true, training will terminate immediately before

--- a/include/lbann/execution_contexts/execution_context.hpp
+++ b/include/lbann/execution_contexts/execution_context.hpp
@@ -30,6 +30,7 @@
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/io/persist.hpp"
+#include "lbann/utils/cloneable.hpp"
 #include "lbann/utils/threads/thread_pool.hpp"
 
 // Forward declaration
@@ -54,30 +55,26 @@ class execution_context
 {
 public:
   /** Constructor. */
-  execution_context(trainer& trainer,
-                    training_algorithm& training_alg,
-                    execution_mode mode);
+  execution_context();
+
   /** Destructor. */
   virtual ~execution_context() = default;
 
-  /** Copy execution_context. */
-  virtual std::unique_ptr<execution_context> copy_execution_context() const
-  {
-    // Use explicit construction of unique pointer since copy
-    // constructor is protected and cannot be accessed in make_unique
-    return std::unique_ptr<execution_context>{new execution_context(*this)};
-  }
+  /** Get a "clean" execution_context of the same type. */
+  virtual std::unique_ptr<execution_context> get_new() const = 0;
 
-  /** Archive for checkpoint and restart */
-  template <class Archive> void serialize(Archive& ar);
+  /** @brief Get a string identifying the type of execution context.
+   *  @details Should match the training algorithm.
+   *  @todo Absorb completely into `get_state_string()`.
+   */
+  virtual std::string get_type() const = 0;
 
   /** @brief Return the state of the execution context as a string */
-  virtual std::string get_state_string() const noexcept
+  virtual std::string get_state_string() const noexcept = 0;
+
+  virtual execution_mode get_execution_mode() const noexcept
   {
-    return build_string("ec.",
-                        to_string(get_execution_mode()),
-                        ".step.",
-                        get_step());
+    return execution_mode::invalid;
   }
 
   /** @brief Current step in the training algorithm
@@ -92,64 +89,29 @@ public:
    */
   void inc_step() noexcept { ++m_step; }
 
-  /** Get the mode that the trainer is currenting executing. */
-  inline void set_execution_mode(execution_mode mode) noexcept
-  {
-    m_execution_mode = mode;
-  }
-
-  /** Get the mode that the trainer is currenting executing. */
-  inline execution_mode get_execution_mode() const noexcept
-  {
-    return m_execution_mode;
-  }
-
   /** Return true if the flag to stop training is set. */
   bool get_terminate_training() const { return m_terminate_training; }
   /** Set the terminate training flag (on or off). */
   void set_terminate_training(bool f) { m_terminate_training = f; }
 
-  /** Grab the trainer from the execution context */
-  const trainer& get_trainer() const { return *m_trainer; }
+  /** @name Checkpointing and Serialization */
+  ///@{
 
-  trainer& get_trainer()
-  {
-    return const_cast<trainer&>(
-      static_cast<const execution_context&>(*this).get_trainer());
-  }
+  /** Archive for checkpoint and restart */
+  template <class Archive> void serialize(Archive& ar);
 
-  const training_algorithm& get_training_algorithm() const
-  {
-    return *m_training_algorithm;
-  }
-
-  training_algorithm& get_training_algorithm()
-  {
-    return const_cast<training_algorithm&>(
-      static_cast<const execution_context&>(*this).get_training_algorithm());
-  }
-
-  thread_pool& get_io_thread_pool() const;
-
-  lbann_comm& get_comm() const
-  {
-    if (!m_comm) {
-      LBANN_ERROR("m_comm is null");
-    }
-    return *m_comm;
-  };
-
-  /** Checkpoint training_algorithm to given file descriptor */
-  virtual void save_to_checkpoint_shared(persist& p);
-  /** Restore training_algorithm by reading checkpoint from given file
-   * descriptor */
-  virtual void load_from_checkpoint_shared(persist& p);
-  virtual void save_to_checkpoint_distributed(persist& p);
-  virtual void load_from_checkpoint_distributed(persist& p);
+  /** @brief Checkpoint exection_context to a shared checkpoint. */
+  virtual void save_to_checkpoint_shared(persist& p) = 0;
+  /** @brief Restore execution_context from a shared checkpoint. */
+  virtual void load_from_checkpoint_shared(persist& p) = 0;
+  /** @brief Checkpoint exection_context to a distributed checkpoint. */
+  virtual void save_to_checkpoint_distributed(persist& p) = 0;
+  /** @brief Restore execution_context from a distributed checkpoint. */
+  virtual void load_from_checkpoint_distributed(persist& p) = 0;
+  ///@}
 
 protected:
   friend class cereal::access;
-  execution_context() = default;
   /** Copy constructor. */
   execution_context(const execution_context& other) = default;
   /** Copy assignment operator. */
@@ -160,17 +122,6 @@ protected:
   execution_context& operator=(execution_context&& other) = default;
 
 private:
-  /** Pointer to the training context (execution environment) for the training
-   * algorithm */
-  trainer* m_trainer;
-
-  training_algorithm* m_training_algorithm;
-
-  /** LBANN communicator. */
-  observer_ptr<lbann_comm> m_comm;
-
-  /** The trainer's current execution mode. */
-  execution_mode m_execution_mode = execution_mode::training;
 
   /** @brief Current step in the training algorithm
    *  @details Step counts the number of iterations in the training
@@ -186,5 +137,4 @@ private:
 };
 
 } // namespace lbann
-
 #endif // LBANN_EXECUTION_CONTEXT_HPP

--- a/include/lbann/execution_contexts/sgd_execution_context.hpp
+++ b/include/lbann/execution_contexts/sgd_execution_context.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_SGD_EXECUTION_CONTEXT_HPP
 #define LBANN_SGD_EXECUTION_CONTEXT_HPP
 
+#include "lbann/base.hpp"
 #include "lbann/execution_contexts/execution_context.hpp"
 
 namespace lbann {
@@ -46,9 +47,7 @@ class sgd_execution_context final : public execution_context
 {
 public:
   /** Constructor. */
-  sgd_execution_context(trainer& trainer,
-                        training_algorithm& training_alg,
-                        execution_mode mode,
+  sgd_execution_context(execution_mode mode,
                         size_t mini_batch_size);
   /** Destructor. */
   virtual ~sgd_execution_context() = default;
@@ -62,10 +61,10 @@ public:
   sgd_execution_context(sgd_execution_context&& other) = default;
   /** Move assignment operator. */
   sgd_execution_context& operator=(sgd_execution_context&& other) = default;
-  /** Copy sgd_execution_context. */
-  std::unique_ptr<execution_context> copy_execution_context() const override
+  /** @brief Get a clean sgd_execution_context. */
+  std::unique_ptr<execution_context> get_new() const override
   {
-    return make_unique<sgd_execution_context>(*this);
+    return make_unique<sgd_execution_context>(execution_mode::invalid, 0UL);
   }
 
   /** Archive for checkpoint and restart */
@@ -120,6 +119,20 @@ public:
   void save_to_checkpoint_distributed(persist& p) override;
   void load_from_checkpoint_distributed(persist& p) override;
 
+  std::string get_type() const override;
+
+  /** Get the mode that the trainer is currenting executing. */
+  void set_execution_mode(execution_mode mode) noexcept
+  {
+    m_execution_mode = mode;
+  }
+
+  /** Get the mode that the trainer is currenting executing. */
+  execution_mode get_execution_mode() const noexcept override
+  {
+    return m_execution_mode;
+  }
+
 private:
   friend class cereal::access;
   sgd_execution_context() = default;
@@ -137,6 +150,8 @@ private:
    *  e.g.  correctly averaging gradients from multiple models.
    */
   size_t m_effective_mini_batch_size;
+
+  execution_mode m_execution_mode;
 };
 
 } // namespace lbann

--- a/include/lbann/layers/io/input_layer.hpp
+++ b/include/lbann/layers/io/input_layer.hpp
@@ -29,14 +29,9 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/data_coordinator/buffered_data_coordinator.hpp"
-#include "lbann/execution_contexts/sgd_execution_context.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/distconv.hpp"
 #include "lbann/models/model.hpp"
-#include <string>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 namespace lbann {
 

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -30,6 +30,7 @@
 #include "lbann/base.hpp"
 #include "lbann/comm.hpp"
 #include "lbann/data_coordinator/data_coordinator.hpp"
+#include "lbann/detect_El_mpi.hpp"
 #include "lbann/execution_contexts/execution_context.hpp"
 #include "lbann/io/persist.hpp"
 #include "lbann/models/model.hpp"
@@ -47,41 +48,51 @@ class lbann_callback;
 class training_algorithm;
 class termination_criteria;
 
-/** Represents an LBANN trainer and its context. */
+/** @brief User-facing class that represents a set of compute resources.
+ *
+ *  A trainer is responsible for managing the interactions of an
+ *  `lbann_comm` object with other objects in the library, most
+ *  notably `model`s and `data_coordinator`s.
+ */
 class trainer
 {
 public:
-  /** Constructor. */
-  trainer(lbann_comm* comm,
-          size_t mini_batch_size,
-          std::unique_ptr<data_coordinator> dc);
+  /** @name Lifecycle management */
+  ///@{
 
-  /** Copy constructor. */
+  /** @brief Construct with a communicator and data coordinator.
+   *  @param[in] comm A reference to a valid `lbann_comm` object.
+   *  @param[in] dc The data coordinator used by this trainer.
+   *  @param[in] mini_batch_size The minibatch size? What's a minibatch? That
+   *                             sounds like an SGD thing...
+   *  @todo I don't know why `mini_batch_size` is here.
+   */
+  trainer(lbann_comm* comm,
+          std::unique_ptr<data_coordinator> dc,
+          size_t mini_batch_size);
+
   trainer(const trainer& other);
-  /** Copy assignment operator. */
   trainer& operator=(const trainer& other);
-  /** Destructor. */
   ~trainer();
 
-  /** Archive for checkpoint and restart */
+  ///@}
+  /** @name Serialization */
+  ///@{
+
+  /** @brief Archive for checkpoint and restart */
   template <class Archive> void serialize(Archive& ar);
 
-  /** Set the trainer's name; this is an arbitrary string
-   *  that may be useful in multi-trainer scenarios, e.g,
-   *  LTFB, jag
+  ///@}
+  /** @name Configuration */
+  ///@{
+
+  /** @brief Set the trainer's name.
+   *  @details This is an arbitrary string that may be useful in
+   *  multi-trainer scenarios, e.g, LTFB, jag, etc.
    */
   void set_name(std::string const& name);
 
-  /** Return the trainer's name; this is an arbitrary string
-   *  that may be useful in multi-trainer scenarios, e.g,
-   *  LTFB, jag
-   */
-  std::string get_name() const { return m_name; }
-
-  /** Human-readable description. */
-  description get_description() const;
-
-  /** Set the random seeds used for the trainer */
+  /** @brief Set the random seeds used for the trainer */
   void set_random_seeds(int root_random_seed,
                         int random_seed,
                         int data_seq_random_seed)
@@ -89,20 +100,6 @@ public:
     m_root_random_seed = root_random_seed;
     m_random_seed = random_seed;
     m_data_seq_random_seed = data_seq_random_seed;
-  }
-
-  int get_random_seed() const { return m_random_seed; }
-  int get_data_seq_random_seed() const { return m_data_seq_random_seed; }
-
-  /** @brief Get the list of callbacks for the trainer. */
-  std::vector<observer_ptr<callback_base>> get_callbacks()
-  {
-    std::vector<observer_ptr<callback_base>> callback_list;
-    callback_list.reserve(m_callbacks.size());
-    for (const auto& ptr : m_callbacks) {
-      callback_list.push_back(ptr.get());
-    }
-    return callback_list;
   }
 
   void add_callback(std::shared_ptr<callback_base> cb)
@@ -114,14 +111,95 @@ public:
     m_callbacks.push_back(std::move(cb));
   }
 
+  /** @brief Set up the trainer. */
+  void setup(std::unique_ptr<thread_pool> io_thread_pool,
+             std::map<execution_mode, generic_data_reader*> data_readers);
+
+  /** @brief Set a flag that can be used to enable / disable the
+   *         background I/O activities.
+   */
+  void allow_background_io_activity(bool enable)
+  {
+    m_background_io_allowed = enable;
+  }
+
+  ///@}
+  /** @name Queries */
+  ///@{
+
+  /** Return the trainer's name; this is an arbitrary string
+   *  that may be useful in multi-trainer scenarios, e.g,
+   *  LTFB, jag
+   */
+  std::string get_name() const { return m_name; }
+
+  /** Human-readable description. */
+  description get_description() const;
+
+  int get_random_seed() const noexcept { return m_random_seed; }
+  int get_data_seq_random_seed() const noexcept
+  {
+    return m_data_seq_random_seed;
+  }
+
+  /** @brief Get the list of callbacks for the trainer. */
+  std::vector<observer_ptr<callback_base>> get_callbacks() const
+  {
+    std::vector<observer_ptr<callback_base>> callback_list;
+    callback_list.reserve(m_callbacks.size());
+    for (const auto& ptr : m_callbacks) {
+      callback_list.push_back(ptr.get());
+    }
+    return callback_list;
+  }
+
   std::vector<std::shared_ptr<callback_base>>& get_callbacks_with_ownership()
   {
     return m_callbacks;
   }
 
-  /** Set up the trainer. */
-  void setup(std::unique_ptr<thread_pool> io_thread_pool,
-             std::map<execution_mode, generic_data_reader*> data_readers);
+  const data_coordinator& get_data_coordinator() const
+  {
+    if (m_data_coordinator == nullptr) {
+      LBANN_ERROR("data_coordinator is nullptr");
+    }
+    return *m_data_coordinator;
+  }
+
+  data_coordinator& get_data_coordinator()
+  {
+    return const_cast<data_coordinator&>(
+      static_cast<const trainer&>(*this).get_data_coordinator());
+  }
+
+  /** @brief Get the I/O thread pool */
+  thread_pool& get_io_thread_pool() const
+  {
+    if (!m_io_thread_pool) {
+      LBANN_ERROR("m_io_thread_pool is null");
+    }
+    return *(m_io_thread_pool.get());
+  }
+
+  /** @brief Get the trainer's comm. */
+  lbann_comm* get_comm() const noexcept { return m_comm; }
+
+  /** @brief Get the trainer's persist object */
+  persist& get_persist_obj() noexcept { return m_persist; }
+
+  /** @brief Get the trainer's maximum mini-batch size. */
+  size_t get_max_mini_batch_size() const noexcept
+  {
+    return m_max_mini_batch_size;
+  }
+
+  /** @brief Are background I/O activities enabled by the input layers */
+  bool background_io_activity_allowed() const noexcept
+  {
+    return m_background_io_allowed;
+  }
+
+  ///@}
 
   using execution_context_key_pair_t =
     typename std::pair<observer_ptr<model>, execution_mode>;
@@ -141,24 +219,8 @@ public:
 
   execution_context& get_execution_context(execution_context_key_pair_t key);
 
-  void delete_execution_context(execution_context_key_pair_t key);
-
-  void for_each_execution_context(
-    std::function<void(observer_ptr<execution_context>)> fn);
-
-  const data_coordinator& get_data_coordinator() const
-  {
-    if (m_data_coordinator == nullptr) {
-      LBANN_ERROR("data_coordinator is nullptr");
-    }
-    return *m_data_coordinator;
-  }
-
-  data_coordinator& get_data_coordinator()
-  {
-    return const_cast<data_coordinator&>(
-      static_cast<const trainer&>(*this).get_data_coordinator());
-  }
+  /** @name Training and evaluation interface */
+  ///@{
 
   void apply(training_algorithm& alg,
              observer_ptr<model> model,
@@ -172,66 +234,77 @@ public:
                 execution_mode mode,
                 El::Int num_batches = 0);
 
-  /** Return the I/O thread pool */
-  thread_pool& get_io_thread_pool() const
-  {
-    if (!m_io_thread_pool) {
-      LBANN_ERROR("m_io_thread_pool is null");
-    }
-    return *(m_io_thread_pool.get());
-  }
+  ///@}
+  /** @name Checkpointing */
+  ///@{
 
-  /** Get the trainer's comm. */
-  inline lbann_comm* get_comm() const { return m_comm; }
+  /** @brief Create a shared checkpoint of the trainer. */
+  void save_to_checkpoint_shared();
 
-  /** Get the trainer's persist object */
-  inline persist& get_persist_obj() { return m_persist; }
+  /** @brief Restore trainer from a shared checkpoint. */
+  void load_from_checkpoint_shared(persist& p);
 
-  /** Get the trainer's maximum mini-batch size. */
-  inline size_t get_max_mini_batch_size() const
-  {
-    return m_max_mini_batch_size;
-  }
+  /** @brief Restore model from a shared checkpoint. */
+  void load_from_checkpoint_shared(model& m, execution_context& c);
 
-  /** Set a flag that can be used to enable / disable the background I/O
-   * activities */
-  void allow_background_io_activity(bool enable)
-  {
-    m_background_io_allowed = enable;
-  }
+  /** @brief Create a distributed checkpoint of the trainer. */
+  void save_to_checkpoint_distributed();
 
-  /** Are background I/O activities enabled by the input layers */
-  bool background_io_activity_allowed() { return m_background_io_allowed; }
+  /** @brief Restore a trainer from a distributed checkpoint. */
+  void load_from_checkpoint_distributed(persist& p);
 
-  // ===========================================
-  // Checkpointing
-  // ===========================================
+  /** @brief Restore a model from a distributed checkpoint. */
+  void load_from_checkpoint_distributed(model& m, execution_context& c);
 
-  /** @brief Checkpoint model to given file descriptor, return number of bytes
-   * written */
-  bool save_to_checkpoint_shared();
-  /** @brief Restore model by reading checkpoint from given file descriptor,
-   * return number of bytes read */
-  bool load_from_checkpoint_shared(persist& p);
-  bool load_from_checkpoint_shared(model& m, execution_context& c);
+  /** @brief Write trainer to proto message */
+  void write_proto(lbann_data::Trainer& proto);
 
-  bool save_to_checkpoint_distributed();
-  bool load_from_checkpoint_distributed(persist& p);
-  bool load_from_checkpoint_distributed(model& m, execution_context& c);
-
-  /** @brief Write model to proto file */
-  void write_proto(lbann_data::Trainer* proto);
+  ///@}
 
 private:
-  /** Give trainer a name. */
+  void delete_execution_context(execution_context_key_pair_t key);
+
+  void for_each_execution_context(
+    std::function<void(observer_ptr<execution_context>)> fn);
+
+private:
+  /** @brief Persist object used for serializing LBANN classes. */
+  persist m_persist;
+
+  /** @brief Hash function for @c m_model_execution_context. */
+  using model_execution_context_hash_t =
+    pair_hash<observer_ptr<model>,
+              execution_mode,
+              std::hash<observer_ptr<model>>,
+              enum_hash<execution_mode>>;
+
+  using ModelContextMapType =
+    std::unordered_map<std::pair<observer_ptr<model>, execution_mode>,
+                       std::unique_ptr<execution_context>,
+                       model_execution_context_hash_t>;
+
+  /** @brief Map from model and execution mode to its execution context */
+  ModelContextMapType m_model_execution_context;
+
+  /** @brief This trainer's name. */
   std::string m_name;
 
-  /** Communicator for the trainer. */
+  /** @brief Current callbacks to process. */
+  std::vector<std::shared_ptr<callback_base>> m_callbacks;
+
+  /** @brief Data Coordinator holding trainers data readers */
+  std::unique_ptr<data_coordinator> m_data_coordinator;
+
+  /** @brief Threads available for I/O */
+  std::unique_ptr<thread_pool> m_io_thread_pool;
+
+  /** @brief Communication domain for the trainer. */
   lbann_comm* m_comm;
 
-  /** @details Maximum possible minibatch size supported by models and
-   *  layers in this trainer.  Note that this field will eventually be
-   *  local to the particular, instance of the training context..
+  /** @brief Maximum possible minibatch size supported by models and
+   *         layers in this trainer.
+   *  @note This field will eventually be local to the particular,
+   *        instance of the training context.
    */
   size_t m_max_mini_batch_size;
 
@@ -242,33 +315,9 @@ private:
   // Random seed used for the RNG used to fetch data
   int m_data_seq_random_seed;
 
-  /** Threads available for I/O */
-  std::unique_ptr<thread_pool> m_io_thread_pool;
-
-  /** Flag that allows input layers to fetch data in the background */
+  /** @brief Flag that allows input layers to fetch data in the background. */
   bool m_background_io_allowed;
 
-  /** Persist object used for serializing LBANN classes */
-  persist m_persist;
-
-  /** Hash function for @c m_model_execution_context */
-  using model_execution_context_hash_t =
-    pair_hash<observer_ptr<model>,
-              execution_mode,
-              std::hash<observer_ptr<model>>,
-              enum_hash<execution_mode>>;
-
-  /** @brief Map from model and execution mode to its execution context */
-  std::unordered_map<std::pair<observer_ptr<model>, execution_mode>,
-                     std::unique_ptr<execution_context>,
-                     model_execution_context_hash_t>
-    m_model_execution_context;
-
-  /** @brief Current callbacks to process. */
-  std::vector<std::shared_ptr<callback_base>> m_callbacks;
-
-  /** @brief Data Coordinator holding trainers data readers */
-  std::unique_ptr<data_coordinator> m_data_coordinator;
 };
 
 } // namespace lbann

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -308,17 +308,28 @@ private:
    */
   size_t m_max_mini_batch_size;
 
-  // Root of the random seed tree: either default or user supplied
+  /** @brief Root of the random seed tree.
+   *  @details Either default or user supplied.
+   */
   int m_root_random_seed;
-  // Random seed used for the general RNGs
+
+  /** @brief Random seed used for the general RNGs. */
   int m_random_seed;
-  // Random seed used for the RNG used to fetch data
+
+  /** @brief Random seed used for the RNG used to fetch data. */
   int m_data_seq_random_seed;
 
   /** @brief Flag that allows input layers to fetch data in the background. */
   bool m_background_io_allowed;
-
 };
+
+/** @brief Get a reference to the global trainer visible to this rank. */
+trainer& get_trainer();
+
+/** @brief Get a const reference to the global trainer visible to this
+ *         rank.
+ */
+trainer const& get_const_trainer();
 
 } // namespace lbann
 

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -292,11 +292,11 @@ private:
   /** @brief Current callbacks to process. */
   std::vector<std::shared_ptr<callback_base>> m_callbacks;
 
-  /** @brief Data Coordinator holding trainers data readers */
-  std::unique_ptr<data_coordinator> m_data_coordinator;
-
   /** @brief Threads available for I/O */
   std::unique_ptr<thread_pool> m_io_thread_pool;
+
+  /** @brief Data Coordinator holding trainers data readers */
+  std::unique_ptr<data_coordinator> m_data_coordinator;
 
   /** @brief Communication domain for the trainer. */
   lbann_comm* m_comm;

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -239,22 +239,22 @@ public:
   ///@{
 
   /** @brief Create a shared checkpoint of the trainer. */
-  void save_to_checkpoint_shared();
+  bool save_to_checkpoint_shared();
 
   /** @brief Restore trainer from a shared checkpoint. */
-  void load_from_checkpoint_shared(persist& p);
+  bool load_from_checkpoint_shared(persist& p);
 
   /** @brief Restore model from a shared checkpoint. */
-  void load_from_checkpoint_shared(model& m, execution_context& c);
+  bool load_from_checkpoint_shared(model& m, execution_context& c);
 
   /** @brief Create a distributed checkpoint of the trainer. */
-  void save_to_checkpoint_distributed();
+  bool save_to_checkpoint_distributed();
 
   /** @brief Restore a trainer from a distributed checkpoint. */
-  void load_from_checkpoint_distributed(persist& p);
+  bool load_from_checkpoint_distributed(persist& p);
 
   /** @brief Restore a model from a distributed checkpoint. */
-  void load_from_checkpoint_distributed(model& m, execution_context& c);
+  bool load_from_checkpoint_distributed(model& m, execution_context& c);
 
   /** @brief Write trainer to proto message */
   void write_proto(lbann_data::Trainer& proto);

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -47,10 +47,12 @@ void construct_std_options();
 
 int allocate_trainer_resources(lbann_comm *comm);
 
-std::unique_ptr<trainer> construct_trainer(lbann_comm *comm,
-                                           lbann_data::Trainer* pb_trainer,
-                                           lbann_data::LbannPB &pb,
-                                           options *opts);
+// The constructed trainer has global scope. This returns a reference
+// to this global trainer.
+trainer& construct_trainer(lbann_comm *comm,
+                           lbann_data::Trainer* pb_trainer,
+                           lbann_data::LbannPB &pb,
+                           options *opts);
 
 std::unique_ptr<thread_pool> construct_io_thread_pool(lbann_comm *comm, options *opts, bool serialized_io);
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -166,14 +166,14 @@ int main(int argc, char* argv[])
     lbann_data::Trainer* pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer =
+    auto& trainer =
       construct_trainer(comm.get(), pb_trainer, pb, opts);
 
-    thread_pool& io_thread_pool = trainer->get_io_thread_pool();
+    thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
     int training_dr_linearized_data_size = -1;
     auto* dr =
-      trainer->get_data_coordinator().get_data_reader(execution_mode::training);
+      trainer.get_data_coordinator().get_data_reader(execution_mode::training);
     if (dr != nullptr) {
       training_dr_linearized_data_size = dr->get_linearized_data_size();
     }
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
                                  comm.get(),
                                  opts,
                                  io_thread_pool,
-                                 trainer->get_callbacks_with_ownership(),
+                                 trainer.get_callbacks_with_ownership(),
                                  training_dr_linearized_data_size);
 
     if (opts->has_string("create_tarball")) {
@@ -197,10 +197,10 @@ int main(int argc, char* argv[])
     if (!opts->get_bool("exit_after_setup")) {
 
       // Train model
-      trainer->train(model.get(), pb_model->num_epochs());
+      trainer.train(model.get(), pb_model->num_epochs());
 
       // Evaluate model on test set
-      trainer->evaluate(model.get(), execution_mode::testing);
+      trainer.evaluate(model.get(), execution_mode::testing);
 
       // has no affect unless option: --st_on was given
       stack_profiler::get()->print();

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -106,19 +106,19 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    auto& trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
-    thread_pool& io_thread_pool = trainer->get_io_thread_pool();
+    thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
     int training_dr_linearized_data_size = -1;
-    auto *dr = trainer->get_data_coordinator().get_data_reader(execution_mode::training);
+    auto *dr = trainer.get_data_coordinator().get_data_reader(execution_mode::training);
     if(dr != nullptr) {
       training_dr_linearized_data_size = dr->get_linearized_data_size();
     }
 
     auto model_1 = build_model_from_prototext(argc, argv, pb_trainer, *(pbs[0]),
                                               comm.get(), opts, io_thread_pool,
-                                              trainer->get_callbacks_with_ownership(),
+                                              trainer.get_callbacks_with_ownership(),
                                               training_dr_linearized_data_size); //ae
     std::unique_ptr<model>
       model_2, //cycgan
@@ -128,14 +128,14 @@ int main(int argc, char *argv[]) {
     if (pbs.size() > 1) {
       model_2 = build_model_from_prototext(argc, argv, pb_trainer, *(pbs[1]),
                                            comm.get(), opts, io_thread_pool,
-                                           trainer->get_callbacks_with_ownership(),
+                                           trainer.get_callbacks_with_ownership(),
                                            training_dr_linearized_data_size);
     }
 
     if (pbs.size() > 2) {
       model_3 = build_model_from_prototext(argc, argv, pb_trainer, *(pbs[2]),
                                            comm.get(), opts, io_thread_pool,
-                                           trainer->get_callbacks_with_ownership(),
+                                           trainer.get_callbacks_with_ownership(),
                                            training_dr_linearized_data_size);
     }
 
@@ -145,16 +145,16 @@ int main(int argc, char *argv[]) {
     const lbann_data::Model pb_model_3 = pbs[2]->model();
 
     if(master) std::cout << " Pre-train autoencoder " << std::endl;
-    trainer->train(model_1.get(), pb_model_1.num_epochs());
-    trainer->evaluate(model_1.get(), execution_mode::testing);
+    trainer.train(model_1.get(), pb_model_1.num_epochs());
+    trainer.evaluate(model_1.get(), execution_mode::testing);
     auto ae_weights = model_1->get_weights();
     model_2->copy_trained_weights_from(ae_weights);
     model_3->copy_trained_weights_from(ae_weights);
 
     //Train cycle GAN
     if (master)  std::cerr << "\nSTARTING train - cycle GAN \n\n";
-    trainer->train(model_2.get(), pb_model_2.num_epochs());
-    trainer->evaluate(model_2.get(), execution_mode::testing);
+    trainer.train(model_2.get(), pb_model_2.num_epochs());
+    trainer.evaluate(model_2.get(), execution_mode::testing);
     auto model2_weights = model_2->get_weights();
 
     //Evaluate on pretrained autoencoder
@@ -163,7 +163,7 @@ int main(int argc, char *argv[]) {
     if(master) std::cout << " Save AE + cycleGAN" << std::endl;
     model_3->save_model();
     if(master) std::cout << " Evaluate cycleGAN model on pretrained autoencoder" << std::endl;
-    trainer->evaluate(model_3.get(), execution_mode::testing);
+    trainer.evaluate(model_3.get(), execution_mode::testing);
 
   } catch (std::exception& e) {
     El::ReportException(e);

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -106,23 +106,23 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    auto& trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
-    thread_pool& io_thread_pool = trainer->get_io_thread_pool();
+    thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
     int training_dr_linearized_data_size = -1;
-    auto *dr = trainer->get_data_coordinator().get_data_reader(execution_mode::training);
+    auto *dr = trainer.get_data_coordinator().get_data_reader(execution_mode::training);
     if(dr != nullptr) {
       training_dr_linearized_data_size = dr->get_linearized_data_size();
     }
 
     auto model_1 = build_model_from_prototext(argc, argv, pb_trainer, *(pbs[0]), comm.get(), opts, io_thread_pool,
-                                              trainer->get_callbacks_with_ownership(),
+                                              trainer.get_callbacks_with_ownership(),
                                               training_dr_linearized_data_size); //discriminator model
     std::unique_ptr<model> model_2 = nullptr; //adversarial model
     if (pbs.size() > 1) {
       model_2 = build_model_from_prototext(argc, argv, pb_trainer, *(pbs[1]), comm.get(), opts, io_thread_pool,
-                                           trainer->get_callbacks_with_ownership(),
+                                           trainer.get_callbacks_with_ownership(),
                                            training_dr_linearized_data_size);
     }
 
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
     while (super_step <= max_super_step) {
       if (master)  std::cerr << "\nSTARTING train - discriminator model at step " << super_step <<"\n\n";
       //@todo freeze generator layers in this step
-      trainer->train(model_1.get(), super_step*pb_model.num_epochs() );
+      trainer.train(model_1.get(), super_step*pb_model.num_epochs() );
 
       //Replace/copy "proxy" layer in adversarial model (model2) with its "equivalent" layer in discriminator model (model1)
       //@todo freeze layers after replacement
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
       }
 
       if (master) std::cerr << "\n STARTING train - adversarial model at step " << super_step << " \n\n";
-      trainer->train(model_2.get(), super_step*pb_model_2.num_epochs() );
+      trainer.train(model_2.get(), super_step*pb_model_2.num_epochs() );
 
       super_step++;
     }

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -80,11 +80,11 @@ int main(int argc, char *argv[]) {
     lbann_data::Trainer *pb_trainer = pb.mutable_trainer();
 
     // Construct the trainer
-    std::unique_ptr<trainer> trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
+    auto& trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]), opts);
 
-    thread_pool& io_thread_pool = trainer->get_io_thread_pool();
+    thread_pool& io_thread_pool = trainer.get_io_thread_pool();
     int training_dr_linearized_data_size = -1;
-    auto *dr = trainer->get_data_coordinator().get_data_reader(execution_mode::testing);
+    auto *dr = trainer.get_data_coordinator().get_data_reader(execution_mode::testing);
     if(dr != nullptr) {
       training_dr_linearized_data_size = dr->get_linearized_data_size();
     } else {
@@ -96,7 +96,7 @@ int main(int argc, char *argv[]) {
       models.emplace_back(
         build_model_from_prototext(argc, argv, pb_trainer, *pb_model,
                                    comm.get(), opts, io_thread_pool,
-                                   trainer->get_callbacks_with_ownership(),
+                                   trainer.get_callbacks_with_ownership(),
                                    training_dr_linearized_data_size));
     }
 
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     if(num_samples == 0) { LBANN_ERROR("The testing data reader does not have any samples"); }
     for(El::Int s = 0; s < num_samples; s++) {
       for(auto&& m : models) {
-        trainer->evaluate(m.get(), execution_mode::testing, 1);
+        trainer.evaluate(m.get(), execution_mode::testing, 1);
       }
     }
 

--- a/src/callbacks/check_dataset.cpp
+++ b/src/callbacks/check_dataset.cpp
@@ -26,6 +26,7 @@
 
 #include "lbann/comm_impl.hpp"
 #include "lbann/callbacks/check_dataset.hpp"
+#include "lbann/execution_contexts/execution_context.hpp"
 #include "lbann/layers/io/input_layer.hpp"
 #include "lbann/utils/serialize.hpp"
 
@@ -136,12 +137,11 @@ void check_dataset::on_epoch_end(model *m) {
 
   std::cout << "Training: my local vector has size " << local_data.size() << std::endl;
   if (comm->am_trainer_master()) {
-    auto& c = static_cast<sgd_execution_context&>(m->get_execution_context());
-    data_coordinator& dc = c.get_trainer().get_data_coordinator();
+    data_coordinator& dc = get_trainer().get_data_coordinator();
     // Build a vector large enough to hold all indices for the model.
     std::vector<int> model_training_set(
       dc.get_num_iterations_per_epoch(execution_mode::training) *
-      c.get_trainer().get_max_mini_batch_size());
+      get_trainer().get_max_mini_batch_size());
 
     std::cout << "Training: my model vector has size " << model_training_set.size() << std::endl;
     // comm->trainer_gatherv(local_data.data(), local_data.size(),

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -231,7 +231,7 @@ void check_gradients::do_check_gradients(model& m) const {
   }
 
   // Load data in input layers
-  data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   dc.fetch_data(mode);
   for (auto&& l : m.get_layers()) {
     if (dynamic_cast<input_layer<DataType>*>(l) != nullptr) {

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -316,8 +316,8 @@ bool checkpoint::open_latest_checkpoint(
   const std::string& task_label,
   const std::string& trainer_name,
   const std::string& alg_name,
-  std::function<void(persist&)> reload_shared_ckpt,
-  std::function<void(persist&)> reload_distributed_ckpt) {
+  std::function<bool(persist&)> reload_shared_ckpt,
+  std::function<bool(persist&)> reload_distributed_ckpt) {
   // if the checkpoint directory is not defined, bail
   if (get_restart_dir().length() == 0 &&  m_per_rank_dir.length() == 0) {
     return false;
@@ -364,7 +364,8 @@ bool checkpoint::open_latest_checkpoint(
       return false;
     }
     p.open_restart(epochdir.c_str());
-    reload_distributed_ckpt(p);
+    if (!reload_distributed_ckpt(p))
+      LBANN_WARNING("Unable to reload distributed checkpoint ", epochdir);
     p.close_restart();
   }
   else {
@@ -383,7 +384,8 @@ bool checkpoint::open_latest_checkpoint(
     // // Ensure all ranks have access to checkpoint dir, needed for loading rank specific rng state
     //   p.m_checkpoint_dir = epochdir;
     // }
-    reload_shared_ckpt(p);
+    if (!reload_shared_ckpt(p))
+      LBANN_WARNING("Unable to reload shared checkpoint ", epochdir);
     /// @todo For the moment let all ranks open the checkpoint files
     p.close_restart();
     // }

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -156,7 +156,7 @@ bool checkpoint::do_checkpoint(model *m, visitor_hook hook) {
   auto& p = get_active_trainer().get_persist_obj();
   auto& c = static_cast<sgd_execution_context&>(m->get_execution_context());
   auto& t = get_active_trainer();
-  if(&t != &c.get_trainer()) { LBANN_ERROR("Mismatched trainers"); }
+  if(&t != &get_trainer()) { LBANN_ERROR("Mismatched trainers"); }
   // if the checkpoint directory is not defined, bail
   if (get_checkpoint_dir().length() == 0 && m_per_rank_dir.length() == 0) {
     return false;
@@ -447,10 +447,10 @@ bool checkpoint::restart(model *m) {
     get_active_trainer().get_name(),
     get_active_training_algorithm().get_type(),
     [&m, &c](persist& p_ref) {
-      return c.get_trainer().load_from_checkpoint_shared(*m, c);
+      return get_trainer().load_from_checkpoint_shared(*m, c);
     },
     [&m, &c](persist& p_ref) {
-      return c.get_trainer().load_from_checkpoint_distributed(*m, c);
+      return get_trainer().load_from_checkpoint_distributed(*m, c);
     });
 }
 

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -316,8 +316,8 @@ bool checkpoint::open_latest_checkpoint(
   const std::string& task_label,
   const std::string& trainer_name,
   const std::string& alg_name,
-  std::function<bool(persist&)> reload_shared_ckpt,
-  std::function<bool(persist&)> reload_distributed_ckpt) {
+  std::function<void(persist&)> reload_shared_ckpt,
+  std::function<void(persist&)> reload_distributed_ckpt) {
   // if the checkpoint directory is not defined, bail
   if (get_restart_dir().length() == 0 &&  m_per_rank_dir.length() == 0) {
     return false;
@@ -364,8 +364,7 @@ bool checkpoint::open_latest_checkpoint(
       return false;
     }
     p.open_restart(epochdir.c_str());
-    auto flag = reload_distributed_ckpt(p);
-    if(!flag) { LBANN_WARNING("Unable to reload distributed checkpoint ", epochdir); }
+    reload_distributed_ckpt(p);
     p.close_restart();
   }
   else {
@@ -384,9 +383,7 @@ bool checkpoint::open_latest_checkpoint(
     // // Ensure all ranks have access to checkpoint dir, needed for loading rank specific rng state
     //   p.m_checkpoint_dir = epochdir;
     // }
-    auto flag = reload_shared_ckpt(p);
-    if(!flag) { LBANN_WARNING("Unable to reload shared checkpoint ", epochdir); }
-    // if(comm->am_trainer_master()) {
+    reload_shared_ckpt(p);
     /// @todo For the moment let all ranks open the checkpoint files
     p.close_restart();
     // }

--- a/src/callbacks/debug_io.cpp
+++ b/src/callbacks/debug_io.cpp
@@ -63,7 +63,7 @@ void debug_io::on_forward_prop_begin(model *m, Layer *l) {
 
   const auto& c = m->get_execution_context();
   auto mode = c.get_execution_mode();
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   if(m->get_comm()->get_rank_in_trainer() < dc.get_data_reader(mode)->get_num_parallel_readers()) {
     if(m_debug_phase == execution_mode::invalid || m_debug_phase == mode) {
       print_fp_start(m, input);
@@ -76,7 +76,7 @@ void debug_io::on_forward_prop_begin(model *m, Layer *l) {
 
 void debug_io::print_fp_start(model *m, input_layer<DataType> *input) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   const auto& step = c.get_step();
   const auto mode = c.get_execution_mode();
   std::cout << "[" << m->get_comm()->get_trainer_rank()
@@ -99,7 +99,7 @@ void debug_io::print_fp_start(model *m, input_layer<DataType> *input) {
 //  179i @ 300s (=5m*60s) + 1i @ 100s (=5m*45s):offset <- num models
 void debug_io::print_phase_start(model *m, execution_mode mode) {
   const auto& c = m->get_execution_context();
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   // Get data reader from first input layer in model
   generic_data_reader* data_reader = dc.get_data_reader(mode);
   const auto& step = c.get_step();
@@ -154,7 +154,7 @@ void debug_io::on_evaluate_forward_prop_begin(model *m, Layer *l) {
 
   const auto& c = m->get_execution_context();
   auto mode = c.get_execution_mode();
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   if(m->get_comm()->get_rank_in_trainer() < dc.get_data_reader(mode)->get_num_parallel_readers()) {
     if(m_debug_phase == execution_mode::invalid || m_debug_phase == mode) {
       print_fp_start(m, input);

--- a/src/callbacks/dump_minibatch_sample_indices.cpp
+++ b/src/callbacks/dump_minibatch_sample_indices.cpp
@@ -55,7 +55,7 @@ void dump_minibatch_sample_indices::serialize(Archive & ar) {
 void dump_minibatch_sample_indices::dump_to_file(model *m, Layer *l, int64_t step) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
   // Print minibatch sample indices of the data coordinator
-  data_coordinator& dc = m->get_execution_context().get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   El::Matrix<El::Int>* indices = dc.get_sample_indices_per_mb(c.get_execution_mode());
   if (indices == nullptr
       || indices->Height() == 0
@@ -70,7 +70,7 @@ void dump_minibatch_sample_indices::dump_to_file(model *m, Layer *l, int64_t ste
        + to_string(c.get_execution_mode())
        + "_e" + std::to_string(c.get_epoch())
        + "_s" + std::to_string(c.get_step())
-       + "_r" + std::to_string(c.get_comm().get_rank_in_trainer())
+       + "_r" + std::to_string(get_trainer().get_comm()->get_rank_in_trainer())
        + "-MB_Sample_Indices");
   El::Write(*indices, file, El::ASCII);
 }

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -265,14 +265,14 @@ void dump_weights::on_epoch_end(model *m) {
 
 void dump_weights::do_dump_weights(const model& m, visitor_hook hook) {
   const auto& context = static_cast<const sgd_execution_context&>(m.get_execution_context());
-  const auto& t = context.get_trainer();
+  const auto& t = get_const_trainer();
 
   // Create directory for weight files
   // Note: Use naming scheme from checkpoint callback
   std::string dir = El::BuildString(
     get_shared_checkpoint_dirname(
       t.get_name(),
-      context.get_training_algorithm().get_type(),
+      context.get_type(),
       m_directory.c_str(),
       hook,
       context.get_execution_mode(),
@@ -290,7 +290,7 @@ void dump_weights::do_dump_weights(const model& m, visitor_hook hook) {
   if (m.get_comm()->am_trainer_master()) {
     auto latest_file = get_last_shared_checkpoint_filename(
       t.get_name(),
-      context.get_training_algorithm().get_type(),
+      context.get_type(),
       m_directory.c_str());
     write_latest(
       latest_file,

--- a/src/callbacks/learning_rate.cpp
+++ b/src/callbacks/learning_rate.cpp
@@ -269,7 +269,7 @@ poly_learning_rate::poly_learning_rate(
 void poly_learning_rate::setup(model *m) {
   learning_rate::setup(m);
   if (m_max_iter == 0ull) {
-    data_coordinator& dc = m->get_execution_context().get_trainer().get_data_coordinator();
+    data_coordinator& dc = get_trainer().get_data_coordinator();
     m_max_iter = m_num_epochs * dc.get_num_iterations_per_epoch(execution_mode::training);
   }
 }

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -594,7 +594,7 @@ EvalType evaluate(model& m, const std::string& metric_name)
   auto& c = m.get_execution_context();
   // Make sure data readers finish asynchronous work
   const auto original_mode = c.get_execution_mode();
-  data_coordinator& dc = m.get_execution_context().get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   dc.collect_background_data_fetch(original_mode);
 
   if(!dc.is_execution_mode_valid(execution_mode::tournament)) {
@@ -605,7 +605,7 @@ EvalType evaluate(model& m, const std::string& metric_name)
   m.mark_data_store_explicitly_loading(execution_mode::tournament);
 
   // Evaluate model on validation set
-  c.get_trainer().evaluate(&m, execution_mode::tournament);
+  get_trainer().evaluate(&m, execution_mode::tournament);
 
   // Get metric value
   bool found_metric = false;
@@ -628,7 +628,7 @@ EvalType evaluate(model& m, const std::string& metric_name)
 
   // Clean up and return metric value
   m.reset_mode(c, original_mode);
-  c.get_trainer().get_data_coordinator().reset_mode(c);
+  get_trainer().get_data_coordinator().reset_mode(c);
   return metric_value;
 }
 
@@ -737,7 +737,7 @@ void ltfb::on_batch_begin(model* m)
     local_model.swap_weights(partner_model);
     local_model.swap_metrics(partner_model);
     local_model.swap_objective_function(partner_model);
-    auto& trainer_ = context.get_trainer();
+    auto& trainer_ = get_trainer();
     auto&& metadata = trainer_.get_data_coordinator().get_dr_metadata();
     local_model.setup(
       trainer_.get_max_mini_batch_size(),

--- a/src/callbacks/monitor_io.cpp
+++ b/src/callbacks/monitor_io.cpp
@@ -48,7 +48,7 @@ void monitor_io::serialize(Archive & ar) {
 
 void monitor_io::on_epoch_end(model *m) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   lbann_comm *comm = m->get_comm();
   std::cout << "Rank " << comm->get_trainer_rank() << "."
             << comm->get_rank_in_trainer() << " processed "
@@ -59,7 +59,7 @@ void monitor_io::on_epoch_end(model *m) {
 
 void monitor_io::on_test_end(model *m) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
-  const data_coordinator& dc = c.get_trainer().get_data_coordinator();
+  const data_coordinator& dc = get_const_trainer().get_data_coordinator();
   lbann_comm *comm = m->get_comm();
   std::cout << "Rank " << comm->get_trainer_rank() << "."
             << comm->get_rank_in_trainer() << " processed "

--- a/src/callbacks/print_statistics.cpp
+++ b/src/callbacks/print_statistics.cpp
@@ -66,7 +66,7 @@ void print_statistics::setup(model *m) {
 
 void print_statistics::on_epoch_begin(model *m) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
-  data_coordinator& dc = m->get_execution_context().get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   lbann_comm *comm = m->get_comm();
   if (comm->am_world_master()) {
     // Print message

--- a/src/callbacks/save_model.cpp
+++ b/src/callbacks/save_model.cpp
@@ -114,7 +114,7 @@ bool save_model::do_save_model_weights(model *m) {
 
   // Shared checkpoint, logic identical to Distributed.i
   makedir(m_dir.c_str());
-  std::string epochdir = get_save_model_dirname(c.get_trainer().get_name(),
+  std::string epochdir = get_save_model_dirname(get_const_trainer().get_name(),
                                                 m->get_name(),
                                                 m_dir.c_str());
   p.open_checkpoint_dir(epochdir.c_str(), comm->am_trainer_master());

--- a/src/callbacks/summarize_images.cpp
+++ b/src/callbacks/summarize_images.cpp
@@ -180,7 +180,7 @@ std::vector<std::pair<size_t, El::Int>>
 autoencoder_strategy::get_image_indices(model const& m) const {
 
   // Grab the data coordinator
-  auto const& dc = m.get_execution_context().get_trainer().get_data_coordinator();
+  auto const& dc = get_const_trainer().get_data_coordinator();
 
   // Grab the data reader
   auto const& data_reader =

--- a/src/callbacks/timer.cpp
+++ b/src/callbacks/timer.cpp
@@ -49,8 +49,7 @@ void timer::serialize(Archive & ar) {
 }
 
 void timer::batch_timing_begin(const model& m) {
-  const auto& c = m.get_execution_context();
-  const auto& mode = c.get_execution_mode();
+  auto const mode = m.get_execution_context().get_execution_mode();
   m_batch_start_times[mode] = get_time();
 }
 

--- a/src/callbacks/variable_minibatch.cpp
+++ b/src/callbacks/variable_minibatch.cpp
@@ -47,7 +47,7 @@ void variable_minibatch::on_train_begin(model *m) {
   // Avoid issues with the train method being called multiple times.
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
   if (c.get_epoch() != 0) { return; }
-  const auto& t = c.get_trainer();
+  const auto& t = get_const_trainer();
 
   // Get first input layer in model
   input_layer<DataType>* input = nullptr;
@@ -67,12 +67,12 @@ void variable_minibatch::on_train_begin(model *m) {
                 << "size and using variable-sized mini-batches" << std::endl;
     }
   }
-  m->get_execution_context().get_trainer().get_data_coordinator().calculate_num_iterations_per_epoch(m_starting_mbsize);
+  get_trainer().get_data_coordinator().calculate_num_iterations_per_epoch(m_starting_mbsize);
 }
 
 void variable_minibatch::on_epoch_end(model *m) {
   const auto& c = static_cast<const sgd_execution_context&>(m->get_execution_context());
-  const auto& t = c.get_trainer();
+  const auto& t = get_const_trainer();
 
   // Get first input layer in model
   input_layer<DataType>* input = nullptr;
@@ -96,7 +96,7 @@ void variable_minibatch::on_epoch_end(model *m) {
       }
       new_mbsize = t.get_max_mini_batch_size();
     }
-    m->get_execution_context().get_trainer().get_data_coordinator().calculate_num_iterations_per_epoch(new_mbsize);
+    get_trainer().get_data_coordinator().calculate_num_iterations_per_epoch(new_mbsize);
     m_current_mini_batch_size = new_mbsize;
     m_ramp_count = ramp_time;
     if (new_lr != 0.0f) {

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -98,12 +98,12 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
     do_epoch_end_cbs(model);
 
     // Evaluate on validation set
-    auto key = c.get_trainer().check_and_build_execution_context(
+    auto key = get_trainer().check_and_build_execution_context(
       c,
       model,
       execution_mode::validation);
     auto& evaluation_context = static_cast<sgd_execution_context&>(
-      c.get_trainer().get_execution_context(key));
+      get_trainer().get_execution_context(key));
     // Check to make sure that the model has a valid execution mode
     // before trying to do inference
     if (dc.is_execution_mode_valid(execution_mode::validation)) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -977,7 +977,7 @@ void model::add_split_layers(std::unordered_set<std::string>& layer_names) {
 // "Note that this is a temporary fix
 // for the current use of the tournament"
 void model::make_data_store_preloaded(execution_mode mode) {
-  data_coordinator& dc = get_execution_context().get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   auto *data_store = dc.get_data_reader(mode)->get_data_store_ptr();
   if(data_store != nullptr && !data_store->is_fully_loaded()) {
     dc.get_data_reader(mode)->get_data_store_ptr()->set_loading_is_complete();
@@ -989,7 +989,7 @@ void model::make_data_store_preloaded(execution_mode mode) {
 // "Note that this is a temporary fix
 // for the current use of the tournament"
 void model::mark_data_store_explicitly_loading(execution_mode mode) {
-  data_coordinator& dc = get_execution_context().get_trainer().get_data_coordinator();
+  data_coordinator& dc = get_trainer().get_data_coordinator();
   auto *data_store = dc.get_data_reader(mode)->get_data_store_ptr();
   if(data_store != nullptr && !data_store->is_fully_loaded()) {
     dc.get_data_reader(mode)->get_data_store_ptr()->set_is_explicitly_loading(true);

--- a/src/proto/factories/trainer_factory.cpp
+++ b/src/proto/factories/trainer_factory.cpp
@@ -58,8 +58,8 @@ std::unique_ptr<trainer> construct_trainer(lbann_comm* comm,
 
   // Instantiate trainer
   auto t = make_unique<trainer>(comm,
-                                proto_trainer.mini_batch_size(),
-                                std::move(dc));
+                                std::move(dc),
+                                proto_trainer.mini_batch_size());
   const auto& name = proto_trainer.name();
   if (!name.empty()) {
     t->set_name(name);

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -32,32 +32,17 @@
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
 #include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
-#include "lbann/io/persist.hpp"
 #include "lbann/io/persist_impl.hpp"
-#include "lbann/layers/transform/dummy.hpp"
-#include "lbann/layers/transform/evaluation.hpp"
-#include "lbann/layers/transform/split.hpp"
-#include "lbann/metrics/layer_metric.hpp"
-#include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/utils/description.hpp"
-#include "lbann/utils/omp_diagnostics.hpp"
-#include "lbann/utils/random.hpp"
+#include "lbann/utils/memory.hpp"
 #include "lbann/utils/serialize.hpp"
 
 // LBANN proto
 #include <lbann.pb.h>
 
-// External dependencies
-#include <mpi.h>
-
-// C dependencies
-#include <unistd.h>
-
 // STL
-#include <iomanip>
-#include <queue>
+#include <functional>
 #include <string>
-#include <unordered_set>
 
 namespace lbann {
 
@@ -66,15 +51,15 @@ namespace lbann {
 ////////////////////////////////////////////////////////////
 
 trainer::trainer(lbann_comm* comm,
-                 size_t mini_batch_size,
-                 std::unique_ptr<data_coordinator> dc)
-  : m_comm(comm), m_max_mini_batch_size(mini_batch_size), m_io_thread_pool(),
-    m_background_io_allowed(true)
+                 std::unique_ptr<data_coordinator> dc,
+                 size_t mini_batch_size)
+  : m_data_coordinator{std::move(dc)},
+    m_comm{comm},
+    m_max_mini_batch_size{mini_batch_size},
+    m_background_io_allowed{true}
 {
-
   // Default trainer name
   m_name = "trainer" + std::to_string(m_comm->get_trainer_rank());
-  m_data_coordinator = std::move(dc);
   m_data_coordinator->set_trainer(*this);
 }
 
@@ -327,7 +312,7 @@ void trainer::evaluate(observer_ptr<model> model,
 // Checkpointing
 // =============================================
 
-bool trainer::save_to_checkpoint_shared()
+void trainer::save_to_checkpoint_shared()
 {
   for_each_execution_context([this](observer_ptr<execution_context> ctx) {
     ctx->save_to_checkpoint_shared(this->get_persist_obj());
@@ -345,31 +330,28 @@ bool trainer::save_to_checkpoint_shared()
     );
   }
 
-  return get_data_coordinator().save_to_checkpoint_shared(get_persist_obj());
+  if (!get_data_coordinator().save_to_checkpoint_shared(get_persist_obj()))
+    LBANN_ERROR("Failed to checkpoint data coordinator.");
 }
 
-bool trainer::load_from_checkpoint_shared(persist& p)
+void trainer::load_from_checkpoint_shared(persist& p)
 {
-  try {
-    load_from_shared_cereal_archive(*this,
-                                    p,
-                                    *get_comm(),
+  load_from_shared_cereal_archive(*this,
+                                  p,
+                                  *get_comm(),
 #ifdef LBANN_HAS_CEREAL_XML_ARCHIVES
-                                    "trainer.xml"
+                                  "trainer.xml"
 #else  // defined LBANN_HAS_CEREAL_BINARY_ARCHIVES
-                                    "trainer.bin"
+                                  "trainer.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
     );
-  }
-  catch (NonexistentArchiveFile const& e) {
-    LBANN_MSG(e.what());
-    return false;
-  }
 
-  return get_data_coordinator().load_from_checkpoint_shared(p);
+  // FIXME (trb 04/07/21): This check should move to the data coordinator.
+  if (!get_data_coordinator().load_from_checkpoint_shared(p))
+    LBANN_ERROR("Failed to reload data coordinator.");
 }
 
-bool trainer::load_from_checkpoint_shared(model& m, execution_context& c)
+void trainer::load_from_checkpoint_shared(model& m, execution_context& c)
 {
   // Reload the RNG once the trainer and all of the  models are setup
   // to avoid spurious turns of the RNGs
@@ -411,19 +393,21 @@ bool trainer::load_from_checkpoint_shared(model& m, execution_context& c)
     }
   }
 
-  return get_data_coordinator().load_from_checkpoint_shared(get_persist_obj());
+  if (!get_data_coordinator().load_from_checkpoint_shared(get_persist_obj()))
+    LBANN_ERROR("Failed to reload data coordinator.");
 }
 
-bool trainer::save_to_checkpoint_distributed()
+void trainer::save_to_checkpoint_distributed()
 {
   for_each_execution_context([this](observer_ptr<execution_context> ctx) {
     ctx->save_to_checkpoint_distributed(this->get_persist_obj());
   });
   save_rng_to_checkpoint_distributed(get_persist_obj(), m_comm);
-  return get_data_coordinator().save_to_checkpoint_shared(get_persist_obj());
+  if (!get_data_coordinator().save_to_checkpoint_shared(get_persist_obj()))
+    LBANN_ERROR("Failed to checkpoint data coordinator");
 }
 
-bool trainer::load_from_checkpoint_distributed(persist& p)
+void trainer::load_from_checkpoint_distributed(persist& p)
 {
   read_cereal_archive(*this,
                       p,
@@ -433,10 +417,11 @@ bool trainer::load_from_checkpoint_distributed(persist& p)
                       "trainer.bin"
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
   );
-  return get_data_coordinator().load_from_checkpoint_distributed(p);
+  if (!get_data_coordinator().load_from_checkpoint_distributed(p))
+    LBANN_ERROR("Failed to reload data coordinator.");
 }
 
-bool trainer::load_from_checkpoint_distributed(model& m, execution_context& c)
+void trainer::load_from_checkpoint_distributed(model& m, execution_context& c)
 {
   load_rng_from_checkpoint(get_persist_obj(), m_comm);
 
@@ -472,15 +457,16 @@ bool trainer::load_from_checkpoint_distributed(model& m, execution_context& c)
       }
     }
   }
-  return get_data_coordinator().load_from_checkpoint_distributed(
-    get_persist_obj());
+  if (!get_data_coordinator().load_from_checkpoint_distributed(
+        get_persist_obj()))
+    LBANN_ERROR("Failed to reload data coordinator.");
 }
 
-void trainer::write_proto(lbann_data::Trainer* proto)
+void trainer::write_proto(lbann_data::Trainer& proto)
 {
-  proto->Clear();
+  proto.Clear();
   if (m_comm->am_world_master()) {
-    proto->set_mini_batch_size(m_max_mini_batch_size);
+    proto.set_mini_batch_size(m_max_mini_batch_size);
   }
 }
 

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -172,13 +172,11 @@ trainer::check_and_build_execution_context(training_algorithm& alg,
     if (dynamic_cast<observer_ptr<sgd_training_algorithm>>(&alg) != nullptr) {
       /// @todo BVE FIXME Figure out how to get a good mini-batch size
       /// in here
-      context = make_unique<sgd_execution_context>(*this,
-                                                   alg,
-                                                   mode,
+      context = make_unique<sgd_execution_context>(mode,
                                                    get_max_mini_batch_size());
     }
     else {
-      context = make_unique<execution_context>(*this, alg, mode);
+      LBANN_ERROR("Unknown execution algorithm type.");
     }
     m_model_execution_context.emplace(key, std::move(context));
   }
@@ -198,14 +196,11 @@ trainer::check_and_build_execution_context(execution_context& c,
     //    observer_ptr<training_algorithm> alg = const_cast
     if (dynamic_cast<observer_ptr</*const */ sgd_execution_context>>(&c) !=
         nullptr) {
-      context = make_unique<sgd_execution_context>(*this,
-                                                   c.get_training_algorithm(),
-                                                   mode,
+      context = make_unique<sgd_execution_context>(mode,
                                                    get_max_mini_batch_size());
     }
     else {
-      context =
-        make_unique<execution_context>(*this, c.get_training_algorithm(), mode);
+      LBANN_ERROR("Unknown execution context type");
     }
     m_model_execution_context.emplace(key, std::move(context));
   }


### PR DESCRIPTION
Severely pare down the API of `execution_context`. Critically examines the API of the base `execution_context` class and eliminates some cruft, notably removing the nonsensical `training_algorithm*` member and externalizing and globalizing the `trainer` object.

Further treatment of this infrastructure is necessary, but this is an initial step in this direction. (Stay tuned for the rest of the steps.)