### PR TITLE
Set the operator data type to match the layer's data type

### DIFF
--- a/include/lbann/layers/operator_layer_impl.hpp
+++ b/include/lbann/layers/operator_layer_impl.hpp
@@ -236,10 +236,6 @@ auto lbann::build_operator_layer_from_pbuf(lbann_comm* comm,
   std::vector<OperatorPtr> ops;
   ops.reserve(num_ops);
   for (int ii = 0; ii < num_ops; ++ii) {
-#ifdef LBANN_DEBUG
-    LBANN_ASSERT(msg.datatype() == params.ops(ii).input_datatype());
-    LBANN_ASSERT(msg.datatype() == params.ops(ii).output_datatype());
-#endif
     lbann_data::Operator op;
     op.CopyFrom(params.ops(ii));
     op.set_input_datatype(msg.datatype());

--- a/include/lbann/layers/operator_layer_impl.hpp
+++ b/include/lbann/layers/operator_layer_impl.hpp
@@ -231,6 +231,8 @@ auto lbann::build_operator_layer_from_pbuf(lbann_comm* comm,
   auto const& params = msg.operator_layer();
 
   auto const num_ops = params.ops_size();
+  LBANN_ASSERT(num_ops == 1UL); // Only support single operator.
+
   std::vector<OperatorPtr> ops;
   ops.reserve(num_ops);
   for (int ii = 0; ii < num_ops; ++ii) {
@@ -238,8 +240,11 @@ auto lbann::build_operator_layer_from_pbuf(lbann_comm* comm,
     LBANN_ASSERT(msg.datatype() == params.ops(ii).input_datatype());
     LBANN_ASSERT(msg.datatype() == params.ops(ii).output_datatype());
 #endif
-    ops.emplace_back(
-      proto::construct_operator<InputT, OutputT, D>(params.ops(ii)));
+    lbann_data::Operator op;
+    op.CopyFrom(params.ops(ii));
+    op.set_input_datatype(msg.datatype());
+    op.set_output_datatype(msg.datatype());
+    ops.emplace_back(proto::construct_operator<InputT, OutputT, D>(op));
   }
   return std::make_unique<LayerType>(*comm, std::move(ops));
 }


### PR DESCRIPTION
This addresses an issue raised by @timmoon10 that arises when changing the layer precision in the python front-end. The `OperatorLayer` will only support a single operator (that change coming in a future PR; adding an ASSERT to hold us over until then), and it doesn't make sense to allow the types to be different.