### PR TITLE
Update Transformer app with recent API changes

### DIFF
--- a/applications/nlp/transformer/dataset.py
+++ b/applications/nlp/transformer/dataset.py
@@ -32,7 +32,8 @@ dataset_train, dataset_val = torchnlp.datasets.wmt_dataset(
 )
 
 # Load token vocabulary
-with open(os.path.join(data_dir, 'vocab.bpe.32000')) as f:
+token_file = os.path.join(data_dir, 'vocab.bpe.32000')
+with open(token_file, 'r', encoding='utf-8') as f:
     tokens = f.read().splitlines()
 tokens.extend(['<unk>', '<s>', '</s>', '<pad>'])
 token_indices = dict(zip(tokens, range(len(tokens))))

--- a/applications/nlp/transformer/evaluate.py
+++ b/applications/nlp/transformer/evaluate.py
@@ -103,8 +103,7 @@ def load_parameter(weight_file):
     data = np.loadtxt(weight_file, dtype=np.float32)
     return torch.nn.Parameter(
         data=torch.from_numpy(data),
-        requires_grad=False
-    )
+        requires_grad=False)
 
 def load_embedding_layer(weights_prefix):
     """Create a PyTorch embedding layer with weights from LBANN.
@@ -114,7 +113,7 @@ def load_embedding_layer(weights_prefix):
     <weights_prefix>-embeddings-Weights.txt.
 
     """
-    weight_file = f'{weights_prefix}-embeddings-Weights.txt'
+    weight_file = f'{weights_prefix}/embeddings.txt'
     weight = load_parameter(weight_file).transpose(1,0)
     return torch.nn.Embedding(
         num_embeddings=vocab_size,
@@ -151,22 +150,22 @@ def load_transformer(weights_prefix):
         # Load weights for self-attention
         attention = layer.self_attn
         attention._qkv_same_embed_dim = False
-        prefix = f'{weights_prefix}-transformer_encoder{i}_attention'
-        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix-Weights.txt')
-        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias-Weights.txt')
-        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix-Weights.txt')
-        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias-Weights.txt')
-        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix-Weights.txt')
-        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias-Weights.txt')
-        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix-Weights.txt')
-        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias-Weights.txt')
+        prefix = f'{weights_prefix}/transformer_encoder{i}_attention'
+        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix.txt')
+        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias.txt')
+        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix.txt')
+        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias.txt')
+        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix.txt')
+        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias.txt')
+        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix.txt')
+        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias.txt')
 
         # Load weights for feedforward network
-        prefix = f'{weights_prefix}-transformer_encoder{i}'
-        layer.linear1.weight = load_parameter(f'{prefix}_fc1_matrix-Weights.txt')
-        layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias-Weights.txt')
-        layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix-Weights.txt')
-        layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias-Weights.txt')
+        prefix = f'{weights_prefix}/transformer_encoder{i}'
+        layer.linear1.weight = load_parameter(f'{prefix}_fc1_matrix.txt')
+        layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias.txt')
+        layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix.txt')
+        layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias.txt')
 
     # Load weights for decoder
     for i, layer in enumerate(transformer.decoder.layers):
@@ -174,35 +173,35 @@ def load_transformer(weights_prefix):
         # Load weights for self-attention
         attention = layer.self_attn
         attention._qkv_same_embed_dim = False
-        prefix = f'{weights_prefix}-transformer_decoder{i}_attention1'
-        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix-Weights.txt')
-        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias-Weights.txt')
-        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix-Weights.txt')
-        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias-Weights.txt')
-        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix-Weights.txt')
-        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias-Weights.txt')
-        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix-Weights.txt')
-        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias-Weights.txt')
+        prefix = f'{weights_prefix}/transformer_decoder{i}_attention1'
+        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix.txt')
+        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias.txt')
+        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix.txt')
+        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias.txt')
+        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix.txt')
+        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias.txt')
+        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix.txt')
+        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias.txt')
 
         # Load weights for attention with memory
         attention = layer.multihead_attn
         attention._qkv_same_embed_dim = False
-        prefix = f'{weights_prefix}-transformer_decoder{i}_attention2'
-        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix-Weights.txt')
-        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias-Weights.txt')
-        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix-Weights.txt')
-        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias-Weights.txt')
-        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix-Weights.txt')
-        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias-Weights.txt')
-        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix-Weights.txt')
-        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias-Weights.txt')
+        prefix = f'{weights_prefix}/transformer_decoder{i}_attention2'
+        attention.q_proj_weight = load_parameter(f'{prefix}_query_matrix.txt')
+        attention.q_proj_bias = load_parameter(f'{prefix}_query_bias.txt')
+        attention.k_proj_weight = load_parameter(f'{prefix}_key_matrix.txt')
+        attention.k_proj_bias = load_parameter(f'{prefix}_key_bias.txt')
+        attention.v_proj_weight = load_parameter(f'{prefix}_value_matrix.txt')
+        attention.v_proj_bias = load_parameter(f'{prefix}_value_bias.txt')
+        attention.out_proj_weight = load_parameter(f'{prefix}_output_matrix.txt')
+        attention.out_proj_bias = load_parameter(f'{prefix}_output_bias.txt')
 
         # Load weights for feedforward network
-        prefix = f'{weights_prefix}-transformer_decoder{i}'
-        layer.linear1.weight = load_parameter(f'{prefix}_fc1_matrix-Weights.txt')
-        layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias-Weights.txt')
-        layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix-Weights.txt')
-        layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias-Weights.txt')
+        prefix = f'{weights_prefix}/transformer_decoder{i}'
+        layer.linear1.weight = load_parameter(f'{prefix}_fc1_matrix.txt')
+        layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias.txt')
+        layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix.txt')
+        layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias.txt')
 
     return transformer
 

--- a/applications/nlp/transformer/train.py
+++ b/applications/nlp/transformer/train.py
@@ -167,7 +167,7 @@ def make_data_reader():
 def make_batch_script(trainer_params, model_params, script_params):
 
     # Create LBANN objects
-    trainer = lbann.Trainer(mini_batch_size=trainer_params.mini_batch_size)
+    trainer = lbann.Trainer(mini_batch_size=trainer_params['mini_batch_size'])
     model = make_model(**model_params)
     reader = make_data_reader()
 
@@ -200,7 +200,7 @@ def make_batch_script(trainer_params, model_params, script_params):
     # Dump weights after every epoch
     model.callbacks.append(
         lbann.CallbackDumpWeights(
-            basename=os.path.join(script_params['work_dir'], 'weights'),
+            directory=os.path.join(script_params['work_dir'], 'weights'),
             epoch_interval=1,
         )
     )


### PR DESCRIPTION
The "dump weights" callback changed the way it names files, so this PR update the evaluation script so that we can import an LBANN-trained Transformer into PyTorch.

Pinging @tnat410.