### PR TITLE
Fix tensor dimension issues

### DIFF
--- a/include/lbann/layers/operator_layer_impl.hpp
+++ b/include/lbann/layers/operator_layer_impl.hpp
@@ -159,6 +159,9 @@ OperatorLayer<InputT, OutputT, Layout, D>::fix_type(std::vector<int> const& in)
   return std::vector<size_t>{cbegin(in), cend(in)};
 }
 
+// WARNING: The next 4 functions all assume the minibatch dim is the
+// width of the matrix.
+
 template <typename InputT, typename OutputT, data_layout Layout, El::Device D>
 std::vector<utils::ConstDistTensorView<InputT, D>>
 OperatorLayer<InputT, OutputT, Layout, D>::get_inputs() const
@@ -166,9 +169,11 @@ OperatorLayer<InputT, OutputT, Layout, D>::get_inputs() const
   auto n_parents = this->get_num_parents();
   std::vector<utils::ConstDistTensorView<InputT, D>> out;
   out.reserve(n_parents);
-  for (int p = 0; p < n_parents; ++p)
-    out.emplace_back(this->get_prev_activations(p),
-                     fix_type(this->get_input_dims(p)));
+  for (int p = 0; p < n_parents; ++p) {
+    auto const& prev_acts = this->get_prev_activations(p);
+    out.emplace_back(prev_acts,
+                     splice_dims(prev_acts.Width(), this->get_input_dims(p)));
+  }
   return out;
 }
 
@@ -179,9 +184,10 @@ OperatorLayer<InputT, OutputT, Layout, D>::get_outputs()
   auto n_children = this->get_num_children();
   std::vector<utils::DistTensorView<OutputT, D>> out;
   out.reserve(n_children);
-  for (int c = 0; c < n_children; ++c)
-    out.emplace_back(this->get_activations(c),
-                     fix_type(this->get_output_dims(c)));
+  for (int c = 0; c < n_children; ++c) {
+    auto& acts = this->get_activations(c);
+    out.emplace_back(acts, splice_dims(acts.Width(), this->get_output_dims(c)));
+  }
   return out;
 }
 
@@ -192,9 +198,11 @@ OperatorLayer<InputT, OutputT, Layout, D>::get_grad_wrt_outputs() const
   auto n_children = this->get_num_children();
   std::vector<utils::ConstDistTensorView<OutputT, D>> out;
   out.reserve(n_children);
-  for (int c = 0; c < n_children; ++c)
-    out.emplace_back(this->get_prev_error_signals(c),
-                     fix_type(this->get_output_dims(c)));
+  for (int c = 0; c < n_children; ++c) {
+    auto const& prev_sigs = this->get_prev_error_signals(c);
+    out.emplace_back(prev_sigs,
+                     splice_dims(prev_sigs.Width(), this->get_output_dims(c)));
+  }
   return out;
 }
 
@@ -205,9 +213,11 @@ OperatorLayer<InputT, OutputT, Layout, D>::get_grad_wrt_inputs()
   auto n_parents = this->get_num_parents();
   std::vector<utils::DistTensorView<InputT, D>> out;
   out.reserve(n_parents);
-  for (int p = 0; p < n_parents; ++p)
-    out.emplace_back(this->get_error_signals(p),
-                     fix_type(this->get_input_dims(p)));
+  for (int p = 0; p < n_parents; ++p) {
+    auto& error_sigs = this->get_error_signals(p);
+    out.emplace_back(error_sigs,
+                     splice_dims(error_sigs.Width(), this->get_input_dims(p)));
+  }
   return out;
 }
 

--- a/include/lbann/utils/dim_helpers.hpp
+++ b/include/lbann/utils/dim_helpers.hpp
@@ -28,37 +28,34 @@
 
 #include <lbann/utils/exception.hpp>
 
-namespace lbann
-{
+namespace lbann {
 
 template <typename T>
 auto get_linear_size(std::vector<T> const& dims)
 {
-  return (dims.size()
-          ? std::accumulate(begin(dims), end(dims), T(1), std::multiplies<T>())
-          : T(0));
+  return (
+    dims.size()
+      ? std::accumulate(begin(dims), end(dims), T(1), std::multiplies<T>())
+      : T(0));
 }
 
 template <typename T>
 auto get_linear_size(size_t ndims, T const* dims)
 {
   return (ndims
-          ? std::accumulate(dims, dims+ndims, T(1), std::multiplies<T>())
-          : T(0));
+            ? std::accumulate(dims, dims + ndims, T(1), std::multiplies<T>())
+            : T(0));
 }
-
 
 template <typename T>
 auto get_strides(size_t ndims, T const* dims, T const& lowest_stride)
 {
   std::vector<T> strides(ndims, lowest_stride);
-  if (ndims > 0)
-  {
-    for (size_t ii = ndims-1; ii != 0; --ii)
-    {
+  if (ndims > 0) {
+    for (size_t ii = ndims - 1; ii != 0; --ii) {
       if (dims[ii] == T(0))
-        LBANN_ERROR("Zero-sized dimension not allowed. Dims[",ii,"] = 0.");
-      strides[ii-1] = strides[ii]*dims[ii];
+        LBANN_ERROR("Zero-sized dimension not allowed. Dims[", ii, "] = 0.");
+      strides[ii - 1] = strides[ii] * dims[ii];
     }
   }
   return strides;
@@ -82,5 +79,46 @@ auto get_packed_strides(std::vector<T> const& dims)
   return get_strides(dims.size(), dims.data(), T(1));
 }
 
-}// namespace lbann
+namespace details {
+
+template <typename T, typename... ArgTs>
+std::enable_if_t<std::is_integral_v<T>>
+accumulate_dims(std::vector<size_t>& acc, T const& x, ArgTs&&... rest);
+
+template <typename T, typename... ArgTs>
+std::enable_if_t<std::is_integral_v<T>>
+accumulate_dims(std::vector<size_t>& acc,
+                std::vector<T> const& x,
+                ArgTs&&... rest);
+
+inline void accumulate_dims(std::vector<size_t>&) {}
+
+template <typename T, typename... ArgTs>
+std::enable_if_t<std::is_integral_v<T>>
+accumulate_dims(std::vector<size_t>& acc, T const& x, ArgTs&&... rest)
+{
+  acc.push_back(x);
+  accumulate_dims(acc, std::forward<ArgTs>(rest)...);
+}
+
+template <typename T, typename... ArgTs>
+std::enable_if_t<std::is_integral_v<T>>
+accumulate_dims(std::vector<size_t>& acc,
+                std::vector<T> const& x,
+                ArgTs&&... rest)
+{
+  acc.insert(end(acc), cbegin(x), cend(x));
+  accumulate_dims(acc, std::forward<ArgTs>(rest)...);
+}
+} // namespace details
+
+template <typename... ArgTs>
+std::vector<size_t> splice_dims(ArgTs&&... args)
+{
+  std::vector<size_t> dims;
+  details::accumulate_dims(dims, std::forward<ArgTs>(args)...);
+  return dims;
+}
+
+} // namespace lbann
 #endif // LBANN_UTILS_DIM_HELPERS_HPP_

--- a/src/utils/unit_test/dim_helpers_test.cpp
+++ b/src/utils/unit_test/dim_helpers_test.cpp
@@ -40,9 +40,7 @@ TEST_CASE("Computing linear sizes", "[dims][utilities]")
 
   SECTION("Higher dims")
   {
-    std::vector<int> dims1 = { 32 },
-      dims2 = { 3,4 },
-      dims3 = { 5,4,6 };
+    std::vector<int> dims1 = {32}, dims2 = {3, 4}, dims3 = {5, 4, 6};
     CHECK(get_linear_size(dims1) == 32);
     CHECK(get_linear_size(dims2) == 12);
     CHECK(get_linear_size(dims3) == 120);
@@ -50,13 +48,13 @@ TEST_CASE("Computing linear sizes", "[dims][utilities]")
 
   SECTION("Zero-sized dimension doesn't throw; returns zero.")
   {
-    std::vector<int> dims = { 5, 0, 4 };
+    std::vector<int> dims = {5, 0, 4};
     CHECK_NOTHROW(get_linear_size(dims));
     CHECK(get_linear_size(dims) == 0);
   }
 }
 
-TEST_CASE("Computing packed strides","[dims][utilities]")
+TEST_CASE("Computing packed strides", "[dims][utilities]")
 {
   SECTION("Empty dims, empty strides")
   {
@@ -67,7 +65,7 @@ TEST_CASE("Computing packed strides","[dims][utilities]")
 
   SECTION("Single dimension, single stride of 1.")
   {
-    std::vector<int> dims = { 32 };
+    std::vector<int> dims = {32};
     auto strides = get_packed_strides(dims);
     CHECK(strides.size() == 1UL);
     CHECK(strides.front() == 1);
@@ -75,7 +73,7 @@ TEST_CASE("Computing packed strides","[dims][utilities]")
 
   SECTION("Two dimensions")
   {
-    std::vector<int> dims = { 4, 8 }, correct = { 8, 1 };
+    std::vector<int> dims = {4, 8}, correct = {8, 1};
     auto strides = get_packed_strides(dims);
     CHECK(strides.size() == dims.size());
     CHECK(strides == correct);
@@ -83,8 +81,7 @@ TEST_CASE("Computing packed strides","[dims][utilities]")
 
   SECTION("Higher dimensions")
   {
-    std::vector<int> dims = {4, 3, 5, 2 },
-      correct = { 30, 10, 2, 1 };
+    std::vector<int> dims = {4, 3, 5, 2}, correct = {30, 10, 2, 1};
     auto strides = get_packed_strides(dims);
     CHECK(strides.size() == dims.size());
     CHECK(strides == correct);
@@ -92,7 +89,20 @@ TEST_CASE("Computing packed strides","[dims][utilities]")
 
   SECTION("Zero-sized dimension throws")
   {
-    std::vector<int> dims = { 3, 2, 0, 7 };
+    std::vector<int> dims = {3, 2, 0, 7};
     CHECK_THROWS(get_packed_strides(dims));
   }
+}
+
+TEST_CASE("Dimension splicing", "[utilities][tensor]")
+{
+  CHECK(splice_dims() == std::vector<size_t>{});
+  CHECK(splice_dims(1, 2, 3) == std::vector<size_t>{1, 2, 3});
+  CHECK(splice_dims(1, std::vector<int>{2, 3}) == std::vector<size_t>{1, 2, 3});
+  CHECK(splice_dims(std::vector<int>{1, 2}, 3) == std::vector<size_t>{1, 2, 3});
+  CHECK(splice_dims(std::vector<int>{1},
+                    std::vector<short>{},
+                    2,
+                    std::vector<char>{3},
+                    std::vector<unsigned>{}) == std::vector<size_t>{1, 2, 3});
 }


### PR DESCRIPTION
Addresses some issues @bvanessen was seeing with tensor dimensions.

The initial implementation was very open to unintentional abuse (e.g., if the "sample dims" are pre-padded with 1s and the minibatch size is 1, should another 1 be prepended or no? There's no way to differentiate). This resolves that by making it the user's responsibility to pass the full tensor dimension. As a result, the operator layer now prepends the minibatch dimension manually.