### PR TITLE
Skip the DFT test on Corona

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -699,6 +699,13 @@ def create_tests(setup_func,
                                                'experiments',
                                                test_name)
 
+        if 'skip_clusters' in _kwargs:
+            if cluster in _kwargs['skip_clusters']:
+                e = "test \"%s\" not supported on cluster \"%s\"" % (test_name, cluster)
+                print('Skip - ' + e)
+                pytest.skip(e)
+            _kwargs.remove("skip_clusters")
+
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:
             _kwargs['work_dir'] = os.path.join(_kwargs['work_dir'], _kwargs['work_subdir'])

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -704,7 +704,7 @@ def create_tests(setup_func,
                 e = "test \"%s\" not supported on cluster \"%s\"" % (test_name, cluster)
                 print('Skip - ' + e)
                 pytest.skip(e)
-            _kwargs.remove("skip_clusters")
+            del _kwargs["skip_clusters"]
 
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:

--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -631,6 +631,7 @@ def assert_failure(return_code, expected_error, error_file_name):
 def create_tests(setup_func,
                  test_file,
                  test_name_base=None,
+                 skip_clusters=[],
                  **kwargs):
     """Create functions that can interact with PyTest
 
@@ -684,6 +685,10 @@ def create_tests(setup_func,
 
         """
         test_name = '{}'.format(test_name_base)
+        if cluster in skip_clusters:
+            e = "test \"%s\" not supported on cluster \"%s\"" % (test_name, cluster)
+            print('Skip - ' + e)
+            pytest.skip(e)
 
         # Load LBANN Python frontend
         import lbann
@@ -698,13 +703,6 @@ def create_tests(setup_func,
             _kwargs['work_dir'] = os.path.join(os.path.dirname(test_file),
                                                'experiments',
                                                test_name)
-
-        if 'skip_clusters' in _kwargs:
-            if cluster in _kwargs['skip_clusters']:
-                e = "test \"%s\" not supported on cluster \"%s\"" % (test_name, cluster)
-                print('Skip - ' + e)
-                pytest.skip(e)
-            del _kwargs["skip_clusters"]
 
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:

--- a/bamboo/unit_tests/test_unit_layer_dft_abs.py
+++ b/bamboo/unit_tests/test_unit_layer_dft_abs.py
@@ -173,5 +173,5 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for _test_func in tools.create_tests(setup_experiment, __file__):
+for _test_func in tools.create_tests(setup_experiment, __file__, skip_clusters=["corona"]):
     globals()[_test_func.__name__] = _test_func


### PR DESCRIPTION
Since we don't have rocFFT support in LBANN, we need to skip this test on Corona. For now, this is accomplished at the cluster level (since we don't really check for enabled features in Python), which is not the most graceful approach. But hey, it works.