### PR TITLE
Bugfix for the checkpoint lenet unit tests

### DIFF
--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -179,43 +179,6 @@ public:
     }
   }
 
-  /**
-   * Get the current execution context for the model.  However, if the current
-   * execution context is not for training and there is a valid training
-   * execution context, return the training context instead.
-   *
-   */
-  inline const SGDExecutionContext& get_current_execution_context_with_training_override(model* m) {
-    const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
-    if(c.get_execution_mode() != execution_mode::training &&
-       this->get_active_trainer().execution_context_valid(m, execution_mode::training)) {
-      const auto& training_ctx = static_cast<SGDExecutionContext&>(
-        this->get_active_trainer().get_execution_context(m, execution_mode::training));
-      return training_ctx;
-    }
-    return c;
-  }
-
-  /**
-   * When generating a checkpoint for non-training execution phases, the epoch
-   * number should be pulled from the training context to provide a proper
-   * ordering of the checkpoint.
-   */
-  inline size_t get_epoch_with_training_override(model* m) {
-    const auto& c = get_current_execution_context_with_training_override(m);
-    return c.get_epoch();
-  }
-
-  /**
-   * When generating a checkpoint for non-training execution phases, the step
-   * count should be pulled from the training context to provide a proper
-   * ordering of the checkpoint.
-   */
-  inline size_t get_step_with_training_override(model* m) {
-    const auto& c = get_current_execution_context_with_training_override(m);
-    return c.get_step();
-  }
-
   bool need_checkpoint(model *m, callback_phase phase);
   std::string find_latest_checkpoint(lbann_comm& comm,
                                      const std::string& trainer_name,

--- a/include/lbann/callbacks/checkpoint.hpp
+++ b/include/lbann/callbacks/checkpoint.hpp
@@ -179,6 +179,43 @@ public:
     }
   }
 
+  /**
+   * Get the current execution context for the model.  However, if the current
+   * execution context is not for training and there is a valid training
+   * execution context, return the training context instead.
+   *
+   */
+  inline const SGDExecutionContext& get_current_execution_context_with_training_override(model* m) {
+    const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
+    if(c.get_execution_mode() != execution_mode::training &&
+       this->get_active_trainer().execution_context_valid(m, execution_mode::training)) {
+      const auto& training_ctx = static_cast<SGDExecutionContext&>(
+        this->get_active_trainer().get_execution_context(m, execution_mode::training));
+      return training_ctx;
+    }
+    return c;
+  }
+
+  /**
+   * When generating a checkpoint for non-training execution phases, the epoch
+   * number should be pulled from the training context to provide a proper
+   * ordering of the checkpoint.
+   */
+  inline size_t get_epoch_with_training_override(model* m) {
+    const auto& c = get_current_execution_context_with_training_override(m);
+    return c.get_epoch();
+  }
+
+  /**
+   * When generating a checkpoint for non-training execution phases, the step
+   * count should be pulled from the training context to provide a proper
+   * ordering of the checkpoint.
+   */
+  inline size_t get_step_with_training_override(model* m) {
+    const auto& c = get_current_execution_context_with_training_override(m);
+    return c.get_step();
+  }
+
   bool need_checkpoint(model *m, callback_phase phase);
   std::string find_latest_checkpoint(lbann_comm& comm,
                                      const std::string& trainer_name,

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -221,10 +221,10 @@ public:
 
   ExecutionContext& get_execution_context(execution_context_key_pair_t key);
 
-  bool execution_context_valid(observer_ptr<model> model,
-                               execution_mode mode);
+  bool execution_context_valid(model& m,
+                               execution_mode mode) const noexcept;
 
-  bool execution_context_valid(execution_context_key_pair_t key);
+  bool execution_context_valid(execution_context_key_pair_t key) const noexcept;
 
   /** @name Training and evaluation interface */
   ///@{

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -221,6 +221,11 @@ public:
 
   ExecutionContext& get_execution_context(execution_context_key_pair_t key);
 
+  bool execution_context_valid(observer_ptr<model> model,
+                               execution_mode mode);
+
+  bool execution_context_valid(execution_context_key_pair_t key);
+
   /** @name Training and evaluation interface */
   ///@{
 

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/comm_impl.hpp"
 #include "lbann/callbacks/checkpoint.hpp"
-
+#include "lbann/execution_algorithms/sgd_execution_context.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/serialize.hpp"
 
@@ -39,7 +39,49 @@
 #include <string>
 
 namespace lbann {
+namespace {
+/**
+ * Get the current execution context for the model.  However, if the current
+ * execution context is not for training and there is a valid training
+ * execution context, return the training context instead.
+ *
+ */
+SGDExecutionContext const&
+get_current_execution_context_with_training_override(model& m, trainer& t)
+{
+  const auto& c =
+    dynamic_cast<SGDExecutionContext const&>(m.get_execution_context());
+  if (c.get_execution_mode() != execution_mode::training &&
+      t.execution_context_valid(m, execution_mode::training)) {
+    return dynamic_cast<SGDExecutionContext const&>(
+      t.get_execution_context(&m, execution_mode::training));
+  }
+  return c;
+}
+
+/**
+ * When generating a checkpoint for non-training execution phases, the epoch
+ * number should be pulled from the training context to provide a proper
+ * ordering of the checkpoint.
+ */
+size_t get_epoch_with_training_override(model& m, trainer& t)
+{
+  return get_current_execution_context_with_training_override(m, t).get_epoch();
+}
+
+/**
+ * When generating a checkpoint for non-training execution phases, the step
+ * count should be pulled from the training context to provide a proper
+ * ordering of the checkpoint.
+ */
+size_t get_step_with_training_override(model& m, trainer& t)
+{
+  return get_current_execution_context_with_training_override(m, t).get_step();
+}
+} // namespace
+
 namespace callback {
+
 // Load from checkpoint occurs during setup callbacks
 void checkpoint::setup(model *m) {
   reload_model(m);
@@ -99,7 +141,6 @@ void checkpoint::on_batch_begin(model *m) {
 
 // Decide if we need to trigger a checkpoint for either mode, based on prototext defined intervals
 bool checkpoint::need_checkpoint(model *m, callback_phase phase) {
-  const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   /* TODO: since we're using clocks, this requires a bcast for each call,
    * we could use number of samples processed to make a local decision */
   // if none of our checkpoint conditions are set, assume we're not checkpointing
@@ -114,9 +155,13 @@ bool checkpoint::need_checkpoint(model *m, callback_phase phase) {
   m_checkpoint_shared = false;
   m_checkpoint_dist = false;
   lbann_comm *comm = m->get_comm();
-  size_t cur_epoch = get_epoch_with_training_override(m);
-  size_t cur_step = get_step_with_training_override(m);
-  // If we are at the end of a training epoch and the training epoch lands on defined interval, ckpt
+  auto& t = this->get_active_trainer();
+  size_t const cur_epoch =
+    get_epoch_with_training_override(*m, t);
+  size_t const cur_step =
+    get_step_with_training_override(*m, t);
+  // If we are at the end of a training epoch and the training epoch lands on
+  // defined interval, ckpt
   if (!m_checkpoint_shared && m_checkpoint_epochs > 0 && (phase == callback_phase::epoch || phase == callback_phase::validation)){
       m_checkpoint_shared = (cur_epoch > 0) && (cur_epoch % m_checkpoint_epochs == 0);
     }
@@ -177,8 +222,8 @@ bool checkpoint::do_checkpoint(model *m, visitor_hook hook) {
   comm->trainer_barrier();
   // let user know we're saving a checkpoint
   if (comm->am_trainer_master()) {
-    epoch = get_epoch_with_training_override(m);
-    step = get_step_with_training_override(m);
+    epoch = get_epoch_with_training_override(*m, t);
+    step = get_step_with_training_override(*m, t);
     timer.Start();
     std::cout << "[" << m->get_name()
               << "." << comm->get_trainer_rank()

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -191,15 +191,14 @@ trainer::get_execution_context(execution_context_key_pair_t key)
     *(m_model_execution_context[key].get()));
 }
 
-bool trainer::execution_context_valid(observer_ptr<model> model,
-                                      execution_mode mode)
+bool trainer::execution_context_valid(model& m,
+                                      execution_mode mode) const noexcept
 {
-  auto key = std::make_pair(model, mode);
-  return execution_context_valid(key);
+  return execution_context_valid(std::make_pair(&m, mode));
 }
 
-bool
-trainer::execution_context_valid(execution_context_key_pair_t key)
+bool trainer::execution_context_valid(
+  execution_context_key_pair_t key) const noexcept
 {
   return (m_model_execution_context.count(key) != 0);
 }

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -191,6 +191,19 @@ trainer::get_execution_context(execution_context_key_pair_t key)
     *(m_model_execution_context[key].get()));
 }
 
+bool trainer::execution_context_valid(observer_ptr<model> model,
+                                      execution_mode mode)
+{
+  auto key = std::make_pair(model, mode);
+  return execution_context_valid(key);
+}
+
+bool
+trainer::execution_context_valid(execution_context_key_pair_t key)
+{
+  return (m_model_execution_context.count(key) != 0);
+}
+
 void trainer::delete_execution_context(execution_context_key_pair_t key)
 {
   if (m_model_execution_context.count(key) == 0) {


### PR DESCRIPTION
Updated the checkpoint logic so that when checkpointing during a
validation phase it will use the current epoch and step counts of the
active trainng execution context.  This will allow the validation
checkpoints to be properly ordered between the normal training
checkponts.  Additionally, under the new SGD execution algorithm, the
validation execution context is reset for every validation phase.  As
a result, two helper functions were added to the checkpoint class that
allow the callback to find the current active training execution
context if it was available, otherwise the active execution context is
used.  This ensures that in an inference only run with checkpoint, the
normal behavior should be preserved.