### PR TITLE
Run ExaGAN discriminators fully within distconv

### DIFF
--- a/applications/physics/cosmology/ExaGAN/DistConvGAN.py
+++ b/applications/physics/cosmology/ExaGAN/DistConvGAN.py
@@ -81,33 +81,21 @@ class ConvBNRelu(lbann.modules.Module):
                 name='{0}_bn_instance{1}'.format(
                     self.name, self.instance))
 
-        # Strided 1x1x1 pooling
+        # Strided pooling
         # Note: Ideally we would do this immediately after the
         # convolution, but we run into issues since the tensor
         # overlaps don't match.
         ### @todo Support strided convolution in distconv
         if self.stride != 1:
-            # layer = lbann.Pooling(
-            #     layer,
-            #     num_dims=3,
-            #     pool_dims_i=1,
-            #     pool_strides_i=self.stride,
-            #     pool_mode='max',
-            #     parallel_strategy=self.ps,
-            #     name='{0}_pool_instance{1}'.format(
-            #     self.name, self.instance)
-            # )
-            layer = lbann.Convolution(
+            layer = lbann.Pooling(
                 layer,
                 num_dims=3,
-                num_output_channels=self.conv.out_channels,
-                conv_dims_i=1,
-                conv_strides_i=2,
-                conv_dilations_i=1,
-                num_groups=1,
+                pool_dims_i=self.stride,
+                pool_strides_i=self.stride,
+                pool_mode='max',
                 parallel_strategy=self.ps,
                 name='{0}_pool_instance{1}'.format(
-                    self.name, self.instance),
+                self.name, self.instance)
             )
 
         # Activation

--- a/applications/physics/cosmology/ExaGAN/DistConvGAN.py
+++ b/applications/physics/cosmology/ExaGAN/DistConvGAN.py
@@ -39,6 +39,7 @@ class ConvBNRelu(lbann.modules.Module):
         super().__init__()
         self.name = name
         self.instance = 0
+        self.stride = stride
         self.bn_statistics_group_size = bn_statistics_group_size
         self.activation = activation
         self.use_bn = use_bn
@@ -48,8 +49,8 @@ class ConvBNRelu(lbann.modules.Module):
         # Initialize convolution
         self.conv = lbann.modules.Convolution3dModule(
             out_channels, kernel_size,
-            stride=stride, padding=padding,
-            bias=False, parallel_strategy=self.ps, 
+            stride=1, padding=padding,
+            bias=False, parallel_strategy=self.ps,
             weights=self.conv_weights,
             name=self.name + '_conv')
 
@@ -66,7 +67,11 @@ class ConvBNRelu(lbann.modules.Module):
 
     def forward(self, x):
         self.instance += 1
+
+        # Convolution
         layer = self.conv(x)
+
+        # Batchnorm
         if self.use_bn:
             layer = lbann.BatchNormalization(
                 layer, weights=self.bn_weights,
@@ -75,12 +80,44 @@ class ConvBNRelu(lbann.modules.Module):
                 parallel_strategy=self.ps,
                 name='{0}_bn_instance{1}'.format(
                     self.name, self.instance))
+
+        # Strided 1x1x1 pooling
+        # Note: Ideally we would do this immediately after the
+        # convolution, but we run into issues since the tensor
+        # overlaps don't match.
+        ### @todo Support strided convolution in distconv
+        if self.stride != 1:
+            # layer = lbann.Pooling(
+            #     layer,
+            #     num_dims=3,
+            #     pool_dims_i=1,
+            #     pool_strides_i=self.stride,
+            #     pool_mode='max',
+            #     parallel_strategy=self.ps,
+            #     name='{0}_pool_instance{1}'.format(
+            #     self.name, self.instance)
+            # )
+            layer = lbann.Convolution(
+                layer,
+                num_dims=3,
+                num_output_channels=self.conv.out_channels,
+                conv_dims_i=1,
+                conv_strides_i=2,
+                conv_dilations_i=1,
+                num_groups=1,
+                parallel_strategy=self.ps,
+                name='{0}_pool_instance{1}'.format(
+                    self.name, self.instance),
+            )
+
+        # Activation
         if self.activation:
             layer = self.activation(
                 layer,
                 parallel_strategy=self.ps,
                 name='{0}_activation_instance{1}'.format(
                     self.name, self.instance))
+
         return layer
 
 class Deconvolution3dModule(lbann.modules.ConvolutionModule):
@@ -126,48 +163,48 @@ class Exa3DGAN(lbann.modules.Module):
 
        self.g_device = gen_device
        #Set parallel strategy
-       self.d_ps = disc_ps 
-       self.g_ps = gen_ps 
+       self.d_ps = disc_ps
+       self.g_ps = gen_ps
        self.use_bn = use_bn
 
        assert self.input_width in [64,128, 256, 512]
 
-       w = [int(self.input_width/16)]*3 #filter size in last disc conv and first gen conv 
+       w = [int(self.input_width/16)]*3 #filter size in last disc conv and first gen conv
        w.insert(0,512) ##num filters in last disc conv and first gen conv
        self.outc_dims = w
-      
+
 
 
        self.inits = {'dense': lbann.NormalInitializer(mean=0,standard_deviation=0.02),
-                      'conv': lbann.NormalInitializer(mean=0,standard_deviation=0.02), 
+                      'conv': lbann.NormalInitializer(mean=0,standard_deviation=0.02),
                       'convT':lbann.NormalInitializer(mean=0,standard_deviation=0.02)}
-      
-       #Discriminator 
+
+       #Discriminator
        d_channels = [64,128,256,512]
        kernel_size=5
        padding = 2
        stride = 2
        self.d1_conv = [convbnrelu(d_channels[i], kernel_size, stride, padding, self.use_bn, bn_stats_grp_sz, False,
-                                  name=self.name+'_disc1_conv'+str(i), 
+                                  name=self.name+'_disc1_conv'+str(i),
                                   activation=lbann.Relu,
                                   parallel_strategy=self.d_ps,
                                   conv_weights=[lbann.Weights(initializer=self.inits['conv'])])
-                   for i in range(len(d_channels))] 
+                   for i in range(len(d_channels))]
        self.d1_fc = fc(1,name=self.name+'_disc1_fc',
                        weights=[lbann.Weights(initializer=self.inits['dense'])])
 
-       #stacked_discriminator, this will be frozen, no optimizer, 
+       #stacked_discriminator, this will be frozen, no optimizer,
        #layer has to be named for callback
        self.d2_conv = [convbnrelu(d_channels[i], kernel_size, stride, padding, self.use_bn, bn_stats_grp_sz, False,
-                                  name=self.name+'_disc2_conv'+str(i), 
+                                  name=self.name+'_disc2_conv'+str(i),
                                   activation=lbann.Relu,
                                   parallel_strategy=self.d_ps,
                                   conv_weights=[lbann.Weights(initializer=self.inits['conv'])])
-                   for i in range(len(d_channels))] 
+                   for i in range(len(d_channels))]
 
        self.d2_fc = fc(1,name=self.name+'_disc2_fc',
                        weights=[lbann.Weights(initializer=self.inits['dense'])])
-        
+
 
        g_channels = [256,128,64]
        kernel_size=2
@@ -176,7 +213,7 @@ class Exa3DGAN(lbann.modules.Module):
                         name=self.name+'_gen'+str(i),
                         parallel_strategy=self.g_ps,
                        weights=[lbann.Weights(initializer=self.inits['convT'])])
-                       for i in range(len(g_channels))] 
+                       for i in range(len(g_channels))]
 
        self.g_convT3 = conv(input_channel, kernel_size, stride, padding, activation=lbann.Tanh,
                             parallel_strategy=self.g_ps,
@@ -196,13 +233,12 @@ class Exa3DGAN(lbann.modules.Module):
 
     def forward_discriminator2(self,y):
         x = self.d2_conv[3](self.d2_conv[2](self.d2_conv[1](self.d2_conv[0](y))))
-        return self.d2_fc(x) 
- 
+        return self.d2_fc(x)
+
     def forward_generator(self,z,ps=None):
         x = lbann.FullyConnected(z, num_neurons = np.prod(self.outc_dims), has_bias = True, device=self.g_device)
-        x = lbann.Reshape(x, dims=list2str(self.outc_dims),name='gen_zin_reshape',device=self.g_device) 
+        x = lbann.Reshape(x, dims=list2str(self.outc_dims),name='gen_zin_reshape',device=self.g_device)
         x = lbann.Relu(self.g_convT[0](x), name='g_relu0',parallel_strategy=ps,device=self.g_device)
         x = lbann.Relu(self.g_convT[1](x), name='g_relu1',parallel_strategy=ps,device=self.g_device)
         x = lbann.Relu(self.g_convT[2](x), name='g_relu2',parallel_strategy=ps,device=self.g_device)
-        return self.g_convT3(x) 
-
+        return self.g_convT3(x)

--- a/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
+++ b/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
@@ -72,7 +72,7 @@ def construct_model(args):
     metrics = []
     callbacks = []
 
-    w  = [args.input_width]*3 
+    w  = [args.input_width]*3
     w.insert(0,args.input_channel)
     _sample_dims = w
 
@@ -81,7 +81,7 @@ def construct_model(args):
     if(args.use_distconv):
       ps = get_parallel_strategy_args(
                 sample_groups=args.mini_batch_size,
-                height_groups=args.depth_groups)
+                depth_groups=args.depth_groups)
 
     g_device = 'GPU'
     input_ = lbann.Input(name='input', device=g_device)
@@ -94,12 +94,12 @@ def construct_model(args):
 
     z = lbann.Reshape(lbann.Gaussian(mean=0.0,stdev=1.0, neuron_dims="64", name='noise_vec', device=g_device),
                       dims='1 64', name='noise_vec_reshape',device=g_device)
-    print("RUN ARGS ", args) 
+    print("RUN ARGS ", args)
 
     d1_real,d1_fake,d_adv, gen_img = model.Exa3DGAN(args.input_width,args.input_channel,
                              g_device,ps,use_bn=args.use_bn)(x1,z)
-    
-    layers=list(lbann.traverse_layer_graph(input_))
+
+    layers=list(lbann.traverse_layer_graph([d1_real, d1_fake]))
    # Setup objective function
     weights = set()
     src_layers = []
@@ -134,7 +134,6 @@ def construct_model(args):
     callbacks.append(lbann.CallbackPrint())
     callbacks.append(lbann.CallbackTimer())
     callbacks.append(lbann.CallbackGPUMemoryUsage())
-
 
     # ------------------------------------------
     # Construct model
@@ -176,7 +175,7 @@ if __name__ == '__main__':
     #Remove cosmoflow/hdf5 stuff
     environment.pop('LBANN_DISTCONV_COSMOFLOW_PARALLEL_IO')
     environment.pop('LBANN_DISTCONV_NUM_IO_PARTITIONS')
-    lbann_args = ['--io_thread=1']
+    lbann_args = ['--num_io_threads=1']
 
     print('LBANN args ', lbann_args)
     print("LBANN ENV VAR ", environment)

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -265,8 +265,12 @@ protected:
   /** @brief Get the values matrix for a specific weights object */
   InputAbsDistMatrixType const& weights_values(size_t idx) const {
     if (idx >= m_weights_proxy.size())
-      LBANN_ERROR("Bad index ", idx, " "
-                  "(size=" , m_weights_proxy.size(), ")");
+    {
+      LBANN_ERROR(
+        this->get_type()," layer \"",this->get_name(),"\" ",
+        "attempted to access weights ",idx,", ",
+        "but there are only ",m_weights_proxy.size()," weights");
+    }
     return m_weights_proxy[idx].values();
   }
 

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1147,9 +1147,11 @@ void base_convolution_adapter<TensorDataType, Device>::setup_bp_tensors() {
   m_kernel_gradient = make_unique<TensorDevType>(kernel_shape, loc, shared_dist);
   // Gradient buffer is needed for auto-tuning the bp filter algorithm
   auto* kernel_optimizer = static_cast<data_type_optimizer<TensorDataType>*>(l.get_weights(0).get_optimizer());
-  assert0(dc::tensor::View(
-            *m_kernel_gradient,
-            kernel_optimizer->get_gradient().Buffer()));
+  if (kernel_optimizer != nullptr) {
+    assert0(dc::tensor::View(
+              *m_kernel_gradient,
+              kernel_optimizer->get_gradient().Buffer()));
+  }
 
   // Bias tensor. Shared by all procs
   if (l.m_bias_scaling_factor != El::To<TensorDataType>(0)) {

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -270,6 +270,11 @@ void convolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
     this->m_bwd_filter_algo = dc::get_convolution_bwd_filter_algorithm();
   }
 
+  // Allocate temporary buffer for kernel
+  // Note: Needed for autotuning the convolution algorithm
+  El::simple_buffer<TensorDataType,Device> temp(this->m_kernel->get_local_size());
+  assert0(dc::tensor::View(*this->m_kernel, temp.data()));
+
   std::vector<int> pads = layer.m_pads;
   std::reverse(pads.begin(), pads.end());
   std::vector<int> strides = layer.m_strides;

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -270,11 +270,6 @@ void convolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
     this->m_bwd_filter_algo = dc::get_convolution_bwd_filter_algorithm();
   }
 
-  // Allocate temporary buffer for kernel
-  // Note: Needed for autotuning the convolution algorithm
-  El::simple_buffer<TensorDataType,Device> temp(this->m_kernel->get_local_size());
-  assert0(dc::tensor::View(*this->m_kernel, temp.data()));
-
   std::vector<int> pads = layer.m_pads;
   std::reverse(pads.begin(), pads.end());
   std::vector<int> strides = layer.m_strides;
@@ -282,6 +277,16 @@ void convolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
   std::vector<int> dilations = layer.m_dilations;
   std::reverse(dilations.begin(), dilations.end());
 
+  // Allocate temporary buffer for kernel gradient buffer, if needed
+  // Note: Needed for autotuning the convolution algorithm
+  El::simple_buffer<TensorDataType,Device> temp;
+  TensorDataType* kernel_gradient_buffer = this->m_kernel_gradient->get_buffer();
+  if (kernel_gradient_buffer == nullptr) {
+    temp.allocate(this->m_kernel_gradient->get_local_size());
+    assert0(dc::tensor::View(*this->m_kernel_gradient, temp.data()));
+  }
+
+  // Setup
   this->m_conv->setup(this->get_prev_activations(),
                       *(this->m_kernel), this->get_activations(),
                       this->get_error_signals(),
@@ -291,6 +296,10 @@ void convolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer(
                       this->m_fwd_algo, this->m_bwd_data_algo,
                       this->m_bwd_filter_algo,
                       workspace_capacity);
+
+  // Clean up
+  assert0(dc::tensor::View(*this->m_kernel_gradient, kernel_gradient_buffer));
+
 }
 #endif // defined LBANN_HAS_DISTCONV
 

--- a/src/layers/learning/deconvolution.cpp
+++ b/src/layers/learning/deconvolution.cpp
@@ -285,6 +285,11 @@ void deconvolution_distconv_adapter<TensorDataType, Layout, Device>::setup_layer
     this->m_bwd_filter_algo = dc::get_convolution_bwd_filter_algorithm();
   }
 
+  // Allocate temporary buffer for kernel
+  // Note: Needed for autotuning the convolution algorithm
+  El::simple_buffer<TensorDataType,Device> temp(this->m_kernel->get_local_size());
+  assert0(dc::tensor::View(*this->m_kernel, temp.data()));
+
   std::vector<int> pads = layer.m_pads;
   std::reverse(pads.begin(), pads.end());
   std::vector<int> strides = layer.m_strides;


### PR DESCRIPTION
Changes:
- distconv has poor support for strided convolution. I've worked around this by making the 5x5x5 convolutions have unit stride, and following them up with 2x2x2 max pooling.
- Fixed bug where distconv convolutions assume the weights have optimizers. This was causing some problems since one copy of the discriminator doesn't have any optimizers.

This depends on https://github.com/LLNL/DiHydrogen/pull/59. [Bamboo is running](https://lc.llnl.gov/bamboo/browse/LBANN-TIM395-1).