### PR TITLE
Correct the copy semantics of the argument parser

### DIFF
--- a/src/utils/unit_test/argument_parser_test.cpp
+++ b/src/utils/unit_test/argument_parser_test.cpp
@@ -56,6 +56,9 @@ TEMPLATE_TEST_CASE ("Testing the argument parser", "[parser][utilities]",
     CHECK_FALSE(parser.help_requested());
     REQUIRE_NOTHROW(parser.parse(argc, argv));
     CHECK(parser.help_requested());
+
+    REQUIRE_NOTHROW(parser.clear());
+    CHECK_FALSE(parser.help_requested());
   }
 
   SECTION("Long help flag")
@@ -66,6 +69,9 @@ TEMPLATE_TEST_CASE ("Testing the argument parser", "[parser][utilities]",
     CHECK_FALSE(parser.help_requested());
     REQUIRE_NOTHROW(parser.parse(argc, argv));
     CHECK(parser.help_requested());
+
+    REQUIRE_NOTHROW(parser.clear());
+    CHECK_FALSE(parser.help_requested());
   }
 
   SECTION("Boolean flags are false by default")
@@ -76,6 +82,12 @@ TEMPLATE_TEST_CASE ("Testing the argument parser", "[parser][utilities]",
 
     CHECK(parser.option_is_defined("flag v"));
     CHECK_FALSE(flag_v);
+
+    SECTION("Clear removes the flag")
+    {
+      REQUIRE_NOTHROW(parser.clear());
+      CHECK_FALSE(parser.option_is_defined("flag v"));
+    }
 
     SECTION("Short flag sets flag to true")
     {


### PR DESCRIPTION
When copying the argument parser, the reference held by Clara's `ExeName` was not updated to the new object, thereby creating a dangling reference to the `exe_name_` slot in the "source" argument parser.

This is not only true of the executable name; it would happen with any existing option. Therefore, the only safe argument parser to copy is an empty argument parser. Since this isn't very useful, I have removed the copy constructor/assignment interfaces from the class.

This was discovered in an attempt to clear the argument parser of existing state by just copy-assigning a default-constructed parser to it. To add clarity, I've just added a `clear()` function to the parser that resets it to its default-constructed state (clearing the exe name, as well as any arguments/flags/options that have been added).