### PR TITLE
Mutation Strategy of Replacing Random Convolution

### DIFF
--- a/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
+++ b/include/lbann/execution_algorithms/ltfb/mutation_strategy.hpp
@@ -63,6 +63,14 @@ public:
   void mutate(model& m, const int& step) final;
 };
 
+// Replace Convolution layers
+class ReplaceConvolution final : public Cloneable<ReplaceConvolution, MutationStrategy>
+{
+public:
+  ReplaceConvolution() = default;
+  void mutate(model& m, const int& step) final;
+};
+
 } // namespace ltfb
 } // namespace lbann
 #endif // LBANN_EXECUTION_ALGORITHMS_LTFB_MUTATION_STRATEGY_HPP_INCLUDED

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -245,6 +245,9 @@ public:
   /** @brief Add weights to model. */
   void add_weights(OwningWeightsPtr&& w);
 
+  /** @brief Remove weights from model. */
+  void remove_weights(std::string const& name);
+
   /** @brief Register a new callback for the model. */
   void add_callback(std::shared_ptr<callback_base> cb);
 

--- a/python/lbann/core/training_algorithm.py
+++ b/python/lbann/core/training_algorithm.py
@@ -209,6 +209,9 @@ class MutationStrategy:
         elif self.strategy == "replace_activation":
             ReplaceActivationMsg = MutationStrategyMsg.ReplaceActivation
             msg.replace_activation.CopyFrom(ReplaceActivationMsg())
+        elif self.strategy == "replace_convolution":
+            ReplaceConvolutionMsg = MutationStrategyMsg.ReplaceConvolution
+            msg.replace_convolution.CopyFrom(ReplaceConvolutionMsg())
         else:
             raise ValueError("Unknown Strategy")
         return msg

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -42,9 +42,9 @@
 #include "lbann/utils/random.hpp"
 
 #ifdef LBANN_HAS_GPU
-  constexpr El::Device Dev = El::Device::GPU;
+constexpr El::Device Dev = El::Device::GPU;
 #else
-  constexpr El::Device Dev = El::Device::CPU;
+constexpr El::Device Dev = El::Device::CPU;
 #endif
 
 namespace lbann {
@@ -202,7 +202,7 @@ void ReplaceActivation::mutate(model& m, const int& step)
 
 void ReplaceConvolution::mutate(model& m, const int& step)
 {
-  static std::vector<int> const kernels = {5, 7, 9};
+  static std::vector<int> const kernels = {3, 5, 7, 9};
   static std::vector<int> const channels = {6, 16, 32};
 
   std::vector<int> conv_layer_indices; // Indices of all convolution layers
@@ -292,15 +292,9 @@ void ReplaceConvolution::mutate(model& m, const int& step)
     auto shim_channels = child.get_output_dims(0)[0];
 
     // Replace shim layer: O/P channels stay the same but I/P channels change
-    m.remove_layer(shim_layer_name);
-    m.insert_layer(make_new_convolution_layer(1,
-                                              0,
-                                              1,
-                                              shim_channels,
-                                              1,
-                                              1,
-                                              shim_layer_name),
-                   name);
+    m.replace_layer(
+      make_new_convolution_layer(1, 0, 1, shim_channels, 1, 1, shim_layer_name),
+      shim_layer_name);
   }
   else {
     std::cout << "Creating shim layer for layer " << name << std::endl;

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -35,8 +35,17 @@
 #include "lbann/layers/activations/relu.hpp"
 #include "lbann/layers/activations/softmax.hpp"
 #include "lbann/layers/math/unary.hpp"
+
+#include "lbann/layers/learning/convolution.hpp"
+
 #include "lbann/models/model.hpp"
 #include "lbann/utils/random.hpp"
+
+#ifdef LBANN_HAS_GPU
+  constexpr El::Device Dev = El::Device::GPU;
+#else
+  constexpr El::Device Dev = El::Device::CPU;
+#endif
 
 namespace lbann {
 namespace ltfb {
@@ -53,12 +62,13 @@ make_new_activation_layer(lbann_comm& comm,
                           std::string const& new_type,
                           std::string const& new_name)
 {
+/*
 #ifdef LBANN_HAS_GPU
   constexpr El::Device Dev = El::Device::GPU;
 #else
   constexpr El::Device Dev = El::Device::CPU;
 #endif
-
+*/
   std::unique_ptr<Layer> layer;
 
   if (new_type == "relu") {
@@ -98,6 +108,50 @@ make_new_activation_layer(lbann_comm& comm,
   else {
     LBANN_ERROR("Unknown new layer type: ", new_type);
   }
+  layer->set_name(new_name);
+  return layer;
+}
+
+/** @brief Construct a new convolution layer with padding adjusted
+ *         such that the output height and width does not change.
+ *  @param[in] old_kernel The old kernel size
+ *  @param[in] old_pad The old padding
+ *  @param[in] new_kernel The new kernel size
+ *  @param[in] new_channels The new number of channels
+ *  @param[in] stride Strides
+ *  @param[in] dilation Dilations
+ *  @param[in] new_name The name of the new activation layer
+ */
+std::unique_ptr<lbann::Layer>
+make_new_convolution_layer(int const& old_kernel,
+                           int const& old_pad,
+                           int const& new_kernel,
+                           int const& new_channels,
+                           int const& stride,
+                           int const& dilation,
+                           std::string const& new_name)
+{
+/*
+#ifdef LBANN_HAS_GPU
+  constexpr El::Device Dev = El::Device::GPU;
+#else
+  constexpr El::Device Dev = El::Device::CPU;
+#endif
+*/
+  const int new_pad = old_pad + (new_kernel - old_kernel) / 2;
+  std::vector<int> layer_kernel{new_kernel, new_kernel},
+    layer_pads{new_pad, new_pad}, layer_strides{stride, stride},
+    layer_dilations{dilation, dilation};
+  auto layer = std::make_unique<
+    lbann::convolution_layer<DataType, data_layout::DATA_PARALLEL, Dev>>(
+    2,
+    new_channels,
+    layer_kernel,
+    layer_pads,
+    layer_strides,
+    layer_dilations,
+    1,
+    true);
   layer->set_name(new_name);
   return layer;
 }
@@ -158,6 +212,128 @@ void ReplaceActivation::mutate(model& m, const int& step)
                                             activation_types[type_index],
                                             activation_layer_names[name_index]),
                   activation_layer_names[name_index]);
+}
+
+void ReplaceConvolution::mutate(model& m, const int& step)
+{
+/*
+#ifdef LBANN_HAS_GPU
+  constexpr El::Device Dev = El::Device::GPU;
+#else
+  constexpr El::Device Dev = El::Device::CPU;
+#endif
+*/
+  static std::vector<int> const kernels = {5, 7, 9};
+  static std::vector<int> const channels = {6, 16, 32};
+
+  std::vector<int> conv_layer_indices; // Indices of all convolution layers
+
+  for (int i = 0; i < m.get_num_layers(); ++i) {
+    // Creating a temp string with lower case representation
+    std::string temp_type = m.get_layer(i).get_type();
+    std::transform(begin(temp_type),
+                   end(temp_type),
+                   begin(temp_type),
+                   [](unsigned char c) { return ::tolower(c); });
+
+    std::string temp_name = m.get_layer(i).get_name();
+    std::transform(begin(temp_name),
+                   end(temp_name),
+                   begin(temp_name),
+                   [](unsigned char c) { return ::tolower(c); });
+
+    // Find the indices of all convolution layers.
+    // Ensure that convolution shim layers are not counted here
+    if (temp_type == "convolution" &&
+        temp_name.find("shim") == std::string::npos) {
+      conv_layer_indices.push_back(i);
+    }
+  }
+
+  // Generate three random numbers - one for new kernel size, one for new
+  // channels and one for conv layer to choose
+  int kernel_index;
+  int channel_index;
+  int conv_index;
+
+  // Generate the random numbers only in the master proc of trainer and
+  // broadcast them so that all procs in a trainer are undergoing the same
+  // mutation
+  if (m.get_comm()->am_trainer_master()) {
+    kernel_index = fast_rand_int(get_fast_generator(), kernels.size());
+    channel_index = fast_rand_int(get_fast_generator(), channels.size());
+    conv_index = fast_rand_int(get_fast_generator(), conv_layer_indices.size());
+  }
+  m.get_comm()->trainer_broadcast(m.get_comm()->get_trainer_master(),
+                                  kernel_index);
+  m.get_comm()->trainer_broadcast(m.get_comm()->get_trainer_master(),
+                                  channel_index);
+  m.get_comm()->trainer_broadcast(m.get_comm()->get_trainer_master(),
+                                  conv_index);
+
+  // Print mutation
+  std::cout << "Changing convolution layer "
+            << m.get_layer(conv_layer_indices[conv_index]).get_name()
+            << ": kernel -  " << kernels[kernel_index] << ": channels - "
+            << channels[channel_index] << std::endl;
+
+  // Get old specifics of layer
+  auto& layer = m.get_layer(conv_layer_indices[conv_index]);
+  using base_conv =
+    lbann::convolution_layer<DataType, data_layout::DATA_PARALLEL, Dev>;
+  auto& cast_layer = dynamic_cast<base_conv&>(layer);
+  const int old_kernel = cast_layer.get_conv_dims()[0];
+  const int old_pad = cast_layer.get_pads()[0];
+  const int old_strides = cast_layer.get_strides()[0];
+  const int old_dilations = cast_layer.get_dilations()[0];
+  const int old_channels = cast_layer.get_output_dims(0)[0];
+  const std::string name = cast_layer.get_name();
+
+  // Get the child of the convolution layer before replacing it
+  auto& child = layer.get_child_layer(0);
+
+  // Replace the convolution layer
+  m.replace_layer(make_new_convolution_layer(old_kernel,
+                                             old_pad,
+                                             kernels[kernel_index],
+                                             channels[channel_index],
+                                             old_strides,
+                                             old_dilations,
+                                             name),
+                  name);
+
+  // Find out if there is a shim layer.
+  // If there, replace it to match channels appropriately
+  // If not, insert a 1x1 conv shim layer to match channels
+  if (child.get_name().find("shim") != std::string::npos) {
+    std::cout << "Replacing shim of layer " << name << std::endl;
+    const std::string shim_layer_name = child.get_name();
+
+    // Get out channels of shim
+    auto shim_channels = child.get_output_dims(0)[0];
+
+    // Replace shim layer: O/P channels stay the same but I/P channels change
+    m.remove_layer(shim_layer_name);
+    m.insert_layer(make_new_convolution_layer(1,
+                                              0,
+                                              1,
+                                              shim_channels,
+                                              1,
+                                              1,
+                                              shim_layer_name),
+                   name);
+  }
+  else {
+    std::cout << "Creating shim layer for layer " << name << std::endl;
+
+    const std::string shim_layer_name = name + "_shim";
+
+    // old_channels should be equal to child_of_shim_channels since
+    // this block should get executed only once
+    m.insert_layer(
+      make_new_convolution_layer(1, 0, 1, old_channels, 1, 1, shim_layer_name),
+      name);
+  }
 }
 
 } // namespace ltfb

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -62,13 +62,6 @@ make_new_activation_layer(lbann_comm& comm,
                           std::string const& new_type,
                           std::string const& new_name)
 {
-/*
-#ifdef LBANN_HAS_GPU
-  constexpr El::Device Dev = El::Device::GPU;
-#else
-  constexpr El::Device Dev = El::Device::CPU;
-#endif
-*/
   std::unique_ptr<Layer> layer;
 
   if (new_type == "relu") {
@@ -131,13 +124,6 @@ make_new_convolution_layer(int const& old_kernel,
                            int const& dilation,
                            std::string const& new_name)
 {
-/*
-#ifdef LBANN_HAS_GPU
-  constexpr El::Device Dev = El::Device::GPU;
-#else
-  constexpr El::Device Dev = El::Device::CPU;
-#endif
-*/
   const int new_pad = old_pad + (new_kernel - old_kernel) / 2;
   std::vector<int> layer_kernel{new_kernel, new_kernel},
     layer_pads{new_pad, new_pad}, layer_strides{stride, stride},
@@ -216,13 +202,6 @@ void ReplaceActivation::mutate(model& m, const int& step)
 
 void ReplaceConvolution::mutate(model& m, const int& step)
 {
-/*
-#ifdef LBANN_HAS_GPU
-  constexpr El::Device Dev = El::Device::GPU;
-#else
-  constexpr El::Device Dev = El::Device::CPU;
-#endif
-*/
   static std::vector<int> const kernels = {5, 7, 9};
   static std::vector<int> const channels = {6, 16, 32};
 

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -307,7 +307,7 @@ void ReplaceConvolution::mutate(model& m, const int& step)
 
     const std::string shim_layer_name = name + "_shim";
 
-    // old_channels should be equal to child_of_shim_channels since
+    // old_channels should be equal to shim_channels since
     // this block should get executed only once
     m.insert_layer(
       make_new_convolution_layer(1, 0, 1, old_channels, 1, 1, shim_layer_name),

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -449,11 +449,20 @@ make_replace_activation(google::protobuf::Message const& msg)
   return std::make_unique<lbann::ltfb::ReplaceActivation>();
 }
 
+std::unique_ptr<lbann::ltfb::ReplaceConvolution>
+make_replace_convolution(google::protobuf::Message const& msg)
+{
+  using ReplaceConvolution = lbann_data::MutationStrategy::ReplaceConvolution;
+  LBANN_ASSERT(dynamic_cast<ReplaceConvolution const*>(&msg));
+  return std::make_unique<lbann::ltfb::ReplaceConvolution>();
+}
+
 MutationStrategyFactory build_default_mutation_factory()
 {
   MutationStrategyFactory factory;
   factory.register_builder("NullMutation", make_null_mutation);
   factory.register_builder("ReplaceActivation", make_replace_activation);
+  factory.register_builder("ReplaceConvolution", make_replace_convolution);
   return factory;
 }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1940,7 +1940,7 @@ void model::replace_layer(OwningLayerPtr&& new_layer, std::string const& old_lay
 
   // Setup relationship between parent of old layer (which becomes parent of new layer) and new layer
   parent.replace_child_layer(new_layer, parent.find_child_layer_index(l));
-  new_layer->add_parent_layer(m_layers[old_layer_index-1]);
+  new_layer->add_parent_layer(l.get_parent_layer_pointer(0));
 
   // Remove weights for the old layer
   auto old_weights_ptrs = m_layers[old_layer_index]->get_weights_pointers();

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1943,6 +1943,7 @@ void model::replace_layer(OwningLayerPtr&& new_layer, std::string const& old_lay
   new_layer->add_parent_layer(l.get_parent_layer_pointer(0));
 
   // Remove weights for the old layer
+  // NOTE : We assume that layers do not share weights
   auto old_weights_ptrs = m_layers[old_layer_index]->get_weights_pointers();
   for (const auto w : old_weights_ptrs) {
      this->remove_weights(std::shared_ptr<weights>(w)->get_name());

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1896,6 +1896,7 @@ void model::remove_layer(std::string const& removable_layer_name) {
   parent.replace_child_layer(l.get_child_layer_pointer(0), parent.find_child_layer_index(l));
 
   // Remove weights for the old layer
+  // NOTE : We assume that layers do not share weights
   auto old_weights_ptrs = m_layers[removable_layer_index]->get_weights_pointers();
   for (const auto w : old_weights_ptrs) {
      this->remove_weights(std::shared_ptr<weights>(w)->get_name());

--- a/src/proto/training_algorithm.proto
+++ b/src/proto/training_algorithm.proto
@@ -73,9 +73,13 @@ message MutationStrategy {
   message ReplaceActivation {
   }
 
+  message ReplaceConvolution {
+  }
+
   oneof strategy {
     NullMutation null_mutation = 1;
     ReplaceActivation replace_activation = 2;
+    ReplaceConvolution replace_convolution = 3;
   }
 } //message Mutation Strategy
 


### PR DESCRIPTION
- Adds the mutation strategy of replacing random convolution layers by changing the kernel size and number of channels
- The padding is appropriately adjusted to account for changing kernel size so that height and width dimensions remain the same
- A shim convolution layer (with kernel size 1) is inserted after changing the number of channels in a convolution layer for matching the channel dimensions. 