### PR TITLE
Fix a sporadic segfault in the invocation tests

### DIFF
--- a/src/utils/protobuf_utils.cpp
+++ b/src/utils/protobuf_utils.cpp
@@ -174,7 +174,7 @@ load_prototext(
   auto names =
     parse_prototext_filenames_from_command_line(master, trainer_rank);
   auto models_out = read_in_prototext_files(master, names);
-  if (models_out.size() == 0 && master) {
+  if (models_out.size() == 0) {
     LBANN_ERROR("Failed to load any prototext files");
   }
   verify_prototext(master, models_out);


### PR DESCRIPTION
The segfault was caused when non-root ranks tried to use protobufs they didn't have. It was essentially a race condition for whether the segfault would appear or the `MPI_Abort` would hit first.