### PR TITLE
Use same device for an operator layer and its operators

### DIFF
--- a/python/lbann/core/operator_layers.py
+++ b/python/lbann/core/operator_layers.py
@@ -41,11 +41,26 @@ def generate_operator_layer(operator_class):
 
     def export_proto(self):
         """Construct and return a protobuf message."""
-        if (self.datatype is None):
-            self.datatype = 0 # Use the default value.
+
+        # Use default datatype if not specified
+        if self.datatype is None:
+            self.datatype = 0
+
+        # Convert device string to enum
+        device = lbann.DeviceAllocation.DEFAULT_DEVICE
+        if isinstance(self.device, str):
+            if self.device.lower() == 'cpu':
+                device = lbann.DeviceAllocation.CPU
+            elif self.device.lower() == 'gpu':
+                device = lbann.DeviceAllocation.GPU
+
+        # Configure operators to match layer
         for o in self.ops:
             o.input_type = self.datatype
             o.output_type = self.datatype
+            o.device_allocation = device
+
+        # Generate Protobuf message
         return OperatorLayer.export_proto(self)
 
     # Return operator layer class


### PR DESCRIPTION
When manually setting the device of operator layers, we also need to set the device of the individual operators. This is annoying for simple operator layers like for ReLU or tanh. The quickest fix is to handle this in the Python front-end, similar to #1977. [Bamboo is in progress](https://lc.llnl.gov/bamboo/browse/LBANN-TIM423-1).