### PR TITLE
Support 3x3 deconvolution with distconv

### DIFF
--- a/bamboo/unit_tests/test_unit_layer_deconvolution_distconv.py
+++ b/bamboo/unit_tests/test_unit_layer_deconvolution_distconv.py
@@ -189,18 +189,12 @@ def construct_model(lbann):
     pads = (1, 1)
     dilations = (1, 1)
     kernel = make_random_array(kernel_dims, 987)
-    bias = make_random_array([kernel_dims[1]], 654)
 
     # Apply deconvolution
     kernel_weights = lbann.Weights(
         optimizer=lbann.SGD(),
         initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(kernel))),
         name='kernel1'
-    )
-    bias_weights = lbann.Weights(
-        optimizer=lbann.SGD(),
-        initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(bias))),
-        name='bias1'
     )
     x = lbann.Reshape(
         x_lbann,
@@ -212,7 +206,7 @@ def construct_model(lbann):
     )
     y = lbann.Deconvolution(
         x,
-        weights=(kernel_weights, bias_weights),
+        weights=kernel_weights,
         num_dims=2,
         num_output_channels=kernel_dims[1],
         has_vectors=True,
@@ -220,7 +214,7 @@ def construct_model(lbann):
         conv_strides=tools.str_list(strides),
         conv_pads=tools.str_list(pads),
         conv_dilations=tools.str_list(dilations),
-        has_bias=True,
+        has_bias=False,
         parallel_strategy=create_parallel_strategy(num_height_groups),
     )
     z = lbann.L2Norm2(y)
@@ -238,7 +232,6 @@ def construct_model(lbann):
         y = pytorch_deconvolution(
             x,
             kernel,
-            bias=bias,
             stride=strides,
             padding=0,
             dilation=dilations,
@@ -248,7 +241,7 @@ def construct_model(lbann):
         val = z
     except:
         # Precomputed value
-        val = 523.9982876632505
+        val = 491.89952150017973
     tol = 8 * val * np.finfo(np.float32).eps
     callbacks.append(lbann.CallbackCheckMetric(
         metric=metrics[-1].name,
@@ -267,7 +260,6 @@ def construct_model(lbann):
     pads = (1, 1, 1)
     dilations = (1, 1, 1)
     kernel = make_random_array(kernel_dims, 234)
-    bias = make_random_array([kernel_dims[1]], 567)
 
     # Apply deconvolution
     kernel_weights = lbann.Weights(
@@ -275,15 +267,10 @@ def construct_model(lbann):
         initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(kernel))),
         name='kernel2'
     )
-    bias_weights = lbann.Weights(
-        optimizer=lbann.SGD(),
-        initializer=lbann.ValueInitializer(values=tools.str_list(np.nditer(bias))),
-        name='bias2'
-    )
     x = x_lbann
     y = lbann.Deconvolution(
         x,
-        weights=(kernel_weights, bias_weights),
+        weights=kernel_weights,
         num_dims=3,
         num_output_channels=kernel_dims[1],
         has_vectors=True,
@@ -291,7 +278,7 @@ def construct_model(lbann):
         conv_strides=tools.str_list(strides),
         conv_pads=tools.str_list(pads),
         conv_dilations=tools.str_list(dilations),
-        has_bias=True,
+        has_bias=False,
         parallel_strategy=create_parallel_strategy(num_height_groups),
     )
     z = lbann.L2Norm2(y)
@@ -304,7 +291,6 @@ def construct_model(lbann):
         y = pytorch_deconvolution(
             x,
             kernel,
-            bias=bias,
             stride=strides,
             padding=0,
             dilation=dilations,
@@ -314,7 +300,7 @@ def construct_model(lbann):
         val = z
     except:
         # Precomputed value
-        val = 1756.356765744791
+        val = 1554.528901443455
     tol = 8 * val * np.finfo(np.float32).eps
     callbacks.append(lbann.CallbackCheckMetric(
         metric=metrics[-1].name,

--- a/include/lbann/layers/learning/base_convolution.hpp
+++ b/include/lbann/layers/learning/base_convolution.hpp
@@ -52,11 +52,11 @@ class base_convolution_adapter: public data_type_distconv_adapter<TensorDataType
   void setup_bp_tensors() override;
   void setup_layer(size_t workspace_capacity) override;
 
-  void fp_compute_convolution();
+  void compute_convolution(TensorDevType& input, TensorDevType& output);
   void fp_apply_bias();
 
-  void bp_compute_convolution_data();
-  void bp_compute_convolution_filter();
+  void compute_convolution_transpose(TensorDevType& input, TensorDevType& output);
+  void bp_compute_gradients(bool convolution_transpose);
 
   std::unique_ptr<dc::Convolution<TensorDataType>> m_conv;
   std::unique_ptr<TensorDevType> m_kernel;

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1187,8 +1187,9 @@ void base_convolution_adapter<TensorDataType, Device>::fp_compute_convolution() 
     TensorDataType, Device>&>(this->layer());
   assert0(dc::tensor::View(
             *m_kernel, l.weights_values(0).LockedBuffer()));
-  m_conv->forward(El::To<TensorDataType>(1), this->get_prev_activations(),
-                  *m_kernel, El::To<TensorDataType>(0), this->get_activations());
+  /// @todo Restore standard convolution
+  m_conv->forward(El::To<TensorDataType>(1), this->get_prev_error_signals(),
+                  *m_kernel, El::To<TensorDataType>(0), this->get_error_signals());
 }
 
 template <typename TensorDataType, El::Device Device>
@@ -1208,9 +1209,10 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_da
     TensorDataType, Device>&>(this->layer());
   assert0(dc::tensor::View(
             *m_kernel, l.weights_values(0).LockedBuffer()));
+  /// @todo Restore standard convolution
   m_conv->backward_data(El::To<TensorDataType>(1), *m_kernel,
-                        this->get_prev_error_signals(),
-                        El::To<TensorDataType>(0), this->get_error_signals());
+                        this->get_prev_activations(),
+                        El::To<TensorDataType>(0), this->get_activations());
 }
 
 template <typename TensorDataType, El::Device Device>
@@ -1244,9 +1246,10 @@ void base_convolution_adapter<TensorDataType, Device>::bp_compute_convolution_fi
   assert0(dc::tensor::View(
             *m_kernel_gradient, kernel_gradient.Buffer()));
   if (has_local_data) {
+    /// @todo Restore standard convolution
     m_conv->backward_filter(gradient_scale,
-                            this->get_prev_activations(),
                             this->get_prev_error_signals(),
+                            this->get_prev_activations(),
                             dst_scale,
                             *m_kernel_gradient, false);
   } else {

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -123,8 +123,11 @@ void convolution_layer<TensorDataType,Layout,Device>::fp_compute() {
   if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
     if (this->distconv_enabled()) {
-      this->get_distconv_adapter().fp_compute_convolution();
-      this->get_distconv_adapter().fp_apply_bias();
+      auto& adapter = this->get_distconv_adapter();
+      adapter.compute_convolution(
+        adapter.get_prev_activations(),
+        adapter.get_activations());
+      adapter.fp_apply_bias();
       return;
     }
 #endif // LBANN_HAS_DISTCONV
@@ -143,12 +146,15 @@ void convolution_layer<TensorDataType,Layout,Device>::bp_compute() {
   if(this->using_gpus()) {
 #ifdef LBANN_HAS_DISTCONV
     if (this->distconv_enabled()) {
-      if (this->get_distconv_adapter().m_conv->is_overlap_bwd_halo_exchange_enabled()) {
-        this->get_distconv_adapter().m_conv->backward_data_exchange_halo(
-          this->get_distconv_adapter().get_prev_error_signals());
+      auto& adapter = this->get_distconv_adapter();
+      if (adapter.m_conv->is_overlap_bwd_halo_exchange_enabled()) {
+        adapter.m_conv->backward_data_exchange_halo(
+          adapter.get_prev_error_signals());
       }
-      this->get_distconv_adapter().bp_compute_convolution_filter();
-      this->get_distconv_adapter().bp_compute_convolution_data();
+      adapter.compute_convolution_transpose(
+        adapter.get_prev_error_signals(),
+        adapter.get_error_signals());
+      adapter.bp_compute_gradients(false);
       return;
     }
 #endif // LBANN_HAS_DISTCONV


### PR DESCRIPTION
Our current distconv support for deconvolution is limited to 2x2 deconvolution with stride 2. Fortunately, we already have implementations for 3x3 deconvolution: just swap the forward and backward steps from standard convolution. This PR makes this change and adds some PyTest tests for the deconvolution layer (with and without distconv). The constraints are the same as those for distconv convolution: kernel sizes must be odd, padding must match kernel size, the data must be either NCHW or NCDHW, etc. It depends on https://github.com/LLNL/DiHydrogen/pull/54.

Note that this PR removes support for 2x2 deconvolution. It would be tricky to retain support since it requires a separate code path. If this is important, perhaps we should support 2x2 convolution with stride 2 inside of distconv, in which case the deconv layer will automatically support that case. This will minimize the amount of distconv implementation knowledge inside of LBANN.

The PyTest tests for distconv conv and distconv deconv both pass for me on Lassen. [Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM369-1).