### PR TITLE
Bugfix data reader catch2 tests

### DIFF
--- a/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
@@ -74,12 +74,16 @@ TEST_CASE("Synthetic data reader public API tests",
 {
   // initialize stuff (boilerplate)
   auto& comm = unit_test::utilities::current_world_comm();
-  lbann::init_random(42, 1);
-  lbann::init_data_seq_random(42);
+  int seed = 42;
+  lbann::init_random(seed, 1);
+  lbann::init_data_seq_random(seed);
 
   // Create a local copy of the RNG to check the synthetic data reader
   lbann::fast_rng_gen ref_fast_generator;
-  ref_fast_generator.seed(lbann::hash_combine(42, 0));
+  // Mix in the rank in trainer
+  seed = lbann::hash_combine(seed, comm.get_rank_in_trainer());
+  // Mix in the I/O thread rank
+  ref_fast_generator.seed(lbann::hash_combine(seed, 0));
 
   // Initalize a per-trainer I/O thread pool
   auto io_thread_pool = lbann::make_unique<lbann::thread_pool>();

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -35,6 +35,7 @@
 #include <lbann/layers/io/input_layer.hpp>
 #include <lbann/utils/memory.hpp>
 #include <lbann/utils/serialize.hpp>
+#include <lbann/utils/lbann_library.hpp>
 #include <lbann/proto/factories.hpp>
 
 #include <lbann.pb.h>
@@ -62,6 +63,8 @@ auto make_model(lbann::lbann_comm& comm)
   lbann_data::LbannPB my_proto;
   if (!pb::TextFormat::ParseFromString(model_prototext, &my_proto))
     throw "Parsing protobuf failed.";
+  // Construct a trainer so that the model can register the input layer
+  lbann::construct_trainer(&comm, my_proto.mutable_trainer(), my_proto);
   auto metadata = mock_datareader_metadata();
   auto my_model = lbann::proto::construct_model(&comm,
                                                 -1,


### PR DESCRIPTION
This fixes the two bugs recently introduced by PR #1962 and #1951 