### PR TITLE
CMake guards for Catch2 and C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,6 +576,11 @@ if (LBANN_WITH_UNIT_TESTING)
   endif ()
   message(STATUS "Found Catch2: ${Catch2_DIR}")
 
+  if (CMAKE_CXX_COMPILER_ID MATCHES "ROCMClang")
+    set_target_properties(Catch2::Catch2
+      PROPERTIES INTERFACE_COMPILE_FEATURES "cxx_std_17")
+  endif()
+
   # Now that Catch2 has been found, start adding the unit tests
   include(CTest)
   include(Catch)

--- a/data_utils/hdf5/CMakeLists.txt
+++ b/data_utils/hdf5/CMakeLists.txt
@@ -27,5 +27,10 @@ if (LBANN_WITH_UNIT_TESTING)
     PRIVATE
     conduit::conduit
     Catch2::Catch2)
-  target_compile_features(helpers_tests PRIVATE cxx_std_17)
+  if ("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    target_compile_features(helpers_tests PRIVATE cxx_std_17)
+  else ()
+    lbann_check_and_append_flag(LBANN_CXX17_FLAG "-std=c++17")
+    target_compile_options(helpers_tests PRIVATE ${LBANN_CXX17_FLAG})
+  endif ()
 endif ()


### PR DESCRIPTION
Added CMake guards to ensure that certain C++ languages are not passed
into Catch2.  Some of these options were causing Catch2 to fail to
cmake.  Reduced the options to only cxx_std_17. (Patch from benson31)