### PR TITLE
Python function to perform naive hyperparameter sweep

### DIFF
--- a/docs/hyperparameter_tuning.rst
+++ b/docs/hyperparameter_tuning.rst
@@ -1,0 +1,105 @@
+.. role:: python(code)
+          :language: python
+
+.. _hyperparameter_tuning:
+
+============================================================
+Hyperparameter Tuning
+============================================================
+
+.. note:: See the docstring for
+          `lbann.contrib.hyperparameter.grid_search` for the API. This
+          page provides additional guidance on usage.
+
+.. note:: This feature is experimental and its API is still being
+          established. Once it has stabilized, the `hyperparameter`
+          submodule should be moved out of the `lbann.contrib`
+          submodule and into the top-level `lbann` module.
+
+When training machine learning models, the optimal hyperparameters are
+usually unknown and some experimentation is required to achieve
+acceptable results. To simplify this process,
+`lbann.contrib.hyperparameter.grid_search` implements a naive grid
+search algorithm. In particular it launches LBANN with multiple
+trainers and trains a separate model on each. If the number of
+candidate models is greater than the number of trainers, then LBANN is
+run multiple times. Afterwards the log file can be analyzed to
+determine the ideal hyperparameter configuration.
+
+The run configuration (e.g. the number of MPI ranks, the work
+directory) is specified with a
+`lbann.launcher.batch_script.BatchScript` object. See
+`lbann.launcher.make_batch_script` for more details on how to
+configure a batch job script.
+
+Models are configured with a user-provided function that takes
+hyperparameters and returns the objects needed for an LBANN
+experiment. Specifically, this function should return a `lbann.Model`,
+`lbann.Optimizer`, `lbann.reader_pb2.DataReader`, and `lbann.Trainer`,
+i.e. the inputs to `lbann.run`. To specify which values to pass into
+this `make_experiment` function, pass lists as keyword arguments into
+`lbann.contrib.hyperparameter.grid_search`: the values in the lists
+will be forwarded to the corresponding keyward argument in the
+`make_experiment` function. The resulting hyperparameter
+configurations will be dumped out in a CSV file (typically
+`hyperparameters.csv` in the work directory).
+
+Note that this grid search functionality is very flexible. Depending
+on how the user defines the `make_experiment` function, it is possible
+to train diverse models with different training algorithms and
+different datasets. However, it is preferable in practice to train
+models with roughly similar performance properties to avoid
+load-balancing issues. This is an effective approach to run the LTFB
+algorithm: it generates an initial population of diverse models that
+can then be subject to an evolutionary process.
+
+Simple Example
+------------------------------
+
+Suppose we want to tune the hyperparameters for a simple logistic
+classifier. We can define the following function to construct the
+model and related objects:
+
+.. code-block:: python
+
+    def make_logistic_classifier(
+            learning_rate=0.1,
+            bias=False,
+            num_labels=10):
+
+        # Construct model
+        x = lbann.Input(data_field='samples')
+        y = lbann.FullyConnected(x, num_neurons=num_labels, has_bias=bias)
+        y_pred = lbann.Softmax(y)
+        y_true = lbann.Input(data_field='labels')
+        z = lbann.CrossEntropy(y_pred, y_true)
+        model = lbann.Model(
+            epochs=1,
+            layers=lbann.traverse_layer_graph(z),
+            objective_function=z)
+
+        # Construct other objects
+        optimizer = lbann.SGD(learn_rate=learning_rate)
+        data_reader = make_data_reader()
+        trainer = lbann.Trainer(mini_batch_size=32)
+
+        return model, optimizer, data_reader, trainer
+
+Then we can perform a grid search with:
+
+.. code-block:: python
+
+    script = lbann.launcher.make_batch_script(nodes=2, procs_per_node=4)
+    lbann.contrib.hyperparameter.grid_search(
+        script,
+        make_logistic_classifier,
+        procs_per_trainer=1,
+        learning_rate=[0.5, 0.1, 0.05, 0.01],
+        bias=[True, False])
+
+This will generate and train eight models. Since we are running with
+eight trainers (8 MPI ranks and 1 rank per trainer), we only need to
+run LBANN once. If we ran with four trainers instead, LBANN would run
+twice. It is not necessary to perfectly line up the number of models
+and the number of trainers, but there could be idle compute nodes if
+they don't match.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ Users are advised to view `the Doxygen API Documentation
    callbacks
    data_transforms
    execution_algorithms
+   hyperparameter_tuning
 
 .. toctree::
    :maxdepth: 1

--- a/python/lbann/contrib/hyperparameter.py
+++ b/python/lbann/contrib/hyperparameter.py
@@ -8,11 +8,30 @@ import lbann.launcher
 import lbann.proto
 
 def cartesian_hyperparameter_sweep(
-        script : lbann.launcher.batch_script.BatchScript,
+        script,
         make_experiment,
         procs_per_trainer=1,
         **kwargs,
 ):
+    """Train LBANN models with Cartesian product of hyperparameter values
+
+    Models are evaluated independently by LBANN trainers. If the
+    number of models is greater than the number of trainers, LBANN is
+    run multiple times.
+
+    Args:
+        script (lbann.launcher.batch_script.BatchScript): Batch script
+            manager with MPI job configuration info.
+        make_experiment (function): Function that returns a tuple with
+            an lbann.Model, lbann.Optimizer,
+            lbann.reader_pb2.DataReader, and lbann.Trainer.
+        procs_per_trainer (int): Number of MPI ranks in an LBANN
+            trainer.
+        **kwargs (list): Hyperparameter values. Each kwarg should be a
+            list of values to pass to the corresponding kwarg in
+            make_experiment.
+
+    """
 
     # MPI launch configuration
     num_nodes = script.nodes
@@ -31,7 +50,7 @@ def cartesian_hyperparameter_sweep(
     # LBANN invocation as needed.
     arg_keys = list(kwargs.keys())
     arg_values = list(kwargs.values())
-    configs_file = open(os.path.join(work_dir, 'configs.csv'), 'w')
+    configs_file = open(os.path.join(work_dir, 'hyperparameters.csv'), 'w')
     configs_file.write('config_id,run_id,trainer_id,')
     configs_file.write(','.join(arg_keys))
     configs_file.write('\n')

--- a/python/lbann/contrib/hyperparameter.py
+++ b/python/lbann/contrib/hyperparameter.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+import itertools
+import os
+import shutil
+
+import lbann
+import lbann.launcher
+import lbann.proto
+
+def cartesian_hyperparameter_sweep(
+        script : lbann.launcher.batch_script.BatchScript,
+        make_experiment,
+        procs_per_trainer=1,
+        **kwargs,
+):
+
+    # MPI launch configuration
+    num_nodes = script.nodes
+    procs_per_node = script.procs_per_node
+    if procs_per_node % procs_per_trainer and procs_per_trainer % procs_per_node:
+        raise RuntimeError(
+            f'Trainer size ({procs_per_trainer}) and '
+            f'number of MPI ranks per node ({procs_per_node}) '
+            'are not multiples of each other')
+    num_trainers = (num_nodes * procs_per_node) // procs_per_trainer
+    num_nodes = (procs_per_trainer * num_trainers) // procs_per_node
+    work_dir = script.work_dir
+
+    # Iterate through Cartesian product of hyperparameter values
+    # Note: Export Protobuf message for each configuration and add
+    # LBANN invocation as needed.
+    arg_keys = list(kwargs.keys())
+    arg_values = list(kwargs.values())
+    configs_file = open(os.path.join(work_dir, 'configs.csv'), 'w')
+    configs_file.write('config_id,run_id,trainer_id,')
+    configs_file.write(','.join(arg_keys))
+    configs_file.write('\n')
+    for config_id, values in enumerate(itertools.product(*arg_values)):
+
+        # Construct experiment
+        args = { key : values[i] for i, key in enumerate(arg_keys) }
+        model, optimizer, reader, trainer = make_experiment(**args)
+
+        # Export Protobuf file
+        run_id = config_id // num_trainers
+        trainer_id = config_id % num_trainers
+        lbann.proto.save_prototext(
+            os.path.join(work_dir, f'run{run_id}.trainer{trainer_id}'),
+            model=model,
+            optimizer=optimizer,
+            data_reader=reader,
+            trainer=trainer)
+
+        # Write hyperparameters to file
+        configs_file.write(f'{config_id},{run_id},{trainer_id},')
+        configs_file.write(','.join(str(val) for val in values))
+        configs_file.write('\n')
+
+        # Invocation to launch LBANN
+        if trainer_id == num_trainers-1:
+            command = [
+                lbann.lbann_exe(),
+                f'--procs_per_trainer={procs_per_trainer}',
+                '--generate_multi_proto',
+                f'--prototext={work_dir}/run{run_id}.trainer0']
+            script.add_parallel_command(
+                command, nodes=num_nodes, procs_per_node=procs_per_node)
+
+    # Special handling for last LBANN run
+    # Note: If number of experiments doesn't neatly divide number of
+    # trainers, repeat the last configuration until we are using a
+    # whole number of nodes.
+    if trainer_id+1 != num_trainers:
+        last_prototext = os.path.join(work_dir, f'run{run_id}.trainer{trainer_id}')
+        while ((trainer_id+1)*procs_per_trainer) % procs_per_node != 0:
+            trainer_id += 1
+            shutil.copyfile(
+                last_prototext,
+                os.path.join(work_dir, f'run{run_id}.trainer{trainer_id}'))
+        command = [
+            lbann.lbann_exe(),
+            f'--procs_per_trainer={procs_per_trainer}',
+            '--generate_multi_proto',
+            f'--prototext={work_dir}/run{run_id}.trainer0']
+        script.add_parallel_command(
+            command,
+            nodes=((trainer_id+1)*procs_per_trainer) // procs_per_node,
+            procs_per_node=procs_per_node)
+
+    # Clean up file with hyperparameters
+    configs_file.close()
+
+    # Run script
+    script.run(True)

--- a/python/lbann/core/model.py
+++ b/python/lbann/core/model.py
@@ -22,9 +22,10 @@ def convert_to_protbuf_enums(subgraph_communication):
 class Model:
     """Neural network model."""
 
-    def __init__(self, epochs, 
+    def __init__(self, epochs,
                  layers=[], weights=[], objective_function=None,
                  metrics=[], callbacks=[],
+                 name=None,
                  summary_dir=None,
                  subgraph_communication=SubgraphCommunication.PT2PT,
                  subgraph_topology=False,
@@ -32,7 +33,9 @@ class Model:
 
         # Scalar fields
         self.epochs = epochs
+        self.name = name
         self.summary_dir = summary_dir
+
         # Get connected layers
         self.layers = list(lbann.core.layer.traverse_layer_graph(layers))
 
@@ -61,6 +64,8 @@ class Model:
         """Construct and return a protobuf message."""
         # Initialize protobuf message
         model = model_pb2.Model()
+        if self.name is not None:
+            model.name = self.name
         model.num_epochs = self.epochs
         model.subgraph_communication = convert_to_protbuf_enums(self.subgraph_communication)
         model.enable_subgraph_topology = self.subgraph_topology


### PR DESCRIPTION
Given a function to configure an LBANN experiment and lists of hyperparameter values, `lbann.contrib.hyperparameter.grid_search` will exhaustively generate all valid configurations and train them with LBANN. In particular, it will use multi-trainer training, possibly in multiple rounds.

For example, suppose you have implemented:
```
def make_lenet(activation, loss, optimizer, learning_rate):
    # <implementation>
    return model, optimizer, data_reader, trainer
```
Then you could do a hyperparameter sweep with:
```
lbann.contrib.hyperparameter.grid_search(
    script,
    make_lenet,
    activation=['relu', 'sigmoid', 'tanh'],
    loss=['cross_entropy', 'mse'],
    optimizer=['sgd', 'adam'],
    learning_rate=[0.1, 0.01, 0.001],
)
```
The log files can be post-processed to find the most promising configurations.