### PR TITLE
Add MIOpen Workspace Size Query for Convolution Layer

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -48,7 +48,7 @@ get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
                             TensorDescriptor const& yDesc,
                             El::SyncInfo<El::Device::GPU> const& si)
 {
-  size_t size = 1 << 30 // @todo Allocate largest free block
+  size_t size = 1 << 30; // @todo Allocate largest free block
   return size;
 }
 
@@ -59,7 +59,7 @@ get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
                                  TensorDescriptor const& dxDesc,
                                  El::SyncInfo<El::Device::GPU> const& si)
 {
-  size_t size = 1 << 30 // @todo Allocate largest free block
+  size_t size = 1 << 30; // @todo Allocate largest free block
   return size;
 }
 
@@ -70,7 +70,7 @@ get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
                                     TensorDescriptor const& dwDesc,
                                     El::SyncInfo<El::Device::GPU> const& si)
 {
-  size_t size = 1 << 30 // @todo Allocate largest free block
+  size_t size = 1 << 30; // @todo Allocate largest free block
   return size;
 }
 

--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -41,6 +41,39 @@ namespace dnn_lib
 
 using namespace cudnn;
 
+inline size_t
+get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
+                            TensorDescriptor const& xDesc,
+                            ConvolutionDescriptor const& convDesc,
+                            TensorDescriptor const& yDesc,
+                            El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size = 1 << 30 // @todo Allocate largest free block
+  return size;
+}
+
+inline size_t
+get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
+                                 TensorDescriptor const& wDesc,
+                                 ConvolutionDescriptor const& convDesc,
+                                 TensorDescriptor const& dxDesc,
+                                 El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size = 1 << 30 // @todo Allocate largest free block
+  return size;
+}
+
+inline size_t
+get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
+                                    TensorDescriptor const& xDesc,
+                                    ConvolutionDescriptor const& convDesc,
+                                    TensorDescriptor const& dwDesc,
+                                    El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size = 1 << 30 // @todo Allocate largest free block
+  return size;
+}
+
 template <typename TensorDataType, typename ScalarParameterType>
 void convolution_forward(
   ScalarParameterType const& alpha_in,

--- a/include/lbann/utils/dnn_lib/miopen/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/convolution.hpp
@@ -68,12 +68,13 @@ get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
 {
   size_t size;
   auto handle_manager = internal::make_default_handle_manager(si);
-  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
-                                                        dyDesc,
-                                                        wDesc,
-                                                        convDesc,
-                                                        dxDesc,
-                                                        &size));
+  CHECK_MIOPEN(
+    miopenConvolutionBackwardDataGetWorkSpaceSize(handle_manager.get(),
+                                                  dyDesc,
+                                                  wDesc,
+                                                  convDesc,
+                                                  dxDesc,
+                                                  &size));
   return size;
 }
 
@@ -86,12 +87,13 @@ get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
 {
   size_t size;
   auto handle_manager = internal::make_default_handle_manager(si);
-  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
-                                                        dyDesc,
-                                                        xDesc,
-                                                        convDesc,
-                                                        dwDesc,
-                                                        &size));
+  CHECK_MIOPEN(
+    miopenConvolutionBackwardWeightsGetWorkSpaceSize(handle_manager.get(),
+                                                    dyDesc,
+                                                    xDesc,
+                                                    convDesc,
+                                                    dwDesc,
+                                                    &size));
   return size;
 }
 

--- a/include/lbann/utils/dnn_lib/miopen/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/convolution.hpp
@@ -41,6 +41,60 @@ namespace dnn_lib
 
 using namespace miopen;
 
+inline size_t
+get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
+                            TensorDescriptor const& xDesc,
+                            ConvolutionDescriptor const& convDesc,
+                            TensorDescriptor const& yDesc,
+                            El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size;
+  auto handle_manager = internal::make_default_handle_manager(si);
+  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
+                                                        wDesc,
+                                                        xDesc,
+                                                        convDesc,
+                                                        yDesc,
+                                                        &size));
+  return size;
+}
+
+inline size_t
+get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
+                                 TensorDescriptor const& wDesc,
+                                 ConvolutionDescriptor const& convDesc,
+                                 TensorDescriptor const& dxDesc,
+                                 El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size;
+  auto handle_manager = internal::make_default_handle_manager(si);
+  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
+                                                        dyDesc,
+                                                        wDesc,
+                                                        convDesc,
+                                                        dxDesc,
+                                                        &size));
+  return size;
+}
+
+inline size_t
+get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
+                                    TensorDescriptor const& xDesc,
+                                    ConvolutionDescriptor const& convDesc,
+                                    TensorDescriptor const& dwDesc,
+                                    El::SyncInfo<El::Device::GPU> const& si)
+{
+  size_t size;
+  auto handle_manager = internal::make_default_handle_manager(si);
+  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
+                                                        dyDesc,
+                                                        xDesc,
+                                                        convDesc,
+                                                        dwDesc,
+                                                        &size));
+  return size;
+}
+
 template <typename TensorDataType, typename ScalarParameterType>
 void convolution_forward(
   ScalarParameterType const& alpha_in,

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -557,8 +557,8 @@ apply_transposed_convolution_dnn(bool during_forward_prop) {
   // Get workspace size
   auto multisync = El::MakeMultiSync(gpu::get_sync_info(workspace));
   size_t workspace_size =
-    dnn_lib::get_bwd_data_conv_workspace_size(m_kernel_dnn_desc,
-                                              input_desc,
+    dnn_lib::get_bwd_data_conv_workspace_size(input_desc,
+                                              m_kernel_dnn_desc,
                                               m_convolution_dnn_desc,
                                               output_desc,
                                               multisync);

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -673,11 +673,11 @@ base_convolution_layer<TensorDataType,Device>
       // Get workspace size
       auto multisync = El::MakeMultiSync(gpu::get_sync_info(workspace));
       size_t workspace_size =
-        dnn_lib::get_bwd_weight_conv_workspace_size(gradient_wrt_output_desc,
-                                                    input_desc,
-                                                    m_convolution_dnn_desc,
-                                                    m_kernel_dnn_desc,
-                                                    multisync);
+        dnn_lib::get_bwd_weights_conv_workspace_size(gradient_wrt_output_desc,
+                                                     input_desc,
+                                                     m_convolution_dnn_desc,
+                                                     m_kernel_dnn_desc,
+                                                     multisync);
       workspace.Resize(workspace_size / sizeof(TensorDataType), 1);
       workspace_size = workspace.Height() * sizeof(TensorDataType);
 


### PR DESCRIPTION
Added the functions in `dnn_lib` namespace for MIOpen corresponding to `miopenConvolution*GetWorkSpaceSize` functions, so that workspaces are properly sizes.  Added equivalent functions for cuDNN that return `1 << 30` (same as prior behavior).