### PR TITLE
Fix compile errors in rotation layer

### DIFF
--- a/include/lbann/layers/image/rotation.hpp
+++ b/include/lbann/layers/image/rotation.hpp
@@ -31,15 +31,16 @@
 
 namespace lbann {
 
-/** brief Rotate a image around its center with a defined angle clockwise.
+/** @brief Rotate a image clockwise around its center
  *
- *  Tensors are assumed to be image data in CHW format. 
+ *  Expects two inputs: a 3D image tensor in CHW format and a scalar
+ *  rotation angle.
  */
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 class rotation_layer : public data_type_layer<TensorDataType> {
   static_assert(Layout == data_layout::DATA_PARALLEL,
                 "rotation_layer only supports DATA_PARALLEL");
-  static_assert(Device == El::Device::CPU, 
+  static_assert(Device == El::Device::CPU,
                 "rotation_layer only supports CPU");
 public:
   /** @name Public Types */
@@ -89,21 +90,27 @@ protected:
     // Get input dimensions
     auto dims = this->get_input_dims(0);
     const auto& angle_dims = this->get_input_dims(1);
-	
-    const auto& num_dims = dims.size();
-    const auto& num_angle_dims = angle_dims.size();
 
     // Check that dimensions are valid
-    std::stringstream err;
-    if (num_dims != 3) {
-      err << get_type() << " layer \"" << this->get_name() << "\" "
-          << "expects 3D input in CHW format, "
-          << "but input dimensions are ";
-      for (size_t i = 0; i < num_dims; ++i) {
-        err << (i > 0 ? " x " : "") << dims[i];
+    if (dims.size() != 3) {
+      std::ostringstream ss;
+      for (size_t i = 0; i < dims.size(); ++i) {
+        ss << (i > 0 ? " x " : "") << dims[i];
       }
-      LBANN_ERROR(err.str());
-    } 
+      LBANN_ERROR(this->get_type()," layer \"",this->get_name(),"\" ",
+        "expects a 3D input in CHW format, ",
+        "but input dimensions are ",ss.str());
+    }
+    if (angle_dims.size() > 1 || angle_dims[0] != 1) {
+      std::ostringstream ss;
+      for (size_t i = 0; i < angle_dims.size(); ++i) {
+        ss << (i > 0 ? " x " : "") << angle_dims[i];
+      }
+      LBANN_ERROR(
+        this->get_type()," layer \"",this->get_name(),"\" ",
+        "expects a scalar input for the angle, ",
+        "but input dimensions are ",ss.str());
+    }
   }
 };
 

--- a/src/layers/image/rotation.cpp
+++ b/src/layers/image/rotation.cpp
@@ -27,7 +27,7 @@
 #define LBANN_ROTATION_LAYER_INSTANTIATE
 #include "lbann/layers/image/rotation.hpp"
 
-#include <math.h>  
+#include <math.h>
 
 namespace lbann {
 
@@ -39,28 +39,27 @@ void rotation_layer<TensorDataType, Layout, Device>::fp_compute() {
   constexpr DataType degree = 180;
   constexpr DataType half = 0.5;
   constexpr DataType zero = 0;
-  
+
   // Input and output tensors
   const auto& local_input = this->get_local_prev_activations();
   auto& local_output = this->get_local_activations();
 
   // Tensor dimensions
   const auto& input_dims = this->get_input_dims(0);
-  const El::Int num_dims = input_dims.size();
   const auto& num_samples = local_input.Width();
-  const El::Int num_channels = input_dims[0]
+  const El::Int num_channels = input_dims[0];
   const El::Int input_height = input_dims[1];
   const El::Int input_width = input_dims[2];
 
   // Get rotation angle
   const auto& angles = this->get_local_prev_activations(1);
-	
+
   // Perform rotation for each input pixel based on the center pixel
   LBANN_OMP_PARALLEL_FOR_COLLAPSE4
   for (El::Int sample = 0; sample < num_samples; ++sample) {
     for (El::Int channel = 0; channel < num_channels; ++channel) {
       for (El::Int output_row = 0; output_row < input_height; ++output_row) {
-        for (El::Int output_col = 0; output_col < input_width; ++output_col) {	
+        for (El::Int output_col = 0; output_col < input_width; ++output_col) {
 
           // Convert to rad
           const auto& angle = angles.Get(0, sample);
@@ -94,18 +93,12 @@ void rotation_layer<TensorDataType, Layout, Device>::fp_compute() {
 	  }
 	  else {
           	pixel_output = zero;
-	  }	 
+	  }
         }
       }
     }
   }
 }
-
-template <typename TensorDataType, data_layout T_layout, El::Device Dev>
-void rotation_layer<TensorDataType, T_layout, Dev>::bp_compute() {
-
-}
-
 
 #define PROTO(T) \
   template class rotation_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -772,7 +772,12 @@ message Layer {
     int64 height = 1;
     int64 width = 2;
   }
-  
+
+  /** @brief Rotate a image clockwise around its center
+   *
+   *  Expects two inputs: a 3D image tensor in CHW format and a scalar
+   *  rotation angle.
+   */
   message Rotation {}
 
   //////////////////////////


### PR DESCRIPTION
The last few commits in PR #1926 had some correctness issues. Also, `-Werror` didn't like some unused variables.

Pinging @tnat410.