### PR TITLE
Remove the explicit finding of HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,7 +632,9 @@ target_link_libraries(lbann PUBLIC Threads::Threads)
 target_link_libraries(lbann PUBLIC clara::clara)
 target_link_libraries(lbann PUBLIC cereal)
 target_link_libraries(lbann PUBLIC OpenMP::OpenMP_CXX)
-target_link_libraries(lbann PUBLIC MPI::MPI_CXX)
+target_link_libraries(lbann PUBLIC
+  $<TARGET_NAME_IF_EXISTS:HWLOC::hwloc>
+  MPI::MPI_CXX)
 target_link_libraries(lbann PUBLIC protobuf::libprotobuf)
 target_link_libraries(lbann PUBLIC ${HYDROGEN_LIBRARIES})
 if (LBANN_HAS_OPENCV)
@@ -650,7 +652,6 @@ target_link_libraries(lbann PUBLIC
 
   $<TARGET_NAME_IF_EXISTS:CNPY::CNPY>
   $<TARGET_NAME_IF_EXISTS:FFTW::FFTW>
-  $<TARGET_NAME_IF_EXISTS:HWLOC::hwloc>
   $<TARGET_NAME_IF_EXISTS:Python::Python>
   $<TARGET_NAME_IF_EXISTS:ZSTR::ZSTR>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,22 +469,6 @@ if (LBANN_WITH_HWLOC)
 endif (LBANN_WITH_HWLOC)
 
 if (LBANN_WITH_CONDUIT)
-  # Apparently we have to find HDF5, too.
-  find_package(HDF5 CONFIG QUIET
-    HINTS ${HDF5_DIR} $ENV{HDF5_DIR}
-    PATH_SUFFIXES share/cmake/hdf5
-    NO_DEFAULT_PATH)
-  if (NOT HDF5_FOUND)
-    find_package(HDF5 CONFIG QUIET)
-  endif ()
-  if (NOT HDF5_FOUND)
-    enable_language(C) # WHY??????????????
-    find_package(HDF5 REQUIRED)
-    set(HDF5_FOUND_WITH_MODULE TRUE)
-  else ()
-    message(STATUS "Found HDF5: ${HDF5_DIR}")
-  endif ()
-
   find_package(Conduit CONFIG QUIET
     HINTS ${Conduit_DIR} $ENV{Conduit_DIR} ${CONDUIT_DIR} $ENV{CONDUIT_DIR}
     PATH_SUFFIXES lib64/cmake lib/cmake

--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -53,8 +53,9 @@ def make_batch_script(
     # can't use an exclusive GPU compute mode since processes may
     # touch the wrong GPU while figuring out ownership.
     if scheduler == 'slurm' and has_gpu(system):
-        launcher_args.extend(['--mpibind=off',
-                              '--nvidia_compute_mode=default'])
+        launcher_args.extend(['--mpibind=off'])
+        if system != 'corona':
+            laucher_args.extend(['--nvidia_compute_mode=default'])
 
     # Optimized thread affinity for Pascal
     # Note: Both GPUs are on socket 0, so we only use cores on that

--- a/python/lbann/contrib/lc/systems.py
+++ b/python/lbann/contrib/lc/systems.py
@@ -16,7 +16,7 @@ class SystemParams:
 # Supported LC systems
 _system_params = {
     'catalyst': SystemParams(24, 0, 'slurm'),
-    'corona':   SystemParams(24, 0, 'slurm'),
+    'corona':   SystemParams(24, 4, 'slurm'),
     'pascal':   SystemParams(36, 2, 'slurm'),
     'quartz':   SystemParams(36, 0, 'slurm'),
     'surface':  SystemParams(16, 2, 'slurm'),


### PR DESCRIPTION
Now, as it should have been all along, this is Conduit's task.

In versions past of Conduit, certain issues could arise when finding
the HDF5 package if it was built differently from how Conduit expected
it. This changed a few versions back, and the Conduit mechanisms for
finding HDF5 now seem (I hope) robust to these issues.