### PR TITLE
Explicitly set the search name for Cereal to be all lowercase.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,11 +196,13 @@ find_package(Threads REQUIRED)
 find_package(Clara REQUIRED)
 
 find_package(CEREAL NO_MODULE
+  NAMES cereal
   HINTS ${CEREAL_DIR} $ENV{CEREAL_DIR}
   PATH_SUFFIXES share/cmake/cereal
   NO_DEFAULT_PATH)
 if (NOT CEREAL_FOUND)
-  find_package(CEREAL NO_MODULE REQUIRED)
+  find_package(CEREAL NO_MODULE REQUIRED
+    NAMES cereal)
 endif ()
 set(LBANN_HAS_CEREAL ${CEREAL_FOUND})
 # The imported target is just called "cereal". Super.

--- a/cmake/configure_files/LBANNConfig.cmake.in
+++ b/cmake/configure_files/LBANNConfig.cmake.in
@@ -71,15 +71,16 @@ endif ()
 
 if (LBANN_HAS_CEREAL)
   find_package(CEREAL NO_MODULE QUIET
+    NAMES cereal
     HINTS ${CEREAL_DIR} $ENV{CEREAL_DIR}
     PATH_SUFFIXES share/cmake/cereal
     NO_DEFAULT_PATH)
   if (NOT CEREAL_FOUND)
-    find_package(CEREAL NO_MODULE QUIET)
+    find_package(CEREAL NO_MODULE QUIET NAMES cereal)
   endif ()
   if (NOT CEREAL_FOUND AND NOT CEREAL_DIR)
     set(CEREAL_DIR "@CEREAL_DIR@")
-    find_package(CEREAL NO_MODULE REQUIRED)
+    find_package(CEREAL NO_MODULE REQUIRED NAMES cereal)
   endif ()
   if (NOT CEREAL_FOUND)
     message(FATAL_ERROR "Required dependency CEREAL not found.")


### PR DESCRIPTION
I haven't had issues, but this should be correct. Closes #2011.