### PR TITLE
Fix bug with user-specified random seeds

### DIFF
--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -887,7 +887,7 @@ void get_cmdline_overrides(const lbann_comm& comm, lbann_data::LbannPB& p)
   if (arg_parser.get<bool>(LBANN_OPTION_DISABLE_CUDA)) {
     model->set_disable_cuda(arg_parser.get<bool>(LBANN_OPTION_DISABLE_CUDA));
   }
-  if (arg_parser.get<int>(LBANN_OPTION_RANDOM_SEED) == -1) {
+  if (arg_parser.get<int>(LBANN_OPTION_RANDOM_SEED) != 0) {
     trainer->set_random_seed(arg_parser.get<int>(LBANN_OPTION_RANDOM_SEED));
   }
   if (arg_parser.get<bool>(LBANN_OPTION_SERIALIZE_IO)) {

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -194,7 +194,8 @@ void construct_std_options()
                         "");
   arg_parser.add_option(LBANN_OPTION_RANDOM_SEED,
                         {"--random_seed", "--rand_seed"},
-                        "[STD] Value to seed RNG",
+                        utils::ENV("LBANN_RANDOM_SEED"),
+                        "[STD] RNG seed",
                         0);
   arg_parser.add_option(LBANN_OPTION_READER, {"--reader"}, "[STD] TODO", "");
   arg_parser.add_option(

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -195,7 +195,7 @@ void construct_std_options()
   arg_parser.add_option(LBANN_OPTION_RANDOM_SEED,
                         {"--random_seed", "--rand_seed"},
                         "[STD] Value to seed RNG",
-                        -1);
+                        0);
   arg_parser.add_option(LBANN_OPTION_READER, {"--reader"}, "[STD] TODO", "");
   arg_parser.add_option(
     LBANN_OPTION_RESTART_DIR,


### PR DESCRIPTION
User-specified random seeds are always ignored due to a bug in how we process the corresponding command-line argument. I've made a quick fix and added an environment variable (`LBANN_RANDOM_SEED`).

[Bamboo is running](https://lc.llnl.gov/bamboo/browse/LBANN-TIM424-1).