### PR TITLE
Bug fixes for MIOpen convolution algorithms

### DIFF
--- a/include/lbann/utils/dnn_enums.hpp
+++ b/include/lbann/utils/dnn_enums.hpp
@@ -51,6 +51,7 @@ enum class bwd_data_conv_alg
   FFT_TILING,
   WINOGRAD,
   WINOGRAD_NONFUSED,
+  IMPLICIT_GEMM,
 };// enum class bwd_conv_alg
 
 /** @brief Which backward convolution filter algorithm to use. */
@@ -63,6 +64,7 @@ enum class bwd_filter_conv_alg
   WINOGRAD,
   WINOGRAD_NONFUSED,
   FFT_TILING,
+  IMPLICIT_GEMM,
 };// enum class bwd_conv_filter
 
 /** @brief Internal LBANN names for supported LRN layer modes.  */

--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -124,7 +124,7 @@ inline miopenConvFwdAlgorithm_t to_miopen(fwd_conv_alg a)
 {
   switch (a)
   {
-  case fwd_conv_alg::IMPLICIT_GEMM: return miopenConvolutionFwdAlgoGEMM;
+  case fwd_conv_alg::IMPLICIT_GEMM: return miopenConvolutionFwdAlgoImplicitGEMM;
   case fwd_conv_alg::GEMM: return miopenConvolutionFwdAlgoGEMM;
   case fwd_conv_alg::DIRECT: return miopenConvolutionFwdAlgoDirect;
   case fwd_conv_alg::FFT: return miopenConvolutionFwdAlgoFFT;
@@ -141,6 +141,7 @@ inline fwd_conv_alg from_miopen(miopenConvFwdAlgorithm_t a)
   switch (a)
   {
   case miopenConvolutionFwdAlgoGEMM: return fwd_conv_alg::GEMM;
+  case miopenConvolutionFwdAlgoImplicitGEMM: return fwd_conv_alg::IMPLICIT_GEMM;
   case miopenConvolutionFwdAlgoDirect: return fwd_conv_alg::DIRECT;
   case miopenConvolutionFwdAlgoFFT: return fwd_conv_alg::FFT;
   case miopenConvolutionFwdAlgoWinograd: return fwd_conv_alg::WINOGRAD;
@@ -160,6 +161,7 @@ inline miopenConvBwdDataAlgorithm_t to_miopen(bwd_data_conv_alg a)
   case bwd_data_conv_alg::FFT: return miopenConvolutionBwdDataAlgoFFT;
   case bwd_data_conv_alg::WINOGRAD: return miopenConvolutionBwdDataAlgoWinograd;
   case bwd_data_conv_alg::WINOGRAD_NONFUSED: return miopenConvolutionBwdDataAlgoWinograd;
+  case bwd_data_conv_alg::IMPLICIT_GEMM: return miopenConvolutionBwdDataAlgoImplicitGEMM;
   default:
     LBANN_ERROR("Invalid backward convolution algorithm requested.");
   }
@@ -175,6 +177,7 @@ inline bwd_data_conv_alg from_miopen(miopenConvBwdDataAlgorithm_t a)
   case miopenConvolutionBwdDataAlgoDirect: return bwd_data_conv_alg::CUDNN_ALGO_1;
   case miopenConvolutionBwdDataAlgoFFT: return bwd_data_conv_alg::FFT;
   case miopenConvolutionBwdDataAlgoWinograd: return bwd_data_conv_alg::WINOGRAD;
+  case miopenConvolutionBwdDataAlgoImplicitGEMM: return bwd_data_conv_alg::IMPLICIT_GEMM;
   default:
     LBANN_ERROR("Invalid backward convolution algorithm requested.");
   }
@@ -190,6 +193,7 @@ inline miopenConvBwdWeightsAlgorithm_t to_miopen(bwd_filter_conv_alg a)
   case bwd_filter_conv_alg::CUDNN_ALGO_0: return miopenConvolutionBwdWeightsAlgoGEMM;
   case bwd_filter_conv_alg::CUDNN_ALGO_1: return miopenConvolutionBwdWeightsAlgoDirect;
   case bwd_filter_conv_alg::WINOGRAD: return miopenConvolutionBwdWeightsAlgoWinograd;
+  case bwd_filter_conv_alg::IMPLICIT_GEMM: return miopenConvolutionBwdWeightsAlgoImplicitGEMM;
   default:
     LBANN_ERROR("Invalid backward convolution filter requested.");
   }
@@ -204,6 +208,7 @@ inline bwd_filter_conv_alg from_miopen(miopenConvBwdWeightsAlgorithm_t a)
   case miopenConvolutionBwdWeightsAlgoGEMM: return bwd_filter_conv_alg::CUDNN_ALGO_0;
   case miopenConvolutionBwdWeightsAlgoDirect: return bwd_filter_conv_alg::CUDNN_ALGO_1;
   case miopenConvolutionBwdWeightsAlgoWinograd: return bwd_filter_conv_alg::WINOGRAD;
+  case miopenConvolutionBwdWeightsAlgoImplicitGEMM: return bwd_filter_conv_alg::IMPLICIT_GEMM;
   default:
     LBANN_ERROR("Invalid backward convolution filter requested.");
   }

--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -146,7 +146,9 @@ inline fwd_conv_alg from_miopen(miopenConvFwdAlgorithm_t a)
   case miopenConvolutionFwdAlgoFFT: return fwd_conv_alg::FFT;
   case miopenConvolutionFwdAlgoWinograd: return fwd_conv_alg::WINOGRAD;
   default:
-    LBANN_ERROR("Invalid forward convolution algorithm requested.");
+    std::ostringstream err;
+    err << "miopenConvFwdAlgorithm_t " << a << " is not supported by LBANN.";
+    LBANN_ERROR(err.str());
   }
 }
 
@@ -179,7 +181,9 @@ inline bwd_data_conv_alg from_miopen(miopenConvBwdDataAlgorithm_t a)
   case miopenConvolutionBwdDataAlgoWinograd: return bwd_data_conv_alg::WINOGRAD;
   case miopenConvolutionBwdDataAlgoImplicitGEMM: return bwd_data_conv_alg::IMPLICIT_GEMM;
   default:
-    LBANN_ERROR("Invalid backward convolution algorithm requested.");
+    std::ostringstream err;
+    err << "miopenConvBwdDataAlgorithm_t " << a << " is not supported by LBANN.";
+    LBANN_ERROR(err.str());
   }
 }
 
@@ -210,7 +214,9 @@ inline bwd_filter_conv_alg from_miopen(miopenConvBwdWeightsAlgorithm_t a)
   case miopenConvolutionBwdWeightsAlgoWinograd: return bwd_filter_conv_alg::WINOGRAD;
   case miopenConvolutionBwdWeightsAlgoImplicitGEMM: return bwd_filter_conv_alg::IMPLICIT_GEMM;
   default:
-    LBANN_ERROR("Invalid backward convolution filter requested.");
+    std::ostringstream err;
+    err << "miopenConvBwdWeightsAlgorithm_t " << a << " is not supported by LBANN.";
+    LBANN_ERROR(err.str());
   }
 }
 

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -93,7 +93,7 @@ set_center_specific_modules()
                 MODULE_CMD="module --force unload StdEnv; module load gcc/8.3.1 mvapich2/2.3 python/3.7.2"
                 ;;
             "zen" | "zen2") # Corona
-                MODULE_CMD="module --force unload StdEnv; module load clang/11.0.0 python/3.7.2 opt rocm/4.0.0 openmpi-gnu/4.0"
+                MODULE_CMD="module --force unload StdEnv; module load clang/11.0.0 python/3.7.2 opt rocm/4.1.0 openmpi-gnu/4.0"
                 ;;
             *)
                 echo "No pre-specified modules found for this system. Make sure to setup your own"
@@ -216,8 +216,8 @@ cat <<EOF  >> ${yaml}
     - compiler:
         spec: clang@amd
         paths:
-          cc: /opt/rocm-4.0.0/llvm/bin/clang
-          cxx: /opt/rocm-4.0.0/llvm/bin/clang++
+          cc: /opt/rocm-4.1.0/llvm/bin/clang
+          cxx: /opt/rocm-4.1.0/llvm/bin/clang++
           f77: /usr/bin/gfortran
           fc: /usr/bin/gfortran
         flags: {}
@@ -230,48 +230,48 @@ cat <<EOF  >> ${yaml}
     hip:
       buildable: False
       version:
-      - 4.0.0
+      - 4.1.0
       externals:
-      - spec: hip@4.0.0 arch=${spack_arch}
-        prefix: /opt/rocm-4.0.0/hip
+      - spec: hip@4.1.0 arch=${spack_arch}
+        prefix: /opt/rocm-4.1.0/hip
         extra_attributes:
           compilers:
-            c: /opt/rocm-4.0.0/llvm/bin/clang
-            c++: /opt/rocm-4.0.0/llvm/bin/clang++
-            hip: /opt/rocm-4.0.0/hip/bin/hipcc
+            c: /opt/rocm-4.1.0/llvm/bin/clang
+            c++: /opt/rocm-4.1.0/llvm/bin/clang++
+            hip: /opt/rocm-4.1.0/hip/bin/hipcc
     hipcub:
       buildable: False
       version:
-      - 4.0.0
+      - 4.1.0
       externals:
-      - spec: hipcub@4.0.0 arch=${spack_arch}
-        prefix: /opt/rocm-4.0.0/hipcub
+      - spec: hipcub@4.1.0 arch=${spack_arch}
+        prefix: /opt/rocm-4.1.0/hipcub
         extra_attributes:
           compilers:
-            c: /opt/rocm-4.0.0/llvm/bin/clang
-            c++: /opt/rocm-4.0.0/llvm/bin/clang++
+            c: /opt/rocm-4.1.0/llvm/bin/clang
+            c++: /opt/rocm-4.1.0/llvm/bin/clang++
     hsa-rocr-dev:
       buildable: False
       version:
-      - 4.0.0
+      - 4.1.0
       externals:
-      - spec: hsa-rocr-dev@4.0.0 arch=${spack_arch}
-        prefix: /opt/rocm-4.0.0
+      - spec: hsa-rocr-dev@4.1.0 arch=${spack_arch}
+        prefix: /opt/rocm-4.1.0
         extra_attributes:
           compilers:
-            c: /opt/rocm-4.0.0/llvm/bin/clang
-            c++: /opt/rocm-4.0.0/llvm/bin/clang++
+            c: /opt/rocm-4.1.0/llvm/bin/clang
+            c++: /opt/rocm-4.1.0/llvm/bin/clang++
     llvm-amdgpu:
       buildable: False
       version:
-      - 4.0.0
+      - 4.1.0
       externals:
-      - spec: llvm-amdgpu@4.0.0 arch=${spack_arch}
-        prefix: /opt/rocm-4.0.0/llvm
+      - spec: llvm-amdgpu@4.1.0 arch=${spack_arch}
+        prefix: /opt/rocm-4.1.0/llvm
         extra_attributes:
           compilers:
-            c: /opt/rocm-4.0.0/llvm/bin/clang
-            c++: /opt/rocm-4.0.0/llvm/bin/clang++
+            c: /opt/rocm-4.1.0/llvm/bin/clang
+            c++: /opt/rocm-4.1.0/llvm/bin/clang++
     rdma-core:
       buildable: False
       version:


### PR DESCRIPTION
- Added missing `ImplicitGEMM` convolution algorithms introduced in [MIOpen 2.9.0](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/releasenotes.html#)
- Improved LBANN error messages for converting from MIOpen convolution algorithm types to LBANN convolution algorithm types
- Changed Spack LC zen architecture build to use ROCm@4.1.0
  - This new version fixes warnings and errors sometimes experienced in previous versions caused by several hard-coded paths to `/opt/rocm/`, because LC systems use `/opt/rocm-$VERSION/`