### PR TITLE
Use default-allocated GPU memory for long-lived buffers

### DIFF
--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -680,12 +680,11 @@ setup_matrices(const El::Grid& grid) {
   }
 
 #ifdef LBANN_HAS_GPU
-  // Use default-allocated device memory for forward prop matrices
-  // Note: Using the GPU memory pool uses more memory than directly
-  // allocating GPU buffers. Since forward prop buffers are rarely
-  // reallocated, the memory pool also has no performance benefit.
+  // Use default-allocated GPU memory for forward prop matrices
+  // Note: GPU memory pool uses more memory and these buffers are
+  // rarely reallocated
   /// @todo Consider using default-allocated device memory when
-  /// training with persistent error signals.
+  /// training with persistent error signals
   if (this->get_device_allocation() == El::Device::GPU) {
     for (auto& input : m_inputs) {
       input->Matrix().SetMemoryMode(0);

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -679,6 +679,22 @@ setup_matrices(const El::Grid& grid) {
     }
   }
 
+#ifdef LBANN_HAS_GPU
+  // Use default-allocated device memory for forward prop matrices
+  // Note: Using the GPU memory pool uses more memory than directly
+  // allocating GPU buffers. Since forward prop buffers are rarely
+  // reallocated, the memory pool also has no performance benefit.
+  /// @todo Consider using default-allocated device memory when
+  /// training with persistent error signals.
+  if (this->get_device_allocation() == El::Device::GPU) {
+    for (auto& input : m_inputs) {
+      input->Matrix().SetMemoryMode(0);
+    }
+    for (auto& output : m_outputs) {
+      output->Matrix().SetMemoryMode(0);
+    }
+  }
+#endif // LBANN_HAS_GPU
 
 }
 

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -107,12 +107,14 @@ void adam<TensorDataType>::setup(WeightsType* w) {
   const auto& gradient = this->get_gradient();
   m_moment1.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
   m_moment2.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+#ifdef LBANN_HAS_GPU
   if (m_moment1->GetLocalDevice() == El::Device::GPU) {
     m_moment1->Matrix().SetMemoryMode(0); // Default-allocated memory
   }
   if (m_moment2->GetLocalDevice() == El::Device::GPU) {
     m_moment2->Matrix().SetMemoryMode(0); // Default-allocated memory
   }
+#endif // LBANN_HAS_GPU
   El::Zeros(*m_moment1, gradient.Height(), gradient.Width());
   El::Zeros(*m_moment2, gradient.Height(), gradient.Width());
 }

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -107,6 +107,12 @@ void adam<TensorDataType>::setup(WeightsType* w) {
   const auto& gradient = this->get_gradient();
   m_moment1.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
   m_moment2.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+  if (m_moment1->GetLocalDevice() == El::Device::GPU) {
+    m_moment1->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
+  if (m_moment2->GetLocalDevice() == El::Device::GPU) {
+    m_moment2->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
   El::Zeros(*m_moment1, gradient.Height(), gradient.Width());
   El::Zeros(*m_moment2, gradient.Height(), gradient.Width());
 }

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -82,6 +82,11 @@ void sgd<TensorDataType>::setup(WeightsType* w) {
   OptimizerType::setup(w);
   const auto& gradient = this->get_gradient();
   m_velocity.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+#ifdef LBANN_HAS_GPU
+  if (m_velocity->GetLocalDevice() == El::Device::GPU) {
+    m_velocity->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
+#endif // LBANN_HAS_GPU
   El::Zeros(*m_velocity, gradient.Height(), gradient.Width());
 }
 


### PR DESCRIPTION
@benson31 and @tnat410 have complained about high memory usage in Resnet-50, such that we can no longer run with a mini-batch of 256 on a Lassen node. In an ideal world, I estimate the memory usage on a single GPU would look like:
```
(300 MB) + (150 MB)*mbsize
```
However, I see:
```
(2.5 GB) + (200 MB)*mbsize
```
Nsight suggests that the excess in the mini-batch term is from over-allocation in the CUB memory pool. When I allocate the activation and weight buffers with `cudaMalloc` instead of the memory pool:
```
(2.4 GB) + (170 MB)*mbsize
```
This memory reduction allows for a 256 mini-batch on a Lassen node. I don't see any effect on performance and [Bamboo has no new failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM410-2).

Next steps are to reduce the excess in the constant term. At least 1 GB is from the hard-coded workspace size for cuDNN convolutions. Nsight suggests that the remaining 1 GB is never actually accessed, but I'm not sure where it's allocated.