### PR TITLE
Optionally use default-allocated GPU memory for long-lived buffers

### DIFF
--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -29,6 +29,7 @@ namespace lbann {
 #define USE_LTFB "ltfb"
 #define VERBOSE "verbose"
 #define WRITE_SAMPLE_LIST "write_sample_list"
+#define USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP "Use Hydrogen's default memory mode for GPU buffers in forward prop"
 
 // Input options
 #define CKPT_DIR "ckpt_dir"

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -680,12 +680,11 @@ setup_matrices(const El::Grid& grid) {
   }
 
 #ifdef LBANN_HAS_GPU
-  // Use default-allocated device memory for forward prop matrices
-  // Note: Using the GPU memory pool uses more memory than directly
-  // allocating GPU buffers. Since forward prop buffers are rarely
-  // reallocated, the memory pool also has no performance benefit.
+  // Use default-allocated GPU memory for forward prop matrices
+  // Note: GPU memory pool uses more memory and these buffers are
+  // rarely reallocated
   /// @todo Consider using default-allocated device memory when
-  /// training with persistent error signals.
+  /// training with persistent error signals
   if (this->get_device_allocation() == El::Device::GPU) {
     for (auto& input : m_inputs) {
       input->Matrix().SetMemoryMode(0);

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -679,6 +679,22 @@ setup_matrices(const El::Grid& grid) {
     }
   }
 
+#ifdef LBANN_HAS_GPU
+  // Use default-allocated device memory for forward prop matrices
+  // Note: Using the GPU memory pool uses more memory than directly
+  // allocating GPU buffers. Since forward prop buffers are rarely
+  // reallocated, the memory pool also has no performance benefit.
+  /// @todo Consider using default-allocated device memory when
+  /// training with persistent error signals.
+  if (this->get_device_allocation() == El::Device::GPU) {
+    for (auto& input : m_inputs) {
+      input->Matrix().SetMemoryMode(0);
+    }
+    for (auto& output : m_outputs) {
+      output->Matrix().SetMemoryMode(0);
+    }
+  }
+#endif // LBANN_HAS_GPU
 
 }
 

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -691,10 +691,10 @@ setup_matrices(const El::Grid& grid) {
     const auto& arg_parser = global_argument_parser();
     if (!arg_parser.get<bool>(USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP)) {
       for (auto& input : m_inputs) {
-        input->Matrix().SetMemoryMode(0);
+        input->Matrix().SetMemoryMode(0); // Directly-allocated memory
       }
       for (auto& output : m_outputs) {
-        output->Matrix().SetMemoryMode(0);
+        output->Matrix().SetMemoryMode(0); // Directly-allocated memory
       }
     }
   }

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -33,6 +33,8 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/trainers/trainer.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 #include "lbann/utils/summary_impl.hpp"
 #include "lbann/utils/tensor_impl.hpp"
 
@@ -680,17 +682,20 @@ setup_matrices(const El::Grid& grid) {
   }
 
 #ifdef LBANN_HAS_GPU
-  // Use default-allocated GPU memory for forward prop matrices
+  // Use directly-allocated GPU memory for forward prop matrices
   // Note: GPU memory pool uses more memory and these buffers are
   // rarely reallocated
-  /// @todo Consider using default-allocated device memory when
+  /// @todo Consider using directly-allocated device memory when
   /// training with persistent error signals
   if (this->get_device_allocation() == El::Device::GPU) {
-    for (auto& input : m_inputs) {
-      input->Matrix().SetMemoryMode(0);
-    }
-    for (auto& output : m_outputs) {
-      output->Matrix().SetMemoryMode(0);
+    const auto& arg_parser = global_argument_parser();
+    if (!arg_parser.get<bool>(USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP)) {
+      for (auto& input : m_inputs) {
+        input->Matrix().SetMemoryMode(0);
+      }
+      for (auto& output : m_outputs) {
+        output->Matrix().SetMemoryMode(0);
+      }
     }
   }
 #endif // LBANN_HAS_GPU

--- a/src/layers/matrix_builder.hpp
+++ b/src/layers/matrix_builder.hpp
@@ -73,7 +73,7 @@ class DefaultMemoryMatrixBuilder : public MatrixBuilder<T>
   // Pinned host memory; memory-pooled device memory
   static constexpr unsigned memory_mode_ = 1U;
 #elif defined(HYDROGEN_HAVE_GPU)
-  // Pinned host memory; default-allocated device memory
+  // Pinned host memory; directly-allocated device memory
   static constexpr unsigned memory_mode_ = (D == El::Device::CPU ? 1U : 0U);
 #else
   // Default memory

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -107,12 +107,14 @@ void adam<TensorDataType>::setup(WeightsType* w) {
   const auto& gradient = this->get_gradient();
   m_moment1.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
   m_moment2.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+#ifdef LBANN_HAS_GPU
   if (m_moment1->GetLocalDevice() == El::Device::GPU) {
     m_moment1->Matrix().SetMemoryMode(0); // Default-allocated memory
   }
   if (m_moment2->GetLocalDevice() == El::Device::GPU) {
     m_moment2->Matrix().SetMemoryMode(0); // Default-allocated memory
   }
+#endif // LBANN_HAS_GPU
   El::Zeros(*m_moment1, gradient.Height(), gradient.Width());
   El::Zeros(*m_moment2, gradient.Height(), gradient.Width());
 }

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -107,6 +107,12 @@ void adam<TensorDataType>::setup(WeightsType* w) {
   const auto& gradient = this->get_gradient();
   m_moment1.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
   m_moment2.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+  if (m_moment1->GetLocalDevice() == El::Device::GPU) {
+    m_moment1->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
+  if (m_moment2->GetLocalDevice() == El::Device::GPU) {
+    m_moment2->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
   El::Zeros(*m_moment1, gradient.Height(), gradient.Width());
   El::Zeros(*m_moment2, gradient.Height(), gradient.Width());
 }

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -26,8 +26,10 @@
 
 #include "lbann/optimizers/adam.hpp"
 #include "lbann/optimizers/adam_impl.hpp"
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/memory.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -108,11 +110,13 @@ void adam<TensorDataType>::setup(WeightsType* w) {
   m_moment1.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
   m_moment2.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
 #ifdef LBANN_HAS_GPU
-  if (m_moment1->GetLocalDevice() == El::Device::GPU) {
-    m_moment1->Matrix().SetMemoryMode(0); // Default-allocated memory
-  }
-  if (m_moment2->GetLocalDevice() == El::Device::GPU) {
-    m_moment2->Matrix().SetMemoryMode(0); // Default-allocated memory
+  if (m_moment1->GetLocalDevice() == El::Device::GPU
+      && m_moment2->GetLocalDevice() == El::Device::GPU) {
+    const auto& arg_parser = global_argument_parser();
+    if (!arg_parser.get<bool>(USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP)) {
+      m_moment1->Matrix().SetMemoryMode(0); // Directly-allocated memory
+      m_moment2->Matrix().SetMemoryMode(0); // Directly-allocated memory
+    }
   }
 #endif // LBANN_HAS_GPU
   El::Zeros(*m_moment1, gradient.Height(), gradient.Width());

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -82,6 +82,11 @@ void sgd<TensorDataType>::setup(WeightsType* w) {
   OptimizerType::setup(w);
   const auto& gradient = this->get_gradient();
   m_velocity.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
+#ifdef LBANN_HAS_GPU
+  if (m_velocity->GetLocalDevice() == El::Device::GPU) {
+    m_velocity->Matrix().SetMemoryMode(0); // Default-allocated memory
+  }
+#endif // LBANN_HAS_GPU
   El::Zeros(*m_velocity, gradient.Height(), gradient.Width());
 }
 

--- a/src/optimizers/sgd.cpp
+++ b/src/optimizers/sgd.cpp
@@ -26,7 +26,9 @@
 
 #include "lbann/optimizers/sgd_impl.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/memory.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -84,7 +86,10 @@ void sgd<TensorDataType>::setup(WeightsType* w) {
   m_velocity.reset(AbsDistMatrixType::Instantiate(gradient.DistData()));
 #ifdef LBANN_HAS_GPU
   if (m_velocity->GetLocalDevice() == El::Device::GPU) {
-    m_velocity->Matrix().SetMemoryMode(0); // Default-allocated memory
+    const auto& arg_parser = global_argument_parser();
+    if (!arg_parser.get<bool>(USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP)) {
+      m_velocity->Matrix().SetMemoryMode(0); // Directly-allocated memory
+    }
   }
 #endif // LBANN_HAS_GPU
   El::Zeros(*m_velocity, gradient.Height(), gradient.Width());

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -95,6 +95,14 @@ void construct_std_options()
                       {"--write_sample_list"},
                       "[STD] Writes out the sample list that was loaded into "
                       "the current directory");
+  arg_parser.add_flag(
+    USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP,
+    {"--use_gpu_default_memory_in_forward_prop"},
+    utils::ENV("LBANN_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP"),
+    "[STD] Use Hydrogen's default memory mode for GPU buffers in "
+    "forward prop (namely activations and weights). This will "
+    "typically use a GPU memory pool, which uses more memory than "
+    "directly allocating GPU memory.");
 
   // Input options
   arg_parser.add_option(

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -29,8 +29,10 @@
 #include "lbann/weights/data_type_weights.hpp"
 #include "lbann/weights/data_type_weights_impl.hpp"
 #include "lbann/optimizers/optimizer.hpp"
-#include "lbann/utils/exception.hpp"
 #include "lbann/io/file_io.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/exception.hpp"
+#include "lbann/utils/options.hpp"
 
 #include <layers.pb.h>
 
@@ -233,7 +235,10 @@ void data_type_weights<TensorDataType>::do_setup_() {
   // Allocate memory
 #ifdef LBANN_HAS_GPU
   if (matrix_dist.device == El::Device::GPU) {
-    m_values->Matrix().SetMemoryMode(0); // Default-allocated memory
+    const auto& arg_parser = global_argument_parser();
+    if (!arg_parser.get<bool>(USE_GPU_DEFAULT_MEMORY_IN_FORWARD_PROP)) {
+      m_values->Matrix().SetMemoryMode(0); // Directly-allocated memory
+    }
   }
 #endif // LBANN_HAS_GPU
   m_values->AlignWith(matrix_dist);


### PR DESCRIPTION
This is a variant of PR #1964 that provides an option to disable that memory optimization.

[Bamboo is running](https://lc.llnl.gov/bamboo/browse/LBANN-TIM412-1). Closes #1964.