### PR TITLE
Download MNIST from PyTorch mirror

### DIFF
--- a/applications/vision/data/mnist/__init__.py
+++ b/applications/vision/data/mnist/__init__.py
@@ -19,10 +19,10 @@ def download_data():
 
     # MNIST data files and associated URLs
     urls = {
-        'train-images-idx3-ubyte': 'http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz',
-        'train-labels-idx1-ubyte': 'http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz',
-        't10k-images-idx3-ubyte': 'http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz',
-        't10k-labels-idx1-ubyte': 'http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz',
+        'train-images-idx3-ubyte': 'https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz',
+        'train-labels-idx1-ubyte': 'https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz',
+        't10k-images-idx3-ubyte': 'https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz',
+        't10k-labels-idx1-ubyte': 'https://ossci-datasets.s3.amazonaws.com/mnist/t10k-labels-idx1-ubyte.gz',
     }
 
     # Download and uncompress MNIST data files, if needed


### PR DESCRIPTION
Our functionality to download MNIST is currently broken. It seems that Yann LeCun website changes settings every few months, so PyTorch has setup their own mirror (see https://github.com/pytorch/vision/pull/3544).