### PR TITLE
Enable spack buildcache

### DIFF
--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -62,7 +62,7 @@ Options:
   ${C}--dry-run${N}               Dry run the commands (no effect)
   ${C}-l | --label${N}            LBANN version label prefix: (default label is local-<SPACK_ARCH_TARGET>,
                           and is built and installed in the spack environment lbann-<label>-<SPACK_ARCH_TARGET>
-  ${C}-j | --build-jobs${N}       Number of parallel processes to use for compiling
+  ${C}-j | --build-jobs${N}       Number of parallel processes to use for compiling, e.g. -j \$((\$(nproc)+2))
   ${C}-m | --mirror${N}           Specify a Spack mirror (and buildcache)
   ${C}--no-modules${N}            Don't try to load any modules (use the existing users environment)
   ${C}--no-tmp-build-dir${N}      Don't put the build directory in tmp space

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -58,7 +58,6 @@ Options:
   ${C}--clean-build${N}           Delete the local link to the build directory
   ${C}--clean-deps${N}            Forcibly uninstall Hydrogen, Aluminum, and DiHydrogen dependencies
   ${C}-d | --install-deps${N}     Install the lbann dependencies in addition to building from local source
-  ${C}--dependencies-only${N}     Stop after installing the lbann dependencies
   ${C}--dry-run${N}               Dry run the commands (no effect)
   ${C}-l | --label${N}            LBANN version label prefix: (default label is local-<SPACK_ARCH_TARGET>,
                           and is built and installed in the spack environment lbann-<label>-<SPACK_ARCH_TARGET>
@@ -95,9 +94,6 @@ while :; do
             ;;
         -d|--install-deps)
             INSTALL_DEPS="TRUE"
-            ;;
-        --dependencies-only)
-            DEPENDENCIES_ONLY="TRUE"
             ;;
         --dry-run)
             DRY_RUN="TRUE"

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -465,7 +465,7 @@ if [[ -n "${USER_MIRROR:-}" ]]; then
     MIRROR=${USER_MIRROR}
 fi
 
-if [[ -n "${MIRROR:-}" ]]; then
+if [[ -n "${MIRROR:-}" && -r "${MIRROR:-}" ]]; then
     CMD="spack mirror add lbann ${MIRROR}"
     echo ${CMD} | tee -a ${LOG}
     [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
@@ -477,9 +477,11 @@ if [[ -n "${MIRROR:-}" ]]; then
 
     # Manually force Spack to trust the keys in the build cache - this is a hack until
     # https://github.com/spack/spack/issues/23186 is fixed
-    CMD="spack gpg trust ${MIRROR}/build_cache/_pgp/B180FE4A5ECF4C02D21E6A67F13D1FBB0E55F96F.pub"
-    echo ${CMD} | tee -a ${LOG}
-    [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+    if [[ -e "${MIRROR}/build_cache/_pgp/B180FE4A5ECF4C02D21E6A67F13D1FBB0E55F96F.pub" ]]; then
+        CMD="spack gpg trust ${MIRROR}/build_cache/_pgp/B180FE4A5ECF4C02D21E6A67F13D1FBB0E55F96F.pub"
+        echo ${CMD} | tee -a ${LOG}
+        [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+    fi
 fi
 
 ##########################################################################################
@@ -555,7 +557,7 @@ fi
 
 ##########################################################################################
 # If there is a local mirror, pad out the install tree so that it can be relocated
-if [[ -n "${MIRROR:-}" ]]; then
+if [[ -n "${MIRROR:-}" && -r "${MIRROR:-}" ]]; then
     spack config add "config:install_tree:padded_length:128"
 fi
 
@@ -603,7 +605,7 @@ echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 
 
-if [[ -n "${MIRROR:-}" && -n "${UPDATE_BUILDCACHE:-}" ]]; then
+if [[ -n "${MIRROR:-}" && -r "${MIRROR:-}"  && -n "${UPDATE_BUILDCACHE:-}" ]]; then
     # Make sure that all of the packages in the environment are in the mirror
     CMD="spack mirror create -d ${MIRROR} --all"
     echo ${CMD} | tee -a ${LOG}

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -474,6 +474,12 @@ if [[ -n "${MIRROR:-}" ]]; then
     CMD="spack buildcache keys --install --trust"
     echo ${CMD} | tee -a ${LOG}
     [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+
+    # Manually force Spack to trust the keys in the build cache - this is a hack until
+    # https://github.com/spack/spack/issues/23186 is fixed
+    CMD="spack gpg trust ${MIRROR}/build_cache/_pgp/B180FE4A5ECF4C02D21E6A67F13D1FBB0E55F96F.pub"
+    echo ${CMD} | tee -a ${LOG}
+    [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 fi
 
 ##########################################################################################

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -136,21 +136,22 @@ set_center_specific_spack_dependencies()
     local spack_arch_target="$2"
 
     if [[ ${center} = "llnl_lc" ]]; then
+        MIRROR="/p/vast1/lbann/spack/mirror"
         case ${spack_arch_target} in
             "power9le" | "power8le") # Lassen, Ray
                 CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp"
-                CENTER_FLAGS="ldflags=\"-fuse-ld=gold\""
+                CENTER_FLAGS="ldflags=-fuse-ld=gold"
                 ;;
             "broadwell" | "haswell" | "sandybridge" | "ivybridge") # Pascal, RZHasGPU, Surface, Catalyst
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13"
-                CENTER_FLAGS="ldflags=\"-fuse-ld=gold\""
+                CENTER_FLAGS="ldflags=-fuse-ld=gold"
                 ;;
             "zen" | "zen2") # Corona
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_DEPENDENCIES="^openmpi ^hwloc@2.3.0"
                 # Don't overwrite the flag here since we set compiler specific flags
-                # CENTER_FLAGS="ldflags=\"-fuse-ld=lld\""
+                # CENTER_FLAGS="ldflags=-fuse-ld=lld"
                 ;;
             *)
                 echo "No center-specified CENTER_DEPENDENCIES."

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -222,8 +222,8 @@ cat <<EOF  >> ${yaml}
         paths:
           cc: /opt/rocm-4.0.0/llvm/bin/clang
           cxx: /opt/rocm-4.0.0/llvm/bin/clang++
-          f77:
-          fc:
+          f77: /usr/bin/gfortran
+          fc: /usr/bin/gfortran
         flags: {}
         operating_system: rhel7
         target: x86_64
@@ -386,7 +386,7 @@ cleanup_clang_compilers()
 
     if [[ ${center} = "llnl_lc" ]]; then
         # LC uses a old default gcc and clang needs a newer default gcc toolchain
-        # Also set LC clang compilers to use lld for faster linking
-        perl -i.perl_bak -0pe 's/(- compiler:.*?spec: clang.*?flags:) (\{\})/$1 \{cflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0, cxxflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0, ldflags: -fuse-ld=lld\}/smg' ${yaml}
+        # Also set LC clang compilers to use lld for faster linking ldflags: -fuse-ld=lld
+        perl -i.perl_bak -0pe 's/(- compiler:.*?spec: clang.*?flags:) (\{\})/$1 \{cflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0, cxxflags: --gcc-toolchain=\/usr\/tce\/packages\/gcc\/gcc-8.1.0\}/smg' ${yaml}
     fi
 }


### PR DESCRIPTION
Add support for using and creating a spack mirror and buildcache.

Fixed the issue of building in a temporary directory.

Corrected how the ldflags are passed.