### PR TITLE
Templated the data_reader_sample_list class

### DIFF
--- a/include/lbann/data_readers/CMakeLists.txt
+++ b/include/lbann/data_readers/CMakeLists.txt
@@ -14,6 +14,8 @@ set_full_path(THIS_DIR_HEADERS
   data_reader_python.hpp
   data_reader_synthetic.hpp
   data_reader_smiles.hpp
+  data_reader_sample_list.hpp
+  data_reader_sample_list_impl.hpp
   )
 
 if (LBANN_HAS_CNPY)

--- a/include/lbann/data_readers/data_reader_HDF5.hpp
+++ b/include/lbann/data_readers/data_reader_HDF5.hpp
@@ -26,6 +26,7 @@
 #ifndef LBANN_DATA_READER_HDF5_REVISED_HPP
 #define LBANN_DATA_READER_HDF5_REVISED_HPP
 
+#include "lbann/data_readers/sample_list_hdf5.hpp"
 #include "lbann/data_readers/data_reader_sample_list.hpp"
 #include "lbann/data_store/data_store_conduit.hpp"
 
@@ -36,7 +37,7 @@ namespace lbann {
 /**
  * A generalized data reader for data stored in HDF5 files.
  */
-class hdf5_data_reader : public data_reader_sample_list
+class hdf5_data_reader : public data_reader_sample_list<sample_list_hdf5<std::string>>
 {
 public:
   hdf5_data_reader(bool shuffle = true);

--- a/include/lbann/data_readers/data_reader_sample_list.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list.hpp
@@ -57,9 +57,11 @@ public:
 
   std::string get_type() const override { return "data_reader_sample_list"; }
 
-  void open_file(size_t index_in,
-                 file_handle_type& file_handle_out,
-                 std::string& sample_name_out);
+  /** @brief Open the file and get the sample name for the given index.
+   *  @returns A pair containing the file handle and the name of the
+   *           sample.
+   */
+  std::pair<file_handle_type, sample_name_type> open_file(size_t index);
   void close_file(size_t index_in);
 
   /**

--- a/include/lbann/data_readers/data_reader_sample_list.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list.hpp
@@ -36,14 +36,14 @@ namespace lbann {
 /**
  * Base class for all readers that employ sample lists
  */
-template<typename sample_list_t>
+template <typename SampleListT>
 class data_reader_sample_list : public generic_data_reader
 {
 public:
-  using sample_name_t = typename sample_list_t::name_t;
-  using sample_t = std::pair<typename sample_list_t::sample_file_id_t, sample_name_t>;
-  using sample_file_id_t = typename sample_list_t::sample_file_id_t;
-  using file_handle_t = typename sample_list_t::file_handle_t;
+  using sample_name_type = typename SampleListT::name_t;
+  using sample_file_id_type = typename SampleListT::sample_file_id_t;
+  using sample_type = std::pair<sample_file_id_type, sample_name_type>;
+  using file_handle_type = typename SampleListT::file_handle_t;
 
   data_reader_sample_list(bool shuffle = true);
   data_reader_sample_list(const data_reader_sample_list&);
@@ -58,7 +58,7 @@ public:
   std::string get_type() const override { return "data_reader_sample_list"; }
 
   void open_file(size_t index_in,
-                 hid_t& file_handle_out,
+                 file_handle_type& file_handle_out,
                  std::string& sample_name_out);
   void close_file(size_t index_in);
 
@@ -74,10 +74,10 @@ public:
    */
   void load() override;
 
-  sample_list_t& get_sample_list() { return m_sample_list; }
+  SampleListT& get_sample_list() { return m_sample_list; }
 
 protected:
-  sample_list_t m_sample_list;
+  SampleListT m_sample_list;
 
   void load_list_of_samples(const std::string sample_list_file);
 

--- a/include/lbann/data_readers/data_reader_sample_list.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list.hpp
@@ -31,29 +31,19 @@
 #include "lbann/data_readers/data_reader.hpp"
 #include <conduit/conduit.hpp>
 
-#ifdef _USE_IO_HANDLE_
-#include "lbann/data_readers/sample_list_conduit_io_handle.hpp"
-#else
-#include "lbann/data_readers/sample_list_hdf5.hpp"
-#endif
-
 namespace lbann {
 
 /**
  * Base class for all readers that employ sample lists
  */
+template<typename sample_list_t>
 class data_reader_sample_list : public generic_data_reader
 {
 public:
-  using sample_name_t = std::string;
-#ifdef _USE_IO_HANDLE_
-  using sample_list_t = sample_list_conduit_io_handle<sample_name_t>;
-#else
-  using sample_list_t = sample_list_hdf5<sample_name_t>;
-#endif
-  using sample_t = std::pair<sample_list_t::sample_file_id_t, sample_name_t>;
-  using sample_file_id_t = sample_list_t::sample_file_id_t;
-  using file_handle_t = sample_list_t::file_handle_t;
+  using sample_name_t = typename sample_list_t::name_t;
+  using sample_t = std::pair<typename sample_list_t::sample_file_id_t, sample_name_t>;
+  using sample_file_id_t = typename sample_list_t::sample_file_id_t;
+  using file_handle_t = typename sample_list_t::file_handle_t;
 
   data_reader_sample_list(bool shuffle = true);
   data_reader_sample_list(const data_reader_sample_list&);

--- a/include/lbann/data_readers/data_reader_sample_list_impl.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list_impl.hpp
@@ -25,6 +25,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifndef LBANN_DATA_READER_SAMPLE_LIST_IMPL_HPP
+#define LBANN_DATA_READER_SAMPLE_LIST_IMPL_HPP
+
 #include "lbann/data_readers/data_reader_sample_list.hpp"
 #include "lbann/data_readers/sample_list_impl.hpp"
 #include "lbann/data_readers/sample_list_open_files_impl.hpp"
@@ -34,19 +37,22 @@
 
 namespace lbann {
 
-data_reader_sample_list::data_reader_sample_list(bool shuffle)
+template<typename sample_list_t>
+data_reader_sample_list<sample_list_t>::data_reader_sample_list(bool shuffle)
   : generic_data_reader(shuffle)
 {}
 
-data_reader_sample_list::data_reader_sample_list(
+template<typename sample_list_t>
+data_reader_sample_list<sample_list_t>::data_reader_sample_list(
   const data_reader_sample_list& rhs)
   : generic_data_reader(rhs)
 {
   copy_members(rhs);
 }
 
-data_reader_sample_list&
-data_reader_sample_list::operator=(const data_reader_sample_list& rhs)
+template<typename sample_list_t>
+data_reader_sample_list<sample_list_t>&
+data_reader_sample_list<sample_list_t>::operator=(const data_reader_sample_list<sample_list_t>& rhs)
 {
   // check for self-assignment
   if (this == &rhs) {
@@ -57,12 +63,14 @@ data_reader_sample_list::operator=(const data_reader_sample_list& rhs)
   return (*this);
 }
 
-void data_reader_sample_list::copy_members(const data_reader_sample_list& rhs)
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::copy_members(const data_reader_sample_list& rhs)
 {
   m_sample_list.copy(rhs.m_sample_list);
 }
 
-void data_reader_sample_list::shuffle_indices(rng_gen& gen)
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::shuffle_indices(rng_gen& gen)
 {
   generic_data_reader::shuffle_indices(gen);
   m_sample_list.compute_epochs_file_usage(get_shuffled_indices(),
@@ -70,7 +78,8 @@ void data_reader_sample_list::shuffle_indices(rng_gen& gen)
                                           *m_comm);
 }
 
-void data_reader_sample_list::load()
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::load()
 {
   if (is_master()) {
     std::cout << "starting data_reader_sample_list::load()\n";
@@ -82,7 +91,8 @@ void data_reader_sample_list::load()
   load_list_of_samples(sample_list_file);
 }
 
-void data_reader_sample_list::load_list_of_samples(
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::load_list_of_samples(
   const std::string sample_list_file)
 {
   // load the sample list
@@ -99,7 +109,7 @@ void data_reader_sample_list::load_list_of_samples(
   }
 
   // Load the sample list
-  if (opts->has_string("slosload_full_sample_list_once")) {
+  if (opts->has_string("load_full_sample_list_once")) {
     std::vector<char> buffer;
     if (m_comm->am_trainer_master()) {
       load_file(sample_list_file, buffer);
@@ -133,7 +143,8 @@ void data_reader_sample_list::load_list_of_samples(
   generic_data_reader::set_file_dir(m_sample_list.get_samples_dirname());
 }
 
-void data_reader_sample_list::load_list_of_samples_from_archive(
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::load_list_of_samples_from_archive(
   const std::string& sample_list_archive)
 {
   // load the sample list
@@ -150,7 +161,9 @@ void data_reader_sample_list::load_list_of_samples_from_archive(
               << std::endl;
   }
 }
-void data_reader_sample_list::open_file(size_t index_in,
+
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::open_file(size_t index_in,
                                         hid_t& file_handle_out,
                                         std::string& sample_name_out)
 {
@@ -164,9 +177,12 @@ void data_reader_sample_list::open_file(size_t index_in,
   }
 }
 
-void data_reader_sample_list::close_file(size_t index)
+template<typename sample_list_t>
+void data_reader_sample_list<sample_list_t>::close_file(size_t index)
 {
   m_sample_list.close_samples_file_handle(index);
 }
 
 } // end of namespace lbann
+
+#endif // LBANN_DATA_READER_SAMPLE_LIST_IMPL_HPP

--- a/include/lbann/data_readers/data_reader_sample_list_impl.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list_impl.hpp
@@ -165,19 +165,14 @@ void data_reader_sample_list<SampleListT>::load_list_of_samples_from_archive(
 }
 
 template <typename SampleListT>
-void data_reader_sample_list<SampleListT>::open_file(
-  size_t index_in,
-  file_handle_type& file_handle_out,
-  std::string& sample_name_out)
+auto data_reader_sample_list<SampleListT>::open_file(size_t index)
+  -> std::pair<file_handle_type, sample_name_type>
 {
-  const sample_type& s = m_sample_list[index_in];
-  sample_name_out = s.second;
-  sample_file_id_type id = s.first;
-  m_sample_list.open_samples_file_handle(index_in);
-  file_handle_out = m_sample_list.get_samples_file_handle(id);
-  if (!m_sample_list.is_file_handle_valid(file_handle_out)) {
-    LBANN_ERROR("file handle is invalid");
-  }
+  auto [sample_id, sample_name] = m_sample_list[index];
+  m_sample_list.open_samples_file_handle(index);
+  auto file_handle_out = m_sample_list.get_samples_file_handle(sample_id);
+  LBANN_ASSERT(m_sample_list.is_file_handle_valid(file_handle_out));
+  return std::make_pair(file_handle_out, std::move(sample_name));
 }
 
 template <typename SampleListT>

--- a/include/lbann/data_readers/data_reader_sample_list_impl.hpp
+++ b/include/lbann/data_readers/data_reader_sample_list_impl.hpp
@@ -37,22 +37,23 @@
 
 namespace lbann {
 
-template<typename sample_list_t>
-data_reader_sample_list<sample_list_t>::data_reader_sample_list(bool shuffle)
+template <typename SampleListT>
+data_reader_sample_list<SampleListT>::data_reader_sample_list(bool shuffle)
   : generic_data_reader(shuffle)
 {}
 
-template<typename sample_list_t>
-data_reader_sample_list<sample_list_t>::data_reader_sample_list(
+template <typename SampleListT>
+data_reader_sample_list<SampleListT>::data_reader_sample_list(
   const data_reader_sample_list& rhs)
   : generic_data_reader(rhs)
 {
   copy_members(rhs);
 }
 
-template<typename sample_list_t>
-data_reader_sample_list<sample_list_t>&
-data_reader_sample_list<sample_list_t>::operator=(const data_reader_sample_list<sample_list_t>& rhs)
+template <typename SampleListT>
+data_reader_sample_list<SampleListT>&
+data_reader_sample_list<SampleListT>::operator=(
+  const data_reader_sample_list<SampleListT>& rhs)
 {
   // check for self-assignment
   if (this == &rhs) {
@@ -63,14 +64,15 @@ data_reader_sample_list<sample_list_t>::operator=(const data_reader_sample_list<
   return (*this);
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::copy_members(const data_reader_sample_list& rhs)
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::copy_members(
+  const data_reader_sample_list& rhs)
 {
   m_sample_list.copy(rhs.m_sample_list);
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::shuffle_indices(rng_gen& gen)
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::shuffle_indices(rng_gen& gen)
 {
   generic_data_reader::shuffle_indices(gen);
   m_sample_list.compute_epochs_file_usage(get_shuffled_indices(),
@@ -78,8 +80,8 @@ void data_reader_sample_list<sample_list_t>::shuffle_indices(rng_gen& gen)
                                           *m_comm);
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::load()
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::load()
 {
   if (is_master()) {
     std::cout << "starting data_reader_sample_list::load()\n";
@@ -91,8 +93,8 @@ void data_reader_sample_list<sample_list_t>::load()
   load_list_of_samples(sample_list_file);
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::load_list_of_samples(
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::load_list_of_samples(
   const std::string sample_list_file)
 {
   // load the sample list
@@ -143,15 +145,15 @@ void data_reader_sample_list<sample_list_t>::load_list_of_samples(
   generic_data_reader::set_file_dir(m_sample_list.get_samples_dirname());
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::load_list_of_samples_from_archive(
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::load_list_of_samples_from_archive(
   const std::string& sample_list_archive)
 {
   // load the sample list
   double tm1 = get_time();
-  std::stringstream ss(sample_list_archive); // any stream can be used
+  std::istringstream iss(sample_list_archive); // any stream can be used
 
-  cereal::BinaryInputArchive iarchive(ss); // Create an input archive
+  cereal::BinaryInputArchive iarchive(iss); // Create an input archive
 
   iarchive(m_sample_list); // Read the data from the archive
   double tm2 = get_time();
@@ -162,14 +164,15 @@ void data_reader_sample_list<sample_list_t>::load_list_of_samples_from_archive(
   }
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::open_file(size_t index_in,
-                                        hid_t& file_handle_out,
-                                        std::string& sample_name_out)
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::open_file(
+  size_t index_in,
+  file_handle_type& file_handle_out,
+  std::string& sample_name_out)
 {
-  const sample_t& s = m_sample_list[index_in];
+  const sample_type& s = m_sample_list[index_in];
   sample_name_out = s.second;
-  sample_file_id_t id = s.first;
+  sample_file_id_type id = s.first;
   m_sample_list.open_samples_file_handle(index_in);
   file_handle_out = m_sample_list.get_samples_file_handle(id);
   if (!m_sample_list.is_file_handle_valid(file_handle_out)) {
@@ -177,8 +180,8 @@ void data_reader_sample_list<sample_list_t>::open_file(size_t index_in,
   }
 }
 
-template<typename sample_list_t>
-void data_reader_sample_list<sample_list_t>::close_file(size_t index)
+template <typename SampleListT>
+void data_reader_sample_list<SampleListT>::close_file(size_t index)
 {
   m_sample_list.close_samples_file_handle(index);
 }

--- a/include/lbann/data_readers/sample_list.hpp
+++ b/include/lbann/data_readers/sample_list.hpp
@@ -88,6 +88,7 @@ struct sample_list_header {
 template <typename sample_name_t>
 class sample_list {
  public:
+  using name_t = sample_name_t;
   /// The type for the index assigned to each sample file
   using sample_file_id_t = std::size_t;
   /** To describe a sample as the id of the file to which it belongs.

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -15,7 +15,6 @@ set_full_path(THIS_DIR_SOURCES
   data_reader_python.cpp
   data_reader_smiles.cpp
   data_reader_HDF5.cpp
-  data_reader_sample_list.cpp
   )
 
 if (LBANN_HAS_CNPY)

--- a/src/data_readers/data_reader_HDF5.cpp
+++ b/src/data_readers/data_reader_HDF5.cpp
@@ -27,6 +27,7 @@
 #include "conduit/conduit_relay_mpi.hpp"
 
 #include "lbann/data_readers/data_reader_HDF5.hpp"
+#include "lbann/data_readers/data_reader_sample_list_impl.hpp"
 #include "lbann/data_readers/sample_list_impl.hpp"
 #include "lbann/data_readers/sample_list_open_files_impl.hpp"
 #include "lbann/utils/timer.hpp"

--- a/src/data_readers/data_reader_HDF5.cpp
+++ b/src/data_readers/data_reader_HDF5.cpp
@@ -325,10 +325,7 @@ void hdf5_data_reader::load_sample(conduit::Node& node,
                                    size_t index,
                                    bool ignore_failure)
 {
-  hid_t file_handle;
-  std::string sample_name;
-
-  data_reader_sample_list::open_file(index, file_handle, sample_name);
+  auto [file_handle,sample_name] = data_reader_sample_list::open_file(index);
   // load data for the field names specified in the user's experiment-schema
   for (auto& [pathname, path_node] : m_useme_node_map) {
     // do not load a "packed" field, as it doesn't exist on disk!


### PR DESCRIPTION
Refactored the data_reader_sample_list class so that it is templated
over the type of sample list.  Moved the data_reader_sample_list.cpp
file to an _impl.hpp file.