### PR TITLE
Adding implementation for callback to perturb weights.

### DIFF
--- a/include/lbann/callbacks/CMakeLists.txt
+++ b/include/lbann/callbacks/CMakeLists.txt
@@ -29,6 +29,7 @@ set_full_path(THIS_DIR_HEADERS
   perturb_adam.hpp
   perturb_dropout.hpp
   perturb_learning_rate.hpp
+  perturb_weights.hpp
   print_model_description.hpp
   print_statistics.hpp
   profiler.hpp

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHT_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHT_HPP_INCLUDED
+
+#include "lbann/callbacks/callback.hpp"
+#include "lbann/weights/weights.hpp"
+
+
+namespace lbann {
+namespace callback {
+
+/** @brief Perturb weights for a specific layer in model.
+ *
+ *  
+ */
+class perturb_weights : public callback_base {
+public:
+
+  /** 
+   *  @param batch_interval Number of training mini-batch steps 
+   *  @param output_name   Name of weight layer
+   */
+  perturb_weights(std::string output_name,
+               El::Int batch_interval = 1);
+
+  perturb_weights* copy() const override { return new perturb_weights(*this); }
+  std::string name() const override { return "perturb weights"; }
+
+  void setup(model* m) override;
+  void on_batch_begin(model* m) override;
+
+  /** @name Serialization */
+  ///@{
+
+  /** @brief Store state to archive for checkpoint and restart */
+  template <class Archive> void serialize(Archive & ar);
+
+  ///@}
+
+private:
+
+  friend class cereal::access;
+  perturb_weights();
+
+   /*
+   *  output_name.
+   */
+  std::string m_output_name;
+  
+  weights* m_output;
+  
+  /** Compute model size. */
+  void perturbed(model& m);
+  
+};
+
+// Builder function
+std::unique_ptr<callback_base>
+build_perturb_weight_callback_from_pbuf(
+  const google::protobuf::Message&, std::shared_ptr<lbann_summary> const&);
+
+} // namespace callback
+} // namespace lbann
+
+#endif // LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHTS_HPP_INCLUDED

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -81,7 +81,7 @@ private:
 
 // Builder function
 std::unique_ptr<callback_base>
-build_perturb_weight_callback_from_pbuf(
+build_perturb_weights_callback_from_pbuf(
   const google::protobuf::Message&, std::shared_ptr<lbann_summary> const&);
 
 } // namespace callback

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -74,8 +74,8 @@ private:
   
   weights* m_output;
   
-  /** Compute model size. */
-  void perturbed(model& m);
+  void perturb(model& m);
+
   
 };
 

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -24,8 +24,8 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#ifndef LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHT_HPP_INCLUDED
-#define LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHT_HPP_INCLUDED
+#ifndef LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHTS_HPP_INCLUDED
+#define LBANN_CALLBACKS_CALLBACK_PERTURB_WEIGHTS_HPP_INCLUDED
 
 #include "lbann/callbacks/callback.hpp"
 #include "lbann/weights/weights.hpp"

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -71,9 +71,7 @@ private:
    *  output_name.
    */
   std::string m_output_name;
-  
-  weights* m_output;
-  
+   
   void perturb(model& m);
 
   

--- a/src/callbacks/CMakeLists.txt
+++ b/src/callbacks/CMakeLists.txt
@@ -30,6 +30,7 @@ set_full_path(THIS_DIR_SOURCES
   perturb_adam.cpp
   perturb_dropout.cpp
   perturb_learning_rate.cpp
+  perturb_weights.cpp
   print_model_description.cpp
   print_statistics.cpp
   profiler.cpp

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -84,7 +84,8 @@ void perturb_weights::perturbed(model& m){
    // Useful constants
   constexpr DataType zero = 0;
   constexpr DataType one = 1;
-
+  const auto range = 3;
+  
   // RNG
   auto& gen = get_generator();
   std::normal_distribution<DataType> dist(zero, one);
@@ -109,22 +110,23 @@ void perturb_weights::perturbed(model& m){
 	// Perturb weights on master process
 	if (comm->am_trainer_master()) {
 		// perturb
-		auto val = temp.Get(0,0);
-		auto perturbed_val = val;
+		for (auto i = 0; i < range; i++){
+			auto val = temp.Get(i,0);
+			auto perturbed_val = val;
 		
-		if (dist(gen) > 0.5){
-			perturbed_val = val * 1.2;
-		}
-		else {
-			perturbed_val = val * 0.8;
-		}
+			if (dist(gen) > 0.5){
+				perturbed_val = val * 1.2;
+			}
+			else {
+				perturbed_val = val * 0.8;
+			}
 
-		temp.Set(0,0,perturbed_val);
-		El::Copy(temp, local_values); 
+			temp.Set(i,0,perturbed_val);
+			El::Copy(temp, local_values); 
  
-		std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
-		std::cout << " Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
-
+			std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
+			std::cout << " Weight "  << i << ": " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
+		}
 	}
 
 	// Communicate new weight from trainer master processes

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -117,14 +117,8 @@ void perturb_weights::perturbed(model& m){
 			auto val = temp.Get(i,0);
 			auto perturbed_val = val;
 			
-			if(val >= lower && val <= upper){	
-				if (dist(gen) > thres){
-					perturbed_val = val * 1.1;
-				}
-				else {
-					perturbed_val = val * 0.9;
-				}
-			}
+			perturbed_val += dist(gen); // dist is a std::normal_distribution
+			perturbed_val = std::min(std::max(perturbed_val, lower), upper);
 			
 			temp.Set(i,0,perturbed_val);
 				

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -129,11 +129,10 @@ void perturb_weights::perturbed(model& m){
 			//auto& new_values_2 = dynamic_cast<El::AbstractDistMatrix<DataType>&>(local_values);
 		
 			// Communicate new weight from trainer master processes
-        		comm->trainer_broadcast(comm->get_trainer_master(), new_values); // local_values);
+        		comm->trainer_broadcast(comm->get_trainer_master(), new_values);
 		
 			// Update weight
-			auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);
-			//out_w.set_value(local_values);		
+			auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);	
 			out_w.set_values(new_values);		
 
 			break;

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -123,7 +123,7 @@ void perturb_weights::perturbed(model& m){
 		El::Copy(temp, local_values); 
  
 		std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
-		std::cout << "Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
+		std::cout << " Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
 
 	}
 

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -73,11 +73,11 @@ void perturb_weights::on_batch_begin(model* m) {
   if (m_output != nullptr && 
       c.get_step() % m_batch_interval == 0 &&
       c.get_step() >= 0) {
-    perturbed(*m);
+    perturb(*m);
   }
 }
 
-void perturb_weights::perturbed(model& m){
+void perturb_weights::perturb(model& m){
 
   auto* comm = m.get_comm();
 

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/comm_impl.hpp"
+#include "lbann/callbacks/perturb_weights.hpp"
+#include "lbann/proto/proto_common.hpp"
+#include "lbann/utils/serialize.hpp"
+#include "lbann/weights/data_type_weights.hpp"
+
+#include <callbacks.pb.h>
+
+
+namespace lbann {
+namespace callback {
+
+perturb_weights::perturb_weights(std::string output_name,
+                           El::Int batch_interval)
+  : callback_base(batch_interval),
+    m_output_name(std::move(output_name)) {
+    m_output = nullptr;
+}
+
+perturb_weights::perturb_weights()
+  : perturb_weights("",0)
+{}
+
+template <class Archive>
+void perturb_weights::serialize(Archive & ar) {
+  ar(::cereal::make_nvp(
+       "BaseCallback",
+       ::cereal::base_class<callback_base>(this)),
+     CEREAL_NVP(m_output_name));
+}
+
+void perturb_weights::setup(model* m) {
+   for (auto* w : m->get_weights()) {
+      if(w->get_name() == m_output_name){
+        m_output = w;
+        break;
+      }
+   }
+    if (m_output == nullptr) {
+      LBANN_ERROR("Current implementation of callback \"", name(), "\" "
+                  "requires a weight object to perturb");
+    }
+}
+
+void perturb_weights::on_batch_begin(model* m) {
+  const auto& c = m->get_execution_context();
+  if (m_output != nullptr && 
+      c.get_step() % m_batch_interval == 0 &&
+      c.get_step() >= 0) {
+    perturbed(*m);
+  }
+}
+
+void perturb_weights::perturbed(model& m){
+	
+  auto* comm = m.get_comm();
+ 
+  // Useful constants
+  constexpr DataType zero = 0;
+  constexpr DataType one = 1;
+
+  // RNG
+  auto& gen = get_generator();
+  std::normal_distribution<DataType> dist(zero, one);
+  
+  //size_t perturbed_weight = 0; //size_t  
+  
+  for (auto* w : m.get_weights()) {
+    if (w == nullptr) {
+      LBANN_ERROR("callback \"", name(), "\" "
+                  "got a weights pointer that is a null pointer");
+    }
+	
+	
+	if (comm->am_trainer_master()) {	
+		if(w->get_name() == m_output_name) {
+			auto& values = w->get_values();
+			//auto& new_values = dynamic_cast<El::AbstractDistMatrix<float>&>(values);
+			auto& new_values = dynamic_cast<El::AbstractDistMatrix<DataType>&>(values);
+
+			auto& local_values = new_values.Matrix();//values.Matrix();
+			El::Matrix<float,El::Device::CPU> temp;
+			El::Copy(local_values, temp);
+	
+			// perturb
+			auto val = temp.Get(0,0);
+			auto perturbed_val = val;
+			
+			if (dist(gen) > 0.5){
+				perturbed_val = val * 1.2;
+			}
+			else {
+				perturbed_val = val * 0.8;
+			}
+
+			temp.Set(0,0,perturbed_val);
+			
+			El::Copy(temp, local_values); 
+	  
+	                std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
+		        std::cout << "Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
+		
+			//
+			auto& new_values_2 = dynamic_cast<El::AbstractDistMatrix<DataType>&>(local_values);
+		
+			// Communicate new weight from trainer master processes
+        		comm->trainer_broadcast(comm->get_trainer_master(), new_values_2); // local_values);
+		
+			// Update weight
+			auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);
+			//out_w.set_value(local_values);		
+			out_w.set_values(new_values_2);		
+
+			break;
+		}
+	}
+  } 
+}
+
+
+std::unique_ptr<callback_base>
+build_perturb_weights_callback_from_pbuf(
+  const google::protobuf::Message& proto_msg, const std::shared_ptr<lbann_summary>&) {
+  const auto& params =
+    dynamic_cast<const lbann_data::Callback::CallbackPerturbWeights&>(proto_msg);
+  return make_unique<perturb_weights>(
+    params.output_name(),
+    params.batch_interval());
+}
+
+} // namespace callback
+} // namespace lbann
+
+#define LBANN_CLASS_NAME callback::perturb_weights
+#include <lbann/macros/register_class_with_cereal.hpp>

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -95,7 +95,8 @@ void perturb_weights::perturbed(model& m){
     	LBANN_ERROR("callback \"", name(), "\" "
                   "got a weights pointer that is a null pointer");
     }
-	
+
+    // Check layer name
     if(w->get_name() == m_output_name) {
 	auto& values = w->get_values();
 	auto& new_values = dynamic_cast<El::AbstractDistMatrix<float>&>(values);
@@ -105,6 +106,7 @@ void perturb_weights::perturbed(model& m){
 	El::Matrix<float,El::Device::CPU> temp;
 	El::Copy(local_values, temp);
 
+	// Perturb weights on master process
 	if (comm->am_trainer_master()) {
 		// perturb
 		auto val = temp.Get(0,0);

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -128,14 +128,14 @@ void perturb_weights::perturbed(model& m){
 	}
 
 	// Communicate new weight from trainer master processes
-	comm->trainer_broadcast(comm->get_trainer_master(), new_values);  
-	std::cout << "Broadcasted" << std::endl;
+	//comm->trainer_broadcast(comm->get_trainer_master(), new_values);  
+	El::Broadcast(new_values, comm->get_trainer_comm(), 0);
+	//std::cout << "Broadcasted" << std::endl;
 		
 	// Update weight
-	auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);
-	//out_w.set_value(local_values);		
+	auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);	
 	out_w.set_values(new_values);		
-	std::cout << "Updated" << std::endl;
+	//std::cout << "Updated" << std::endl;
 
 	break;
 

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -89,8 +89,7 @@ void perturb_weights::perturbed(model& m){
   auto& gen = get_generator();
   std::normal_distribution<DataType> dist(zero, one);
   
-  //size_t perturbed_weight = 0; //size_t  
-  
+   
   for (auto* w : m.get_weights()) {
     if (w == nullptr) {
       LBANN_ERROR("callback \"", name(), "\" "
@@ -126,7 +125,7 @@ void perturb_weights::perturbed(model& m){
 	                std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
 		        std::cout << "Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
 		
-			//
+			// cast local value back
 			auto& new_values_2 = dynamic_cast<El::AbstractDistMatrix<DataType>&>(local_values);
 		
 			// Communicate new weight from trainer master processes

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -126,15 +126,15 @@ void perturb_weights::perturbed(model& m){
 		        std::cout << "Weight " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
 		
 			// cast local value back
-			auto& new_values_2 = dynamic_cast<El::AbstractDistMatrix<DataType>&>(local_values);
+			//auto& new_values_2 = dynamic_cast<El::AbstractDistMatrix<DataType>&>(local_values);
 		
 			// Communicate new weight from trainer master processes
-        		comm->trainer_broadcast(comm->get_trainer_master(), new_values_2); // local_values);
+        		comm->trainer_broadcast(comm->get_trainer_master(), new_values); // local_values);
 		
 			// Update weight
 			auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*m_output);
 			//out_w.set_value(local_values);		
-			out_w.set_values(new_values_2);		
+			out_w.set_values(new_values);		
 
 			break;
 		}

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -111,7 +111,8 @@ void perturb_weights::perturbed(model& m){
 
 	// Perturb weights on master process		
 	if (comm->am_trainer_master()) {
-		for (auto i = 0; i < range; i++){		
+		for (auto i = 0; i < temp.Height(); i++){		
+
 			
 			// perturb				
 			auto val = temp.Get(i,0);

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -81,11 +81,8 @@ message Callback {
     CallbackDumpModelGraph dump_model_graph = 49;
     CallbackPerturbLearningRate perturb_learning_rate = 50;
     CallbackComputeModelSize compute_model_size = 51;
-<<<<<<< HEAD
     CallbackKFAC kfac = 52;
     CallbackPerturbWeights perturb_weights = 53;
-=======
->>>>>>> cedf56dfc7ca6379440fafb0c282953fd1d4e543
   }
 
   message CallbackLTFB {
@@ -413,7 +410,6 @@ message Callback {
     int64 batch_interval = 2;
   }
 
-<<<<<<< HEAD
   message CallbackKFAC {
     // Space-separated pairs of the initial and the target damping value.
     // If only one value is specified, it will be used throughout training.
@@ -453,7 +449,4 @@ message Callback {
     string output_name = 1;
     int64 batch_interval = 2;
   }
-
-=======
->>>>>>> cedf56dfc7ca6379440fafb0c282953fd1d4e543
 }

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -81,8 +81,7 @@ message Callback {
     CallbackDumpModelGraph dump_model_graph = 49;
     CallbackPerturbLearningRate perturb_learning_rate = 50;
     CallbackComputeModelSize compute_model_size = 51;
-    CallbackKFAC kfac = 52;
-    CallbackPerturbWeights perturb_weights = 53;
+    CallbackPerturbWeights perturb_weights = 52;
   }
 
   message CallbackLTFB {
@@ -409,41 +408,6 @@ message Callback {
     string output_name = 1;
     int64 batch_interval = 2;
   }
-
-  message CallbackKFAC {
-    // Space-separated pairs of the initial and the target damping value.
-    // If only one value is specified, it will be used throughout training.
-    // default: "callback::kfac::damping_0_default"
-    string damping_act = 1;
-    string damping_err = 2;
-    string damping_bn_act = 3;
-    string damping_bn_err = 4;
-
-    uint64 damping_warmup_steps = 5; // default: damping_warmup_steps_default
-    double kronecker_decay = 6; // default: callback::kfac::kronecker_decay_default
-
-    bool print_time = 7; // default: false
-    bool print_matrix = 8; // default: false
-    bool print_matrix_summary = 9; // default: false
-
-    bool use_pi = 10; // default: false
-
-    // Space-separated pairs of the initial and the target update intervals.
-    // If only one value is specified, it will be used throughout training.
-    string update_intervals = 11; // default: "1"
-    uint64 update_interval_steps = 12; // default: 0
-
-    string inverse_strategy = 13; // Options: all, each, root (default: all)
-
-    string disable_layers = 14; // List of layers to be ignored by the callback
-
-    // Factor to be multiplied to the learning rate (default: 1)
-    float learning_rate_factor = 15;
-    // Factor to be multiplied to the learning rate for GRU layers
-    // (default: learning_rate_factor)
-    float learning_rate_factor_gru = 16;
-  }
-
 
   message CallbackPerturbWeights {
     string output_name = 1;

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -81,6 +81,11 @@ message Callback {
     CallbackDumpModelGraph dump_model_graph = 49;
     CallbackPerturbLearningRate perturb_learning_rate = 50;
     CallbackComputeModelSize compute_model_size = 51;
+<<<<<<< HEAD
+    CallbackKFAC kfac = 52;
+    CallbackPerturbWeights perturb_weights = 53;
+=======
+>>>>>>> cedf56dfc7ca6379440fafb0c282953fd1d4e543
   }
 
   message CallbackLTFB {
@@ -408,4 +413,47 @@ message Callback {
     int64 batch_interval = 2;
   }
 
+<<<<<<< HEAD
+  message CallbackKFAC {
+    // Space-separated pairs of the initial and the target damping value.
+    // If only one value is specified, it will be used throughout training.
+    // default: "callback::kfac::damping_0_default"
+    string damping_act = 1;
+    string damping_err = 2;
+    string damping_bn_act = 3;
+    string damping_bn_err = 4;
+
+    uint64 damping_warmup_steps = 5; // default: damping_warmup_steps_default
+    double kronecker_decay = 6; // default: callback::kfac::kronecker_decay_default
+
+    bool print_time = 7; // default: false
+    bool print_matrix = 8; // default: false
+    bool print_matrix_summary = 9; // default: false
+
+    bool use_pi = 10; // default: false
+
+    // Space-separated pairs of the initial and the target update intervals.
+    // If only one value is specified, it will be used throughout training.
+    string update_intervals = 11; // default: "1"
+    uint64 update_interval_steps = 12; // default: 0
+
+    string inverse_strategy = 13; // Options: all, each, root (default: all)
+
+    string disable_layers = 14; // List of layers to be ignored by the callback
+
+    // Factor to be multiplied to the learning rate (default: 1)
+    float learning_rate_factor = 15;
+    // Factor to be multiplied to the learning rate for GRU layers
+    // (default: learning_rate_factor)
+    float learning_rate_factor_gru = 16;
+  }
+
+
+  message CallbackPerturbWeights {
+    string output_name = 1;
+    int64 batch_interval = 2;
+  }
+
+=======
+>>>>>>> cedf56dfc7ca6379440fafb0c282953fd1d4e543
 }

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -54,6 +54,7 @@
 #include "lbann/callbacks/perturb_adam.hpp"
 #include "lbann/callbacks/perturb_dropout.hpp"
 #include "lbann/callbacks/perturb_learning_rate.hpp"
+#include "lbann/callbacks/perturb_weights.hpp"
 #include "lbann/callbacks/print_model_description.hpp"
 #include "lbann/callbacks/print_statistics.hpp"
 #include "lbann/callbacks/profiler.hpp"
@@ -165,6 +166,8 @@ void register_default_builders(factory_type& factory)
                            build_perturb_dropout_callback_from_pbuf);
   factory.register_builder("CallbackPerturbLearningRate",
                            build_perturb_learning_rate_callback_from_pbuf);
+    factory.register_builder("CallbackPerturbWeights",
+                           build_perturb_weights_callback_from_pbuf);
   factory.register_builder("CallbackPolyLearningRate",
                            build_poly_learning_rate_callback_from_pbuf);
   factory.register_builder("CallbackPrintModelDescription",


### PR DESCRIPTION
Adding perturb_weights callback.

Note: There is the assumption that weight layer is used for crop operation, i.e. its dimension is 3.
Perturbation values are range from 0.3 to 0.7 .