### PR TITLE
Bug fix for arg parse refactor

### DIFF
--- a/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/convolution.hpp
@@ -42,7 +42,7 @@ namespace dnn_lib
 using namespace cudnn;
 
 inline size_t
-get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
+get_fwd_conv_workspace_size(FilterDescriptor const& wDesc,
                             TensorDescriptor const& xDesc,
                             ConvolutionDescriptor const& convDesc,
                             TensorDescriptor const& yDesc,
@@ -54,7 +54,7 @@ get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
 
 inline size_t
 get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
-                                 TensorDescriptor const& wDesc,
+                                 FilterDescriptor const& wDesc,
                                  ConvolutionDescriptor const& convDesc,
                                  TensorDescriptor const& dxDesc,
                                  El::SyncInfo<El::Device::GPU> const& si)
@@ -67,7 +67,7 @@ inline size_t
 get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
                                     TensorDescriptor const& xDesc,
                                     ConvolutionDescriptor const& convDesc,
-                                    TensorDescriptor const& dwDesc,
+                                    FilterDescriptor const& dwDesc,
                                     El::SyncInfo<El::Device::GPU> const& si)
 {
   size_t size = 1 << 30; // @todo Allocate largest free block

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -68,9 +68,7 @@ int guess_global_rank() noexcept
 int main(int argc, char* argv[])
 {
   auto& arg_parser = global_argument_parser();
-  construct_std_options();
-  construct_datastore_options();
-  construct_datareader_options();
+  construct_all_options();
   try {
     arg_parser.parse(argc, argv);
   }

--- a/model_zoo/lbann_help.cpp
+++ b/model_zoo/lbann_help.cpp
@@ -36,7 +36,7 @@ using namespace lbann;
 
 int main(int argc, char *argv[]) {
   auto& arg_parser = global_argument_parser();
-  construct_std_options();
+  construct_all_options();
 
   try {
     arg_parser.parse(argc, argv);

--- a/unit_test/MPICatchMain.cpp
+++ b/unit_test/MPICatchMain.cpp
@@ -45,9 +45,6 @@ int main(int argc, char* argv[])
   lbann::init_random(13);
   expert::register_world_comm(*world_comm);
 
-  // as of Mar 2021, required for data_readers
-  lbann::options::get()->init(argc, argv);
-
   // Initialize Catch2
   Catch::Session session;
 

--- a/unit_test/MPICatchMain.cpp
+++ b/unit_test/MPICatchMain.cpp
@@ -40,6 +40,8 @@
 using namespace unit_test::utilities;
 int main(int argc, char* argv[])
 {
+  lbann::construct_all_options();
+
   // Set up the communication domain
   auto world_comm = lbann::initialize(argc, argv);
   lbann::init_random(13);

--- a/unit_test/SequentialCatchMain.cpp
+++ b/unit_test/SequentialCatchMain.cpp
@@ -28,12 +28,15 @@
 #include <catch2/catch.hpp>
 #include <lbann/utils/dnn_lib/helpers.hpp>
 #include <lbann/utils/random_number_generators.hpp>
+#include <lbann/utils/options.hpp>
 
 int main(int argc, char* argv[]) {
 #ifdef LBANN_HAS_DNN_LIB
   hydrogen::gpu::Initialize();
   lbann::dnn_lib::initialize();
 #endif // LBANN_HAS_DNN_LIB
+
+  lbann::construct_all_options();
 
   // Initialize the general RNGs and the data sequence RNGs
   int random_seed = 42;


### PR DESCRIPTION
Addresses bugs that appeared after merging #1891 and #1940.

- Removes last remnants of old options
- FIxes type on convolution workspace functions for cuDNN
- Adds missing options initilization to lbann and MPI test