### PR TITLE
Remove redundant check in "perturb weights" callback

### DIFF
--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -57,7 +57,7 @@ void perturb_weights::serialize(Archive & ar) {
 
 void perturb_weights::setup(model* m) {
    weights* m_output = nullptr;
-   
+
    for (auto* w : m->get_weights()) {
       if(w->get_name() == m_output_name){
         m_output = w;
@@ -79,11 +79,11 @@ void perturb_weights::on_batch_begin(model* m) {
         m_output = w;
         break;
       }
-   }  
-  
-  if (m_output != nullptr && 
+   }
+
+  if (m_output != nullptr &&
       c.get_step() % m_batch_interval == 0 &&
-      c.get_step() >= 0) {
+      c.get_step() > 0) {
     perturb(*m);
   }
 }
@@ -97,7 +97,7 @@ void perturb_weights::perturb(model& m){
   constexpr DataType one = 1;
   constexpr DataType lower = 0.3;
   constexpr DataType upper = 0.7;
-  
+
   // RNG
   auto& gen = get_generator();
   std::normal_distribution<DataType> dist(zero, one);
@@ -118,22 +118,22 @@ void perturb_weights::perturb(model& m){
 	El::Matrix<DataType,El::Device::CPU> temp;
 	El::Copy(local_values, temp);
 
-	// Perturb weights on master process		
+	// Perturb weights on master process
 	if (comm->am_trainer_master()) {
-		for (auto i = 0; i < temp.Height(); i++){		
+		for (auto i = 0; i < temp.Height(); i++){
 
-			
-			// perturb				
+
+			// perturb
 			auto val = temp.Get(i,0);
 			auto perturbed_val = val;
-			
+
 			perturbed_val += dist(gen); // dist is a std::normal_distribution
 			perturbed_val = std::min(std::max(perturbed_val, lower), upper);
-			
+
 			temp.Set(i,0,perturbed_val);
-				
-			El::Copy(temp, local_values); 
-			  
+
+			El::Copy(temp, local_values);
+
 			std::cout << "Trainer [ " << m.get_comm()->get_trainer_rank() << " ], Step " << m.get_execution_context().get_step();
 			std::cout << " Weight " << i << ": " << val << " Perturbed weight  " <<  perturbed_val << std::endl;
 
@@ -142,14 +142,14 @@ void perturb_weights::perturb(model& m){
 
 	// Communicate new weight from trainer master processes
 	El::Broadcast(new_values, comm->get_trainer_comm(), 0);
-		
+
 	// Update weight
-	auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*w);	
-	out_w.set_values(new_values);		
+	auto& out_w = dynamic_cast<data_type_weights<DataType>&>(*w);
+	out_w.set_values(new_values);
 
 	break;
     }
-  } 
+  }
 }
 
 

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -82,8 +82,7 @@ void perturb_weights::on_batch_begin(model* m) {
    }
 
   if (m_output != nullptr &&
-      c.get_step() % m_batch_interval == 0 &&
-      c.get_step() > 0) {
+      c.get_step() % m_batch_interval == 0) {
     perturb(*m);
   }
 }


### PR DESCRIPTION
Building with `-Werror`, GCC complained about a comparison that always returns `true`: https://github.com/LLNL/lbann/blob/ecad0fe7ac9ae84cfd4ac834fc54bb08cd4938ce/src/callbacks/perturb_weights.cpp#L86
We can either remove it or make it skip the first step.

Pinging @tnat410.