### PR TITLE
Fixed the MPI Catch2 filesystem test for the SMILES data reader.

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -114,7 +114,7 @@ class generic_data_reader {
   generic_data_reader(const generic_data_reader&) = default;
   generic_data_reader& operator=(const generic_data_reader&) = default;
 
-  virtual ~generic_data_reader() {}
+  virtual ~generic_data_reader();
   virtual generic_data_reader* copy() const = 0;
 
   /** Archive for checkpoint and restart */

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -672,7 +672,7 @@ if [[ "${SPEC_ONLY}" == "TRUE" ]]; then
 fi
 
 # Try to concretize the environment and catch the return code
-CMD="spack concretize --reuse ${INSTALL_BUILD_EXTRAS}"
+CMD="spack concretize ${INSTALL_BUILD_EXTRAS}"
 #CMD="spack concretize --reuse ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
@@ -725,7 +725,7 @@ fi
 
 ##########################################################################################
 # Actually install LBANN from local source
-CMD="spack install --reuse ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
+CMD="spack install ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
 #CMD="spack install --reuse ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -672,7 +672,7 @@ if [[ "${SPEC_ONLY}" == "TRUE" ]]; then
 fi
 
 # Try to concretize the environment and catch the return code
-CMD="spack concretize ${INSTALL_BUILD_EXTRAS}"
+CMD="spack concretize --reuse ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 
@@ -724,7 +724,7 @@ fi
 
 ##########################################################################################
 # Actually install LBANN from local source
-CMD="spack install ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
+CMD="spack install --reuse ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -673,6 +673,7 @@ fi
 
 # Try to concretize the environment and catch the return code
 CMD="spack concretize --reuse ${INSTALL_BUILD_EXTRAS}"
+#CMD="spack concretize --reuse ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 
@@ -725,6 +726,7 @@ fi
 ##########################################################################################
 # Actually install LBANN from local source
 CMD="spack install --reuse ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
+#CMD="spack install --reuse ${BUILD_JOBS} ${INSTALL_BUILD_EXTRAS}"
 echo ${CMD} | tee -a ${LOG}
 [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -157,12 +157,12 @@ set_center_specific_spack_dependencies()
         # MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
         case ${spack_arch_target} in
             "power9le" | "power8le") # Lassen, Ray
-                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105 ^py-packaging@17.1"
+                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105 ^libtool@2.4.2 ^py-packaging@17.1"
                 CENTER_FLAGS="+gold"
                 ;;
             "broadwell" | "haswell" | "sandybridge" | "ivybridge") # Pascal, RZHasGPU, Surface, Catalyst
                 # On LC the mvapich2 being used is built against HWLOC v1
-                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^py-packaging@17.1"
+                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^py-packaging@17.1"
                 CENTER_FLAGS="+gold"
                 ;;
             "zen" | "zen2") # Corona

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -157,12 +157,12 @@ set_center_specific_spack_dependencies()
         # MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
         case ${spack_arch_target} in
             "power9le" | "power8le") # Lassen, Ray
-                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105"
+                CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105 ^py-packaging@17.1"
                 CENTER_FLAGS="+gold"
                 ;;
             "broadwell" | "haswell" | "sandybridge" | "ivybridge") # Pascal, RZHasGPU, Surface, Catalyst
                 # On LC the mvapich2 being used is built against HWLOC v1
-                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13"
+                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^py-packaging@17.1"
                 CENTER_FLAGS="+gold"
                 ;;
             "zen" | "zen2") # Corona

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -44,6 +44,13 @@ namespace lbann {
 #undef DEBUG
 //#define DEBUG
 
+generic_data_reader::~generic_data_reader() {
+  if (m_data_store != nullptr) {
+    delete m_data_store;
+    m_data_store = nullptr;
+  }
+}
+
 template <class Archive>
 void generic_data_reader::serialize( Archive & ar ) {
   ar(CEREAL_NVP(m_current_mini_batch_idx),

--- a/src/data_readers/unit_test/data_reader_HDF5_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_test.cpp
@@ -69,7 +69,7 @@ TEST_CASE("hdf5 data reader schema tests",
   lbann::init_random(0, 2);
   lbann::init_data_seq_random(42);
   auto& arg_parser = lbann::global_argument_parser();
-  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  arg_parser.clear(); // Clear the argument parser.
   lbann::construct_all_options(); // Reset to the default state.
 
   // create working directory
@@ -304,7 +304,7 @@ TEST_CASE("hdf5 data reader schema tests",
     }
   } // SECTION("hdf5_reader: node_map")
 
-  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  arg_parser.clear(); // Clear the argument parser.
   // Cleanup the data readers
   for (auto t : all_readers) {
     delete t.second;

--- a/src/data_readers/unit_test/data_reader_HDF5_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_test.cpp
@@ -38,6 +38,8 @@
 
 #include "./data_reader_common_catch2.hpp"
 #include "lbann/data_readers/data_reader_HDF5.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 // input data; each of these contain a single variable: "const std::string"
 #include "./test_data/hdf5_hrrl_data_schema.yaml"
@@ -66,6 +68,9 @@ TEST_CASE("hdf5 data reader schema tests",
   auto& comm = unit_test::utilities::current_world_comm();
   lbann::init_random(0, 2);
   lbann::init_data_seq_random(42);
+  auto& arg_parser = lbann::global_argument_parser();
+  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  lbann::construct_all_options(); // Reset to the default state.
 
   // create working directory
   std::string work_dir = create_test_directory("hdf5_reader");
@@ -92,6 +97,13 @@ TEST_CASE("hdf5 data reader schema tests",
   write_file(hdf5_hrrl_test_sample_list,
              work_dir,
              "hdf5_hrrl_test.sample_list");
+
+  // set up the options that the reader expects
+  char const* argv[] = {"smiles_functional_black_box.exe",
+    "--use_data_store",
+    "--preload_data_store"};
+  int const argc = sizeof(argv) / sizeof(argv[0]);
+  REQUIRE_NOTHROW(arg_parser.parse(argc, argv));
 
   // instantiate the data readers
   lbann::generic_data_reader* train_ptr = nullptr;
@@ -291,6 +303,12 @@ TEST_CASE("hdf5 data reader schema tests",
       REQUIRE(test_val == new_val);
     }
   } // SECTION("hdf5_reader: node_map")
+
+  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  // Cleanup the data readers
+  for (auto t : all_readers) {
+    delete t.second;
+  }
 }
 
 //==========================================================================

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -30,6 +30,7 @@
 #include "MPITestHelpers.hpp"
 
 #include "lbann/proto/proto_common.hpp"
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/options.hpp"
 #include "lbann/utils/random_number_generators.hpp"
 #include "lbann/utils/file_utils.hpp"
@@ -73,7 +74,7 @@ void test_fetch(lbann::generic_data_reader* reader);
 
 bool directory_exists(std::string s);
 
-TEST_CASE("functional black-box", "[.filesystem][data reader][mpi][smiles]")
+TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles]")
 {
   //currently, tests are sequential; they can (should?) be expanded
   //to multiple ranks
@@ -196,12 +197,14 @@ TEST_CASE("functional black-box", "[.filesystem][data reader][mpi][smiles]")
   }
 
   // set up the options that the reader expects
-  // TODO MRW
-  // opts->set_option("use_data_store", true);
-  // opts->set_option("preload_data_store", true);
-  // opts->set_option("sequence_length", Max_seq_len);
-  // opts->set_option("vocab", vocab_fn);
-  // opts->set_option("prototext", prototext_fn);
+  char const* argv[] = {"smiles_functional_black_box.exe",
+    "--use_data_store",
+    "--preload_data_store",
+    "--sequence_length=100",
+    "--vocab", vocab_fn.c_str()};
+  int const argc = sizeof(argv) / sizeof(argv[0]);
+  auto& arg_parser = lbann::global_argument_parser();
+  REQUIRE_NOTHROW(arg_parser.parse(argc, argv));
 
   // instantiate and load the data readers
   std::map<lbann::execution_mode, lbann::generic_data_reader*> data_readers;

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles
   lbann::init_random(0, 2);
   lbann::init_data_seq_random(42);
   auto& arg_parser = lbann::global_argument_parser();
-  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  arg_parser.clear(); // Clear the argument parser.
   lbann::construct_all_options();
 
   //make non-const copies
@@ -241,7 +241,7 @@ TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles
     }
   }
 
-  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  arg_parser.clear(); // Clear the argument parser.
   // Cleanup the data readers
   for (auto t : data_readers) {
     delete t.second;

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -74,7 +74,7 @@ void test_fetch(lbann::generic_data_reader* reader);
 
 bool directory_exists(std::string s);
 
-TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles]")
+TEST_CASE("SMILES functional black-box", "[.filesystem][data_reader][mpi][smiles]")
 {
   //currently, tests are sequential; they can (should?) be expanded
   //to multiple ranks

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -82,6 +82,8 @@ TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles
   auto& comm = unit_test::utilities::current_world_comm();
   lbann::init_random(0, 2);
   lbann::init_data_seq_random(42);
+  auto& arg_parser = lbann::global_argument_parser();
+  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
   lbann::construct_all_options();
 
   //make non-const copies
@@ -203,7 +205,6 @@ TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles
     "--sequence_length=100",
     "--vocab", vocab_fn.c_str()};
   int const argc = sizeof(argv) / sizeof(argv[0]);
-  auto& arg_parser = lbann::global_argument_parser();
   REQUIRE_NOTHROW(arg_parser.parse(argc, argv));
 
   // instantiate and load the data readers
@@ -238,6 +239,12 @@ TEST_CASE("SMILES functional black-box", "[.filesystem][data reader][mpi][smiles
     if (test_ptr) {
       test_fetch(test_ptr);
     }
+  }
+
+  arg_parser = lbann::default_arg_parser_type{}; // Clear the argument parser.
+  // Cleanup the data readers
+  for (auto t : data_readers) {
+    delete t.second;
   }
 }
 


### PR DESCRIPTION
Updated to use the new argument parser.

CI is running here https://lc.llnl.gov/gitlab/vanessen/lbann/-/pipelines/140638