### PR TITLE
Fix incorrect args in example script in docs

### DIFF
--- a/docs/running_lbann.rst
+++ b/docs/running_lbann.rst
@@ -355,13 +355,12 @@ A simple example
     # ----------------------------------
 
     # Setup trainer
-    trainer = lbann.Trainer()
+    mini_batch_size = 64
+    trainer = lbann.Trainer(mini_batch_size)
 
     # Setup model
-    mini_batch_size = 64
     num_epochs = 5
-    model = lbann.Model(mini_batch_size,
-                        num_epochs,
+    model = lbann.Model(num_epochs,
                         layers=lbann.traverse_layer_graph(input),
                         objective_function=loss,
                         metrics=[lbann.Metric(acc, name='accuracy', unit='%')],

--- a/model_zoo/data_readers/data_reader_mnist.prototext
+++ b/model_zoo/data_readers/data_reader_mnist.prototext
@@ -3,7 +3,7 @@ data_reader {
     name: "mnist"
     role: "train"
     shuffle: true
-    data_filedir: "/p/lscratchh/brainusr/datasets/MNIST"
+    data_filedir: "/p/vast1/lbann/datasets/mnist"
     data_filename: "train-images-idx3-ubyte"
     label_filename: "train-labels-idx1-ubyte"
     validation_percent: 0.1
@@ -19,7 +19,7 @@ data_reader {
     name: "mnist"
     role: "test"
     shuffle: true
-    data_filedir: "/p/lscratchh/brainusr/datasets/MNIST"
+    data_filedir: "/p/vast1/lbann/datasets/mnist"
     data_filename: "t10k-images-idx3-ubyte"
     label_filename: "t10k-labels-idx1-ubyte"
     absolute_sample_count: 0


### PR DESCRIPTION
The simple example script in the [ReadTheDocs](https://lbann.readthedocs.io/en/latest/running_lbann.html#a-simple-example) was broken by one of the trainer refactors. After tweaking some of the Python kwargs and copying MNIST to `pvast`, I can run the script on Lassen.