### PR TITLE
Add DYAD for checkpointed-file-based LTFB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,8 @@ option(LBANN_WITH_CONDUIT "Enable Conduit library" ON)
 
 option(LBANN_WITH_CUDNN "Include Nvidia cuDNN" ON)
 
+option(LBANN_WITH_DYAD "Enable DYAD (depends on flux-core)" OFF)
+
 # For now, we just assert CPU support.
 option(LBANN_WITH_ONEDNN "Include OneDNN API support" OFF)
 
@@ -530,6 +532,14 @@ if (LBANN_WITH_CNPY)
   find_package(CNPY REQUIRED)
   set(LBANN_HAS_CNPY ${CNPY_FOUND})
 endif (LBANN_WITH_CNPY)
+
+if (LBANN_WITH_DYAD)
+  find_package(DYAD REQUIRED)
+  set(LBANN_HAS_DYAD ${DYAD_FOUND})
+  if (DYAD_FOUND)
+    target_link_libraries(lbann PUBLIC DYAD::DYAD)
+  endif (DYAD_FOUND)
+endif (LBANN_WITH_DYAD)
 
 if (LBANN_WITH_HWLOC)
   find_package(HWLOC REQUIRED)
@@ -990,6 +1000,7 @@ append_str_tf(_str
   LBANN_HAS_DIHYDROGEN
   LBANN_HAS_DISTCONV
   LBANN_HAS_DOXYGEN
+  LBANN_HAS_DYAD
   LBANN_HAS_FFTW
   LBANN_HAS_HIPTT
   LBANN_HAS_HYDROGEN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,9 +536,6 @@ endif (LBANN_WITH_CNPY)
 if (LBANN_WITH_DYAD)
   find_package(DYAD REQUIRED)
   set(LBANN_HAS_DYAD ${DYAD_FOUND})
-  if (DYAD_FOUND)
-    target_link_libraries(lbann PUBLIC DYAD::DYAD)
-  endif (DYAD_FOUND)
 endif (LBANN_WITH_DYAD)
 
 if (LBANN_WITH_HWLOC)
@@ -705,6 +702,10 @@ get_target_property(LBANN_MPI_CXX_INCL_DIRS
 if (NOT LBANN_MPI_CXX_INCL_DIRS)
   target_include_directories(lbann PRIVATE $<$<COMPILE_LANGUAGE:HIP>:${MPI_CXX_COMPILER_INCLUDE_DIRS}>)
 endif ()
+
+if (DYAD_FOUND)
+  target_link_libraries(lbann PUBLIC DYAD::DYAD)
+endif (DYAD_FOUND)
 
 if (LBANN_FLAG_Werror_OK)
   target_compile_options(lbann

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -57,6 +57,7 @@
 #endif // LBANN_HAS_CEREAL
 
 #cmakedefine LBANN_HAS_DIHYDROGEN
+#cmakedefine LBANN_HAS_DYAD
 #cmakedefine LBANN_HAS_OPENCV
 #cmakedefine LBANN_HAS_TBINF
 #cmakedefine LBANN_HAS_CNPY

--- a/cmake/modules/FindDYAD.cmake
+++ b/cmake/modules/FindDYAD.cmake
@@ -1,0 +1,52 @@
+# Defines the following variables:
+#   - DYAD_FOUND
+#   - DYAD_LIBRARIES
+#   - DYAD_INCLUDE_DIRS
+#
+# Also creates an imported target DYAD
+
+# Find the header
+find_path(DYAD_INCLUDE_DIRS dyad_stream_api.hpp
+  HINTS ${DYAD_DIR} $ENV{DYAD_DIR}
+  PATH_SUFFIXES include
+  NO_DEFAULT_PATH
+  DOC "Directory with DYAD header.")
+find_path(DYAD_INCLUDE_DIRS dyad_stream_api.hpp)
+
+# Find the library
+find_library(DYAD_LIBRARY dyad_fstream
+  HINTS ${DYAD_DIR} $ENV{DYAD_DIR}
+  PATH_SUFFIXES lib64 lib
+  NO_DEFAULT_PATH
+  DOC "The DYAD library.")
+find_library(DYAD_LIBRARY dyad_fstream)
+
+# Standard handling of the package arguments
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(DYAD
+  DEFAULT_MSG
+  DYAD_LIBRARY DYAD_INCLUDE_DIRS)
+
+# Setup the imported target
+if (NOT TARGET DYAD::DYAD)
+  add_library(DYAD::DYAD INTERFACE IMPORTED)
+endif (NOT TARGET DYAD::DYAD)
+
+# Set the include directories for the target
+set_property(TARGET DYAD::DYAD APPEND
+  PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${DYAD_INCLUDE_DIRS})
+
+# Set the link libraries for the target
+set_property(TARGET DYAD::DYAD APPEND
+  PROPERTY INTERFACE_LINK_LIBRARIES ${DYAD_LIBRARY})
+
+#
+# Cleanup
+#
+
+# Set the include directories
+mark_as_advanced(FORCE DYAD_INCLUDE_DIRS)
+
+# Set the libraries
+set(DYAD_LIBRARIES DYAD::DYAD)
+mark_as_advanced(FORCE DYAD_LIBRARY)

--- a/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
+++ b/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
@@ -37,6 +37,10 @@
 #include <string>
 #include <unordered_map>
 
+#ifdef LBANN_HAS_DYAD
+#include "dyad_stream_api.hpp"
+#endif // LBANN_HAS_DYAD
+
 namespace lbann {
 namespace ltfb {
 
@@ -272,6 +276,31 @@ public:
 private:
   std::string ckpt_basedir_;
 }; // class CheckpointFile
+
+#ifdef LBANN_HAS_DYAD
+/// See @c lbann::callbacks::ltfb::communication_algorithm::checkpoint_file_dyad
+class CheckpointFileDyad final
+  : public Cloneable<CheckpointFileDyad, RandomPairwiseExchange::ExchangeStrategy>
+{
+  using BaseType =
+    Cloneable<CheckpointFileDyad, RandomPairwiseExchange::ExchangeStrategy>;
+
+public:
+  CheckpointFileDyad(std::set<std::string> const& weights_names,
+                     const dyad::dyad_params& dparams);
+  CheckpointFileDyad(std::set<std::string>&& weights_names,
+                     const dyad::dyad_params& dparams);
+  std::unique_ptr<model>
+  get_partner_model(model const& m, El::Int partner_trainer, size_t step) final;
+
+  dyad::dyad_stream_core& get_dyad();
+
+private:
+  std::string ckpt_basedir_;
+
+  dyad::dyad_stream_core m_dyad;
+}; // class CheckpointFileDyad
+#endif // LBANN_HAS_DYAD
 
 class CheckpointBinary final
   : public Cloneable<CheckpointBinary, RandomPairwiseExchange::ExchangeStrategy>

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -57,6 +57,10 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef LBANN_HAS_DYAD
+#include "dyad_stream_api.hpp"
+#endif // LBANN_HAS_DYAD
+
 // Forward-declare protobuf class
 namespace lbann_data {
 class Model;
@@ -240,6 +244,11 @@ public:
   /** @brief Restore model by reading checkpoint from given file descriptor,
    * return number of bytes read */
   bool load_from_checkpoint_shared(persist& p);
+
+#ifdef LBANN_HAS_DYAD
+  bool save_to_checkpoint_dyad(persist& p, dyad::dyad_stream_core& dyad);
+  bool load_from_checkpoint_dyad(persist& p, dyad::dyad_stream_core& dyad);
+#endif // LBANN_HAS_DYAD
 
   bool save_to_checkpoint_distributed(persist& p);
   bool load_from_checkpoint_distributed(persist& p);

--- a/src/execution_algorithms/ltfb/CMakeLists.txt
+++ b/src/execution_algorithms/ltfb/CMakeLists.txt
@@ -27,6 +27,7 @@
 set_full_path(THIS_DIR_SOURCES
   checkpoint_binary.cpp
   checkpoint_file.cpp
+  checkpoint_file_dyad.cpp
   meta_learning_strategy.cpp
   mutation_strategy.cpp
   random_pairwise_exchange.cpp

--- a/src/execution_algorithms/ltfb/checkpoint_file_dyad.cpp
+++ b/src/execution_algorithms/ltfb/checkpoint_file_dyad.cpp
@@ -1,0 +1,122 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#include "lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp"
+
+#include "lbann/comm_impl.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/weights/data_type_weights.hpp"
+
+#include "checkpoint_common.hpp"
+
+#ifdef LBANN_HAS_DYAD
+namespace lbann {
+namespace ltfb {
+
+CheckpointFileDyad::CheckpointFileDyad(std::set<std::string> const& weights_names,
+                                       const dyad::dyad_params& dparams)
+  : BaseType(weights_names), ckpt_basedir_{dparams.m_dyad_path_cons}
+{
+  m_dyad.init(dparams);
+}
+
+CheckpointFileDyad::CheckpointFileDyad(std::set<std::string>&& weights_names,
+                                       const dyad::dyad_params& dparams)
+  : BaseType(std::move(weights_names)), ckpt_basedir_{dparams.m_dyad_path_cons}
+{
+  m_dyad.init(dparams);
+}
+
+std::unique_ptr<model>
+CheckpointFileDyad::get_partner_model(model const& m,
+                                      El::Int partner_trainer,
+                                      size_t step)
+{
+  auto const& comm = *m.get_comm();
+
+  // Start by copying this model, then do the exchange.
+  auto partner_model_ptr = std::make_unique<model>(m);
+  model& partner_model = *partner_model_ptr;
+
+  // Keep track of weights that shouldn't be exchanged
+  std::unordered_map<std::string, std::unique_ptr<weights>> restore_weights;
+  auto const& weights_names = this->weights_names();
+  if (!weights_names.empty()) {
+    for (auto w : partner_model.get_weights()) {
+      if (weights_names.find(w->get_name()) == weights_names.cend()) {
+        using TensorDataType = DataType;
+        using WeightsType = data_type_weights<TensorDataType>;
+        restore_weights[w->get_name()] =
+          std::make_unique<WeightsType>(dynamic_cast<WeightsType&>(*w));
+      }
+    }
+  }
+
+  // Checkpoint directories
+  const auto basedir =
+    (ckpt_basedir_.empty() ? std::string("") : add_delimiter(ckpt_basedir_));
+  const auto local_trainer = comm.get_trainer_rank();
+  const std::string send_dir =
+    (basedir + partner_model.get_name() + "_trainer" +
+     std::to_string(local_trainer) + "_step" + std::to_string(step));
+  const std::string recv_dir =
+    (basedir + partner_model.get_name() + "_trainer" +
+     std::to_string(partner_trainer) + "_step" + std::to_string(step));
+
+  // Save model checkpoint
+  {
+    persist p;
+    p.set_cb_type(callback_type::model_only);
+    p.open_checkpoint(send_dir, comm.am_trainer_master());
+    comm.trainer_barrier();
+    partner_model.save_to_checkpoint_dyad(p, m_dyad);
+    p.close_checkpoint();
+  }
+
+  // Load model checkpoint from partner trainer
+  {
+    persist p;
+    p.set_cb_type(callback_type::model_only);
+    p.open_restart(recv_dir);
+    partner_model.load_from_checkpoint_dyad(p, m_dyad);
+    p.close_restart();
+  }
+
+  /// @todo Should be unneeded, but we experience hangs without it
+  comm.trainer_barrier();
+
+  restore_model_weights(partner_model, restore_weights);
+
+  return partner_model_ptr;
+}
+
+dyad::dyad_stream_core& CheckpointFileDyad::get_dyad()
+{
+  return m_dyad;
+}
+
+} // namespace ltfb
+} // namespace lbann
+#endif // LBANN_HAS_DYAD

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -391,6 +391,41 @@ make_checkpoint_file(std::set<std::string> weights_names,
                                                        params.checkpoint_dir());
 }
 
+#ifdef LBANN_HAS_DYAD
+std::unique_ptr<lbann::ltfb::CheckpointFileDyad>
+make_checkpoint_file_dyad(std::set<std::string> weights_names,
+                          google::protobuf::Message const& msg)
+{
+  using CkptFile =
+    lbann_data::RandomPairwiseExchange::ExchangeStrategy::CheckpointFileDyad;
+  auto const& params = dynamic_cast<CkptFile const&>(msg);
+  // TODO: further DYAD parameterization can happen here
+  dyad::dyad_params dparams;
+  dparams.m_dyad_path_cons = params.base_dir();
+  dparams.m_dyad_path_prod = params.base_dir();
+  dparams.m_kvs_namespace = params.kvs_namespace();
+  dparams.m_key_depth = params.key_depth();
+  dparams.m_key_bins = params.key_bins();
+  dparams.m_shared_storage = params.shared_storage();
+  dparams.m_debug = params.debug();
+  return std::make_unique<lbann::ltfb::CheckpointFileDyad>(std::move(weights_names),
+                                                           dparams);
+}
+#else
+std::unique_ptr<lbann::ltfb::CheckpointFile>
+make_checkpoint_file_dyad(std::set<std::string> weights_names,
+                          google::protobuf::Message const& msg)
+{
+ #if 1
+  LBANN_ERROR("Cannot use the exchange strategy 'checkpoint_file_dyad' ",
+              "because DYAD is not enabled.");
+  return nullptr;
+ #else
+  return make_checkpoint_file(weights_names, msg);
+ #endif
+}
+#endif // LBANN_HAS_DYAD
+
 std::unique_ptr<lbann::ltfb::SendRecvWeights>
 make_sendrecv_weights(std::set<std::string> weights_names,
                       google::protobuf::Message const& msg)
@@ -424,6 +459,7 @@ ExchangeStrategyFactory build_default_exchange_factory()
   ExchangeStrategyFactory factory;
   factory.register_builder("CheckpointBinary", make_checkpoint_binary);
   factory.register_builder("CheckpointFile", make_checkpoint_file);
+  factory.register_builder("CheckpointFileDyad", make_checkpoint_file_dyad);
   factory.register_builder("SendRecvWeights", make_sendrecv_weights);
   return factory;
 }

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -2586,6 +2586,79 @@ bool model::load_from_checkpoint_shared(persist& p)
   return true;
 }
 
+#ifdef LBANN_HAS_DYAD
+bool model::save_to_checkpoint_dyad(persist& p, dyad::dyad_stream_core& dyad)
+{
+  if (! dyad.m_initialized) {
+    return save_to_checkpoint_shared(p);
+  }
+
+  const std::string trainer_dir = p.get_checkpoint_dir();
+
+  // This "pushes" the model-specific directory to the "stack". After
+  // the call, p.get_checkpoint_dir() returns the model-specific
+  // directory.
+  p.open_checkpoint_dir(file::join_path(trainer_dir, this->get_name()),
+                        m_comm->am_trainer_master());
+
+  // Make sure that the master has had a chance to create the directories
+  // (trb 12/14/2020): I don't think this matters; all output is from
+  //                   the trainer master...
+  m_comm->trainer_barrier();
+
+  // Open the stream for writing
+  dyad::ofstream_dyad ofs_dyad;
+  ofs_dyad.init(dyad);
+  std::ofstream& ofs = ofs_dyad.get_stream();
+  if (m_comm->am_trainer_master()) {
+    ofs_dyad.open(file::join_path(p.get_checkpoint_dir(), "model.bin"));
+    LBANN_ASSERT(ofs.good());
+  }
+
+  // Write the checkpoint
+  {
+    lbann::RootedBinaryOutputArchive ar(ofs, m_comm->get_trainer_grid());
+    ar(*this);
+  }
+
+  p.open_checkpoint_dir(trainer_dir, false);
+  return true;
+}
+
+bool model::load_from_checkpoint_dyad(persist& p, dyad::dyad_stream_core& dyad)
+{
+  if (! dyad.m_initialized) {
+    return load_from_checkpoint_shared(p);
+  }
+
+  const std::string trainer_dir = p.get_checkpoint_dir();
+  p.open_restart(file::join_path(trainer_dir, get_name()));
+  // Assume checkpoint reload from epoch end not step end
+
+  dyad::ifstream_dyad ifs_dyad;
+  ifs_dyad.init(dyad);
+  std::ifstream& ifs = ifs_dyad.get_stream();
+  if (m_comm->am_trainer_master())
+  {
+    ifs_dyad.open(file::join_path(p.get_checkpoint_dir(), "model.bin"));
+    LBANN_ASSERT(ifs.good());
+  }
+
+  // Restore the checkpoint
+  {
+    lbann::RootedBinaryInputArchive ar(ifs, m_comm->get_trainer_grid());
+    ar(*this);
+  }
+
+  m_model_is_setup = false;
+  p.set_restart_dir(trainer_dir);
+#ifdef LBANN_HAS_GPU
+  hydrogen::gpu::SynchronizeDevice();
+#endif // LBANN_HAS_GPU
+  return true;
+}
+#endif // LBANN_HAS_DYAD
+
 bool model::save_to_checkpoint_distributed(persist& p)
 {
   const std::string trainer_dir = p.get_checkpoint_dir();

--- a/src/proto/training_algorithm.proto
+++ b/src/proto/training_algorithm.proto
@@ -115,12 +115,21 @@ message RandomPairwiseExchange {
     message CheckpointFile {
       string checkpoint_dir = 1;
     }
+    message CheckpointFileDyad {
+      string base_dir = 1;
+      string kvs_namespace = 2;
+      uint32 key_depth = 3;
+      uint32 key_bins = 4;
+      bool shared_storage = 5;
+      bool debug = 6;
+    }
 
     repeated string weights_name = 1;
     oneof strategy {
       SendRecvWeights sendrecv_weights = 2;
       CheckpointBinary checkpoint_binary = 3;
       CheckpointFile checkpoint_file = 4;
+      CheckpointFileDyad checkpoint_file_dyad = 5;
     }
   }// message ExchangeStrategy
 }// message RandomPairwiseExchange


### PR DESCRIPTION
- Spack package recipe for DYAD needs to be added to spack as well as the the modification on LBANN's spack recipe
- DYAD hook via `CheckpointFileDyad`
- User options for DYAD passed via `RandomPairwiseExchange::ExchangeStrategy::CheckpointFileDyad` 
   - `base_dir`: DYAD managed directory for producer and consumer
   - `kvs_namespace`: Flux KVS namespace
   - `key_dept`, `key_bins`: DYAD key hashing parameters
   - `shared_storag`: whether the DYAD-managed directory is on shared filesystem or not 
   - `debug`: whether to enable DYAD debug messages printed out to flux log
   
TODO:
  local directory creation on local storage