### PR TITLE
Bug fixes for ROCm builds

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn.hpp
@@ -113,6 +113,7 @@ constexpr dnnMathType_t DNN_DEFAULT_MATH = CUDNN_DEFAULT_MATH;
 constexpr dnnTensorFormat_t DNN_TENSOR_NCHW = CUDNN_TENSOR_NCHW;
 constexpr dnnRNGType_t DNN_RNG_PSEUDO_XORWOW = 0;
 constexpr dnnLRNMode_t DNN_LRN_CROSS_CHANNEL = CUDNN_LRN_CROSS_CHANNEL_DIM1;
+constexpr dnnMathType_t DNN_TENSOR_OP_MATH_ALLOW_CONVERSION = CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
 
 ////////////////////////////////////////////////////////////
 // Functions for to/from cuDNN types conversion

--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -113,6 +113,7 @@ constexpr dnnMathType_t DNN_DEFAULT_MATH = 0;
 constexpr dnnTensorFormat_t DNN_TENSOR_NCHW = 0;
 constexpr dnnRNGType_t DNN_RNG_PSEUDO_XORWOW = MIOPEN_RNG_PSEUDO_XORWOW;
 constexpr dnnLRNMode_t DNN_LRN_CROSS_CHANNEL = miopenLRNCrossChannel;
+constexpr dnnMathType_t DNN_TENSOR_OP_MATH_ALLOW_CONVERSION = -1; // not supported with ROCm
 
 ////////////////////////////////////////////////////////////
 // Functions for to/from MIOpen types conversion

--- a/include/lbann/utils/gpu/cuda.hpp
+++ b/include/lbann/utils/gpu/cuda.hpp
@@ -96,6 +96,8 @@
 namespace lbann {
 namespace cuda {
 
+constexpr cudaMemcpyKind GPU_MEMCPY_DEVICE_TO_DEVICE = cudaMemcpyDeviceToDevice;
+
 // -------------------------------------------------------------
 // Wrapper classes
 // -------------------------------------------------------------
@@ -221,6 +223,13 @@ void copy_tensor(
   const std::vector<size_t>& input_strides,
   TensorDataType* output,
   const std::vector<size_t>& output_strides);
+
+void mem_copy_async(
+  void* output,
+  const void* input,
+  const size_t count,
+  cudaMemcpyKind kind,
+  cudaStream_t stream);
 
 // -------------------------------------------------------------
 // Utilities for Thrust

--- a/include/lbann/utils/gpu/rocm.hpp
+++ b/include/lbann/utils/gpu/rocm.hpp
@@ -140,6 +140,14 @@ void copy_tensor(
   TensorDataType* output,
   const std::vector<size_t>& output_strides);
 
+template <typename TensorDataType>
+void mem_copy_async(
+  TensorDataType* output,
+  const TensorDataType* input,
+  const std::vecotr<size_t>& dims,
+  hipMemcpyKind kind,
+  hipStream_t stream);
+
 // -------------------------------------------------------------
 // Utilities for Thrust
 // -------------------------------------------------------------

--- a/include/lbann/utils/gpu/rocm.hpp
+++ b/include/lbann/utils/gpu/rocm.hpp
@@ -96,6 +96,8 @@
 namespace lbann {
 namespace rocm {
 
+constexpr hipMemcpyKind GPU_MEMCPY_DEVICE_TO_DEVICE = hipMemcpyDeviceToDevice;
+
 // -------------------------------------------------------------
 // Wrapper classes
 // -------------------------------------------------------------
@@ -140,11 +142,10 @@ void copy_tensor(
   TensorDataType* output,
   const std::vector<size_t>& output_strides);
 
-template <typename TensorDataType>
 void mem_copy_async(
-  TensorDataType* output,
-  const TensorDataType* input,
-  const std::vecotr<size_t>& dims,
+  void* output,
+  const void* input,
+  const size_t count,
   hipMemcpyKind kind,
   hipStream_t stream);
 

--- a/src/callbacks/check_nan.cpp
+++ b/src/callbacks/check_nan.cpp
@@ -156,6 +156,8 @@ struct DumpWeightsFunctor : DefaultErrorReporter
   }
 }; // struct DumpWeightsFunctor
 
+template <typename T> using SingleTypeDataTypeLayer = data_type_layer<T, T>;
+
 /** Dump the local network matrices for debugging.
  *  Dump only the local matrices because not every rank will
  *  necessarily have bad data, and the check is purely local.
@@ -165,7 +167,8 @@ void dump_network(model *m) {
 
   const auto& c = dynamic_cast<sgd_execution_context&>(m->get_execution_context());
   for (auto* l : m->get_layers()) {
-    using LayerTypes = h2::meta::tlist::ExpandTL<data_type_layer, ValidFPTypes>;
+    using LayerTypes = h2::meta::tlist::ExpandTL<SingleTypeDataTypeLayer,
+                                                           ValidFPTypes>;
     using Dispatcher = h2::multimethods::SwitchDispatcher<DumpLayerFunctor,
                                                           void,
                                                           Layer,

--- a/src/execution_algorithms/kfac/kfac_block_gru.cpp
+++ b/src/execution_algorithms/kfac/kfac_block_gru.cpp
@@ -27,6 +27,7 @@
 
 #include "lbann/execution_algorithms/kfac/kfac_block_gru.hpp"
 #include "lbann/execution_algorithms/kfac/kfac_util.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
 
 namespace lbann {
 
@@ -68,7 +69,12 @@ void kfac_block_gru<El::Device::GPU>::on_forward_prop_end() {
   if(m_reserve_space_fwd.size() != reserve_space.size())
     m_reserve_space_fwd.allocate(reserve_space.size());
   const auto& sync_info = this->get_sync_info();
-  gpu_lib::mem
+  gpu_lib::mem_copy_async(
+      m_reserve_space_fwd.data(),
+      reserve_space.data(),
+      reserve_space.size(),
+      gpu_lib::GPU_MEMCPY_DEVICE_TO_DEVICE,
+      sync_info.Stream());
   /*CHECK_CUDA(cudaMemcpyAsync(
       m_reserve_space_fwd.data(),
       reserve_space.data(),

--- a/src/execution_algorithms/kfac/kfac_block_gru.cpp
+++ b/src/execution_algorithms/kfac/kfac_block_gru.cpp
@@ -68,12 +68,14 @@ void kfac_block_gru<El::Device::GPU>::on_forward_prop_end() {
   if(m_reserve_space_fwd.size() != reserve_space.size())
     m_reserve_space_fwd.allocate(reserve_space.size());
   const auto& sync_info = this->get_sync_info();
-  CHECK_CUDA(cudaMemcpyAsync(
+  gpu_lib::mem
+  /*CHECK_CUDA(cudaMemcpyAsync(
       m_reserve_space_fwd.data(),
       reserve_space.data(),
       reserve_space.size(),
       cudaMemcpyDeviceToDevice,
       sync_info.Stream()));
+      */
 }
 #endif // LBANN_HAS_GPU
 
@@ -520,7 +522,7 @@ template <>
 void kfac_block_gru<El::Device::GPU>::check_dnn_lib_spec() const {
 #ifdef LBANN_HAS_DNN_LIB
   const auto math_type = dnn_lib::get_default_convolution_math_type();
-  if(math_type != CUDNN_DEFAULT_MATH) {
+  if(math_type != dnn_lib::DNN_DEFAULT_MATH) {
     std::stringstream ss;
     ss << "The structure of cuDNN's reserve space might not be"
        << " what the GRU K-FAC implementation expects when Tensor Cores are enabled.";

--- a/src/execution_algorithms/kfac/kfac_block_gru.cu
+++ b/src/execution_algorithms/kfac/kfac_block_gru.cu
@@ -178,13 +178,13 @@ void kfac_gru_util::unpack_reserve_space(
     const size_t local_batch_size,
     const El::SyncInfo<El::Device::GPU>& sync_info) {
   const size_t count = hidden_size*seq_length*local_batch_size;
-  const cudnnMathType_t math_type = dnn_lib::get_default_convolution_math_type();
+  const dnn_lib::dnnMathType_t math_type = dnn_lib::get_default_convolution_math_type();
   size_t offset = 0;
-  if(math_type == CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION) {
+  if(math_type == dnn_lib::DNN_TENSOR_OP_MATH_ALLOW_CONVERSION) {
     const size_t align_base = 4;
     offset = ((size_t) ((0.5*hidden_size*seq_length*local_batch_size+align_base-1)/align_base))*align_base;
-  } else if(math_type != CUDNN_DEFAULT_MATH)
-    LBANN_ERROR("Unsupported cuDNN math type.");
+  } else if(math_type != dnn_lib::DNN_DEFAULT_MATH)
+    LBANN_ERROR("Unsupported dnn lib math type.");
 
   constexpr size_t block_size = 256;
   const size_t grid_size = (count + block_size - 1) / block_size;

--- a/src/utils/cuda.cu
+++ b/src/utils/cuda.cu
@@ -459,6 +459,20 @@ void copy_tensor<cpu_fp16>(
 #include "lbann/macros/instantiate.hpp"
 #undef PROTO
 
+void mem_copy_async(
+  void* output,
+  const void* input,
+  const size_t count,
+  cudaMemcpyKind kind,
+  cudaStream_t stream) {
+  CHECK_CUDA(cudaMemcpyAsync(
+    output,
+    input,
+    count,
+    kind,
+    stream));
+}
+
 } // namespace cuda
 } // namespace lbann
 #endif // LBANN_HAS_CUDA

--- a/src/utils/rocm.cpp
+++ b/src/utils/rocm.cpp
@@ -220,6 +220,20 @@ void copy_tensor<cpu_fp16>(
 #include "lbann/macros/instantiate.hpp"
 #undef PROTO
 
+void mem_copy_async(
+  void* output,
+  const void* input,
+  const size_t count,
+  hipMemcpyKind kind,
+  hipStream_t stream) {
+  CHECK_ROCM(hipMemcpyAsync(
+    output,
+    input,
+    count,
+    kind,
+    stream));
+}
+
 } // namespace rocm
 } // namespace lbann
 #endif // LBANN_HAS_ROCM


### PR DESCRIPTION
Fixes 2 bugs for ROCm builds introduced in #1897 and #1739:

- #1897 added CUDA functions and data types outside `#ifdef LBANN_HAS_CUDA` directives
  - Extended the `gpu_lib` namespace to define CUDA and ROCm equivalents, replacing CUDA-specific code with `gpu_lib` namespace functions and data types
  - Added a `mem_copy_async` function, one for ROCm, one for CUDA
- #1739 changed the `data_type_layer` template from unary -> binary, causing a bug when compiling with clang in the H2 `Expand` functions here: https://github.com/LLNL/DiHydrogen/blob/62e52e22184556a028750bb73d8aed92cedb8884/include/h2/meta/typelist/Expand.hpp#L37
  - Added a helper to make the binary template look unary