### PR TITLE
Use Aluminum shuffler in Distconv for ExaGAN model

### DIFF
--- a/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
+++ b/applications/physics/cosmology/ExaGAN/train_distconv_gan.py
@@ -162,6 +162,10 @@ if __name__ == '__main__':
     # Runtime parameters/arguments
     environment = lbann.contrib.args.get_distconv_environment(
         num_io_partitions=args.depth_groups)
+    environment['INPUT_WIDTH'] = os.environ['INPUT_WIDTH']
+    environment['DATA_DIR'] = os.environ['DATA_DIR']
+    environment['LBANN_DISTCONV_HALO_EXCHANGE'] = 'AL'
+    environment['LBANN_DISTCONV_TENSOR_SHUFFLER'] = 'AL'
 
     if args.dynamically_reclaim_error_signals:
         environment['LBANN_KEEP_ERROR_SIGNALS'] = 0


### PR DESCRIPTION
The hybrid shuffler in Distconv only supports intra-node communication, so it is unsuitable for applications where a single sample does not fit in a node.