### PR TITLE
Update the perturb weight callback

### DIFF
--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -45,8 +45,9 @@ public:
    *  @param batch_interval Number of training mini-batch steps 
    *  @param output_name   Name of weight layer
    */
-  perturb_weights(std::string output_name,
-               El::Int batch_interval = 1);
+  perturb_weights(EvalType upper, EvalType lower, EvalType scale, 
+		  std::string output_name,
+                  El::Int batch_interval = 1);
 
   perturb_weights* copy() const override { return new perturb_weights(*this); }
   std::string name() const override { return "perturb weights"; }
@@ -71,6 +72,12 @@ private:
    *  output_name.
    */
   std::string m_output_name;
+
+
+  EvalType m_upper;
+  EvalType m_lower;
+  EvalType m_scale;
+
    
   void perturb(model& m);
 

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -77,15 +77,13 @@ private:
    */
   std::string m_output_name;
 
-   /*
-   *  upper.
-   *  lower.
-   *  scale.
-   *  perturb_probability.
-   */	
+  /// Upper bound of the perturbed weight
   EvalType m_upper;
+  /// Lower bound of the perturbed weight
   EvalType m_lower;
+  /// Scale of normal distribution N(1,0) for the perturbed weight
   EvalType m_scale;
+  /// The probability of perturbing the weight
   EvalType m_perturb_probability;
 
    

--- a/include/lbann/callbacks/perturb_weights.hpp
+++ b/include/lbann/callbacks/perturb_weights.hpp
@@ -44,8 +44,12 @@ public:
   /** 
    *  @param batch_interval Number of training mini-batch steps 
    *  @param output_name   Name of weight layer
+   *  @param upper   Upper bound of the perturbed weight
+   *  @param lower   Lower bound of the perturbed weight 
+   *  @param scale   Scale of normal distribution N(1,0) for the perturbed weight
+   *  @param perturb_probability   The probability of perturbing the weight 
    */
-  perturb_weights(EvalType upper, EvalType lower, EvalType scale, 
+  perturb_weights(EvalType upper, EvalType lower, EvalType scale, EvalType perturb_probability,
 		  std::string output_name,
                   El::Int batch_interval = 1);
 
@@ -73,10 +77,16 @@ private:
    */
   std::string m_output_name;
 
-
+   /*
+   *  upper.
+   *  lower.
+   *  scale.
+   *  perturb_probability.
+   */	
   EvalType m_upper;
   EvalType m_lower;
   EvalType m_scale;
+  EvalType m_perturb_probability;
 
    
   void perturb(model& m);

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -410,7 +410,10 @@ message Callback {
   }
 
   message CallbackPerturbWeights {
-    string output_name = 1;
-    int64 batch_interval = 2;
+    float upper = 1; // Upper bound for weight value
+    float lower = 2; // Lower bound for weight value
+    float scale = 3; // Scale of normal distribution N(1,0)
+    string output_name = 4;
+    int64 batch_interval = 5;
   }
 }

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -413,7 +413,8 @@ message Callback {
     float upper = 1; // Upper bound for weight value
     float lower = 2; // Lower bound for weight value
     float scale = 3; // Scale of normal distribution N(1,0)
-    string output_name = 4;
-    int64 batch_interval = 5;
+    float perturb_probability = 4; // Probability of perturbing the weight
+    string output_name = 5;
+    int64 batch_interval = 6;
   }
 }


### PR DESCRIPTION
Update the perturb weight callback to support better range of weight values.
Add upper bound parameter for weight values.
Add lower bound parameter for weight values.
Add scale parameter for scaling normal distribution N(1,0) for the perturb values.
Add perturbation probability parameter.
Make the callback only perturbs weight during training.