### PR TITLE
Add onnx callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,9 @@ endif ()
 set(LBANN_HAS_DIHYDROGEN TRUE)
 message(STATUS "Found DiHydrogen: ${DiHydrogen_DIR}")
 
+# Include onnx dependency
+find_package(ONNX CONFIG REQUIRED)
+
 # Inherit half-precision stuff from Hydrogen
 set(LBANN_HAS_HALF ${HYDROGEN_HAVE_HALF}) # This is CPU-only
 
@@ -657,6 +660,7 @@ target_include_directories(lbann PUBLIC
 target_compile_features(lbann PUBLIC cxx_std_17)
 
 # Use the IMPORTED targets when possible.
+target_link_libraries(lbann PUBLIC onnx)
 target_link_libraries(lbann PUBLIC LbannProto)
 target_link_libraries(lbann PUBLIC Threads::Threads)
 target_link_libraries(lbann PUBLIC clara::clara)

--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -18,6 +18,7 @@ set_full_path(THIS_DIR_HEADERS
   dump_outputs.hpp
   dump_weights.hpp
   early_stopping.hpp
+  export_onnx.hpp
   gpu_memory_usage.hpp
   hang.hpp
   imcomm.hpp

--- a/include/lbann/callbacks/export_onnx.hpp
+++ b/include/lbann/callbacks/export_onnx.hpp
@@ -30,6 +30,9 @@
 #define LBANN_CALLBACKS_EXPORT_ONNX_HPP_INCLUDED
 
 #include "lbann/callbacks/callback.hpp"
+
+#include <google/protobuf/message.h>
+#include <lbann/base.hpp>
 #include <onnx/onnx_pb.h>
 #include <iostream>
 #include <memory>
@@ -47,20 +50,29 @@ class export_onnx : public callback_base {
 
 public:
   /** @brief export_onnx Constructor. */
-  export_onnx();
+  export_onnx(std::shared_ptr<lbann_summary> const& summarizer);
 
+  /** @brief Copy constructor */
+  callback_base* copy() const override {
+    LBANN_ERROR( "This callback is not copyable.");
+    return nullptr;
+  }
 
+  /** @brief Return name of callback */
+  std::string name() const override { return "export_onnx"; }
 
 private:
 
+  /* @brief lbann_summary object */
+  std::shared_ptr<lbann_summary> m_summarizer;
 
 
 }; // class export_onnx
 
 std::unique_ptr<callback_base>
 build_export_onnx_callback_from_pbuf(
-  const google::protobuf::message&,
-  const std::shared_ptr<lbann_summary>&);
+  const google::protobuf::Message& proto_msg,
+  const std::shared_ptr<lbann_summary>& summarizer);
 
 } // namespace callback
 } // namespace lbann

--- a/include/lbann/callbacks/export_onnx.hpp
+++ b/include/lbann/callbacks/export_onnx.hpp
@@ -61,7 +61,16 @@ public:
   /** @brief Return name of callback */
   std::string name() const override { return "export_onnx"; }
 
+  /* @brief gather model info */
+  void on_setup_end(model* m) override;
+
+  /* @brief gather graph/layer info */
+  void on_train_begin(model* m) override;
+
 private:
+
+  /* @brief onnx ModelProto object */
+  onnx::ModelProto mp_;
 
   /* @brief lbann_summary object */
   std::shared_ptr<lbann_summary> m_summarizer;

--- a/include/lbann/callbacks/export_onnx.hpp
+++ b/include/lbann/callbacks/export_onnx.hpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// export_onnx .hpp .cpp - Exports trained model to onnx format
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_EXPORT_ONNX_HPP_INCLUDED
+#define LBANN_CALLBACKS_EXPORT_ONNX_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+#include <onnx/onnx_pb.h>
+#include <iostream>
+#include <memory>
+#include <vector>
+
+using namespace onnx;
+
+namespace lbann {
+namespace callback {
+
+/** @class export_onnx
+ *  @brief Callback to export a trained model to onnx format
+ */
+class export_onnx : public callback_base {
+
+public:
+  /** @brief export_onnx Constructor. */
+  export_onnx();
+
+
+
+private:
+
+
+
+}; // class export_onnx
+
+std::unique_ptr<callback_base>
+build_export_onnx_callback_from_pbuf(
+  const google::protobuf::message&,
+  const std::shared_ptr<lbann_summary>&);
+
+} // namespace callback
+} // namespace lbann
+
+#endif  // LBANN_CALLBACKS_EXPORT_ONNX_HPP_INCLUDED

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -334,6 +334,9 @@ public:
   /** @brief Add layer specific data to onnx node */
   virtual void fill_onnx_node(onnx::NodeProto& node) const;
 
+  //** @brief Get ONNX operator type */
+  virtual std::string get_onnx_op_type() const;
+
   const Layer& get_parent_layer(size_t index=0) const;
   const Layer& get_child_layer(size_t index=0) const;
 

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -45,6 +45,7 @@
 #endif // LBANN_HAS_DISTCONV
 #include <string>
 #include <vector>
+#include <onnx/onnx_pb.h>
 
 /** @brief A utility macro for easily defining default-constructed sub-class
  *  builders.*/
@@ -329,6 +330,9 @@ public:
 
   /** @brief Write layer to proto file */
   virtual void write_proto(lbann_data::Layer* proto) const;
+
+  /** @brief Add layer specific data to onnx node */
+  virtual void fill_onnx_node(onnx::NodeProto& node) const;
 
   const Layer& get_parent_layer(size_t index=0) const;
   const Layer& get_child_layer(size_t index=0) const;

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Add the source files for this directory
+# test
 set_full_path(THIS_DIR_SOURCES
   callback.cpp
   check_dataset.cpp

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -18,6 +18,7 @@ set_full_path(THIS_DIR_SOURCES
   dump_outputs.cpp
   dump_weights.cpp
   early_stopping.cpp
+  export_onnx.cpp
   gpu_memory_usage.cpp
   hang.cpp
   imcomm.cpp

--- a/src/callbacks/export_onnx.cpp
+++ b/src/callbacks/export_onnx.cpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+//
+// export_onnx .hpp .cpp - Exports trained model to onnx format
+////////////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include "lbann/callbacks/export_onnx.hpp"
+
+namespace lbann {
+namespace callback {
+
+export_onnx::export_onnx()
+{
+  std::cout << "I do stuff!" << endl;
+}
+
+std::unique_ptr<callback_base>
+build_summarize_images_callback_from_pbuf(
+  const google::protobuf::Message& proto_msg,
+  const std::shared_ptr<lbann_summary>& summarizer) {
+
+  return make_unique<export_onnx>(summarizer);
+}
+}// namespace callback
+}// namespace lbann

--- a/src/callbacks/export_onnx.cpp
+++ b/src/callbacks/export_onnx.cpp
@@ -45,7 +45,89 @@ namespace callback {
 export_onnx::export_onnx(std::shared_ptr<lbann_summary> const& summarizer)
   : m_summarizer(summarizer)
 {
-  std::cout << "I do stuff!" << std::endl;
+  std::cout << "I do stuff! different?" << std::endl;
+}
+
+void export_onnx::on_setup_end(model* m)
+{
+  std::cout << "TEST" << std::endl;
+
+  mp_.set_ir_version(7);
+  //FIXME: what goes here? ONNX operators?
+  // The empty string ("") domain indicates the operators defined
+  // as part of the ONNX specification; other domains correspond
+  // to operator sets of other vendors (e.g., they can be used to
+  // provide vendor-specific extensions to ONNX)
+  auto* opset = mp_.add_opset_import();
+  opset->set_domain("");
+  opset->set_version(1);
+
+  mp_.set_producer_name("LBANN");
+  mp_.set_producer_version(LBANN_MAKE_STR(LBANN_VERSION));
+  mp_.set_domain("lbann/LLNL/com.github");
+  // FIXME: model version is version of graph encoded.
+  //        Should this be passed in?
+  mp_.set_model_version(1);
+  mp_.set_doc_string("Livermore Big Artificial Neural Network");
+  // FIXME: what should go here??
+  auto* metadata = mp_.add_metadata_props();
+  metadata->set_key("name of thing");
+  metadata->set_value("thing");
+}
+
+void export_onnx::on_train_begin(model* m)
+{
+  // graph info
+  auto* gp = mp_.mutable_graph();
+  auto const layers = m->get_layers();
+  // node info
+  for (auto const* layer : layers)
+  {
+    auto* np = gp->add_node();
+    layer->fill_onnx_node(*np);
+    std::cout << "name: " << np->name() << std::endl;
+  }
+  gp->set_name(m->get_name());
+
+  // FIXME: Dims and data type for graph?
+  auto* initializer = gp->add_initializer();
+  int32_t dims[] = {1, 2, 3};
+  for( auto dim : dims )
+  {
+    initializer->add_dims(dim);
+  }
+  // FIXME: Get TensorDataType?
+  initializer->set_data_type(0);
+
+  // FIXME: What goes here?
+  auto* sparse_initializer = gp->add_sparse_initializer();
+  auto* sparse_values = sparse_initializer->mutable_values();
+  for( auto dim : dims )
+  {
+    sparse_values->add_dims(dim);
+  }
+  // FIXME: Get TensorDataType?
+  sparse_values->set_data_type(0);
+
+  auto* sparse_indices = sparse_initializer->mutable_indices();
+  for( auto dim : dims )
+  {
+    sparse_indices->add_dims(dim);
+  }
+  // FIXME: Get TensorDataType?
+  sparse_indices->set_data_type(0);
+
+
+  // FIXME: Name, layers, get_type
+  gp->set_doc_string(m->get_name());
+
+  // FIXME: What is graph input and output?
+  auto* input = gp->add_input();
+  auto* output = gp->add_output();
+
+  // FIXME: What is this stuff?
+  auto* value_info = gp->add_value_info();
+  auto* quantization_annotation = gp->add_quantization_annotation();
 }
 
 std::unique_ptr<callback_base>

--- a/src/callbacks/export_onnx.cpp
+++ b/src/callbacks/export_onnx.cpp
@@ -25,20 +25,31 @@
 //
 // export_onnx .hpp .cpp - Exports trained model to onnx format
 ////////////////////////////////////////////////////////////////////////////////
+//#include <catch2/catch.hpp>
 
 #include <iostream>
 #include "lbann/callbacks/export_onnx.hpp"
 
+#include "lbann/layers/io/input_layer.hpp"
+
+#include "lbann/proto/helpers.hpp"
+#include "lbann/utils/factory.hpp"
+#include "lbann/utils/summary_impl.hpp"
+
+#include <callbacks.pb.h>
+
+
 namespace lbann {
 namespace callback {
 
-export_onnx::export_onnx()
+export_onnx::export_onnx(std::shared_ptr<lbann_summary> const& summarizer)
+  : m_summarizer(summarizer)
 {
-  std::cout << "I do stuff!" << endl;
+  std::cout << "I do stuff!" << std::endl;
 }
 
 std::unique_ptr<callback_base>
-build_summarize_images_callback_from_pbuf(
+build_export_onnx_callback_from_pbuf(
   const google::protobuf::Message& proto_msg,
   const std::shared_ptr<lbann_summary>& summarizer) {
 

--- a/src/callbacks/export_onnx.cpp
+++ b/src/callbacks/export_onnx.cpp
@@ -44,14 +44,10 @@ namespace callback {
 
 export_onnx::export_onnx(std::shared_ptr<lbann_summary> const& summarizer)
   : m_summarizer(summarizer)
-{
-  std::cout << "I do stuff! different?" << std::endl;
-}
+{}
 
 void export_onnx::on_setup_end(model* m)
 {
-  std::cout << "TEST" << std::endl;
-
   mp_.set_ir_version(7);
   //FIXME: what goes here? ONNX operators?
   // The empty string ("") domain indicates the operators defined
@@ -85,12 +81,13 @@ void export_onnx::on_train_begin(model* m)
   {
     auto* np = gp->add_node();
     layer->fill_onnx_node(*np);
-    std::cout << "name: " << np->name() << std::endl;
   }
   gp->set_name(m->get_name());
 
   // FIXME: Dims and data type for graph?
   auto* initializer = gp->add_initializer();
+
+  // Fake dims for initializer.dims
   int32_t dims[] = {1, 2, 3};
   for( auto dim : dims )
   {
@@ -128,6 +125,8 @@ void export_onnx::on_train_begin(model* m)
   // FIXME: What is this stuff?
   auto* value_info = gp->add_value_info();
   auto* quantization_annotation = gp->add_quantization_annotation();
+
+  std::cout << gp->DebugString() << std::endl;
 }
 
 std::unique_ptr<callback_base>

--- a/src/callbacks/unit_test/CMakeLists.txt
+++ b/src/callbacks/unit_test/CMakeLists.txt
@@ -1,5 +1,6 @@
 set_full_path(THIS_DIR_MPI_CATCH2_TEST_FILES
   print_statistics_test.cpp
+  export_onnx_test.cpp
   )
 
 set(LBANN_MPI_CATCH2_TEST_FILES

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -526,6 +526,28 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
   }
 }
 
+void Layer::fill_onnx_node(onnx::NodeProto& node) const {
+  //   repeated string input = 1;    // namespace Value
+  for(auto const* parent : this->get_parent_layers())
+    node.add_input(parent->get_name());
+  //repeated string output = 2;   // namespace Value
+  for(auto const* child : this->get_parent_layers())
+    node.add_output(child->get_name());
+  node.set_name(this->get_name());
+
+  //string op_type = 4;  // namespace Operator
+
+  // FIXME: Why does a layer need a domain?
+  //string domain
+  node.set_domain(this->get_type());
+
+  //repeated AttributeProto attribute = 5;
+
+  //string doc_string = 6;
+  node.set_doc_string(this->get_description());
+
+}
+
 const Layer& Layer::get_parent_layer(size_t index) const {
   if (index >= m_parent_layers.size()) {
     LBANN_ERROR(

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -527,25 +527,33 @@ void Layer::write_proto(lbann_data::Layer* proto) const {
 }
 
 void Layer::fill_onnx_node(onnx::NodeProto& node) const {
-  //   repeated string input = 1;    // namespace Value
   for(auto const* parent : this->get_parent_layers())
     node.add_input(parent->get_name());
-  //repeated string output = 2;   // namespace Value
   for(auto const* child : this->get_parent_layers())
     node.add_output(child->get_name());
   node.set_name(this->get_name());
 
-  //string op_type = 4;  // namespace Operator
+  // FIXME: Do the names need formatting?
+  //string op_type
+  node.set_op_type(this->get_onnx_op_type());
 
   // FIXME: Why does a layer need a domain?
   //string domain
   node.set_domain(this->get_type());
 
+  // FIXME: What goes here?
   //repeated AttributeProto attribute = 5;
 
-  //string doc_string = 6;
-  node.set_doc_string(this->get_description());
+  // FIXME: Do the layers need a doc_string?
+  //string doc_string
+  node.set_doc_string(this->get_type());
 
+}
+
+std::string Layer::get_onnx_op_type() const {
+  // FIXME: I can't find any docs that tell me what to return
+  //        from the layers. Help!
+  return this->get_name();
 }
 
 const Layer& Layer::get_parent_layer(size_t index) const {

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -406,5 +406,4 @@ message Callback {
   message CallbackExportOnnx {
 
   }
-
 }

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -80,6 +80,7 @@ message Callback {
     CallbackSummarizeImages summarize_images = 48;
     CallbackDumpModelGraph dump_model_graph = 49;
     CallbackPerturbLearningRate perturb_learning_rate = 50;
+    CallbackExportOnnx export_onnx = 51;
   }
 
   message CallbackLTFB {
@@ -400,6 +401,10 @@ message Callback {
     bool perturb_during_training = 2; // Whether to periodically perturb during training (default: False)
     int64 batch_interval = 3;         // Frequency of perturbation if perturb_during_training is true
     string weights = 4;               // Optimizer weights with lr to perturb (default: All)
+
+  /** @brief Export trained model in onnx format */
+  message CallbackExportOnnx {
+
   }
 
 }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -43,6 +43,7 @@
 #include "lbann/callbacks/dump_outputs.hpp"
 #include "lbann/callbacks/dump_weights.hpp"
 #include "lbann/callbacks/early_stopping.hpp"
+#include "lbann/callbacks/export_onnx.hpp"
 #include "lbann/callbacks/gpu_memory_usage.hpp"
 #include "lbann/callbacks/hang.hpp"
 #include "lbann/callbacks/imcomm.hpp"
@@ -138,6 +139,8 @@ void register_default_builders(factory_type& factory)
                            build_dump_weights_callback_from_pbuf);
   factory.register_builder("CallbackEarlyStopping",
                            build_early_stopping_callback_from_pbuf);
+  factory.register_builder("CallbackExportOnnx",
+                           build_export_onnx_callback_from_pbuf);
   factory.register_builder("CallbackGPUMemoryUsage",
                            build_gpu_memory_usage_callback_from_pbuf);
   factory.register_builder("CallbackHang",

--- a/src/utils/unit_test/CMakeLists.txt
+++ b/src/utils/unit_test/CMakeLists.txt
@@ -14,6 +14,8 @@ set_full_path(THIS_DIR_SEQ_CATCH2_TEST_FILES
   serialize_matrix_test.cpp
   type_erased_matrix_test.cpp
 
+  #callback_export_onnx_test.cpp
+
   stubs/preset_env_accessor.hpp
   stubs/preset_env_accessor.cpp
   )


### PR DESCRIPTION
Template for pulling the necessary data from lbann is in place. I could use some help determining what to pass to some (most) of the onnx fields. 

One of the biggest ones is the op_type that I need to fill in for the layers. I think I might need to import and opset, and make sure the op_type for each layer matches the corresponding layer in the opset, but I wasn't able to figure out if there is some kind of "default" we could match. Each layer needs to return the correct value for op_type.