### PR TITLE
Mutation Strategy of Replacing Random Activation

### DIFF
--- a/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
+++ b/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
@@ -1,0 +1,156 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
+#define LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
+
+#include "lbann/utils/random.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/layers/math/unary.hpp"
+#include "lbann/layers/activations/relu.hpp"
+#include "lbann/layers/activations/softmax.hpp"
+#include "lbann/layers/activations/elu.hpp"
+#include "lbann/layers/activations/leaky_relu.hpp"
+#include "lbann/layers/activations/log_softmax.hpp"
+
+namespace lbann {
+namespace ltfb {
+
+class MutationStrategy : public Cloneable<HasAbstractFunction<MutationStrategy>>
+{
+public:
+  MutationStrategy() {};
+  virtual ~MutationStrategy() = default;
+
+public:
+  /** @brief Apply a change to the model.
+   *  @param[in,out] m The model to change.
+   *  @param[in] step The current execution step in LTFB
+   */
+  virtual void mutate(model& m, const int& step) = 0;
+};
+
+// No Mutation
+class NullMutation : public Cloneable<NullMutation, MutationStrategy>
+{
+
+public:
+  NullMutation() = default; 
+  void mutate(model&, const int&) override {}
+};
+
+// Replace activation layers
+class ReplaceActivation : public Cloneable<ReplaceActivation, MutationStrategy>
+{
+private:
+  std::vector<std::string> m_activation_types = {"relu", "tanh", "softmax", "elu", "leaky relu", "log softmax"};
+
+public:
+  ReplaceActivation() = default;
+
+  std::unique_ptr<lbann::Layer> make_new_activation_layer(lbann::lbann_comm& comm,
+                                                          std::string const& new_type,
+                                                          std::string const& new_name)
+  {
+    using DataType = float;
+    #ifdef LBANN_HAS_GPU
+      constexpr El::Device Dev = El::Device::GPU;
+    #else
+      constexpr El::Device Dev = El::Device::CPU;
+    #endif
+
+    std::unique_ptr<lbann::Layer> layer;
+
+    if(new_type == "relu") {
+       layer = std::make_unique<
+           lbann::relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm); 
+    } else if (new_type == "tanh") {
+       layer = std::make_unique<
+            lbann::tanh_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
+    } else if (new_type == "softmax") {
+       layer = std::make_unique<
+            lbann::softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, softmax_mode::INSTANCE);
+    } else if (new_type == "elu") {
+       layer = std::make_unique<
+            lbann::elu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, 1);
+    } else if (new_type == "leaky relu") {
+       layer = std::make_unique<
+            lbann::leaky_relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, 0.01);
+    } else if (new_type == "log softmax") {
+       layer = std::make_unique<
+            lbann::log_softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
+    } else {
+       LBANN_ERROR("Unknown new layer type: ", new_type);
+    }
+    layer->set_name(new_name);
+    return layer;
+  }
+
+  void mutate(model& m, const int& step)
+  {
+    std::vector<std::string> activation_layer_names;
+
+    auto& comm = *m.get_comm();
+    
+    for (int i = 0; i < m.get_num_layers(); ++i)
+    {
+       // Creating a temp string with lower case representation
+       std::string temp_type = m.get_layer(i).get_type();
+       std::transform(temp_type.begin(), temp_type.end(),
+                                         temp_type.begin(), ::tolower);    
+
+       if (std::find(m_activation_types.cbegin(), m_activation_types.cend(), temp_type)
+                                                              != m_activation_types.cend()) {
+         activation_layer_names.push_back(m.get_layer(i).get_name());
+       }
+    }
+
+    // Generate two random numbers - one for new layer type and one for old layer name
+    int type_index = fast_rand_int(get_fast_generator(), m_activation_types.size());
+    int name_index = fast_rand_int(get_fast_generator(), activation_layer_names.size());
+
+    // Name of new layer
+    std::string new_layer_name = "new_" + m_activation_types[type_index] 
+                                        + std::to_string(step) + std::to_string(name_index);
+      
+    // Print mutation
+    std::cout << "Replacing " << activation_layer_names[name_index] << " with " << new_layer_name << std::endl;
+ 
+    // Replace layer
+    m.replace_layer(make_new_activation_layer(comm, m_activation_types[type_index], new_layer_name), 
+                    activation_layer_names[name_index]);
+
+    // Erase old layer from activation layer list
+    activation_layer_names.erase(activation_layer_names.cbegin() + name_index);
+
+    // Add new layer to activation layer list
+    activation_layer_names.push_back(new_layer_name);  
+  }
+};
+
+} // namespace ltfb
+
+} // namespace lbann
+#endif // LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED

--- a/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
+++ b/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
@@ -26,7 +26,8 @@
 #ifndef LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
 #define LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
 
-#include "lbann/layers/layer.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/cloneable.hpp"
 
 namespace lbann {
 namespace ltfb {
@@ -37,7 +38,6 @@ public:
   MutationStrategy(){};
   virtual ~MutationStrategy() = default;
 
-public:
   /** @brief Apply a change to the model.
    *  @param[in,out] m The model to change.
    *  @param[in] step The current execution step in LTFB
@@ -46,32 +46,21 @@ public:
 };
 
 // No Mutation
-class NullMutation : public Cloneable<NullMutation, MutationStrategy>
+class NullMutation final : public Cloneable<NullMutation, MutationStrategy>
 {
 
 public:
   NullMutation() = default;
-  void mutate(model&, const int&) override {}
+  void mutate(model& m, const int& step) final {}
 };
 
 // Replace activation layers
-class ReplaceActivation : public Cloneable<ReplaceActivation, MutationStrategy>
+class ReplaceActivation final
+  : public Cloneable<ReplaceActivation, MutationStrategy>
 {
 public:
   ReplaceActivation() = default;
-
-  /** @brief Construct a new activation layer.
-   *  @param[in] comm The current communicator
-   *  @param[in] new_type The type of the new activation layer (ReLU or tanh
-   * etc)
-   *  @param[in] new_name The name of the new activation layer
-   */
-
-  std::unique_ptr<lbann::Layer>
-  make_new_activation_layer(lbann::lbann_comm& comm,
-                            std::string const& new_type,
-                            std::string const& new_name);
-  void mutate(model& m, const int& step);
+  void mutate(model& m, const int& step) final;
 };
 
 } // namespace ltfb

--- a/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
+++ b/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
@@ -26,14 +26,7 @@
 #ifndef LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
 #define LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED
 
-#include "lbann/utils/random.hpp"
-#include "lbann/models/model.hpp"
-#include "lbann/layers/math/unary.hpp"
-#include "lbann/layers/activations/relu.hpp"
-#include "lbann/layers/activations/softmax.hpp"
-#include "lbann/layers/activations/elu.hpp"
-#include "lbann/layers/activations/leaky_relu.hpp"
-#include "lbann/layers/activations/log_softmax.hpp"
+#include "lbann/layers/layer.hpp"
 
 namespace lbann {
 namespace ltfb {
@@ -41,7 +34,7 @@ namespace ltfb {
 class MutationStrategy : public Cloneable<HasAbstractFunction<MutationStrategy>>
 {
 public:
-  MutationStrategy() {};
+  MutationStrategy(){};
   virtual ~MutationStrategy() = default;
 
 public:
@@ -57,100 +50,30 @@ class NullMutation : public Cloneable<NullMutation, MutationStrategy>
 {
 
 public:
-  NullMutation() = default; 
+  NullMutation() = default;
   void mutate(model&, const int&) override {}
 };
 
 // Replace activation layers
 class ReplaceActivation : public Cloneable<ReplaceActivation, MutationStrategy>
 {
-private:
-  std::vector<std::string> m_activation_types = {"relu", "tanh", "softmax", "elu", "leaky relu", "log softmax"};
-
 public:
   ReplaceActivation() = default;
 
-  std::unique_ptr<lbann::Layer> make_new_activation_layer(lbann::lbann_comm& comm,
-                                                          std::string const& new_type,
-                                                          std::string const& new_name)
-  {
-    using DataType = float;
-    #ifdef LBANN_HAS_GPU
-      constexpr El::Device Dev = El::Device::GPU;
-    #else
-      constexpr El::Device Dev = El::Device::CPU;
-    #endif
+  /** @brief Construct a new activation layer.
+   *  @param[in] comm The current communicator
+   *  @param[in] new_type The type of the new activation layer (ReLU or tanh
+   * etc)
+   *  @param[in] new_name The name of the new activation layer
+   */
 
-    std::unique_ptr<lbann::Layer> layer;
-
-    if(new_type == "relu") {
-       layer = std::make_unique<
-           lbann::relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm); 
-    } else if (new_type == "tanh") {
-       layer = std::make_unique<
-            lbann::tanh_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
-    } else if (new_type == "softmax") {
-       layer = std::make_unique<
-            lbann::softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, softmax_mode::INSTANCE);
-    } else if (new_type == "elu") {
-       layer = std::make_unique<
-            lbann::elu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, 1);
-    } else if (new_type == "leaky relu") {
-       layer = std::make_unique<
-            lbann::leaky_relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, 0.01);
-    } else if (new_type == "log softmax") {
-       layer = std::make_unique<
-            lbann::log_softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
-    } else {
-       LBANN_ERROR("Unknown new layer type: ", new_type);
-    }
-    layer->set_name(new_name);
-    return layer;
-  }
-
-  void mutate(model& m, const int& step)
-  {
-    std::vector<std::string> activation_layer_names;
-
-    auto& comm = *m.get_comm();
-    
-    for (int i = 0; i < m.get_num_layers(); ++i)
-    {
-       // Creating a temp string with lower case representation
-       std::string temp_type = m.get_layer(i).get_type();
-       std::transform(temp_type.begin(), temp_type.end(),
-                                         temp_type.begin(), ::tolower);    
-
-       if (std::find(m_activation_types.cbegin(), m_activation_types.cend(), temp_type)
-                                                              != m_activation_types.cend()) {
-         activation_layer_names.push_back(m.get_layer(i).get_name());
-       }
-    }
-
-    // Generate two random numbers - one for new layer type and one for old layer name
-    int type_index = fast_rand_int(get_fast_generator(), m_activation_types.size());
-    int name_index = fast_rand_int(get_fast_generator(), activation_layer_names.size());
-
-    // Name of new layer
-    std::string new_layer_name = "new_" + m_activation_types[type_index] 
-                                        + std::to_string(step) + std::to_string(name_index);
-      
-    // Print mutation
-    std::cout << "Replacing " << activation_layer_names[name_index] << " with " << new_layer_name << std::endl;
- 
-    // Replace layer
-    m.replace_layer(make_new_activation_layer(comm, m_activation_types[type_index], new_layer_name), 
-                    activation_layer_names[name_index]);
-
-    // Erase old layer from activation layer list
-    activation_layer_names.erase(activation_layer_names.cbegin() + name_index);
-
-    // Add new layer to activation layer list
-    activation_layer_names.push_back(new_layer_name);  
-  }
+  std::unique_ptr<lbann::Layer>
+  make_new_activation_layer(lbann::lbann_comm& comm,
+                            std::string const& new_type,
+                            std::string const& new_name);
+  void mutate(model& m, const int& step);
 };
 
 } // namespace ltfb
-
 } // namespace lbann
 #endif // LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED

--- a/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
+++ b/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
@@ -26,6 +26,8 @@
 #ifndef LBANN_EXECUTION_ALGORITHMS_LTFB_RANDOM_PAIRWISE_EXCHANGE_HPP_INCLUDED
 #define LBANN_EXECUTION_ALGORITHMS_LTFB_RANDOM_PAIRWISE_EXCHANGE_HPP_INCLUDED
 
+#include "mutation_strategy.hpp"
+
 #include "meta_learning_strategy.hpp"
 
 #include <google/protobuf/message.h>
@@ -122,10 +124,12 @@ public:
    *  @param[in] winner_strategy Strategy for determining the winner
    *             of a tournament.
    *  @param[in] comm_algo Algorithm for exchanging models.
+   *  @param[in] mutate_algo Algorithm for mutating models.
    */
   RandomPairwiseExchange(std::string metric_name,
                          metric_strategy winner_strategy,
-                         std::unique_ptr<ExchangeStrategy> comm_algo);
+                         std::unique_ptr<ExchangeStrategy> comm_algo,
+                         std::unique_ptr<MutationStrategy> mutate_algo);
 
   /** @brief Constructor
    *  @param[in] metrics The list of metric/strategy pairs. A metric
@@ -134,10 +138,12 @@ public:
    *             model must win ALL of the metric comparisons to be
    *             declared the winner.
    *  @param[in] comm_algo Algorithm for exchanging models.
+   *  @param[in] mutate_algo Algorithm for mutating models.
    */
   RandomPairwiseExchange(
     std::unordered_map<std::string, metric_strategy> metrics,
-    std::unique_ptr<ExchangeStrategy> comm_algo);
+    std::unique_ptr<ExchangeStrategy> comm_algo,
+    std::unique_ptr<MutationStrategy> mutate_algo);
 
   ~RandomPairwiseExchange() = default;
   RandomPairwiseExchange(RandomPairwiseExchange const& other);
@@ -193,6 +199,10 @@ private:
    *  pretend such a thing exists; it makes me feel better, anyway).
    */
   std::unique_ptr<ExchangeStrategy> m_comm_algo;
+
+  /** @brief The strategy for mutation of a model - insert more details later
+   */
+  std::unique_ptr<MutationStrategy> m_mutate_algo;  
 
 }; // class RandomPairwiseExchange
 

--- a/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
+++ b/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
@@ -200,7 +200,12 @@ private:
    */
   std::unique_ptr<ExchangeStrategy> m_comm_algo;
 
-  /** @brief The strategy for mutation of a model - insert more details later
+  /** @brief The strategy for mutation of a model
+   *
+   *  When a trainer loses in a LTFB tournament, the winning model is 
+   *  copied over to it and this mutation strategy is applied to the
+   *  copied model to explore a new model. This is relevant to neural
+   *  architecture search (NAS). 
    */
   std::unique_ptr<MutationStrategy> m_mutate_algo;  
 

--- a/python/lbann/core/training_algorithm.py
+++ b/python/lbann/core/training_algorithm.py
@@ -188,7 +188,11 @@ class LTFB(TrainingAlgorithm):
 
 class MutationStrategy:
     """The strategy for mutation after a tournament in LTFB.
-       INSERT FURTHER DESCRIPTION HERE.
+       
+       When a trainer loses in a LTFB tournament, the winning model is 
+       copied over to it and this mutation strategy is applied to the
+       copied model to explore a new model. This is relevant to neural
+       architecture search (NAS).
     """
 
     def __init__(self, strategy: str = "null_mutation"):
@@ -330,7 +334,7 @@ class RandomPairwiseExchange(MetaLearningStrategy):
               with respect to this metric
             exchange_strategy:
               The algorithm used for exchanging models.
-            mutate_strategy:
+            mutation_strategy:
               The algorithm used for mutating models.
         """
 

--- a/python/lbann/core/training_algorithm.py
+++ b/python/lbann/core/training_algorithm.py
@@ -186,6 +186,29 @@ class LTFB(TrainingAlgorithm):
         params.local_training_algorithm.CopyFrom(self.local_algo.export_proto())
         return params
 
+class MutationStrategy:
+    """The strategy for mutation after a tournament in LTFB.
+       INSERT FURTHER DESCRIPTION HERE.
+    """
+
+    def __init__(self, strategy: str = "null_mutation"):
+        self.strategy = strategy
+
+    def export_proto(self):
+        """Get a protobuf representation of this object."""
+
+        MutationStrategyMsg = AlgoProto.MutationStrategy
+        msg = MutationStrategyMsg()
+        if self.strategy == "null_mutation":
+            NullMutationMsg = MutationStrategyMsg.NullMutation
+            msg.null_mutation.CopyFrom(NullMutationMsg())
+        elif self.strategy == "replace_activation":
+            ReplaceActivationMsg = MutationStrategyMsg.ReplaceActivation
+            msg.replace_activation.CopyFrom(ReplaceActivationMsg())
+        else:
+            raise ValueError("Unknown Strategy")
+        return msg
+
 class RandomPairwiseExchange(MetaLearningStrategy):
     """The classic LTFB pairwise tourament metalearning strategy.
 
@@ -297,7 +320,8 @@ class RandomPairwiseExchange(MetaLearningStrategy):
 
     def __init__(self,
                  metric_strategies: dict[str,int] = {},
-                 exchange_strategy = ExchangeStrategy()):
+                 exchange_strategy = ExchangeStrategy(),
+                 mutation_strategy = MutationStrategy()):
         """Construct a new RandomPairwiseExchange metalearning strategy.
 
         Args:
@@ -306,10 +330,13 @@ class RandomPairwiseExchange(MetaLearningStrategy):
               with respect to this metric
             exchange_strategy:
               The algorithm used for exchanging models.
+            mutate_strategy:
+              The algorithm used for mutating models.
         """
 
         self.metric_strategies = metric_strategies
         self.exchange_strategy = exchange_strategy
+        self.mutation_strategy = mutation_strategy
 
     def export_proto(self):
         """Get a protobuf representation of this object."""
@@ -319,6 +346,7 @@ class RandomPairwiseExchange(MetaLearningStrategy):
             msg.metric_name_strategy_map[key] = value
 
         msg.exchange_strategy.CopyFrom(self.exchange_strategy.export_proto())
+        msg.mutation_strategy.CopyFrom(self.mutation_strategy.export_proto())
         return msg
 
 class KFAC(TrainingAlgorithm):

--- a/src/execution_algorithms/ltfb/CMakeLists.txt
+++ b/src/execution_algorithms/ltfb/CMakeLists.txt
@@ -3,6 +3,7 @@ set_full_path(THIS_DIR_SOURCES
   checkpoint_binary.cpp
   checkpoint_file.cpp
   meta_learning_strategy.cpp
+  mutation_strategy.cpp
   random_pairwise_exchange.cpp
   sendrecv_weights.cpp
   )

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -1,0 +1,140 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/execution_algorithms/ltfb/mutation_strategy.hpp"
+
+#include "lbann/layers/activations/activations.hpp"
+#include "lbann/layers/activations/elu.hpp"
+#include "lbann/layers/activations/leaky_relu.hpp"
+#include "lbann/layers/activations/log_softmax.hpp"
+#include "lbann/layers/activations/relu.hpp"
+#include "lbann/layers/activations/softmax.hpp"
+#include "lbann/layers/math/unary.hpp"
+#include "lbann/models/model.hpp"
+#include "lbann/utils/random.hpp"
+
+namespace lbann {
+namespace ltfb {
+
+std::unique_ptr<lbann::Layer>
+ReplaceActivation::make_new_activation_layer(lbann::lbann_comm& comm,
+                                             std::string const& new_type,
+                                             std::string const& new_name)
+{
+#ifdef LBANN_HAS_GPU
+  constexpr El::Device Dev = El::Device::GPU;
+#else
+  constexpr El::Device Dev = El::Device::CPU;
+#endif
+
+  std::unique_ptr<lbann::Layer> layer;
+
+  if (new_type == "relu") {
+    layer = std::make_unique<
+      lbann::relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
+  }
+  else if (new_type == "tanh") {
+    layer = std::make_unique<
+      lbann::tanh_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
+  }
+  else if (new_type == "softmax") {
+    layer = std::make_unique<
+      lbann::softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(
+      &comm,
+      softmax_mode::INSTANCE);
+  }
+  else if (new_type == "elu") {
+    layer = std::make_unique<
+      lbann::elu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm, 1);
+  }
+  else if (new_type == "leaky relu") {
+    layer = std::make_unique<
+      lbann::leaky_relu_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm,
+                                                                          0.01);
+  }
+  else if (new_type == "log softmax") {
+    layer = std::make_unique<
+      lbann::log_softmax_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(
+      &comm);
+  }
+  else if (new_type == "sigmoid") {
+    layer = std::make_unique<
+      lbann::sigmoid_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(&comm);
+  }
+  else {
+    LBANN_ERROR("Unknown new layer type: ", new_type);
+  }
+  layer->set_name(new_name);
+  return layer;
+}
+
+void ReplaceActivation::mutate(model& m, const int& step)
+{
+  std::vector<std::string> activation_types = {"relu",
+                                               "tanh",
+                                               "elu",
+                                               "sigmoid",
+                                               "leaky relu"};
+  std::vector<std::string> activation_layer_names;
+
+  auto& comm = *m.get_comm();
+
+  for (int i = 0; i < m.get_num_layers(); ++i) {
+    // Creating a temp string with lower case representation
+    std::string temp_type = m.get_layer(i).get_type();
+    std::transform(begin(temp_type),
+                   end(temp_type),
+                   begin(temp_type),
+                   [](unsigned char c) { return ::tolower(c); });
+
+    if (std::find(activation_types.cbegin(),
+                  activation_types.cend(),
+                  temp_type) != activation_types.cend()) {
+      activation_layer_names.push_back(m.get_layer(i).get_name());
+    }
+  }
+
+  // Generate two random numbers - one for new layer type and one for old layer
+  // name
+  int const type_index =
+    fast_rand_int(get_fast_generator(), activation_types.size());
+  int const name_index =
+    fast_rand_int(get_fast_generator(), activation_layer_names.size());
+
+  // Print mutation
+  std::cout << "Changing type of activation layer "
+            << activation_layer_names[name_index] << " to "
+            << activation_types[type_index] << std::endl;
+
+  // Replace layer
+  m.replace_layer(make_new_activation_layer(comm,
+                                            activation_types[type_index],
+                                            activation_layer_names[name_index]),
+                  activation_layer_names[name_index]);
+}
+
+} // namespace ltfb
+} // namespace lbann

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -24,6 +24,8 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "lbann/execution_algorithms/ltfb/mutation_strategy.hpp"
+
 #include "lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp"
 
 #include "lbann/base.hpp"
@@ -134,8 +136,9 @@ bool local_wins(EvalType local,
 
 RandomPairwiseExchange::RandomPairwiseExchange(
   std::unordered_map<std::string, metric_strategy> metrics,
-  std::unique_ptr<ExchangeStrategy> comm_algo)
-  : m_metrics{std::move(metrics)}, m_comm_algo{std::move(comm_algo)}
+  std::unique_ptr<ExchangeStrategy> comm_algo,
+  std::unique_ptr<MutationStrategy> mutate_algo)
+  : m_metrics{std::move(metrics)}, m_comm_algo{std::move(comm_algo)}, m_mutate_algo{std::move(mutate_algo)}
 {
   LBANN_ASSERT(m_metrics.size());
 }
@@ -143,14 +146,16 @@ RandomPairwiseExchange::RandomPairwiseExchange(
 RandomPairwiseExchange::RandomPairwiseExchange(
   std::string metric_name,
   metric_strategy winner_strategy,
-  std::unique_ptr<ExchangeStrategy> comm_algo)
+  std::unique_ptr<ExchangeStrategy> comm_algo,
+  std::unique_ptr<MutationStrategy> mutate_algo)
   : RandomPairwiseExchange({{metric_name, winner_strategy}},
-                           std::move(comm_algo))
+                           std::move(comm_algo), std::move(mutate_algo))
 {}
 
 RandomPairwiseExchange::RandomPairwiseExchange(
   RandomPairwiseExchange const& other)
-  : m_metrics{other.m_metrics}, m_comm_algo{other.m_comm_algo->clone()}
+  : m_metrics{other.m_metrics}, m_comm_algo{other.m_comm_algo->clone()},
+    m_mutate_algo{other.m_mutate_algo->clone()}
 {}
 
 std::unordered_map<std::string, EvalType>
@@ -307,15 +312,15 @@ void RandomPairwiseExchange::select_next(model& m,
     // FIXME (trb 03/18/21): This is ... not great. We need to
     // unravel the "fake" polymorphism in the model non-hierarchy
     // soon.
-    using DAGModel = directed_acyclic_graph_model;
-    auto& local_model = dynamic_cast<DAGModel&>(m);
-    auto& partner_dag_model = dynamic_cast<DAGModel&>(*partner_model);
-    local_model = std::move(partner_dag_model);
+    
+    // Losing model mutates according to mutation strategy
+    m_mutate_algo->mutate(m, step);
+
     auto& trainer = get_trainer();
     auto&& metadata = trainer.get_data_coordinator().get_dr_metadata();
     m.setup(trainer.get_max_mini_batch_size(),
             metadata,
-            /*force=*/true);
+            true); 
   }
 
   LBANN_LOG_TRAINER_MASTER(comm,
@@ -413,8 +418,46 @@ ExchangeStrategyFactory& get_exchange_factory()
   return factory;
 }
 
+using MutationStrategyFactory = lbann::generic_factory<
+  lbann::ltfb::MutationStrategy,
+  std::string,
+  lbann::proto::generate_builder_type<
+    lbann::ltfb::MutationStrategy,
+    google::protobuf::Message const&>>;
+
+std::unique_ptr<lbann::ltfb::NullMutation>
+make_null_mutation(google::protobuf::Message const& msg)
+{
+  using NullMutation = lbann_data::MutationStrategy::NullMutation;
+  LBANN_ASSERT(dynamic_cast<NullMutation const*>(&msg));
+  return std::make_unique<lbann::ltfb::NullMutation>();  
+}
+
+std::unique_ptr<lbann::ltfb::ReplaceActivation>
+make_replace_activation(google::protobuf::Message const& msg)
+{
+  using ReplaceActivation = lbann_data::MutationStrategy::ReplaceActivation;
+  LBANN_ASSERT(dynamic_cast<ReplaceActivation const*>(&msg));
+  return std::make_unique<lbann::ltfb::ReplaceActivation>();
+}
+
+MutationStrategyFactory build_default_mutation_factory()
+{
+  MutationStrategyFactory factory;
+  factory.register_builder("NullMutation", make_null_mutation);
+  factory.register_builder("ReplaceActivation", make_replace_activation);
+  return factory;
+}
+
+MutationStrategyFactory& get_mutation_factory()
+{
+  static MutationStrategyFactory factory = build_default_mutation_factory();
+  return factory;
+}
+
 } // namespace
 
+// For ExchangeStrategy
 template <>
 std::unique_ptr<lbann::ltfb::RandomPairwiseExchange::ExchangeStrategy>
 lbann::make_abstract<lbann::ltfb::RandomPairwiseExchange::ExchangeStrategy>(
@@ -434,6 +477,22 @@ lbann::make_abstract<lbann::ltfb::RandomPairwiseExchange::ExchangeStrategy>(
     proto::helpers::message_type(exchange_params),
     std::move(weights_names),
     exchange_params);
+}
+
+// For MutationStrategy
+template <>
+std::unique_ptr<lbann::ltfb::MutationStrategy>
+lbann::make_abstract<lbann::ltfb::MutationStrategy>(
+  const google::protobuf::Message& msg)
+{
+  using ProtoStrategy = lbann_data::MutationStrategy;
+  auto const& params = dynamic_cast<ProtoStrategy const&>(msg);
+
+  auto const& mutate_params = 
+    proto::helpers::get_oneof_message(params, "strategy");
+  return get_mutation_factory().create_object(
+    proto::helpers::message_type(mutate_params),
+    mutate_params);
 }
 
 template <>
@@ -459,7 +518,10 @@ lbann::make<lbann::ltfb::RandomPairwiseExchange>(
 
   using ExchangeStrategyType =
     lbann::ltfb::RandomPairwiseExchange::ExchangeStrategy;
+  using MutationStrategyType = 
+    lbann::ltfb::MutationStrategy;
   return make_unique<lbann::ltfb::RandomPairwiseExchange>(
     std::move(metric_map),
-    make_abstract<ExchangeStrategyType>(msg.exchange_strategy()));
+    make_abstract<ExchangeStrategyType>(msg.exchange_strategy()),
+    make_abstract<MutationStrategyType>(msg.mutation_strategy()));
 }

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -316,9 +316,9 @@ void RandomPairwiseExchange::select_next(model& m,
     auto& local_model = dynamic_cast<DAGModel&>(m);
     auto& partner_dag_model = dynamic_cast<DAGModel&>(*partner_model);
     local_model = std::move(partner_dag_model);
-    
+
     // Losing model mutates according to mutation strategy
-    m_mutate_algo->mutate(local_model, step);
+    m_mutate_algo->mutate(m, step);
 
     auto& trainer = get_trainer();
     auto&& metadata = trainer.get_data_coordinator().get_dr_metadata();

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -312,15 +312,19 @@ void RandomPairwiseExchange::select_next(model& m,
     // FIXME (trb 03/18/21): This is ... not great. We need to
     // unravel the "fake" polymorphism in the model non-hierarchy
     // soon.
+    using DAGModel = directed_acyclic_graph_model;
+    auto& local_model = dynamic_cast<DAGModel&>(m);
+    auto& partner_dag_model = dynamic_cast<DAGModel&>(*partner_model);
+    local_model = std::move(partner_dag_model);
     
     // Losing model mutates according to mutation strategy
-    m_mutate_algo->mutate(m, step);
+    m_mutate_algo->mutate(local_model, step);
 
     auto& trainer = get_trainer();
     auto&& metadata = trainer.get_data_coordinator().get_dr_metadata();
     m.setup(trainer.get_max_mini_batch_size(),
             metadata,
-            true); 
+            /*force*/true); 
   }
 
   LBANN_LOG_TRAINER_MASTER(comm,

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -138,7 +138,9 @@ RandomPairwiseExchange::RandomPairwiseExchange(
   std::unordered_map<std::string, metric_strategy> metrics,
   std::unique_ptr<ExchangeStrategy> comm_algo,
   std::unique_ptr<MutationStrategy> mutate_algo)
-  : m_metrics{std::move(metrics)}, m_comm_algo{std::move(comm_algo)}, m_mutate_algo{std::move(mutate_algo)}
+  : m_metrics{std::move(metrics)}, 
+    m_comm_algo{std::move(comm_algo)}, 
+    m_mutate_algo{std::move(mutate_algo)}
 {
   LBANN_ASSERT(m_metrics.size());
 }
@@ -149,12 +151,14 @@ RandomPairwiseExchange::RandomPairwiseExchange(
   std::unique_ptr<ExchangeStrategy> comm_algo,
   std::unique_ptr<MutationStrategy> mutate_algo)
   : RandomPairwiseExchange({{metric_name, winner_strategy}},
-                           std::move(comm_algo), std::move(mutate_algo))
+                           std::move(comm_algo), 
+                           std::move(mutate_algo))
 {}
 
 RandomPairwiseExchange::RandomPairwiseExchange(
   RandomPairwiseExchange const& other)
-  : m_metrics{other.m_metrics}, m_comm_algo{other.m_comm_algo->clone()},
+  : m_metrics{other.m_metrics}, 
+    m_comm_algo{other.m_comm_algo->clone()},
     m_mutate_algo{other.m_mutate_algo->clone()}
 {}
 
@@ -317,14 +321,14 @@ void RandomPairwiseExchange::select_next(model& m,
     auto& partner_dag_model = dynamic_cast<DAGModel&>(*partner_model);
     local_model = std::move(partner_dag_model);
 
-    // Losing model mutates according to mutation strategy
+    // Winning model mutates according to mutation strategy
     m_mutate_algo->mutate(m, step);
 
     auto& trainer = get_trainer();
     auto&& metadata = trainer.get_data_coordinator().get_dr_metadata();
     m.setup(trainer.get_max_mini_batch_size(),
             metadata,
-            /*force*/true); 
+            /*force*/true);
   }
 
   LBANN_LOG_TRAINER_MASTER(comm,

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1920,11 +1920,11 @@ void model::replace_layer(OwningLayerPtr&& new_layer, std::string const& old_lay
   parent.replace_child_layer(new_layer, parent.find_child_layer_index(l));
   new_layer->add_parent_layer(m_layers[old_layer_index-1]);
 
+  // Destroy memory of old layer - for now, remove from m_layers
+  m_layers.erase(m_layers.cbegin()+old_layer_index); 
+
   // Add new layer to layer list
   add_layer(std::move(new_layer));
-
-  // Destroy memory of old layer - for now, remove from m_layers
-  m_layers.erase(m_layers.cbegin()+old_layer_index);
 }
 
 // =============================================

--- a/src/proto/training_algorithm.proto
+++ b/src/proto/training_algorithm.proto
@@ -66,6 +66,19 @@ message LTFB {
   TerminationCriteria stopping_criteria = 3;
 }// message LTFB
 
+message MutationStrategy {
+  message NullMutation {
+  }
+
+  message ReplaceActivation {
+  }
+
+  oneof strategy {
+    NullMutation null_mutation = 1;
+    ReplaceActivation replace_activation = 2;
+  }
+} //message Mutation Strategy
+
 // The classic LTFB algorithm. Implements MetaLearningStrategy.
 message RandomPairwiseExchange {
   enum MetricStrategy {
@@ -75,6 +88,7 @@ message RandomPairwiseExchange {
 
   map<string, MetricStrategy> metric_name_strategy_map = 1;
   ExchangeStrategy exchange_strategy = 2;
+  MutationStrategy mutation_strategy = 3;
 
   // This uses the "oneof" strategy because we don't really want
   // downstreams adding strategies willy nilly.


### PR DESCRIPTION
- Adds MutationStrategy as an argument to RandomPairwiseExchange in LTFB for Neural Architecture Search
- Adds the mutation strategy of replacing random activation layers in the winning model after a tournament in LTFB