### PR TITLE
Always mix MPI rank within trainer into RNG seeds

### DIFF
--- a/include/lbann/utils/random_number_generators.hpp
+++ b/include/lbann/utils/random_number_generators.hpp
@@ -125,8 +125,9 @@ fast_rng_gen& get_fast_io_generator();
 /** @brief Initialize the random number generator (with optional seed).
  *
  *  @param seed Seed value for the random number generator
- *  @param comm If present, mixes the process's rank within the model
- *              into the seed; if not, uses the MPI world rank.
+ *  @param comm If present, mixes the process's rank within the
+ *              trainer into the seed; if not, uses the MPI world
+ *              rank.
  *
  */
 void init_random(int seed = -1, int num_io_RNGs = 1, lbann_comm *comm = nullptr);

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -225,15 +225,8 @@ trainer& construct_trainer(lbann_comm *comm,
 #ifndef LBANN_DETERMINISTIC
   if (!pb_trainer->random_init_trainers_identically()) {
     random_seed = hash_combine(random_seed, comm->get_trainer_rank());
-    // Also update the data sequence random seed
     data_seq_random_seed = random_seed;
   }
-
-  // Under normal conditions, reinitialize the random number generator so
-  // that regularization techniques (e.g. dropout) generate unique patterns
-  // on different ranks.
-  // At this point the data sequence random seed is no longer updated
-  random_seed = hash_combine(random_seed, comm->get_rank_in_world());
 #else
   if(comm->am_world_master()) {
     std::cout <<


### PR DESCRIPTION
@benson31 has noticed some unit test failures with `gaussian_fill` when he runs with >4 procs. It seems that this is because the unit test initializes all ranks in the trainer with the same RNG seed, which causes the resulting distribution to be non-normal. The main driver in `lbann_library.cpp` mixes the rank in the trainer into the seeds, and this PR just moves that behavior into the `init_random` function for convenience.

This also irons out an inconsistency in how we handle RNG seeds in the deterministic build. In that case, we mixed the rank into the Elemental seed but not into the LBANN seeds. I don't think this old behavior was helping us stay invariant to the number of processes (really, the only way is to only call the RNG on rank 0 like we do in `gaussian_fill_procdet`/`uniform_fill_procdet`). With that in mind, this change at least makes sure that the RNGs produce good distributions.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM408-3).