### PR TITLE
Add a missing filesystem tag to a test that expects LC filesystems

### DIFF
--- a/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
@@ -57,7 +57,7 @@ h5out_32.h5 4 RUN_ID/000000004 RUN_ID/000000005 RUN_ID/000000006 RUN_ID/00000000
 
 } // namespace
 
-TEST_CASE("hdf5 data reader", "[mpi][data reader][sample_list][hdf5]")
+TEST_CASE("hdf5 data reader", "[mpi][data reader][sample_list][hdf5][.filesystem]")
 {
   auto& comm = unit_test::utilities::current_world_comm();
 


### PR DESCRIPTION
This test was throwing up warnings when run on non-LC systems.