### PR TITLE
Make sure sub-graph-specific code is encapsulated in Python submodules

### DIFF
--- a/python/lbann/models/__init__.py
+++ b/python/lbann/models/__init__.py
@@ -2,4 +2,3 @@ from lbann.models.alexnet import AlexNet
 from lbann.models.lenet import LeNet
 from lbann.models.resnet import ResNet, ResNet18, ResNet34, ResNet50, ResNet101, ResNet152
 from lbann.models.transformer import Transformer, TransformerEncoderLayer, TransformerDecoderLayer
-from lbann.models.subgraph import *

--- a/python/lbann/modules/__init__.py
+++ b/python/lbann/modules/__init__.py
@@ -10,4 +10,3 @@ from lbann.modules.base import Module, FullyConnectedModule, ChannelwiseFullyCon
 from lbann.modules.rnn import LSTMCell, GRU, ChannelwiseGRU
 from lbann.modules.transformer import MultiheadAttention
 from lbann.modules.graph import *
-from lbann.modules.subgraph import *


### PR DESCRIPTION
By importing sub-graph code directly into our base Python submodules (`lbann.modules`, `lbann.models`), we were overwriting the non-sub-graph implementations of multi-head attention and Transformer. Forcing the user to load `lbann.modules.subgraph` or `lbann.models.subgraph` seems appropriate since this is an advanced, experimental feature.

[No new Bamboo failures](https://lc.llnl.gov/bamboo/browse/LBANN-TIM438-1). Pinging @aj-prime and @tnat410.