### PR TITLE
Add dimension checks to the binary operators

### DIFF
--- a/src/layers/regularizers/layer_norm.cu
+++ b/src/layers/regularizers/layer_norm.cu
@@ -184,8 +184,8 @@ void fp_impl(lbann_comm& comm,
   const auto& local_input = dynamic_cast<const GPUMatType&>(input.LockedMatrix());
   auto& local_output = dynamic_cast<GPUMatType&>(output.Matrix());
   auto& local_statistics = dynamic_cast<GPUMatType&>(statistics.Matrix());
-  auto local_means = El::LockedView(local_statistics, El::IR(0), El::ALL);
-  auto local_vars = El::LockedView(local_statistics, El::IR(1), El::ALL);
+  auto local_means = El::View(local_statistics, El::IR(0), El::ALL);
+  auto local_vars = El::View(local_statistics, El::IR(1), El::ALL);
 
   // Dimensions
   const size_t sample_size = input.Height();

--- a/src/operators/math/binary.cpp
+++ b/src/operators/math/binary.cpp
@@ -469,6 +469,8 @@ struct LogicalXorOpImpl
     auto const& input0 = inputs[0].data();                                     \
     auto const& input1 = inputs[1].data();                                     \
     auto& output = outputs.front().data();                                     \
+    LBANN_ASSERT(input0.Height() == input1.Height());                          \
+    LBANN_ASSERT(input0.Width() == input1.Width());                            \
     internal::EntrywiseZipInto(input0,                                         \
                                input1,                                         \
                                output,                                         \
@@ -488,6 +490,8 @@ struct LogicalXorOpImpl
     auto const& grad_wrt_output = grads_wrt_outputs.front().data();            \
     auto& grad_wrt_input0 = grads_wrt_inputs[0].data();                        \
     auto& grad_wrt_input1 = grads_wrt_inputs[1].data();                        \
+    LBANN_ASSERT(grad_wrt_input0.Height() == grad_wrt_input1.Height());        \
+    LBANN_ASSERT(grad_wrt_input0.Width() == grad_wrt_input1.Width());          \
     internal::apply_binary_backprop_operator(input0,                           \
                                              input1,                           \
                                              grad_wrt_output,                  \

--- a/src/operators/math/binary.cu
+++ b/src/operators/math/binary.cu
@@ -436,6 +436,8 @@ struct LogicalXorOpImpl {
     auto const& input0 = inputs[0].data();                              \
     auto const& input1 = inputs[1].data();                              \
     auto& output = outputs.front().data();                              \
+    LBANN_ASSERT(input0.Height() == input1.Height());                   \
+    LBANN_ASSERT(input0.Width() == input1.Width());                     \
     internal::EntrywiseZipInto(input0,                                  \
                                input1,                                  \
                                output,                                  \
@@ -455,6 +457,8 @@ struct LogicalXorOpImpl {
     auto const& grad_wrt_output = grads_wrt_outputs.front().data();     \
     auto& grad_wrt_input0 = grads_wrt_inputs[0].data();                 \
     auto& grad_wrt_input1 = grads_wrt_inputs[1].data();                 \
+    LBANN_ASSERT(grad_wrt_input0.Height() == grad_wrt_input1.Height()); \
+    LBANN_ASSERT(grad_wrt_input0.Width() == grad_wrt_input1.Width());   \
     internal::apply_binary_backprop_operator(input0,                    \
                                              input1,                    \
                                              grad_wrt_output,           \


### PR DESCRIPTION
Addresses a debugging issue.

While debugging this issue, I also realized we had an issue where `LockedView`s were being used instead of `View`s. This fixes that, too, mostly to have the hassle of a separate PR.