### PR TITLE
Make layer copy/move constructors protected in the base classes

### DIFF
--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -101,8 +101,6 @@ public:
     : Layer(),
       m_persistent_error_signals{persistent_error_signals}
   {}
-  data_type_layer(const data_type_layer<InputTensorDataType, OutputTensorDataType>& other);
-  data_type_layer& operator=(const data_type_layer<InputTensorDataType, OutputTensorDataType>& other);
   virtual ~data_type_layer() = default;
 
   /** Get a string representing the layer datatype
@@ -182,6 +180,15 @@ public:
   ///@}
 
 protected:
+
+  /** @brief Protected lifecycle functions */
+  ///@{
+  data_type_layer(data_type_layer&& other) = default;
+  data_type_layer(data_type_layer const& other);
+
+  data_type_layer& operator=(data_type_layer&& other) = default;
+  data_type_layer& operator=(data_type_layer const& other);
+  ///@}
 
   // ===========================================================
   // Protected Tensor access functions

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -154,11 +154,11 @@ struct ParallelStrategy {
   int filter_splits = 0;
   /** Number of times the layer is replicated (for FC layers right now). */
   int replications = 0;
-      /** Enable subgraph for the layer. */ 
-  bool enable_subgraph = false;  
-  /** Branch number in the sub graph. */  
-  int sub_branch_tag = 0; 
-  /** percentage of parent resources to be allocated to this branch. */ 
+      /** Enable subgraph for the layer. */
+  bool enable_subgraph = false;
+  /** Branch number in the sub graph. */
+  int sub_branch_tag = 0;
+  /** percentage of parent resources to be allocated to this branch. */
   int sub_branch_resource_percentage = 0;
   bool operator==(const ParallelStrategy &ps) const {
     return sample_groups == ps.sample_groups &&
@@ -173,9 +173,9 @@ struct ParallelStrategy {
         channel_splits == ps.channel_splits &&
         filter_groups == ps.filter_groups &&
         filter_splits == ps.filter_splits &&
-        replications == ps.replications &&  
-        sub_branch_tag == ps.sub_branch_tag &&  
-        sub_branch_resource_percentage == ps.sub_branch_resource_percentage &&  
+        replications == ps.replications &&
+        sub_branch_tag == ps.sub_branch_tag &&
+        sub_branch_resource_percentage == ps.sub_branch_resource_percentage &&
         enable_subgraph == ps.enable_subgraph;
   }
   bool operator!=(const ParallelStrategy &ps) const {
@@ -198,8 +198,8 @@ inline std::ostream &operator<<(std::ostream &os,
      << ", " << ps.filter_groups
      << "/" << ps.filter_splits
      << ", " << ps.replications
-     << "/" << ps.sub_branch_tag  
-     << "," << ps.sub_branch_resource_percentage  
+     << "/" << ps.sub_branch_tag
+     << "," << ps.sub_branch_resource_percentage
      << "/" << ps.enable_subgraph
      << "}";
   return os;
@@ -237,9 +237,6 @@ class Layer {
 public:
 
   Layer();
-
-  Layer(const Layer& other);
-  Layer& operator=(const Layer& other);
   virtual ~Layer() = default;
 
   /** @brief Copy function.
@@ -281,62 +278,62 @@ public:
   }
 
   void reset_subgrid_ranks(std::set<int> sub_grid_rank)
-  { 
+  {
     m_subgrid_ranks.reset(new std::set<int>(sub_grid_rank.begin(),sub_grid_rank.end()));
   }
 
   std::set<int> get_subgrid_ranks() const
-  { 
+  {
     return *m_subgrid_ranks;
   }
 
   void reset_parent_tags(std::vector<int> tags)
-  { 
+  {
     m_parent_tags.reset(new std::vector<int>(tags.begin(),tags.end()));
   }
 
   std::vector<int> get_parent_tags() const
-  { 
+  {
     return *m_parent_tags;
   }
 
   void set_num_spliting_groups(El::Int spliting_groups)
-  { 
+  {
     m_num_spliting_groups = spliting_groups;
   }
 
   El::Int get_num_spliting_groups() const
-  { 
+  {
     return m_num_spliting_groups;
   }
 
   void set_subgrid_index(std::string index)
-  { 
+  {
     m_subgrid_index = index;
   }
 
   std::string get_subgrid_index() const
-  { 
+  {
     return m_subgrid_index;
   }
 
   void reset_mygrid(std::shared_ptr<El::Grid> grid)
-  { 
+  {
     m_mygrid = grid;
   }
 
   std::shared_ptr<El::Grid> get_mygrid() const
-  { 
+  {
     return m_mygrid;
   }
 
   void reset_inter_subgrid_vc_comm(std::shared_ptr<El::mpi::Comm> mpi_comm)
-  { 
+  {
     m_interSubGridVCComm = mpi_comm;
   }
 
   std::shared_ptr<El::mpi::Comm> get_inter_subgrid_vc_comm() const
-  { 
+  {
     return m_interSubGridVCComm;
   }
 
@@ -344,7 +341,7 @@ public:
   {
     apply_subgraph_parallelism = true;
   }
-  //model wide sub graph parallelism enabled 
+  //model wide sub graph parallelism enabled
   bool is_subgraph_parallelism_enabled()
   {
     return apply_subgraph_parallelism;
@@ -371,7 +368,7 @@ public:
   {
     m_num_spliting_groups = num_grps;
   }
-  //enable subgraph parallelism for this layer 
+  //enable subgraph parallelism for this layer
   //to set variable for ssplit layer
   void set_enable_subgraph_variable()
   {
@@ -608,6 +605,14 @@ public:
 
 protected:
 
+  /** @name Protected lifecycle functions */
+  ///@{
+  Layer(Layer&& other) = default;
+  Layer(Layer const& other);
+  Layer& operator=(Layer&& other) = default;
+  Layer& operator=(Layer const& other);
+  ///@}
+
   /** @name Weights-related accessors */
   ///@{
   void add_weights(ViewingWeightsPtr w) {
@@ -785,8 +790,8 @@ protected:
 
   bool run_layer_in_subgraph = false;
 
-  /** Ranks in grid for the sub-graph */  
-  std::unique_ptr<std::set <int>> m_subgrid_ranks; 
+  /** Ranks in grid for the sub-graph */
+  std::unique_ptr<std::set <int>> m_subgrid_ranks;
   std::unique_ptr<std::vector<int>> m_parent_tags;
   std::string m_subgrid_index="";
   El::Int m_num_spliting_groups=1;

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -40,9 +40,9 @@ namespace lbann {
 
 template <typename InputTensorDataType, typename OutputTensorDataType>
 data_type_layer<InputTensorDataType, OutputTensorDataType>::
-data_type_layer(const data_type_layer<InputTensorDataType, OutputTensorDataType>& other) :
-  Layer(other),
-  m_persistent_error_signals(other.m_persistent_error_signals) {
+data_type_layer(data_type_layer const& other)
+  : Layer(other),
+    m_persistent_error_signals(other.m_persistent_error_signals) {
 
   // Deep matrix copies
   m_inputs.reserve(other.m_inputs.size());
@@ -66,7 +66,7 @@ data_type_layer(const data_type_layer<InputTensorDataType, OutputTensorDataType>
 template <typename InputTensorDataType, typename OutputTensorDataType>
 data_type_layer<InputTensorDataType, OutputTensorDataType>&
 data_type_layer<InputTensorDataType, OutputTensorDataType>::
-operator=(const data_type_layer<InputTensorDataType, OutputTensorDataType>& other) {
+operator=(data_type_layer const& other) {
   Layer::operator=(other);
 
   // Deep matrix copies


### PR DESCRIPTION
Should be a no-op change, just for consistency.