### PR TITLE
Fix launch issue on Lassen

### DIFF
--- a/bamboo/unit_tests/test_catch2_unit_tests.py
+++ b/bamboo/unit_tests/test_catch2_unit_tests.py
@@ -13,7 +13,7 @@ def hack_find_spack_build_dir(basedir):
 
 def get_system_seq_launch(cluster):
     if cluster in ['lassen', 'ray']:
-        return ['lrun', '-1']
+        return ['lrun', '-1', '--smpiargs=\"-disable_gpu_hooks\"']
     return ['srun', '-N1', '-n1', '--mpibind=off']
 
 def get_system_mpi_launch(cluster):


### PR DESCRIPTION
The bamboo tests were showing a failure for the sequential Catch test drivers, but none of the tests themselves were failing. The issue has to do with how jsrun handles MPI-less executables. See olcf/olcf-user-docs#78 for more info. Anyway, this was causing a return code of "139" instead of "0", so the test was marked as failing.