### PR TITLE
Restore global batch/epoch count for validation

### DIFF
--- a/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
@@ -50,7 +50,9 @@ public:
   sgd_training_algorithm(std::string name,
                          std::unique_ptr<sgd_termination_criteria> stop)
     : BaseType{std::move(name)},
-      m_stopping_criteria{std::move(stop)}
+      m_stopping_criteria{std::move(stop)},
+      m_validation_context{execution_mode::validation, 1UL},
+      m_validation_epochs{1UL}
   {}
 
   sgd_training_algorithm(const sgd_training_algorithm& other);
@@ -140,6 +142,13 @@ protected:
 
 private:
   std::unique_ptr<sgd_termination_criteria> m_stopping_criteria;
+
+  // FIXME (trb 07/20/21): This is a hack. These aren't actually
+  // copyable objects (it wouldn't make sense), so when the training
+  // algorithm is copied, these are reset to defaults. "In the
+  // future", we'll externalize validation and this won't be an issue.
+  sgd_execution_context m_validation_context;
+  size_t m_validation_epochs;
 };
 
 template <>

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -36,13 +36,16 @@
 
 #include <cstddef>
 #include <limits>
+#include <unordered_map>
 
 namespace lbann {
 
 sgd_training_algorithm::sgd_training_algorithm(
   sgd_training_algorithm const& other)
   : BaseType(other.get_name()),
-    m_stopping_criteria{other.m_stopping_criteria->clone()}
+    m_stopping_criteria{other.m_stopping_criteria->clone()},
+    m_validation_context{execution_mode::validation, 1UL},
+    m_validation_epochs{1UL}
 {}
 
 sgd_training_algorithm&
@@ -50,6 +53,8 @@ sgd_training_algorithm::operator=(sgd_training_algorithm const& other)
 {
   BaseType::operator=(other);
   m_stopping_criteria = other.m_stopping_criteria->clone();
+  m_validation_context = sgd_execution_context{execution_mode::validation, 1UL};
+  m_validation_epochs = 1UL;
   return *this;
 }
 
@@ -84,12 +89,12 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
                                    data_coordinator& dc,
                                    sgd_termination_criteria const& term)
 {
-  // Setup a "training-global" validation context:
-  using ValidationContext = sgd_execution_context;
-  static ValidationContext evaluation_context(
-    execution_mode::validation,
+  auto& evaluation_context = m_validation_context;
+  auto& num_validation_epochs = m_validation_epochs;
+  evaluation_context.set_current_mini_batch_size(
     dc.get_mini_batch_size(execution_mode::validation));
-  static size_t num_validation_epochs = 1UL;
+  evaluation_context.set_effective_mini_batch_size(
+    dc.get_mini_batch_size(execution_mode::validation));
 
   // Initialize some state so it knows we're training now.
   c.set_execution_mode(execution_mode::training);

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
+
 #include "lbann/base.hpp"
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/execution_contexts/sgd_execution_context.hpp"
@@ -85,10 +86,10 @@ void sgd_training_algorithm::train(sgd_execution_context& c,
 {
   // Setup a "training-global" validation context:
   using ValidationContext = sgd_execution_context;
-  ValidationContext evaluation_context(
+  static ValidationContext evaluation_context(
     execution_mode::validation,
     dc.get_mini_batch_size(execution_mode::validation));
-  size_t num_validation_epochs = 1UL;
+  static size_t num_validation_epochs = 1UL;
 
   // Initialize some state so it knows we're training now.
   c.set_execution_mode(execution_mode::training);


### PR DESCRIPTION
@samadejacobs Please verify that this restores the functionality that you want.

~Note that the validation count is global *within the `sgd_training_algorithm::train()` call*. Thus, when doing LTFB, for example, it will reset each time local training is called.~

Now, the validation epoch count is global across an LBANN run.