### PR TITLE
Make sure GPU grid dims are valid in slice/concat layers

### DIFF
--- a/src/layers/transform/concatenate.cu
+++ b/src/layers/transform/concatenate.cu
@@ -315,6 +315,7 @@ void fp_compute_impl(
     grid_dims.x = (max_input_dims[3] + block_size - 1) / block_size;
     grid_dims.y = max_input_dims[2];
     grid_dims.z = max_input_dims[1];
+    gpu_lib::clip_grid_dims(grid_dims);
     hydrogen::gpu::LaunchKernel(
       concat4d_kernel<TensorDataType>,
       grid_dims, block_dims, 0, sync_info,
@@ -470,6 +471,7 @@ void bp_compute_impl(
     grid_dims.x = (max_input_grad_dims[3] + block_size - 1) / block_size;
     grid_dims.y = max_input_grad_dims[2];
     grid_dims.z = max_input_grad_dims[1];
+    gpu_lib::clip_grid_dims(grid_dims);
     hydrogen::gpu::LaunchKernel(
       slice4d_kernel<TensorDataType>,
       grid_dims, block_dims, 0, sync_info,

--- a/src/layers/transform/slice.cu
+++ b/src/layers/transform/slice.cu
@@ -308,6 +308,7 @@ void fp_compute_impl(
     grid_dims.x = (max_output_dims[3] + block_size - 1) / block_size;
     grid_dims.y = max_output_dims[2];
     grid_dims.z = max_output_dims[1];
+    gpu_lib::clip_grid_dims(grid_dims);
     hydrogen::gpu::LaunchKernel(
       slice4d_kernel<TensorDataType>,
       grid_dims, block_dims, 0, sync_info,
@@ -459,6 +460,7 @@ void bp_compute_impl(
     grid_dims.x = (max_output_grad_dims[3] + block_size - 1) / block_size;
     grid_dims.y = max_output_grad_dims[2];
     grid_dims.z = max_output_grad_dims[1];
+    gpu_lib::clip_grid_dims(grid_dims);
     hydrogen::gpu::LaunchKernel(
       concat4d_kernel<TensorDataType>,
       grid_dims, block_dims, 0, sync_info,


### PR DESCRIPTION
I've noticed some CUDA errors when concatenating very large tensors. Looks like we forgot the slice and concat layers in #1946.