### PR TITLE
Fix changes that should not have been in #2020

### DIFF
--- a/include/lbann/layers/operator_layer_impl.hpp
+++ b/include/lbann/layers/operator_layer_impl.hpp
@@ -227,9 +227,9 @@ template <typename InputT,
           typename OutputT,
           lbann::data_layout Layout,
           El::Device D>
-std::unique_ptr<Layer>
-lbann::build_operator_layer_from_pbuf(lbann_comm* comm,
-                                      lbann_data::Layer const& msg)
+auto lbann::build_operator_layer_from_pbuf(lbann_comm* comm,
+                                           lbann_data::Layer const& msg)
+  -> std::unique_ptr<Layer>
 {
   using LayerType = OperatorLayer<InputT, OutputT, Layout, D>;
   using OperatorType = Operator<InputT, OutputT, D>;

--- a/include/lbann/proto/operator_factory_impl.hpp
+++ b/include/lbann/proto/operator_factory_impl.hpp
@@ -137,7 +137,7 @@ OperatorFactory<InT, OutT, D> build_default_factory()
 } // namespace lbann
 
 template <typename InT, typename OutT, El::Device D>
-OperatorFactory<InT, OutT, D>& lbann::proto::get_operator_factory()
+auto lbann::proto::get_operator_factory() -> OperatorFactory<InT, OutT, D>&
 {
   static auto factory = details::build_default_factory<InT, OutT, D>();
   return factory;


### PR DESCRIPTION
I don't know how or why these changes happened? But basically, the trailing return type (whose namespace resolution depends on being AFTER the function name opens the scope) moved to the front of the prototype but did not have namespaces added. I like it the other way better, so I just restored that.