### PR TITLE
Stop printing stack trace on throw test.

### DIFF
--- a/bamboo/common_python/tools.py
+++ b/bamboo/common_python/tools.py
@@ -704,6 +704,15 @@ def create_tests(setup_func,
                                                'experiments',
                                                test_name)
 
+        # Print full stack on error
+        if 'lbann_args' in _kwargs:
+            if isinstance(_kwargs['lbann_args'], str):
+                _kwargs['lbann_args'] += ' --print_stack_on_throw'
+            else:
+                _kwargs['lbann_args'].append('--print_stack_on_throw')
+        else:
+            _kwargs['lbann_args'] = ['--print_stack_on_throw']
+
         # If the user provided a suffix for the work directory, append it
         if 'work_subdir' in _kwargs:
             _kwargs['work_dir'] = os.path.join(_kwargs['work_dir'], _kwargs['work_subdir'])

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -94,7 +94,7 @@ public:
    *  By default, a human-readable report is immediately printed to
    *  the standard error stream.
    */
-  exception(std::string message = "", bool print = true);
+  exception(std::string message = "");
   const char* what() const noexcept override;
 
   /** Print human-readable report to stream.
@@ -112,6 +112,11 @@ private:
 
 };
 using lbann_exception = exception;
+
+inline std::ostream& operator<<(std::ostream& os, exception const& e) {
+  e.print_report(os);
+  return os;
+}
 
 /** @brief Build a string from the arguments.
  *

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -26,11 +26,15 @@
 
 #include "lbann/utils/exception.hpp"
 #include "lbann/comm_impl.hpp"
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/stack_trace.hpp"
 
 namespace lbann {
 namespace {
-bool print_stack_on_throw() noexcept { return true; }
+bool print_stack_on_throw() noexcept {
+  static const bool val = global_argument_parser().get<bool>("print stack on throw");
+  return val;
+}
 } // namespace
 
 exception::exception(std::string message)

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -28,6 +28,7 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/data_readers/data_reader.hpp"
 #include "lbann/models/directed_acyclic_graph.hpp"
+#include "lbann/utils/environment_variable.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/lbann_library.hpp"
 
@@ -50,6 +51,10 @@ namespace lbann {
 
 void construct_std_options() {
   auto& arg_parser = global_argument_parser();
+  arg_parser.add_flag("print stack on throw",
+                      {"--print_stack_on_throw"},
+                      utils::ENV("LBANN_PRINT_STACK_TRACE_ON_THROW"),
+                      "Print a stack trace when constructing an LBANN exception");
   arg_parser.add_option(MAX_RNG_SEEDS_DISPLAY,
                         {"--rng_seeds_per_trainer_to_display"},
                         utils::ENV("LBANN_RNG_SEEDS_PER_TRAINER_TO_DISPLAY"),

--- a/unit_test/SequentialCatchMain.cpp
+++ b/unit_test/SequentialCatchMain.cpp
@@ -24,8 +24,11 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "lbann/utils/lbann_library.hpp"
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+
+#include "lbann/utils/argument_parser.hpp"
 #include <lbann/utils/dnn_lib/helpers.hpp>
 #include <lbann/utils/random_number_generators.hpp>
 
@@ -35,14 +38,14 @@ int main(int argc, char* argv[]) {
   lbann::dnn_lib::initialize();
 #endif // LBANN_HAS_DNN_LIB
 
+  lbann::construct_std_options();
 
   // Initialize the general RNGs and the data sequence RNGs
-  int random_seed = 42;
+  int const random_seed = 42;
   lbann::init_random(random_seed);
   lbann::init_data_seq_random(random_seed);
 
-  int result = Catch::Session().run(argc, argv);
-
+  int const result = Catch::Session().run(argc, argv);
 
 #ifdef LBANN_HAS_DNN_LIB
   lbann::dnn_lib::destroy();


### PR DESCRIPTION
Running with `--print_stack_on_throw` or by setting `LBANN_PRINT_STACK_TRACE_ON_THROW=1` in the environment will restore the old behavior.