### PR TITLE
Bugfix for user builds

### DIFF
--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -681,12 +681,15 @@ LBANN_SPEC_HASH=$(spack find -cl | grep -v "\-\-\-\-\-\-" | grep lbann${AT_LBANN
 # If the user only wants to configure the environment
 [[ ${CONFIGURE_ONLY:-} ]] && exit_with_instructions
 
-LINK_DIR="${LINK_DIR:-${CORE_BUILD_PATH}}"
-BUILD_DIR=$(dirname ${LINK_DIR})
-if [[ ! -d "${BUILD_DIR}" ]]; then
-    CMD="mkdir -p ${BUILD_DIR}"
-    echo ${CMD}
-    [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+# For developer builds create a user friendly link to the spack build directory
+if [[ -z "${USER_BUILD:-}" ]]; then
+    LINK_DIR="${LINK_DIR:-${CORE_BUILD_PATH}}"
+    BUILD_DIR=$(dirname ${LINK_DIR})
+    if [[ ! -d "${BUILD_DIR}" ]]; then
+        CMD="mkdir -p ${BUILD_DIR}"
+        echo ${CMD}
+        [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+    fi
 fi
 
 # Check to see if the link to the build directory exists and is valid


### PR DESCRIPTION
Added a guard to ensure that the base directory for the link to the
build directory is not created when doing a user install.