### PR TITLE
Debugging Distconv models

### DIFF
--- a/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
+++ b/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
@@ -84,7 +84,7 @@ def construct_model(args):
                 depth_groups=args.depth_groups)
 
     g_device = 'GPU'
-    input_ = lbann.Input(name='input', device=g_device)
+    input_ = lbann.Input(name='input', data_field='samples')
     input_ = lbann.Reshape(input_, dims=list2str(_sample_dims),name='in_reshape', device=g_device),
     x1 = lbann.Identity(input_, parallel_strategy=None, name='x1')
     x2 = lbann.Identity(input_, name='x2') if args.compute_mse else None

--- a/include/lbann/layers/io/input_layer.hpp
+++ b/include/lbann/layers/io/input_layer.hpp
@@ -190,6 +190,7 @@ class input_layer : public data_type_layer<TensorDataType> {
   distconv_adapter_type& get_distconv_adapter() override;
   const distconv_adapter_type& get_distconv_adapter() const override;
   bool keep_original_outputs(int index) const override;
+  bool keep_original_gradient_wrt_outputs(int index) const override;
 ///@}
 #endif // LBANN_HAS_DISTCONV
 };

--- a/include/lbann/layers/io/input_layer.hpp
+++ b/include/lbann/layers/io/input_layer.hpp
@@ -45,15 +45,17 @@ class input_distconv_adapter: public data_type_distconv_adapter<TensorDataType> 
   using TensorHost = dc::TensorHost<TensorDataType>;
   using TensorHostShuffler = dc::TensorHostShuffler<TensorDataType>;
 
-  input_distconv_adapter(Layer& layer, const bool shuffle_required);
+  input_distconv_adapter(
+    Layer& layer,
+    data_field_type data_field,
+    const bool shuffle_required);
   virtual ~input_distconv_adapter() = default;
 
-  TensorHostShuffler &get_shuffler(const TensorHost &src, const TensorHost &dst,
-                                   int mat_idx);
+  TensorHostShuffler &get_shuffler(const TensorHost &src, const TensorHost &dst);
   void setup_fp_tensors() override;
   std::unique_ptr<TensorDevType> setup_activations_i(int index) const override;
   dc::Shape get_activations_local_shape(int index) const override;
-  dc::Shape get_activations_shape(int index) const;
+  dc::Shape get_activations_shape(int index) const override;
   void setup_shuffler_buffers(const TensorHost &src, const TensorHost &dst);
 
   // No bp tensors needed for this layer.
@@ -69,15 +71,18 @@ class input_distconv_adapter: public data_type_distconv_adapter<TensorDataType> 
   // Nothing to do here as everything is done in fp_compute_distconv.
   void fp_setup(El::Int mini_batch_size) override {}
   void fp_compute();
-  bool is_input_processed(size_t index) const;
 
  private:
-  std::vector<bool> m_is_input_processed;
-  std::vector<std::unique_ptr<TensorHost>> m_original_host_tensors;
-  std::vector<std::unique_ptr<TensorHost>> m_host_tensors;
+
+  /// @brief Data field accessed by corresponding input layer
+  data_field_type m_data_field;
+
+  bool m_is_input_processed;
+  std::unique_ptr<TensorHost> m_original_host_tensor;
+  std::unique_ptr<TensorHost> m_host_tensor;
 
   const bool m_shuffle_required;
-  std::vector<std::array<std::unique_ptr<TensorHostShuffler>, 4>> m_shufflers;
+  std::array<std::unique_ptr<TensorHostShuffler>, 4> m_shufflers;
   std::unique_ptr<TensorDataType> m_shuffler_src_buf;
   size_t m_shuffler_src_buf_size = 0;
   std::unique_ptr<TensorDataType> m_shuffler_dst_buf;
@@ -185,7 +190,7 @@ class input_layer : public data_type_layer<TensorDataType> {
   }
   void setup_distconv_adapter(const DataReaderMetaData& dr_metadata) override {
     this->get_distconv_adapter_ptr() = make_unique<distconv_adapter_type>(
-        *this, dr_metadata.shuffle_required);
+      *this, m_data_field, dr_metadata.shuffle_required);
   }
   distconv_adapter_type& get_distconv_adapter() override;
   const distconv_adapter_type& get_distconv_adapter() const override;

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -65,8 +65,6 @@ void buffered_data_coordinator<TensorDataType>::setup_data_fields(
 
 #ifdef LBANN_HAS_DISTCONV
   if (dc::is_cosmoflow_parallel_io_enabled()) {
-    El::Int num_neurons = get_linearized_data_size();
-    num_neurons /= dc::get_number_of_io_partitions();
     // TODO: Make sure that TensorDatType is equivalent to the HDF5
     // data reader's data type (float as default).
     // TensorDataType is assumed to be 2-byte integer types such as
@@ -80,15 +78,33 @@ void buffered_data_coordinator<TensorDataType>::setup_data_fields(
   /// ranks are participating in I/O
   El::Int local_mini_batch_size = max_mini_batch_size / this->m_comm->get_procs_per_trainer();
   El::Int partial_mini_batch_size = max_mini_batch_size % this->m_comm->get_procs_per_trainer();
-#ifdef LBANN_HAS_DISTCONV
-  if (dc::is_cosmoflow_parallel_io_enabled()) {
-    assert_eq(local_mini_batch_size, 1);
-    assert_eq(partial_mini_batch_size, 0);
-  }
-#endif // LBANN_HAS_DISTCONV
   if(partial_mini_batch_size > 0 && this->m_comm->get_rank_in_trainer() < partial_mini_batch_size) {
     local_mini_batch_size++;
   }
+
+#ifdef LBANN_HAS_DISTCONV
+  if (dc::is_cosmoflow_parallel_io_enabled()) {
+    // Manually resize buffers for CosmoFlow data tensors
+    assert_eq(local_mini_batch_size, 1);
+    assert_eq(partial_mini_batch_size, 0);
+    El::Int linearized_size = get_linearized_data_size();
+    linearized_size /= dc::get_number_of_io_partitions();
+    for (const auto& buf_map : m_data_buffers) {
+      const data_buffer_map_t& buffer_map = buf_map;
+      for (const auto& [mode, data_buffer] : buffer_map) {
+        auto& input_buffers = data_buffer->m_input_buffers;
+        if (input_buffers.count(INPUT_DATA_TYPE_SAMPLES) > 0
+            && input_buffers[INPUT_DATA_TYPE_SAMPLES]->IsEmpty()) {
+          input_buffers[INPUT_DATA_TYPE_SAMPLES]->Resize(linearized_size,
+                                                         max_mini_batch_size);
+          El::Zeros_seq(data_buffer->m_indices_fetched_per_mb,
+                        local_mini_batch_size,
+                        1);
+        }
+      }
+    }
+  }
+#endif // LBANN_HAS_DISTCONV
 
   // Check to see if there are any data fields with unallocated buffers
   for (auto& data_field : m_active_data_fields) {

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -486,6 +486,16 @@ keep_original_outputs(int index) const {
   // into distconv tensors.
   return true;
 }
+
+template <typename TensorDataType,
+          data_layout T_layout,
+          El::Device Dev>
+bool input_layer<TensorDataType, T_layout, Dev>::
+keep_original_gradient_wrt_outputs(int index) const {
+  // Error signals are ignored
+  return false;
+}
+
 #endif // LBANN_HAS_DISTCONV
 
 #define PROTO_DEVICE(T, Device) \

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -182,34 +182,33 @@ void input_layer<T,L,D>::fill_onnx_node(onnx::GraphProto& graph) const
 template <typename TensorDataType,
           data_layout T_layout, El::Device Dev>
 input_distconv_adapter<TensorDataType, T_layout, Dev>::
-input_distconv_adapter(Layer& layer, const bool shuffle_required)
+input_distconv_adapter(
+  Layer& layer,
+  const data_field_type data_field,
+  const bool shuffle_required)
   : data_type_distconv_adapter<TensorDataType>(layer),
-  m_shuffle_required(shuffle_required) {
+    m_data_field(data_field),
+    m_shuffle_required(shuffle_required) {
+
+  // Distconv currently only supports CosmoFlow data
+  if (m_data_field != INPUT_DATA_TYPE_SAMPLES
+      && m_data_field != INPUT_DATA_TYPE_RESPONSES) {
+    LBANN_ERROR(
+      "attempted to create distconv adapter for ",
+      "input layer with unsupported data field (",m_data_field,")");
+  }
+
   // Input data is only processed when its consumer layer is also
   // enabled for distconv
-  for (int i = 0; i < layer.get_num_children(); ++i) {
-    m_is_input_processed.push_back(layer.get_child_layers()[i]->distconv_enabled());
-  }
-  if (m_shuffle_required) {
-    m_shufflers.resize(layer.get_num_children());
-  }
-}
+  m_is_input_processed = layer.get_child_layer().distconv_enabled();
 
-template <typename TensorDataType,
-          data_layout T_layout, El::Device Dev>
-bool input_distconv_adapter<TensorDataType, T_layout, Dev>::
-is_input_processed(size_t index) const {
-  if (index >= m_is_input_processed.size()) {
-    LBANN_ERROR("Invalid index: ", index);
-  }
-  return m_is_input_processed[index];
 }
 
 template <typename TensorDataType,
           data_layout T_layout, El::Device Dev>
 typename input_distconv_adapter<TensorDataType, T_layout, Dev>::TensorHostShuffler&
 input_distconv_adapter<TensorDataType, T_layout, Dev>::get_shuffler(
-    const TensorHost &src, const TensorHost &dst, int mat_idx) {
+    const TensorHost &src, const TensorHost &dst) {
   size_t cur_mb_size = src.get_shape()[dc::get_sample_dim()];
   auto src_buf = m_shuffler_src_buf.get();
   auto dst_buf = m_shuffler_dst_buf.get();
@@ -224,7 +223,7 @@ input_distconv_adapter<TensorDataType, T_layout, Dev>::get_shuffler(
     shfl_idx = 1 + static_cast<int>(mode);
   }
   assert_always(shfl_idx >= 0 && shfl_idx < 4);
-  auto &shfl = m_shufflers[mat_idx][shfl_idx];
+  auto &shfl = m_shufflers[shfl_idx];
   if (shfl == nullptr) {
     shfl = make_unique<TensorHostShuffler>(
         src, dst, src_buf, dst_buf);
@@ -237,10 +236,10 @@ template <typename TensorDataType,
 void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
   const auto sample_dist = dc::get_hydrogen_data_parallel_distribution(
       dc::get_num_dims(this->layer()));
-  for (int mat_idx = 0; mat_idx < this->layer().get_num_children(); ++mat_idx) {
-    if (!is_input_processed(mat_idx)) continue;
 
-    const auto shape = this->get_activations_shape(mat_idx);
+  if (m_is_input_processed) {
+
+    const auto shape = this->get_activations_shape(0);
     auto local_shape = shape;
     if (m_shuffle_required) {
       local_shape[dc::get_sample_dim()] = 0;
@@ -254,7 +253,7 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
     const dc::LocaleMPI loc(dc::get_mpi_comm(), false);
 
     auto dist = this->get_activations_dist();
-    if (mat_idx == 1) {
+    if (m_data_field == INPUT_DATA_TYPE_RESPONSES) {
       // assumes no halo for the ground-truth data
       dist.clear_overlap();
     }
@@ -264,29 +263,29 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
     const auto original_host_tensor_dist = m_shuffle_required ?
         sample_dist : dist_no_halo;
     // Create a view to the host LBANN matrix
-    m_original_host_tensors.emplace_back(
-        make_unique<TensorHost>(shape, loc, original_host_tensor_dist, local_shape));
+    m_original_host_tensor
+      = make_unique<TensorHost>(shape, loc, original_host_tensor_dist, local_shape);
 
     // When shuffled, host tensor will have the same distribution as
     // the final output; otherwise, it is just a view to the host
     // LBANN matrix, so no overlap.
     auto host_tensor_dist = m_shuffle_required ? dist : dist_no_halo;
-    m_host_tensors.emplace_back(
-        make_unique<TensorHost>(shape, loc, host_tensor_dist));
+    m_host_tensor
+      = make_unique<TensorHost>(shape, loc, host_tensor_dist);
 
     if (m_shuffle_required) {
       // TODO: This is a temporary hack. Should use
       // CUDAHostPooledAllocator, but the shuffler is
       // only specialized for BaseAllocator.
-      size_t buf_size = m_host_tensors.back()->get_local_real_size()
-          * sizeof(TensorDataType);
+      size_t buf_size = m_host_tensor->get_local_real_size() * sizeof(TensorDataType);
       TensorDataType *buf = nullptr;
       CHECK_CUDA(cudaMallocHost(&buf, buf_size));
       // Note buf should be deallocated.
-      dc::tensor::View(*m_host_tensors.back(), buf);
-      setup_shuffler_buffers(*m_original_host_tensors.back(),
-                             *m_host_tensors.back());
+      dc::tensor::View(*m_host_tensor, buf);
+      setup_shuffler_buffers(*m_original_host_tensor,
+                             *m_host_tensor);
     }
+
   }
 
   this->setup_activations();
@@ -297,12 +296,12 @@ template <typename TensorDataType,
 std::unique_ptr<typename input_distconv_adapter<TensorDataType, T_layout, Dev>::TensorDevType>
 input_distconv_adapter<TensorDataType, T_layout, Dev>::
 setup_activations_i(int index) const {
-  if (!is_input_processed(index)) return nullptr;
-  if (index == 0) {
+  if (!m_is_input_processed) return nullptr;
+  if (m_data_field == INPUT_DATA_TYPE_SAMPLES) {
     return data_type_distconv_adapter<TensorDataType>::
         setup_activations_i(index);
-  } else {
-    assert_eq(index, 1);
+  }
+  else if (m_data_field == INPUT_DATA_TYPE_RESPONSES) {
     // Note: the default setup_activations_i can't be used because
     // the distribution might need to be changed to remove
     // overlap. This can be fixed by making each tensor hav a
@@ -316,6 +315,9 @@ setup_activations_i(int index) const {
     assert0(t->allocate());
     t->zero(hydrogen::cuda::GetDefaultStream());
     return t;
+  }
+  else {
+    LBANN_ERROR("unsupported data field (",m_data_field,")");
   }
 }
 
@@ -332,23 +334,27 @@ template <typename TensorDataType,
           data_layout T_layout, El::Device Dev>
 dc::Shape input_distconv_adapter<TensorDataType, T_layout, Dev>::
 get_activations_shape(int index) const {
-  if (index == 0) {
+  if (m_data_field == INPUT_DATA_TYPE_SAMPLES) {
     return data_type_distconv_adapter<TensorDataType>::
         get_activations_shape(index);
-  } else {
-    assert_eq(index, 1);
+  }
+  else if (m_data_field == INPUT_DATA_TYPE_RESPONSES) {
     // TODO: This is a temporary hack. The label tensor shape should
     //be set based on the shape set by the data reader, but the data
     //reader does not provide it. Using the shape shape as the data
     //tensor works fine for the U-Net model.
-    auto shape = this->get_activations_shape(0);
+    auto shape = data_type_distconv_adapter<TensorDataType>::
+      get_activations_shape(0); /// @todo Should this be getting shape corresponding to INPUT_DATA_TYPE_SAMPLES?
     auto label_size = data_type_distconv_adapter<TensorDataType>::
-        get_activations_shape(1).reduce_prod();
+        get_activations_shape(0).reduce_prod();
     const std::string env = std::getenv("DISTCONV_LABEL_NUM_CHANNELS");
     auto num_channels = env != ""
         ? std::stoi(env) : label_size / shape.reduce_prod();
     shape[-2] = num_channels;
     return shape;
+  }
+  else {
+    LBANN_ERROR("unsupported data field (",m_data_field,")");
   }
 }
 
@@ -377,7 +383,7 @@ template <typename TensorDataType,
 bool input_distconv_adapter<TensorDataType, T_layout, Dev>::
 child_copy_required(size_t output_index) const {
   // Not required when label is not handled.
-  if (output_index == 1 && !is_input_processed(1)) {
+  if (m_data_field == INPUT_DATA_TYPE_RESPONSES && !m_is_input_processed) {
     return false;
   } else {
     return data_type_distconv_adapter<TensorDataType>::
@@ -390,7 +396,7 @@ template <typename TensorDataType,
 bool input_distconv_adapter<TensorDataType, T_layout, Dev>::
 child_shuffle_required(size_t output_index) const {
   // Not required when label is not handled.
-  if (output_index == 1 && !is_input_processed(1)) {
+  if (m_data_field == INPUT_DATA_TYPE_RESPONSES && !m_is_input_processed) {
     return false;
   } else {
     return data_type_distconv_adapter<TensorDataType>::
@@ -410,18 +416,17 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::fp_compute() {
   const int mb_size = static_cast<sgd_execution_context&>(
       l.get_model()->get_execution_context()).get_current_mini_batch_size();
 
-  for (int mat_idx = 0; mat_idx < l.get_num_children(); ++mat_idx) {
-    if (!is_input_processed(mat_idx)) continue;
+  if (m_is_input_processed) {
 
     // TODO: This is diabled as it raises an error when the HDF5 data
     // reader with hyperslab labels is used. Remove this assertion or
-    // reshape the actiavtion tensor (mat_idx=1).
+    // reshape the actiavtion tensor (data_field = RESPONSES).
     // assert_eq(mb_size * dc::get_number_of_io_partitions(),
-    //           l.get_activations(mat_idx).Width());
+    //           l.get_activations().Width());
 
-    auto &original_tensor = *m_original_host_tensors[mat_idx];
-    auto &host_tensor = *m_host_tensors[mat_idx];
-    auto &device_tensor = this->get_activations(mat_idx);
+    auto& original_tensor = *m_original_host_tensor;
+    auto& host_tensor = *m_host_tensor;
+    auto& device_tensor = this->get_activations();
 
     // Adjust the mini-batch size
     original_tensor.set_outermost_dimension(mb_size);
@@ -429,33 +434,35 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::fp_compute() {
     device_tensor.set_outermost_dimension(mb_size);
 
     // Setup view
-    assert0(dc::tensor::View(
+    assert0(
+      dc::tensor::View(
         original_tensor,
-        l.get_activations(mat_idx).LockedBuffer()));
+        l.get_activations().LockedBuffer()));
 
     // Shuffle if necessary
     if (m_shuffle_required) {
       get_shuffler(
-          original_tensor, host_tensor, mat_idx).shuffle_forward(
-              original_tensor.get_const_base_ptr(),
-              host_tensor.get_base_ptr());
-    } else {
+        original_tensor, host_tensor).shuffle_forward(
+          original_tensor.get_const_base_ptr(),
+          host_tensor.get_base_ptr());
+    }
+    else {
       // The input buffer is already partitioned
-      assert0(dc::tensor::View(
+      assert0(
+        dc::tensor::View(
           host_tensor, original_tensor.get_const_buffer()));
     }
 
     // After this, there is no inter-process communication, so it's
     // safe to exit if the local tensor is empty.
-    if (host_tensor.get_local_size() == 0) {
-      continue;
+    if (host_tensor.get_local_size() > 0) {
+      prof_region_begin("copy-to-device", prof_colors[1], false);
+      assert0(dc::tensor::Copy(device_tensor, host_tensor, stream));
+      prof_region_end("copy-to-device", false);
     }
 
-    prof_region_begin("copy-to-device", prof_colors[1], false);
-    assert0(dc::tensor::Copy(
-        device_tensor, host_tensor, stream));
-    prof_region_end("copy-to-device", false);
   }
+
 }
 
 template <typename TensorDataType,

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -213,6 +213,7 @@ void init_data_readers(
                                                           key_labels,
                                                           key_responses,
                                                           hyperslab_labels);
+      reader_hdf5->set_has_data_field(INPUT_DATA_TYPE_SAMPLES, true);
       reader_hdf5->set_has_labels(!readme.disable_labels());
       reader_hdf5->set_has_responses(!readme.disable_responses());
       reader_hdf5->set_num_responses(readme.num_responses());


### PR DESCRIPTION
@hariharan-devarajan has observed runtime errors when he runs the CosmoFlow and ExaGAN models with Distconv. Debugging, it looks like these are mostly because PR #1951 did not update some of Distconv's hacks with data ingestion. With this PR, both the CosmoFlow and ExaGAN models run for me on Lassen.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM422-1).