### PR TITLE
Optimize data transfer in input layers

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -8,6 +8,8 @@ Support for new layers:
 Python front-end:
 
 Performance optimizations:
+ - Enabled the input layers to use a view of the I/O buffers in the
+ buffered data coordinator
 
 Model portability & usability:
 

--- a/include/lbann/data_coordinator/io_data_buffer.hpp
+++ b/include/lbann/data_coordinator/io_data_buffer.hpp
@@ -63,7 +63,7 @@ public:
       m_input_buffers[idt].reset(new StarVCMatDT<TensorDataType, El::Device::CPU>(comm->get_trainer_grid()));
 #if defined(LBANN_HAS_GPU)
       // Pin the memory so that we get efficient GPU data transfer
-      m_input_buffers[idt]->Matrix().SetMemoryMode(1);
+      m_input_buffers[idt]->Matrix().SetMemoryMode(3);
 #endif // LBANN_HAS_GPU
     }
   }

--- a/include/lbann/data_coordinator/io_data_buffer.hpp
+++ b/include/lbann/data_coordinator/io_data_buffer.hpp
@@ -63,7 +63,7 @@ public:
       m_input_buffers[idt].reset(new StarVCMatDT<TensorDataType, El::Device::CPU>(comm->get_trainer_grid()));
 #if defined(LBANN_HAS_GPU)
       // Pin the memory so that we get efficient GPU data transfer
-      m_input_buffers[idt]->Matrix().SetMemoryMode(3);
+      m_input_buffers[idt]->Matrix().SetMemoryMode(1);
 #endif // LBANN_HAS_GPU
     }
   }

--- a/include/lbann/data_coordinator/io_data_buffer.hpp
+++ b/include/lbann/data_coordinator/io_data_buffer.hpp
@@ -61,6 +61,10 @@ public:
     //    by the data reader
     for(auto idt : input_data_type_iterator()) {
       m_input_buffers[idt].reset(new StarVCMatDT<TensorDataType, El::Device::CPU>(comm->get_trainer_grid()));
+#if defined(LBANN_HAS_GPU)
+      // Pin the memory so that we get efficient GPU data transfer
+      m_input_buffers[idt]->Matrix().SetMemoryMode(1);
+#endif // LBANN_HAS_GPU
     }
   }
 

--- a/include/lbann/utils/CMakeLists.txt
+++ b/include/lbann/utils/CMakeLists.txt
@@ -34,6 +34,8 @@ set_full_path(THIS_DIR_HEADERS
   statistics.hpp
   summary.hpp
   summary_impl.hpp
+  tensor.hpp
+  tensor_impl.hpp
   timer.hpp
   trainer_file_utils.hpp
   type_erased_matrix.hpp

--- a/include/lbann/utils/tensor.hpp
+++ b/include/lbann/utils/tensor.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_TENSOR_HPP
+#define LBANN_UTILS_TENSOR_HPP
+
+#include "lbann/base.hpp"
+
+namespace lbann {
+
+/// @brief Function to efficiently select the best method for copying between
+/// two distributed tensors. Enable selection between synchronous and
+/// asynchronous copies based on tensor distribution and
+/// pre-processing macros
+template <typename TDT>
+void do_tensor_copy(const BaseDistMat& src,
+                    El::AbstractDistMatrix<TDT>& tgt);
+
+/// @brief If distributed tensors have the same distribution setup the
+/// target to use a view to the source tensor, otherwise copy the src
+/// to target.
+template <typename TDT>
+void view_or_copy_tensor(const BaseDistMat& src,
+                         El::AbstractDistMatrix<TDT>& tgt);
+}
+
+#endif // LBANN_UTILS_TENSOR_HPP

--- a/include/lbann/utils/tensor_impl.hpp
+++ b/include/lbann/utils/tensor_impl.hpp
@@ -1,0 +1,71 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_UTILS_TENSOR_IMPL_HPP
+#define LBANN_UTILS_TENSOR_IMPL_HPP
+
+#include "lbann/utils/tensor.hpp"
+
+namespace lbann {
+
+template <typename TDT>
+void do_tensor_copy(const BaseDistMat& src,
+                    El::AbstractDistMatrix<TDT>& tgt) {
+  bool copy_async = false;
+#if defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)
+  auto src_dist_data = src.DistData();
+  auto tgt_dist_data = tgt.DistData();
+  // Asynchronously copy CPU data to GPU data if they are otherwise aligned
+  if ((src.dist_data.device == El::Device::CPU)
+      && (tgt_dist_data.device == El::Device::GPU)) {
+    src_dist_data.device = El::Device::GPU;
+    copy_async = (src_dist_data == tgt_dist_data);
+  }
+#endif // defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)
+  if (copy_async) {
+    El::CopyAsync(src, tgt);
+  }
+  else {
+    El::Copy(src, tgt);
+  }
+}
+
+template <typename TDT>
+void view_or_copy_tensor(const BaseDistMat& src,
+                         El::AbstractDistMatrix<TDT>& tgt) {
+
+  if (src.DistData() == tgt.DistData()) {
+    El::LockedView(tgt,
+                   dynamic_cast<const El::AbstractDistMatrix<TDT>&>(src));
+  }
+  else {
+    do_tensor_copy(src, tgt);
+  }
+}
+
+}
+
+#endif // LBANN_UTILS_TENSOR_IMPL_HPP

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -62,6 +62,12 @@
 #include <vector>
 
 namespace lbann {
+
+// Declare the trainer finalization. It's declared here because it is
+// *not* for public consumption. It is implemented in
+// src/utils/lbann_library.cpp.
+void finalize_trainer();
+
 namespace {
 lbann_comm* world_comm_ = nullptr;
 }// namespace <anon>
@@ -129,6 +135,7 @@ world_comm_ptr initialize(int& argc, char**& argv) {
 }
 
 void finalize(lbann_comm* comm) {
+  finalize_trainer();
 #ifdef LBANN_HAS_NVSHMEM
   nvshmem::finalize();
 #endif // LBANN_HAS_NVSHMEM

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -34,6 +34,7 @@
 #include "lbann/utils/profiling.hpp"
 #include "lbann/utils/distconv.hpp"
 #include "lbann/utils/serialize.hpp"
+#include "lbann/utils/tensor_impl.hpp"
 #include "lbann/io/persist_impl.hpp"
 
 namespace lbann {
@@ -285,7 +286,7 @@ void buffered_data_coordinator<TensorDataType>::distribute_from_local_matrix(exe
   for(auto idt : input_data_type_iterator()) {
     if(buf.m_input_buffers.count(idt)) {
       if(input_buffers.count(idt)) {
-        El::Copy(*buf.m_input_buffers[idt], *input_buffers[idt]);
+        view_or_copy_tensor(*buf.m_input_buffers[idt], *input_buffers[idt]);
       }
     }else {
       if(input_buffers.count(idt)) {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -145,6 +145,10 @@ trainer const& get_const_trainer() {
   return *global_trainer_;
 }
 
+void finalize_trainer() {
+  global_trainer_.reset();
+}
+
 /// Construct a trainer that contains a lbann comm object and threadpool
 trainer& construct_trainer(lbann_comm *comm,
                            lbann_data::Trainer* pb_trainer,


### PR DESCRIPTION
Refactored common code in the data_type_layer to provide a utility
function to view or copy a distributed tensor (view_or_copy_tensor).
This replaces code in both the fp_setup_inputs and
view_or_copy_prev_error_signals_.

Updated the buffered_data_coordinator's distribute_from_local_matrix
function to use the view_or_copy_tensor function between the
io_buffers double buffer and the input layer's activations.

Added code to pin the io_buffer's memory to improve host to device
memory transfers.