### PR TITLE
Bug fix for K-FAC callback with ROCm

### DIFF
--- a/include/lbann/utils/im2col.hpp
+++ b/include/lbann/utils/im2col.hpp
@@ -66,7 +66,7 @@ void im2col(const El::Matrix<TensorDataType, El::Device::GPU>& im,
             const int * im_pads,
             const int * window_dims,
             const int * window_strides,
-            const cudaStream_t& stream);
+            const El::SyncInfo<El::Device::GPU>& sync_info);
 #endif // LBANN_HAS_GPU
 
 /** Get the height and the width of col matrix.

--- a/src/callbacks/kfac/kfac_block_bn.cu
+++ b/src/callbacks/kfac/kfac_block_bn.cu
@@ -76,6 +76,17 @@ void kfac_bn_util::compute_bn_factor_data2col(
   constexpr size_t block_size = 256;
   const size_t num_threads = batch_size * num_channels * spatial_prod;
   const size_t grid_size = (num_threads + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_compute_bn_factor_data2col_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    activations.LockedBuffer(),
+    errors.LockedBuffer(),
+    scales.LockedBuffer(),
+    biases.LockedBuffer(),
+    cols.Buffer(),
+    batch_size, num_channels, spatial_prod,
+    num_threads);
+/*
   kfac_compute_bn_factor_data2col_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
           activations.LockedBuffer(),
@@ -85,6 +96,7 @@ void kfac_bn_util::compute_bn_factor_data2col(
           cols.Buffer(),
           batch_size, num_channels, spatial_prod,
           num_threads);
+*/
 }
 
 } // namespace callback

--- a/src/callbacks/kfac/kfac_block_fc_conv.cpp
+++ b/src/callbacks/kfac/kfac_block_fc_conv.cpp
@@ -592,7 +592,7 @@ void im2col(const El::Matrix<DataType, El::Device::GPU>& im,
       num_channels, im_num_dims,
       im_dims, im_pads,
       window_dims, window_strides,
-      sync_info.Stream());
+      sync_info);
 }
 #endif // LBANN_HAS_GPU
 

--- a/src/callbacks/kfac/kfac_block_fc_conv.cu
+++ b/src/callbacks/kfac/kfac_block_fc_conv.cu
@@ -69,9 +69,15 @@ void kfac_fc_conv_util::get_diagonal<El::Device::GPU>(
   constexpr size_t block_size = 256;
   const size_t num_threads = height;
   const size_t grid_size = (num_threads + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_get_diagonal_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    diag.Buffer(), A.LockedBuffer(), height);
+  /*
   kfac_get_diagonal_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
           diag.Buffer(), A.LockedBuffer(), height);
+          */
 }
 
 template <>
@@ -84,10 +90,18 @@ void kfac_fc_conv_util::conv_transpose<El::Device::GPU>(
   constexpr size_t block_size = 256;
   const size_t num_elems = mini_batch_size*num_channels*spatial_prod;
   const size_t grid_size = (num_elems + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_conv_transpose_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    activations.LockedBuffer(), act_columns.Buffer(),
+    mini_batch_size, num_channels, spatial_prod,
+    num_elems);
+  /*
   kfac_conv_transpose_kernel<DataType><<<grid_size, block_size, 0, sync_info.Stream()>>>(
       activations.LockedBuffer(), act_columns.Buffer(),
       mini_batch_size, num_channels, spatial_prod,
       num_elems);
+      */
 }
 
 } // namespace callback

--- a/src/callbacks/kfac/kfac_util.cu
+++ b/src/callbacks/kfac/kfac_util.cu
@@ -137,10 +137,17 @@ void add_to_diagonal(
   const size_t height = A.Height();
   constexpr size_t block_size = 256;
   const size_t grid_size = (height + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_add_to_diagonal_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    A.Buffer(), height, damping,
+    damping_bn_err, is_bn);
+  /*
   kfac_add_to_diagonal_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
       A.Buffer(), height, damping,
       damping_bn_err, is_bn);
+      */
 }
 
 template <>
@@ -151,9 +158,15 @@ void fill_upper_tri(
   constexpr size_t block_size = 256;
   // TODO: Launch N^2/2 threads instead of N^2
   const size_t grid_size = (height*height + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_fill_upper_tri_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    A.Buffer(), height);
+  /*
   kfac_fill_upper_tri_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
       A.Buffer(), height);
+      */
 }
 
 template <>
@@ -164,9 +177,15 @@ void update_kronecker_average(
     const El::SyncInfo<El::Device::GPU>& sync_info) {
   constexpr size_t block_size = 256;
   const size_t grid_size = (count + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_update_kronecker_average_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    Aave.Buffer(), A.LockedBuffer(), count, decay);
+  /*
   kfac_update_kronecker_average_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
       Aave.Buffer(), A.LockedBuffer(), count, decay);
+      */
 }
 
 template <>
@@ -177,9 +196,15 @@ void identity(
   constexpr size_t block_size = 256;
   const size_t num_threads = height*height;
   const size_t grid_size = (num_threads + block_size - 1) / block_size;
+  hydrogen::gpu::LaunchKernel(
+    kfac_identity_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    A.Buffer(), height);
+  /*
   kfac_identity_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
           A.Buffer(), height);
+          */
 }
 
 template <>
@@ -192,9 +217,15 @@ void pack_lower_tri(
   const size_t num_threads = height*height;
   const size_t grid_size = (num_threads + block_size - 1) / block_size;
   // TODO: Launch N^2/2 threads instead of N^2
+  hydrogen::gpu::LaunchKernel(
+    kfac_pack_lower_tri_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    L.Buffer(), A.LockedBuffer(), height);
+  /*
   kfac_pack_lower_tri_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
           L.Buffer(), A.LockedBuffer(), height);
+          */
 }
 
 template <>
@@ -207,9 +238,15 @@ void unpack_lower_tri(
   const size_t num_threads = height*height;
   const size_t grid_size = (num_threads + block_size - 1) / block_size;
   // TODO: Launch N^2/2 threads instead of N^2
+  hydrogen::gpu::LaunchKernel(
+    kfac_unpack_lower_tri_kernel<DataType>,
+    grid_size, block_size, 0, sync_info,
+    A.Buffer(), L.LockedBuffer(), height);
+  /*
   kfac_unpack_lower_tri_kernel<DataType>
       <<<grid_size, block_size, 0, sync_info.Stream()>>>(
           A.Buffer(), L.LockedBuffer(), height);
+          */
 }
 
 } // namespace kfac_util

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -46,6 +46,7 @@ endif ()
 if (LBANN_HAS_ROCM)
   # Add the ROCM source files for this directory
   set_full_path(THIS_DIR_CU_SOURCES
+    im2col.cu
     rocm.cpp
     )
 endif ()


### PR DESCRIPTION
This fixes a bug introduced in #1634 that causes ROCm builds to fail.

- Swap out CUDA kernel calls for `hydrogen::gpu::LaunchKernel`
- Use `El::SyncInfo` in place of `cudaStream_t`
- Updated CMakeLists to fix undefined reference with ROCm build