### PR TITLE
Bugfix for ROCm convolution

### DIFF
--- a/include/lbann/utils/dnn_lib/miopen/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/convolution.hpp
@@ -262,11 +262,12 @@ void add_tensor(ScalarParameterType const& alpha_in,
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
   auto beta = El::To<LibScalingParamT>(beta_in);
+  const auto zero = El::TypeTraits<LibScalingParamT>::Zero();
   CHECK_MIOPEN(miopenOpTensor(handle_manager.get(),
                               miopenTensorOpAdd,
-                              &alpha,
+                              &zero,
                               cDesc,
-                              C.Buffer(),
+                              C.LockedBuffer(),
                               &alpha,
                               aDesc,
                               A.LockedBuffer(),

--- a/src/utils/miopen.cpp
+++ b/src/utils/miopen.cpp
@@ -1063,10 +1063,10 @@ namespace {
 // Non-deterministic algorithms.
 std::vector<miopenConvFwdAlgorithm_t> nondet_fwd_algos = {};
 std::vector<miopenConvBwdDataAlgorithm_t> nondet_bwd_data_algos = {
-  miopenConvolutionBwdDataAlgoGEMM
+  //miopenConvolutionBwdDataAlgoGEMM
 };
 std::vector<miopenConvBwdWeightsAlgorithm_t> nondet_bwd_filter_algos = {
-  miopenConvolutionBwdWeightsAlgoGEMM
+  //miopenConvolutionBwdWeightsAlgoGEMM
   //HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_3
 };
 
@@ -1150,7 +1150,16 @@ AlgoType find_best_algorithm(
     }
   }
   if (time_map.empty()) {
-    LBANN_ERROR("No valid convolution algorithms.");
+    if (deterministic) {
+      LBANN_WARNING("No valid deterministic convolution algorithms, "
+                    "trying again with deterministic=false");
+      return find_best_algorithm(perf_results,
+                                 nondeterministic_algos,
+                                 false,
+                                 max_ws_size);
+    } else {
+      LBANN_ERROR("No valid convolution algorithms.");
+    }
   }
   AlgoType best_algo = time_map.begin()->first;
   float min_time = std::numeric_limits<float>::max();


### PR DESCRIPTION
Addresses errors from bamboo unit test `test_unit_layer_convolution.py`

- Empties `nondet_*_algos` vectors as the MIOpen docs do not specify if any convolution algorithms are non-deterministic
- Adds a warning if a deterministic algorithm cannot be found and returns a non-deterministic algorithm
  - This is not totally necessary because we now assume all algorithms are deterministic, but is good to have if the MIOpen docs are updated with that information
- Corrects a wrong implementation of `miopen::add_tensor`