### PR TITLE
Added the C language to the CMakeLists.txt and SetupMPI.cmake to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.17)
 
+project(LBANN CXX)
+
 # C isn't required by LBANN but packages such as Conduit are forcing C dependencies in MPI
-project(LBANN C CXX)
+enable_language(C)
 
 # Prevent in-source builds
 if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 
-project(LBANN CXX)
+# C isn't required by LBANN but packages such as Conduit are forcing C dependencies in MPI
+project(LBANN C CXX)
 
 # Prevent in-source builds
 if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)

--- a/cmake/modules/SetupMPI.cmake
+++ b/cmake/modules/SetupMPI.cmake
@@ -4,6 +4,11 @@ if (NOT MPI_CXX_FOUND)
   find_package(MPI REQUIRED COMPONENTS CXX)
 endif ()
 
+# This shouldn't be required but packages such as Conduit are forcing C dependencies in MPI
+if (NOT MPI_C_FOUND)
+  find_package(MPI REQUIRED COMPONENTS C)
+endif ()
+
 if (NOT TARGET MPI::MPI_CXX)
   add_library(MPI::MPI_CXX INTERFACE IMPORTED)
   if (MPI_CXX_COMPILE_FLAGS)

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -62,6 +62,7 @@ Options:
   ${C}--dry-run${N}               Dry run the commands (no effect)
   ${C}-l | --label${N}            LBANN version label prefix: (default label is local-<SPACK_ARCH_TARGET>,
                           and is built and installed in the spack environment lbann-<label>-<SPACK_ARCH_TARGET>
+  ${C}-j | --build-jobs${N}       Number of parallel processes to use for compiling
   ${C}--no-modules${N}            Don't try to load any modules (use the existing users environment)
   ${C}--no-tmp-build-dir${N}      Don't put the build directory in tmp space
   ${C}--spec-only${N}             Stop after a spack spec command
@@ -104,6 +105,15 @@ while :; do
             # Change default LBANN version label
             if [ -n "${2}" ]; then
                 LBANN_LABEL_PREFIX=${2}
+                shift
+            else
+                echo "\"${1}\" option requires a non-empty option argument" >&2
+                exit 1
+            fi
+            ;;
+        -j|--build-jobs)
+            if [ -n "${2}" ]; then
+                BUILD_JOBS="-j${2}"
                 shift
             else
                 echo "\"${1}\" option requires a non-empty option argument" >&2
@@ -545,7 +555,7 @@ fi
 
 ##########################################################################################
 # Actually install LBANN from local source
-CMD="spack install"
+CMD="spack install ${BUILD_JOBS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 


### PR DESCRIPTION
address a new build configuration propagated by Conduit.

Added a flag to specify the number of parallel jobs in the spack
install command.