### PR TITLE
Run Catch2 tests and save Spack artifacts in Bamboo

### DIFF
--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -6,23 +6,29 @@ import os, re, subprocess
 
 
 def test_compiler_build_script(cluster, dirname):
-    output_file_name = '%s/bamboo/compiler_tests/output/build_script_output.txt' % (dirname)
-    error_file_name = '%s/bamboo/compiler_tests/error/build_script_error.txt' % (dirname)
+    bamboo_base_dir = '%s/bamboo/compiler_tests' % (dirname)
+    output_file_name = '%s/output/build_script_output.txt' % (bamboo_base_dir)
+    error_file_name = '%s/error/build_script_error.txt' % (bamboo_base_dir)
+
     # Get environment variables
     BAMBOO_AGENT = os.getenv('bamboo_agentId')
+
+    common_cmd = '%s/scripts/build_lbann.sh -d -l bamboo-%s --test --clean-build -j $(($(nproc)+2)) -- +deterministic +vision +numpy' % (dirname, BAMBOO_AGENT)
     if cluster in ['lassen', 'pascal', 'ray']:
-        command = '%s/scripts/build_lbann.sh -d -l bamboo-%s --test --clean-build -j $(($(nproc)+2)) -- +cuda +deterministic +half +fft +vision +numpy > %s 2> %s' % (
-            dirname, BAMBOO_AGENT, output_file_name, error_file_name)
+        command = '%s +cuda +half +fft ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     elif cluster in ['corona']:
-        command = '%s/scripts/build_lbann.sh -d -l bamboo-%s --test --clean-build -j $(($(nproc)+2)) -- +rocm +deterministic +vision +numpy > %s 2> %s' % (
-            dirname, BAMBOO_AGENT, output_file_name, error_file_name)
+        command = '%s +rocm ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     elif cluster in ['catalyst']:
-        command = '%s/scripts/build_lbann.sh -d -l bamboo-%s --test --clean-build -j $(($(nproc)+2)) -- +onednn +deterministic +half +fft +vision +numpy > %s 2> %s' % (
-            dirname, BAMBOO_AGENT, output_file_name, error_file_name)
+        command = '%s +onednn +half +fft ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     else:
         e = 'test_compiler_build_script: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)
         pytest.skip(e)
 
     return_code = os.system(command)
+
+    gather_artifacts_cmd = 'cp %s/spack-*.txt %s/output' % (dirname, bamboo_base_dir)
+    os.system(gather_artifacts_cmd)
+
     tools.assert_success(return_code, error_file_name)
+

--- a/bamboo/compiler_tests/test_compiler.py
+++ b/bamboo/compiler_tests/test_compiler.py
@@ -2,8 +2,7 @@ import sys
 sys.path.insert(0, '../common_python')
 import tools
 import pytest
-import os, re, subprocess
-
+import os, re
 
 def test_compiler_build_script(cluster, dirname):
     bamboo_base_dir = '%s/bamboo/compiler_tests' % (dirname)
@@ -15,11 +14,11 @@ def test_compiler_build_script(cluster, dirname):
 
     common_cmd = '%s/scripts/build_lbann.sh -d -l bamboo-%s --test --clean-build -j $(($(nproc)+2)) -- +deterministic +vision +numpy' % (dirname, BAMBOO_AGENT)
     if cluster in ['lassen', 'pascal', 'ray']:
-        command = '%s +cuda +half +fft ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
+        command = '%s +cuda +half +fft > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     elif cluster in ['corona']:
-        command = '%s +rocm ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
+        command = '%s +rocm > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     elif cluster in ['catalyst']:
-        command = '%s +onednn +half +fft ^hydrogen@develop > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
+        command = '%s +onednn +half +fft > %s 2> %s' % (common_cmd, output_file_name, error_file_name)
     else:
         e = 'test_compiler_build_script: Unsupported Cluster %s' % cluster
         print('Skip - ' + e)

--- a/bamboo/unit_tests/test_catch2_unit_tests.py
+++ b/bamboo/unit_tests/test_catch2_unit_tests.py
@@ -1,0 +1,56 @@
+import sys
+sys.path.insert(0, '../common_python')
+import tools
+import pytest
+import os, re
+import subprocess as sp
+
+def hack_find_spack_build_dir(basedir):
+    with os.scandir(basedir) as it:
+        for entry in it:
+            if entry.is_dir() and re.match(r'spack-.*', entry.name):
+                return entry.path
+
+def get_system_seq_launch(cluster):
+    if cluster in ['lassen', 'ray']:
+        return ['lrun', '-1']
+    return []
+
+def get_system_mpi_launch(cluster):
+    if cluster in ['lassen', 'ray']:
+        return ['jsrun', '-n2', '-r1', '-a4', '-c40', '-g4', '-d', 'packed', '-b', 'packed:10']
+    elif cluster == 'pascal':
+        return ['srun', '-N2', '--ntasks-per-node=2', '--mpibind=off']
+    else: # Corona and Catalyst
+        return ['srun', '-N2', '--ntasks-per-node=4']
+
+def test_run_sequential_catch_tests(cluster, dirname):
+    output_dir = os.path.join(dirname, 'bamboo', 'unit_tests')
+    build_dir = hack_find_spack_build_dir(dirname)
+    seq_catch_exe = os.path.join(build_dir, 'unit_test', 'seq-catch-tests')
+    if not os.path.exists(seq_catch_exe):
+        print('Skip - executable not found')
+        pytest.skip('executable not found')
+    # Run the sequential tests
+    seq_launch = get_system_seq_launch(cluster)
+    seq_output_file_name = 'seq_catch_tests_output-%s.xml' % (cluster)
+    seq_output_file = os.path.join(output_dir, seq_output_file_name)
+    seq_catch_args = [seq_catch_exe, '-r', 'junit', '-o', seq_output_file]
+    output = sp.run(seq_launch + seq_catch_args)
+    tools.assert_success(output.returncode, seq_output_file)
+
+def test_run_parallel_catch_tests(cluster, dirname):
+    output_dir = os.path.join(dirname, 'bamboo', 'unit_tests')
+    build_dir = hack_find_spack_build_dir(dirname)
+    mpi_catch_exe = os.path.join(build_dir, 'unit_test', 'mpi-catch-tests')
+    if not os.path.exists(mpi_catch_exe):
+        print('Skip - executable not found')
+        pytest.skip('executable not found')
+    # Run the parallel tests
+    mpi_launch = get_system_mpi_launch(cluster)
+    mpi_output_file_name = 'mpi_catch_tests_output-%s-rank=%%r-size=%%s.xml' % (cluster)
+    mpi_output_file = os.path.join(output_dir, mpi_output_file_name)
+    mpi_catch_args = [mpi_catch_exe, '-r', 'junit', '-o', mpi_output_file]
+    output = sp.run(mpi_launch + mpi_catch_args)
+    tools.assert_success(output.returncode, mpi_output_file)
+    

--- a/bamboo/unit_tests/test_catch2_unit_tests.py
+++ b/bamboo/unit_tests/test_catch2_unit_tests.py
@@ -14,7 +14,7 @@ def hack_find_spack_build_dir(basedir):
 def get_system_seq_launch(cluster):
     if cluster in ['lassen', 'ray']:
         return ['lrun', '-1']
-    return []
+    return ['srun', '-N1', '-n1', '--mpibind=off']
 
 def get_system_mpi_launch(cluster):
     if cluster in ['lassen', 'ray']:


### PR DESCRIPTION
The updates to the Bamboo infrastructure impacted the utility of the web interface by not exporting significant log files to places they'd be picked up as artifacts. This addresses that issue.

Additionally, because of how Spack looks for unit tests (namely, via "make test" (or equivalent)), the Catch2 tests are not run by Bamboo anymore. This resumes running them via a more manual process (i.e., an additional test case).