### PR TITLE
Cleanup data reader tests memory leaks

### DIFF
--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
@@ -165,7 +165,7 @@ TEST_CASE("hdf5 data reader transform tests",
   conduit::Node node;
   node.parse(hdf5_hrrl_data_sample, "yaml");
 
-  lbann::hdf5_data_reader* hdf5_dr = new lbann::hdf5_data_reader();
+  auto hdf5_dr = std::make_unique<lbann::hdf5_data_reader>();
   DataReaderHDF5WhiteboxTester white_box_tester;
 
   conduit::Node schema;
@@ -240,7 +240,7 @@ TEST_CASE("hdf5 data reader pack test",
   lbann::init_random(0, 2);
   lbann::init_data_seq_random(42);
 
-  lbann::hdf5_data_reader* hdf5_dr = new lbann::hdf5_data_reader();
+  auto hdf5_dr = std::make_unique<lbann::hdf5_data_reader>();
   DataReaderHDF5WhiteboxTester white_box_tester;
 
   hdf5_dr->set_role("train");

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
@@ -152,7 +152,7 @@ TEST_CASE("hdf5 data reader data field fetch tests",
   conduit::Node ref_node;
   ref_node.parse(hdf5_hrrl_data_sample_id, "yaml");
 
-  lbann::hdf5_data_reader* hdf5_dr = new lbann::hdf5_data_reader();
+  auto hdf5_dr = std::make_unique<lbann::hdf5_data_reader>();
   DataReaderHDF5WhiteboxTester white_box_tester;
 
   // Setup the data schema for this HRRL data set
@@ -168,8 +168,8 @@ TEST_CASE("hdf5 data reader data field fetch tests",
 
   El::Int num_samples = 1;
 
-  auto data_store = new lbann::data_store_conduit(hdf5_dr);
-  hdf5_dr->set_data_store(data_store);
+  auto data_store = std::make_unique<lbann::data_store_conduit>(hdf5_dr.get());
+  hdf5_dr->set_data_store(data_store.get());
   // Take the sample and place it into the data store
   int index = 0;
   auto& ds = hdf5_dr->get_data_store();

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
@@ -168,8 +168,10 @@ TEST_CASE("hdf5 data reader data field fetch tests",
 
   El::Int num_samples = 1;
 
-  auto data_store = std::make_unique<lbann::data_store_conduit>(hdf5_dr.get());
-  hdf5_dr->set_data_store(data_store.get());
+  {
+    auto data_store = std::make_unique<lbann::data_store_conduit>(hdf5_dr.get());
+    hdf5_dr->set_data_store(data_store.release());
+  }
   // Take the sample and place it into the data store
   int index = 0;
   auto& ds = hdf5_dr->get_data_store();

--- a/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("hdf5 data reader", "[mpi][data_reader][sample_list][hdf5][.filesystem
 {
   auto& comm = unit_test::utilities::current_world_comm();
 
-  lbann::hdf5_data_reader* hdf5_dr = new lbann::hdf5_data_reader();
+  auto hdf5_dr = std::make_unique<lbann::hdf5_data_reader>();
   // Avoid the sample list code checking that the files really exist
   // in the file system
   hdf5_dr->get_sample_list().unset_data_file_check();

--- a/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Sample list", "[mpi][data_reader][smiles]")
   auto const& g = comm.get_trainer_grid();
   lbann::utils::grid_manager mgr(g);
 
-  lbann::smiles_data_reader *smiles = new lbann::smiles_data_reader(true /*shuffle*/);
+  auto smiles = std::make_unique<lbann::smiles_data_reader>(/*shuffle=*/true);
   // Avoid the sample list code checking that the files really exist
   // in the file system
   smiles->get_sample_list().unset_data_file_check();

--- a/src/data_readers/unit_test/data_reader_smiles_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_test.cpp
@@ -47,7 +47,7 @@ TEST_CASE("SMILES string encoder", "[data_reader][smiles]")
 
   std::stringstream vocab("# 0 % 1 ( 2 ) 3 + 4 - 5 . 6 / 7 0 8 1 9 2 10 3 11 4 12 5 13 6 14 7 15 8 16 9 17 = 18 @ 19 B 20 C 21 F 22 H 23 I 24 N 25 O 26 P 27 S 28 [ 29 \\ 30 ] 31 c 32 e 33 i 34 l 35 n 36 o 37 p 38 r 39 s 40 <bos> 41 <eos> 42 <pad> 43 <unk> 44");
 
-  lbann::smiles_data_reader *smiles = new lbann::smiles_data_reader(true);
+  auto smiles = std::make_unique<lbann::smiles_data_reader>(true);
   smiles->load_vocab(vocab);
 
   const std::string smi_1("C#CCCNC1=NN(C)C=C1"); // good


### PR DESCRIPTION
Switched data reader tests from using raw pointers to unique pointers for instantiating the data reader.