### PR TITLE
LTFB support for multiple metrics

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,6 +1,9 @@
 ============================== (Pending) Release Notes: v1.00 ==============================
 Support for new training algorithms:
  - LTFB is now a first-class training algorithm.
+ - LTFB now allows multiple metrics. The local algorithm is favored by
+   each trainer and a partner model must win every metric to be declared
+   the tournament winner.
  - The batched iterative optimizer (sgd_training_algorithm) was
    refactored for consistency.
  - Improved documentation of training algorithm infrastructure.

--- a/bamboo/unit_tests/test_unit_algo_ltfb.py
+++ b/bamboo/unit_tests/test_unit_algo_ltfb.py
@@ -65,8 +65,7 @@ def setup_experiment(lbann):
     RPE = lbann.RandomPairwiseExchange
     SGD = lbann.BatchedIterativeOptimizer
     metalearning = RPE(
-        metric_name='random',
-        metric_strategy=RPE.MetricStrategy.HIGHER_IS_BETTER)
+        metric_strategies={'random': RPE.MetricStrategy.HIGHER_IS_BETTER})
     ltfb = lbann.LTFB("ltfb",
                       metalearning=metalearning,
                       local_algo=SGD("local sgd",

--- a/python/lbann/core/training_algorithm.py
+++ b/python/lbann/core/training_algorithm.py
@@ -295,30 +295,28 @@ class RandomPairwiseExchange(MetaLearningStrategy):
                 raise ValueError("Unknown strategy")
             return msg
 
-    def __init__(self, metric_name: str,
-                 metric_strategy: int = MetricStrategy.LOWER_IS_BETTER,
+    def __init__(self,
+                 metric_strategies: dict[str,int] = {},
                  exchange_strategy = ExchangeStrategy()):
         """Construct a new RandomPairwiseExchange metalearning strategy.
 
         Args:
-            metric_name:
-              The name of the metric to use for tournaments. Must be
-              present in all models seen by this strategy.
-            metric_strategy:
-              Criterion for picking a tournament winner.
+            metric_strategies:
+              Map from metric name to the criterion for picking a winner
+              with respect to this metric
             exchange_strategy:
               The algorithm used for exchanging models.
         """
 
-        self.metric_name = metric_name
-        self.metric_strategy = metric_strategy
+        self.metric_strategies = metric_strategies
         self.exchange_strategy = exchange_strategy
 
     def export_proto(self):
         """Get a protobuf representation of this object."""
 
         msg = AlgoProto.RandomPairwiseExchange()
-        msg.metric_name = self.metric_name
-        msg.metric_strategy = self.metric_strategy
+        for key, value in self.metric_strategies.items():
+            msg.metric_name_strategy_map[key] = value
+
         msg.exchange_strategy.CopyFrom(self.exchange_strategy.export_proto())
         return msg

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -44,6 +44,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace lbann {
 namespace ltfb {
@@ -64,6 +65,18 @@ namespace {
 template <typename... Args> void Output(std::ostream& os, Args&&... args)
 {
   (os << ... << args) << "\n";
+}
+
+template <typename PrintableT>
+std::string stringify(std::unordered_map<std::string, PrintableT> const& m_in)
+{
+  std::map<std::string, PrintableT> m(std::cbegin(m_in), std::cend(m_in));
+  std::ostringstream oss;
+  oss << "{";
+  for (auto const& [key,val] : m)
+    oss << " \"" << key << "\": " << val << ",";
+  oss << " }";
+  return oss.str();
 }
 
 std::string stringify(std::vector<std::string> const& v)
@@ -314,11 +327,11 @@ void RandomPairwiseExchange::select_next(model& m,
                            " (trainer ",
                            local_trainer,
                            " score = ",
-                           local_scores.begin()->second,
+                           stringify(local_scores),
                            ", trainer ",
                            partner_trainer,
                            " score = ",
-                           partner_scores.begin()->second,
+                           stringify(partner_scores),
                            ")");
 }
 

--- a/src/proto/training_algorithm.proto
+++ b/src/proto/training_algorithm.proto
@@ -73,9 +73,8 @@ message RandomPairwiseExchange {
     HIGHER_IS_BETTER = 1;
   }
 
-  string metric_name = 1;
-  MetricStrategy metric_strategy = 2;
-  ExchangeStrategy exchange_strategy = 3;
+  map<string, MetricStrategy> metric_name_strategy_map = 1;
+  ExchangeStrategy exchange_strategy = 2;
 
   // This uses the "oneof" strategy because we don't really want
   // downstreams adding strategies willy nilly.


### PR DESCRIPTION
This adds the multi-metric support feature to RandomPairwiseExchange. All metrics must exist in every model. The local model is favored; a partner model must win ALL metrics to be declared the winner.

The front-ends use associative maps (dictionaries in python, maps in protobuf). See the LTFB test file for a usage example.