### PR TITLE
Fix a logic error in PFE

### DIFF
--- a/python/lbann/core/operator_layers.py
+++ b/python/lbann/core/operator_layers.py
@@ -53,7 +53,7 @@ def generate_operator_layer(operator_class):
                 device = lbann.DeviceAllocation.CPU
             elif self.device.lower() == 'gpu':
                 device = lbann.DeviceAllocation.GPU
-        else:
+        elif self.device is not None:
             raise TypeError('Unknown type for field device ' + str(type(device)))
 
         # Configure operators to match layer


### PR DESCRIPTION
Introduced in #2028. The case in which the device allocation was not explicitly set was not considered.