### PR TITLE
NumPy weight initializer

### DIFF
--- a/bamboo/unit_tests/.gitignore
+++ b/bamboo/unit_tests/.gitignore
@@ -1,2 +1,3 @@
 .cache
 *.prototext
+temp

--- a/bamboo/unit_tests/test_unit_weights_numpy_initializer.py
+++ b/bamboo/unit_tests/test_unit_weights_numpy_initializer.py
@@ -8,7 +8,7 @@ import numpy as np
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
 current_dir = os.path.dirname(current_file)
-weights_dir = os.path.join(current_dir, 'weights')
+weights_dir = os.path.join(current_dir, 'temp')
 sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
 import tools
 os.makedirs(weights_dir, exist_ok=True)

--- a/bamboo/unit_tests/test_unit_weights_numpy_initializer.py
+++ b/bamboo/unit_tests/test_unit_weights_numpy_initializer.py
@@ -1,0 +1,257 @@
+import functools
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+weights_dir = os.path.join(current_dir, 'weights')
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+os.makedirs(weights_dir, exist_ok=True)
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20210826)
+_num_samples = 11
+_sample_dims = (4,3,2)
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = np.random.normal(size=(_num_samples,_sample_size)).astype(np.float32)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:]
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples()
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    x = lbann.Identity(lbann.Input())
+    x_lbann = x
+
+    # Objects for LBANN model
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Data-parallel weights layer
+    # ------------------------------------------
+    # Note: Weights are stored in one column of (STAR,STAR)
+    # distributed matrix
+
+    # Weights
+    weights_values = np.random.normal(size=_sample_dims).astype(np.float32)
+    weights_file = os.path.join(weights_dir, 'dataparallel_weights.npy')
+    np.save(weights_file, weights_values)
+
+    # LBANN implementation
+    x = lbann.Reshape(x_lbann, dims=tools.str_list(_sample_dims))
+    weights = lbann.Weights(
+        initializer=lbann.NumpyInitializer(file=weights_file),
+    )
+    weights = lbann.WeightsLayer(
+        weights=weights,
+        dims=tools.str_list(_sample_dims),
+    )
+    y = lbann.Multiply(x, weights)
+    z = lbann.L2Norm2(y)
+    metrics.append(lbann.Metric(z, name='data-parallel weights layer'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).reshape(_sample_dims).astype(np.float64)
+        y = x * weights_values
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Data-parallel FC layer
+    # ------------------------------------------
+    # Note: Weights are stored in (STAR,STAR) distributed matrix
+
+    # Weights
+    output_size = 7
+    linearity = np.random.normal(size=(output_size, _sample_size)).astype(np.float32)
+    linearity = linearity.astype(np.float64)
+    bias = np.random.normal(size=output_size).astype(np.float32)
+    linearity_file = os.path.join(weights_dir, 'dataparallel_fc_linearity.npy')
+    bias_file = os.path.join(weights_dir, 'dataparallel_fc_bias.npy')
+    np.save(linearity_file, linearity)
+    np.save(bias_file, bias)
+
+    # LBANN implementation
+    x = x_lbann
+    linearity_weights \
+        = lbann.Weights(initializer=lbann.NumpyInitializer(file=linearity_file))
+    bias_weights \
+        = lbann.Weights(initializer=lbann.NumpyInitializer(file=bias_file))
+    y = lbann.FullyConnected(
+        x,
+        weights=(linearity_weights, bias_weights),
+        data_layout='data_parallel',
+        num_neurons=output_size,
+        has_bias=True,
+        transpose=False)
+    z = lbann.L2Norm2(y)
+    metrics.append(lbann.Metric(z, name='data-parallel FC layer'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        y = np.matmul(linearity, x) + bias
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Model-parallel FC layer
+    # ------------------------------------------
+    # Note: Weights are stored in (MC,MR) distributed matrix
+
+    # Weights
+    output_size = 9
+    linearity = np.random.normal(size=(output_size, _sample_size)).astype(np.float32)
+    bias = np.random.normal(size=output_size).astype(np.float32)
+    bias = bias.astype(np.float64)
+    linearity_file = os.path.join(weights_dir, 'modelparallel_fc_linearity.npy')
+    bias_file = os.path.join(weights_dir, 'modelparallel_fc_bias.npy')
+    np.save(linearity_file, linearity)
+    np.save(bias_file, bias)
+
+    # LBANN implementation
+    x = x_lbann
+    linearity_weights \
+        = lbann.Weights(initializer=lbann.NumpyInitializer(file=linearity_file))
+    bias_weights \
+        = lbann.Weights(initializer=lbann.NumpyInitializer(file=bias_file))
+    y = lbann.FullyConnected(
+        x,
+        weights=(linearity_weights, bias_weights),
+        data_layout='model_parallel',
+        num_neurons=output_size,
+        has_bias=True,
+        transpose=False)
+    z = lbann.L2Norm2(y)
+    metrics.append(lbann.Metric(z, name='model-parallel FC layer'))
+
+    # NumPy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        y = np.matmul(linearity, x) + bias
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+for _test_func in tools.create_tests(setup_experiment, __file__):
+    globals()[_test_func.__name__] = _test_func

--- a/include/lbann/weights/initializer.hpp
+++ b/include/lbann/weights/initializer.hpp
@@ -77,7 +77,7 @@ public:
 
 };
 
-/** @brief Fill weights with a constant value. */
+/** @brief Fill weights with a single constant value. */
 template <typename TensorDataType>
 class constant_initializer
   : public Cloneable<constant_initializer<TensorDataType>,
@@ -110,6 +110,9 @@ private:
  *
  *  The number of weight entries must exactly match the number of
  *  provided values.
+ *
+ *  @note Most weights are stored in row-major order. However, the
+ *  fully-connected layer's linearity weights are column-major.
  */
 template <typename TensorDataType>
 class value_initializer
@@ -139,6 +142,9 @@ private:
 };
 
 /** @brief Fill weights with values from a NumPy file.
+ *
+ *  Expects a .npy file with float32 or float64 values in C-style,
+ *  row-major order.
  */
 template <typename TensorDataType>
 class numpy_initializer

--- a/include/lbann/weights/initializer.hpp
+++ b/include/lbann/weights/initializer.hpp
@@ -63,6 +63,8 @@ public:
   /** @brief The tensor type expected in this object. */
   using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
 
+  ///@}
+
 public:
   data_type_weights_initializer() = default;
   virtual ~data_type_weights_initializer() = default;
@@ -86,6 +88,8 @@ public:
 
   /** @brief The tensor type expected in this object. */
   using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
+
+  ///@}
 
 public:
   constant_initializer(TensorDataType value)
@@ -118,6 +122,8 @@ public:
   /** @brief The tensor type expected in this object. */
   using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
 
+  ///@}
+
 public:
   value_initializer(std::vector<TensorDataType> values)
     : m_values{std::move(values)}
@@ -132,6 +138,35 @@ private:
 
 };
 
+/** @brief Fill weights with values from a NumPy file.
+ */
+template <typename TensorDataType>
+class numpy_initializer
+  : public Cloneable<numpy_initializer<TensorDataType>,
+                     data_type_weights_initializer<TensorDataType>> {
+public:
+  /** @name Public Types */
+  ///@{
+
+  /** @brief The tensor type expected in this object. */
+  using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
+
+  ///@}
+
+public:
+  numpy_initializer(std::string file)
+    : m_file{std::move(file)}
+  {}
+  std::string get_type() const override { return "NumPy"; }
+  void fill(AbsDistMatrixType& matrix) override;
+
+private:
+
+  /** NumPy file */
+  std::string m_file;
+
+};
+
 /** @brief Draw weights values from a uniform random distribution. */
 template <typename TensorDataType>
 class uniform_initializer
@@ -143,6 +178,8 @@ public:
 
   /** @brief The tensor type expected in this object. */
   using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
+
+  ///@}
 
  public:
   uniform_initializer(TensorDataType min = El::To<TensorDataType>(0),
@@ -206,6 +243,10 @@ build_value_initializer_from_pbuf(google::protobuf::Message const& msg);
 
 template <typename TensorDataType>
 std::unique_ptr<weights_initializer>
+build_numpy_initializer_from_pbuf(google::protobuf::Message const& msg);
+
+template <typename TensorDataType>
+std::unique_ptr<weights_initializer>
 build_uniform_initializer_from_pbuf(google::protobuf::Message const& msg);
 
 template <typename TensorDataType>
@@ -217,6 +258,7 @@ build_normal_initializer_from_pbuf(google::protobuf::Message const& msg);
   extern template class data_type_weights_initializer<T>; \
   extern template class constant_initializer<T>;          \
   extern template class value_initializer<T>;             \
+  extern template class numpy_initializer<T>;             \
   extern template class uniform_initializer<T>;           \
   extern template class normal_initializer<T>
 

--- a/src/proto/factories/weights_factory.cpp
+++ b/src/proto/factories/weights_factory.cpp
@@ -71,6 +71,8 @@ private:
                               build_constant_initializer_from_pbuf<T>);
     factory_.register_builder("ValueInitializer",
                               build_value_initializer_from_pbuf<T>);
+    factory_.register_builder("NumpyInitializer",
+                              build_numpy_initializer_from_pbuf<T>);
     factory_.register_builder("UniformInitializer",
                               build_uniform_initializer_from_pbuf<T>);
     factory_.register_builder("NormalInitializer",

--- a/src/proto/weights.proto
+++ b/src/proto/weights.proto
@@ -42,14 +42,15 @@ message Initializer {
   oneof initializer_type {
     ConstantInitializer constant_initializer = 20;
     ValueInitializer value_initializer = 21;
-    UniformInitializer uniform_initializer = 22;
-    NormalInitializer normal_initializer = 23;
-    GlorotNormalInitializer glorot_normal_initializer = 24;
-    GlorotUniformInitializer glorot_uniform_initializer = 25;
-    HeNormalInitializer he_normal_initializer = 26;
-    HeUniformInitializer he_uniform_initializer = 27;
-    LeCunNormalInitializer lecun_normal_initializer = 28;
-    LeCunUniformInitializer lecun_uniform_initializer = 29;
+    NumpyInitializer numpy_initializer = 22;
+    UniformInitializer uniform_initializer = 23;
+    NormalInitializer normal_initializer = 24;
+    GlorotNormalInitializer glorot_normal_initializer = 25;
+    GlorotUniformInitializer glorot_uniform_initializer = 26;
+    HeNormalInitializer he_normal_initializer = 27;
+    HeUniformInitializer he_uniform_initializer = 28;
+    LeCunNormalInitializer lecun_normal_initializer = 29;
+    LeCunUniformInitializer lecun_uniform_initializer = 30;
   }
 
   // Weight initializers
@@ -58,6 +59,9 @@ message Initializer {
   }
   message ValueInitializer {
     string values = 1;
+  }
+  message NumpyInitializer {
+    string file = 1;
   }
   message UniformInitializer {
     double min = 1;

--- a/src/proto/weights.proto
+++ b/src/proto/weights.proto
@@ -54,13 +54,30 @@ message Initializer {
   }
 
   // Weight initializers
+
+  /** @brief Fill weights with a single constant value. */
   message ConstantInitializer {
     double value = 1;
   }
+  /** @brief Fill weights with values from a list.
+   *
+   *  The number of weight entries must exactly match the number of
+   *  provided values.
+   *
+   *  @note Most weights are stored in row-major order. However, the
+   *  fully-connected layer's linearity weights are column-major.
+   */
   message ValueInitializer {
+    /// Space-separated list of values
     string values = 1;
   }
+  /** @brief Fill weights with values from a NumPy file.
+   *
+   *  Expects a .npy file with float32 or float64 values in C-style,
+   *  row-major order.
+   */
   message NumpyInitializer {
+    /// NumPy file
     string file = 1;
   }
   message UniformInitializer {

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -33,6 +33,9 @@
 #include "lbann/utils/random.hpp"
 
 #include <weights.pb.h>
+#ifdef LBANN_HAS_CNPY
+#include <cnpy.h>
+#endif // LBANN_HAS_CNPY
 
 #include <sstream>
 
@@ -102,6 +105,102 @@ void value_initializer<TensorDataType>::fill(AbsDistMatrixType& matrix) {
 }
 
 template <typename TensorDataType>
+void numpy_initializer<TensorDataType>::fill(AbsDistMatrixType& matrix) {
+#ifndef LBANN_HAS_CNPY
+  LBANN_ERROR("CNPY not detected");
+#else
+
+  // Load NumPy file
+  cnpy::NpyArray array = cnpy::npy_load(m_file);
+  const size_t num_values = array.num_bytes() / array.word_size;
+  if (matrix.Height() * matrix.Width() != (El::Int) num_values) {
+    LBANN_ERROR(
+      "NumPy weight initializer attempted to initialize a ",
+      matrix.Height()," x ",matrix.Width()," weights matrix, "
+      "but ",m_file," contains ",num_values," values");
+  }
+  if (array.fortran_order) {
+    LBANN_ERROR(
+      "NumPy weight initializer does not support Fortran order ",
+      "(error while loading ",m_file,")");
+  }
+
+  // Extract weight values from NumPy array
+  // Note: Consider viewing instead of copying when the array is
+  // already in the right datatype.
+  std::vector<TensorDataType> values(num_values);
+  switch (array.word_size) {
+  case 4:
+  {
+    const auto* src = array.data<float>();
+    auto* dst = values.data();
+    LBANN_OMP_PARALLEL_FOR
+    for (size_t i=0; i<num_values; ++i) {
+      dst[i] = src[i];
+    }
+    break;
+  }
+  case 8:
+  {
+    const auto* src = array.data<double>();
+    auto* dst = values.data();
+    LBANN_OMP_PARALLEL_FOR
+    for (size_t i=0; i<num_values; ++i) {
+      dst[i] = src[i];
+    }
+    break;
+  }
+  default:
+    LBANN_ERROR(
+      "NumPy weight initializer only supports float32 and float64 data",
+      "(error while loading ",m_file,")");
+  }
+
+  // Construct CPU matrix from weight values
+  using CPUMatType = El::DistMatrix<TensorDataType, El::STAR, El::STAR, El::ELEMENT, El::Device::CPU>;
+  CPUMatType cpu_matrix(matrix.Grid(), matrix.Root());
+  if (matrix.Width() == 1) {
+    cpu_matrix.LockedAttach(
+      matrix.Height(),
+      matrix.Width(),
+      matrix.Grid(),
+      matrix.ColAlign(),
+      matrix.RowAlign(),
+      values.data(),
+      matrix.Height(),
+      matrix.Root());
+  }
+  else {
+    if (array.shape.size() != 2) {
+      LBANN_ERROR(
+        "NumPy weight initializer attempted to initialize a ",
+        matrix.Height()," x ",matrix.Width()," weights matrix, "
+        "but ",m_file," contains a ",array.shape.size(),"-D array");
+    }
+    if ((El::Int) array.shape[0] != matrix.Height()
+        || (El::Int) array.shape[1] != matrix.Width()) {
+      LBANN_ERROR(
+        "NumPy weight initializer attempted to initialize a ",
+        matrix.Height()," x ",matrix.Width()," weights matrix, "
+        "but ",m_file," contains a ",
+        array.shape[0]," x ",array.shape[1], " array");
+    }
+    El::Matrix<TensorDataType, El::Device::CPU> cpu_matrix_trans(
+      matrix.Width(),
+      matrix.Height(),
+      values.data(),
+      matrix.Width());
+    cpu_matrix.Resize(matrix.Height(), matrix.Width());
+    El::Transpose(cpu_matrix_trans, cpu_matrix.Matrix());
+  }
+
+  // Copy CPU matrix to weights matrix
+  El::Copy(cpu_matrix, matrix);
+
+#endif // LBANN_HAS_CNPY
+}
+
+template <typename TensorDataType>
 description uniform_initializer<TensorDataType>::get_description() const {
   auto desc = data_type_weights_initializer<TensorDataType>::get_description();
   std::stringstream ss;
@@ -153,6 +252,14 @@ build_value_initializer_from_pbuf(google::protobuf::Message const& msg) {
 
 template <typename TensorDataType>
 std::unique_ptr<weights_initializer>
+build_numpy_initializer_from_pbuf(google::protobuf::Message const& msg) {
+  const auto& params =
+    dynamic_cast<lbann_data::Initializer::NumpyInitializer const&>(msg);
+  return make_unique<numpy_initializer<TensorDataType>>(params.file());
+}
+
+template <typename TensorDataType>
+std::unique_ptr<weights_initializer>
 build_uniform_initializer_from_pbuf(google::protobuf::Message const& msg) {
   const auto& params =
     dynamic_cast<lbann_data::Initializer::UniformInitializer const&>(msg);
@@ -184,12 +291,15 @@ build_normal_initializer_from_pbuf(google::protobuf::Message const& msg) {
   template class data_type_weights_initializer<T>;                           \
   template class constant_initializer<T>;                                    \
   template class value_initializer<T>;                                       \
+  template class numpy_initializer<T>;                                       \
   template class uniform_initializer<T>;                                     \
   template class normal_initializer<T>;                                      \
   template std::unique_ptr<weights_initializer>                              \
   build_constant_initializer_from_pbuf<T>(google::protobuf::Message const&); \
   template std::unique_ptr<weights_initializer>                              \
   build_value_initializer_from_pbuf<T>(google::protobuf::Message const&);    \
+  template std::unique_ptr<weights_initializer>                              \
+  build_numpy_initializer_from_pbuf<T>(google::protobuf::Message const&);    \
   template std::unique_ptr<weights_initializer>                              \
   build_uniform_initializer_from_pbuf<T>(google::protobuf::Message const&);  \
   template std::unique_ptr<weights_initializer>                              \

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -171,6 +171,8 @@ void numpy_initializer<TensorDataType>::fill(AbsDistMatrixType& matrix) {
       matrix.Root());
   }
   else {
+    // Weights in fully-connected layer are in Fortran-order. Need to
+    // transpose NumPy array before copying in Hydrogen matrix
     if (array.shape.size() != 2) {
       LBANN_ERROR(
         "NumPy weight initializer attempted to initialize a ",


### PR DESCRIPTION
This PR adds a weight initializer that loads from a .npy file. This allows for training pretrained models without needing to store all the weight values within the prototext file.

One complication regarding the FC layer. The linearity matrix is logically `output_size x input_size` and is stored in column-major order. NumPy typically stores in row-major order, so I've added some checks to do the necessary transposes internally. This layout matches [PyTorch's `Linear` layer](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html#torch.nn.Linear), but is the transpose of [Keras' `Dense` layer](https://keras.io/api/layers/core_layers/dense/).

[Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM406-1).