### PR TITLE
Remove the auto-print "feature" of the LBANN exception ctor.

### DIFF
--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -37,8 +37,8 @@
 #define LBANN_ERROR(...)                                        \
   do {                                                          \
     const int rank_LBANN_ERROR = lbann::get_rank_in_world();    \
-    throw lbann::exception(                                     \
-      lbann::build_string(                                      \
+    throw ::lbann::exception(                                   \
+      ::lbann::build_string(                                    \
         "LBANN error",                                          \
         (rank_LBANN_ERROR >= 0                                  \
          ? " on rank " + std::to_string(rank_LBANN_ERROR)       \
@@ -90,32 +90,36 @@
 
 namespace lbann {
 
-/** Exception.
+/** @class exception
+ *  @brief The base exception for LBANN errors.
+ *
  *  A stack trace is recorded when the exception is constructed.
  */
 class exception : public std::exception {
 public:
-
-  /** Constructor.
-   *  By default, a human-readable report is immediately printed to
-   *  the standard error stream.
+  /** @brief Default constructor.
+   *
+   *  Uses a generic message that reports the rank and stack trace.
    */
-  exception(std::string message = "", bool print = true);
-  const char* what() const noexcept override;
+  exception();
 
-  /** Print human-readable report to stream.
-   *  Reports the exception message and the stack trace.
+  /** @brief Constructor with message.
+   *
+   *  The message is interpolated into a longer report that includes
+   *  the stack trace from where the constructor is called.
+   *  Unfortunately, the constructor frame is usually included in
+   *  that stack trace.
    */
+  exception(std::string message);
+
+  char const* what() const noexcept override;
+
+  /** @brief Print the what() string to the stream. */
   void print_report(std::ostream& os = std::cerr) const;
 
 private:
   /** Human-readable exception message. */
   std::string m_message;
-  /** Human-readable stack trace.
-   *  The stack trace is recorded when the exception is constructed.
-   */
-  std::string m_stack_trace;
-
 };
 using lbann_exception = exception;
 

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -49,7 +49,7 @@ exception::exception(std::string message)
   auto const stack_trace = stack_trace::get();
   auto const star_rule = std::string(64, '*');
   std::ostringstream oss;
-  oss << star_rule << "\n" << message;
+  oss << star_rule << "\n" << message << "\n";
   if (!stack_trace.empty()) {
     oss << "Stack trace:\n" << stack_trace;
   }

--- a/src/utils/exception.cpp
+++ b/src/utils/exception.cpp
@@ -25,46 +25,40 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/utils/exception.hpp"
-#include "lbann/utils/stack_trace.hpp"
+
 #include "lbann/comm_impl.hpp"
+#include "lbann/utils/stack_trace.hpp"
 
 namespace lbann {
 
-exception::exception(std::string message, bool print)
-  : m_message(message),
-    m_stack_trace(stack_trace::get()) {
-
-  // Construct default message if none is provided
-  if (m_message.empty()) {
-    std::stringstream ss("LBANN exception");
-    const auto& rank = get_rank_in_world();
-    if (rank >= 0) {
-      ss << " on rank " << rank;
-    }
-    m_message = ss.str();
+static std::string default_error_message()
+{
+  std::ostringstream oss("LBANN exception", std::ios_base::ate);
+  const auto rank = get_rank_in_world();
+  if (rank >= 0) {
+    oss << " on rank " << rank;
   }
-
-  // Print report to standard error stream
-  if (print) { print_report(std::cerr); }
-
+  return oss.str();
 }
 
-const char* exception::what() const noexcept {
-  return m_message.c_str();
-}
+exception::exception() : exception(default_error_message()) {}
 
-void exception::print_report(std::ostream& os) const {
-  std::stringstream ss;
-  ss << "****************************************************************"
-     << std::endl
-     << m_message << std::endl;
-  if (!m_stack_trace.empty()) {
-    ss << "Stack trace:" << std::endl
-       << m_stack_trace;
+exception::exception(std::string message)
+{
+  // Build the "real" what() string, complete with stack trace:
+  auto const stack_trace = stack_trace::get();
+  auto const star_rule = std::string(64, '*');
+  std::ostringstream oss;
+  oss << star_rule << "\n" << message;
+  if (!stack_trace.empty()) {
+    oss << "Stack trace:\n" << stack_trace;
   }
-  ss << "****************************************************************"
-     << std::endl;
-  os << ss.str();
+  oss << star_rule << "\n";
+  m_message = oss.str();
 }
+
+const char* exception::what() const noexcept { return m_message.c_str(); }
+
+void exception::print_report(std::ostream& os) const { os << m_message; }
 
 } // namespace lbann


### PR DESCRIPTION
I also took the liberty to clean up a few things in the exception class. In particular, there's no reason to store the stack trace in its own string; it is only used in the thing that gets printed by `print_report()`.

The biggest change is that the `what()` string now just stores the whole report message, and `print_report()` just writes the `what()` string to the given stream. The visible behavior should be mostly the same for users -- `lbann.cpp` for instance only calls `print_report()` to a file stream if the user has requested that stack traces dump to files. `El::ReportException()` will print the `what()` string, which now includes the stack trace. But this is the behavior we want anyway since the stack trace is no longer reported when the exception is constructed.

I also did a little cleanup in `stack_trace.cpp`, where I noticed that `lbann::exception::print_report()` was being used. I only wish I could do more.