### PR TITLE
Removed local fields to track if a data reader has labels or responses

### DIFF
--- a/include/lbann/data_readers/compound_data_reader.hpp
+++ b/include/lbann/data_readers/compound_data_reader.hpp
@@ -125,6 +125,18 @@ class generic_compound_data_reader : public generic_data_reader {
     return false;
   }
 
+  void set_has_labels(const bool b) override {
+    for (auto&& reader : m_data_readers) {
+      reader->set_has_labels(b);
+    }
+  }
+  /// Whether or not a data reader has a response field
+  void set_has_responses(const bool b) override {
+    for (auto&& reader : m_data_readers) {
+      reader->set_has_responses(b);
+    }
+  }
+
   //************************************************************************
 
  protected:

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -307,6 +307,11 @@ class generic_data_reader {
   virtual bool has_labels() const { return m_supported_input_types.at(input_data_type::LABELS); }
   virtual bool has_responses() const { return m_supported_input_types.at(input_data_type::RESPONSES); }
 
+  /// Whether or not a data reader has labels
+  virtual void set_has_labels(const bool b) { m_supported_input_types[input_data_type::LABELS] = b; }
+  /// Whether or not a data reader has a response field
+  virtual void set_has_responses(const bool b) { m_supported_input_types[input_data_type::RESPONSES] = b; }
+
   /**
    * During the network's update phase, the data reader will
    * advanced the current position pointer.  If the pointer wraps

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -58,10 +58,6 @@ class hdf5_reader : public generic_data_reader {
   void load() override;
   void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
 
-  /// Whether to fetch a label from the last column.
-  void set_has_labels(const bool b) { m_supported_input_types[input_data_type::LABELS] = b; }
-  /// Whether to fetch a response from the last column.
-  void set_has_responses(const bool b) { m_supported_input_types[input_data_type::RESPONSES] = b; }
   void set_num_responses(const size_t num_responses) {
     m_all_responses.resize(num_responses);
   }

--- a/include/lbann/data_readers/data_reader_numpy.hpp
+++ b/include/lbann/data_readers/data_reader_numpy.hpp
@@ -56,11 +56,6 @@ class numpy_reader : public generic_data_reader {
     return "numpy_reader";
   }
 
-  /// Set whether to fetch labels.
-  void set_has_labels(bool b) { m_has_labels = b; }
-  /// Set whether to fetch responses.
-  void set_has_responses(bool b) { m_has_responses = b; }
-
   void load() override;
 
   int get_num_labels() const override { return m_num_labels; }
@@ -69,7 +64,7 @@ class numpy_reader : public generic_data_reader {
   const std::vector<int> get_data_dims() const override {
     std::vector<int> dims(m_data.shape.begin() + 1,
                           m_data.shape.end());
-    if (m_has_labels || m_has_responses) {
+    if (m_supported_input_types.at(input_data_type::LABELS) || m_supported_input_types.at(input_data_type::RESPONSES)) {
       dims.back() -= 1;
     }
     return dims;
@@ -86,10 +81,6 @@ class numpy_reader : public generic_data_reader {
   int m_num_features = 0;
   /// Number of label classes.
   int m_num_labels = 0;
-  /// Whether to fetch a label from the last column.
-  bool m_has_labels = true;
-  /// Whether to fetch a response from the last column.
-  bool m_has_responses = false;
   /**
    * Underlying numpy data.
    * Note raw data is managed with shared smart pointer semantics (relevant

--- a/include/lbann/data_readers/data_reader_numpy_npz.hpp
+++ b/include/lbann/data_readers/data_reader_numpy_npz.hpp
@@ -55,10 +55,6 @@ namespace lbann {
       return "numpy_npz_reader";
     }
 
-    /// Set whether to fetch labels.
-    void set_has_labels(bool b) { m_has_labels = b; }
-    /// Set whether to fetch responses.
-    void set_has_responses(bool b) { m_has_responses = b; }
     /// Set a scaling factor for int16 data.
     void set_scaling_factor_int16(DataType s) { m_scaling_factor_int16 = s; }
 
@@ -88,10 +84,6 @@ namespace lbann {
     int m_num_labels = 0;
     /// Number of features in each response.
     int m_num_response_features = 0;
-    /// Whether to fetch a label from the last column.
-    bool m_has_labels = true;
-    /// Whether to fetch a response from the last column.
-    bool m_has_responses = false;
     /**
      * Underlying numpy data.
      * Note raw data is managed with shared smart pointer semantics (relevant

--- a/include/lbann/data_readers/data_reader_numpy_npz_conduit.hpp
+++ b/include/lbann/data_readers/data_reader_numpy_npz_conduit.hpp
@@ -57,10 +57,6 @@ class numpy_npz_conduit_reader : public generic_data_reader {
     return "numpy_npz_conduit_reader";
   }
 
-  /// Set whether to fetch labels.
-  void set_has_labels(bool b) { m_has_labels = b; }
-  /// Set whether to fetch responses.
-  void set_has_responses(bool b) { m_has_responses = b; }
   /// Set a scaling factor for int16 data.
   void set_scaling_factor_int16(DataType s) { m_scaling_factor_int16 = s; }
 
@@ -89,10 +85,6 @@ class numpy_npz_conduit_reader : public generic_data_reader {
     int m_num_labels = 0;
     /// Number of features in each response.
     int m_num_response_features = 0;
-    /// Whether to fetch a label from the last column.
-    bool m_has_labels = true;
-    /// Whether to fetch a response from the last column.
-    bool m_has_responses = true;
 
     std::vector<int> m_data_dims;
     int m_data_word_size = 0;
@@ -108,7 +100,7 @@ class numpy_npz_conduit_reader : public generic_data_reader {
 
     std::vector<std::string> m_filenames;
 
-    bool load_numpy_npz_from_file(const std::unordered_set<int> &data_ids, std::unordered_set<int>& label_classes); 
+    bool load_numpy_npz_from_file(const std::unordered_set<int> &data_ids, std::unordered_set<int>& label_classes);
 
     void load_conduit_node(const std::string filename, int data_id, conduit::Node &output, bool reset = true);
 

--- a/src/data_readers/data_reader_numpy_npz.cpp
+++ b/src/data_readers/data_reader_numpy_npz.cpp
@@ -49,8 +49,6 @@ namespace lbann {
     m_num_features(other.m_num_features),
     m_num_labels(other.m_num_labels),
     m_num_response_features(other.m_num_response_features),
-    m_has_labels(other.m_has_labels),
-    m_has_responses(other.m_has_responses),
     m_data(other.m_data),
     m_labels(other.m_labels),
     m_responses(other.m_responses),
@@ -62,8 +60,6 @@ namespace lbann {
     m_num_features = other.m_num_features;
     m_num_labels = other.m_num_labels;
     m_num_response_features = other.m_num_response_features;
-    m_has_labels = other.m_has_labels;
-    m_has_responses = other.m_has_responses;
     m_data = other.m_data;
     m_labels = other.m_labels;
     m_responses = other.m_responses;
@@ -85,8 +81,8 @@ namespace lbann {
 
     std::vector<std::tuple<const bool, const std::string, cnpy::NpyArray &> > npyLoadList;
     npyLoadList.push_back(std::forward_as_tuple(true,            NPZ_KEY_DATA,      m_data));
-    npyLoadList.push_back(std::forward_as_tuple(m_has_labels,    NPZ_KEY_LABELS,    m_labels));
-    npyLoadList.push_back(std::forward_as_tuple(m_has_responses, NPZ_KEY_RESPONSES, m_responses));
+    npyLoadList.push_back(std::forward_as_tuple(m_supported_input_types[input_data_type::LABELS],    NPZ_KEY_LABELS,    m_labels));
+    npyLoadList.push_back(std::forward_as_tuple(m_supported_input_types[input_data_type::RESPONSES], NPZ_KEY_RESPONSES, m_responses));
     for(const auto& npyLoad : npyLoadList) {
       // Check whether the tensor have to be loaded.
       if(!std::get<0>(npyLoad)) {
@@ -118,7 +114,7 @@ namespace lbann {
                                      m_data.shape.end(),
                                      (unsigned) 1,
                                      std::multiplies<unsigned>());
-    if(m_has_responses) {
+    if(m_supported_input_types[input_data_type::RESPONSES]) {
       m_num_response_features = std::accumulate(m_responses.shape.begin() + 1,
                                                 m_responses.shape.end(),
                                                 (unsigned) 1,
@@ -131,7 +127,7 @@ namespace lbann {
                             " not supported");
     }
 
-    if (m_has_labels) {
+    if (m_supported_input_types[input_data_type::LABELS]) {
       // Determine number of label classes.
       std::unordered_set<int> label_classes;
       if (m_labels.word_size != 4) {
@@ -187,7 +183,7 @@ namespace lbann {
   }
 
   bool numpy_npz_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
-    if (!m_has_labels) {
+    if (!m_supported_input_types[input_data_type::LABELS]) {
       throw lbann_exception("numpy_npz_reader: do not have labels");
     }
     const int label = m_labels.data<int>()[data_id];
@@ -196,7 +192,7 @@ namespace lbann {
   }
 
   bool numpy_npz_reader::fetch_response(Mat& Y, int data_id, int mb_idx) {
-    if (!m_has_responses) {
+    if (!m_supported_input_types[input_data_type::RESPONSES]) {
       throw lbann_exception("numpy_npz_reader: do not have responses");
     }
 

--- a/src/data_readers/data_reader_numpy_npz_conduit.cpp
+++ b/src/data_readers/data_reader_numpy_npz_conduit.cpp
@@ -65,8 +65,6 @@ void numpy_npz_conduit_reader::copy_members(const numpy_npz_conduit_reader &rhs)
   m_num_features = rhs.m_num_features;
   m_num_labels = rhs.m_num_labels;
   m_num_response_features = rhs.m_num_response_features;
-  m_has_labels = rhs.m_has_labels;
-  m_has_responses = rhs.m_has_responses;
   m_data_dims = rhs.m_data_dims;
   m_data_word_size = rhs.m_data_word_size;
   m_response_word_size = rhs.m_response_word_size;
@@ -184,7 +182,7 @@ void numpy_npz_conduit_reader::do_preload_data_store() {
   // Nikoli says we're not using labels, so I'm commenting this section out
   // (this section is a mess, anyway)
   #if 0
-  if (m_has_labels) {
+  if (m_supported_input_types[input_data_type::LABELS]) {
 
     // get max element. Yes, I know you can do this with, e.g, lambda
     // expressions and c++11 and etc, etc. But that's just B-ugly and
@@ -303,7 +301,7 @@ bool numpy_npz_conduit_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
 }
 
 bool numpy_npz_conduit_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
-  if (!m_has_labels) {
+  if (!m_supported_input_types[input_data_type::LABELS]) {
     LBANN_ERROR("numpy_npz_conduit_reader: do not have labels");
   }
   if (m_num_labels == 0) {
@@ -320,7 +318,7 @@ bool numpy_npz_conduit_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
 }
 
 bool numpy_npz_conduit_reader::fetch_response(Mat& Y, int data_id, int mb_idx) {
-  if (!m_has_responses) {
+  if (!m_supported_input_types[input_data_type::RESPONSES]) {
     LBANN_ERROR("numpy_npz_conduit_reader: do not have responses");
   }
 
@@ -407,14 +405,14 @@ void numpy_npz_conduit_reader::fill_in_metadata() {
     std::cout << "data word size: " << m_data_word_size << "\n";
   }
 
-  if (m_has_labels) {
+  if (m_supported_input_types[input_data_type::LABELS]) {
     word_size = node[LBANN_DATA_ID_STR(data_id) + "/frm/word_size"].value();
     if (word_size != 4) {
       LBANN_ERROR("numpy_npz_conduit_reader: label should be in int32, but word_size= " + std::to_string(word_size));
     }
   }
 
-  if (m_has_responses) {
+  if (m_supported_input_types[input_data_type::RESPONSES]) {
     m_response_word_size = node[LBANN_DATA_ID_STR(data_id) + "/responses/word_size"].value();
     auto r_shape = node[LBANN_DATA_ID_STR(data_id) + "/responses/shape"].as_uint64_array();
     int n = r_shape.number_of_elements();


### PR DESCRIPTION
and switched to using the newer m_supported_input_types unordered map.