### PR TITLE
Remove the Cloneable interface from the training algorithms.

### DIFF
--- a/include/lbann/execution_algorithms/kfac.hpp
+++ b/include/lbann/execution_algorithms/kfac.hpp
@@ -57,9 +57,8 @@ namespace lbann {
  *  deep convolutional neural networks." Proceedings of the IEEE
  *  Conference on Computer Vision and Pattern Recognition. 2019.
  */
-class KFAC final : public Cloneable<KFAC, TrainingAlgorithm>
+class KFAC final : public TrainingAlgorithm
 {
-  using BaseType = Cloneable<KFAC, TrainingAlgorithm>;
 
 public:
   using TermCriteriaType = SGDTerminationCriteria;
@@ -89,9 +88,11 @@ public:
     double learning_rate_factor_gru,
     size_t compute_interval);
 
-  KFAC(KFAC const& other);
-  KFAC& operator=(const KFAC& other);
   ~KFAC() noexcept = default;
+  KFAC(KFAC const& other) = delete;
+  KFAC& operator=(const KFAC& other) = delete;
+  KFAC(KFAC&& other) = default;
+  KFAC& operator=(KFAC&& other) = default;
   ///@}
   /** @brief Queries */
   ///@{

--- a/include/lbann/execution_algorithms/ltfb.hpp
+++ b/include/lbann/execution_algorithms/ltfb.hpp
@@ -64,10 +64,8 @@ namespace lbann {
  *  then do some other stuff, this class can certainly serve as a
  *  useful guide, but is not likely to be the out-of-the-box solution.
  */
-class LTFB final : public Cloneable<LTFB, TrainingAlgorithm>
+class LTFB final : public TrainingAlgorithm
 {
-  using BaseType = Cloneable<LTFB, TrainingAlgorithm>;
-
 public:
   using TermCriteriaType = ltfb::LTFBTerminationCriteria;
   using ExeContextType = ltfb::LTFBExecutionContext;
@@ -87,19 +85,17 @@ public:
        std::unique_ptr<TrainingAlgorithm> local_training_algorithm,
        std::unique_ptr<ltfb::MetaLearningStrategy> meta_learning_strategy,
        ltfb::LTFBTerminationCriteria stopping_criteria)
-    : BaseType{std::move(name)},
+    : TrainingAlgorithm{std::move(name)},
       m_local_algo{std::move(local_training_algorithm)},
       m_meta_learning_strategy{std::move(meta_learning_strategy)},
       m_termination_criteria{std::move(stopping_criteria)}
   {}
 
-  LTFB(LTFB const& other)
-    : BaseType(other),
-      m_local_algo{other.m_local_algo->clone()},
-      m_meta_learning_strategy{other.m_meta_learning_strategy->clone()},
-      m_termination_criteria{other.m_termination_criteria}
-  {}
   ~LTFB() noexcept = default;
+  LTFB(LTFB const& other) = delete;
+  LTFB& operator=(LTFB const&) = delete;
+  LTFB(LTFB&&) = default;
+  LTFB& operator=(LTFB&&) = default;
   ///@}
   /** @brief Queries */
   ///@{

--- a/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
@@ -41,23 +41,21 @@ namespace lbann {
 
 /** @brief Base class for LBANN SGD-family training algorithms. */
 class SGDTrainingAlgorithm
-  : public Cloneable<SGDTrainingAlgorithm, TrainingAlgorithm>
+  : public TrainingAlgorithm
 {
-  using BaseType = Cloneable<SGDTrainingAlgorithm, TrainingAlgorithm>;
-
 public:
   /** @brief Construct with a name. */
   SGDTrainingAlgorithm(std::string name,
-                         std::unique_ptr<SGDTerminationCriteria> stop)
-    : BaseType{std::move(name)},
+                       std::unique_ptr<SGDTerminationCriteria> stop)
+    : TrainingAlgorithm{std::move(name)},
       m_stopping_criteria{std::move(stop)},
       m_validation_context{execution_mode::validation, 1UL},
       m_validation_epochs{1UL}
   {}
 
-  SGDTrainingAlgorithm(const SGDTrainingAlgorithm& other);
+  SGDTrainingAlgorithm(const SGDTrainingAlgorithm& other) = delete;
   SGDTrainingAlgorithm&
-  operator=(const SGDTrainingAlgorithm& other);
+  operator=(const SGDTrainingAlgorithm& other) = delete;
 
   SGDTrainingAlgorithm(SGDTrainingAlgorithm&& other) = default;
   SGDTrainingAlgorithm& operator=(SGDTrainingAlgorithm&& other) = default;

--- a/include/lbann/execution_algorithms/training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/training_algorithm.hpp
@@ -39,7 +39,7 @@
 
 namespace lbann {
 
-/** @class training_algorithm
+/** @class TrainingAlgorithm
  *  @brief Base class for LBANN training_algorithms.
  *
  *  A "training algorithm" is defined as a method for modifying one or
@@ -82,7 +82,6 @@ namespace lbann {
  *        reading from disk is not sufficient.
  */
 class TrainingAlgorithm
-  : public Cloneable<HasAbstractFunction<TrainingAlgorithm>>
 {
 public:
   /** @name Lifecycle Management */
@@ -167,8 +166,8 @@ public:
 protected:
   /** @name In-hierarchy Lifecycle Management */
   ///@{
-  TrainingAlgorithm(const TrainingAlgorithm& other) = default;
-  TrainingAlgorithm& operator=(const TrainingAlgorithm& other) = default;
+  TrainingAlgorithm(const TrainingAlgorithm& other) = delete;
+  TrainingAlgorithm& operator=(const TrainingAlgorithm& other) = delete;
   TrainingAlgorithm(TrainingAlgorithm&& other) = default;
   TrainingAlgorithm& operator=(TrainingAlgorithm&& other) = default;
   ///@}

--- a/src/execution_algorithms/kfac.cpp
+++ b/src/execution_algorithms/kfac.cpp
@@ -69,7 +69,7 @@ KFAC::KFAC(
   double learning_rate_factor,
   double learning_rate_factor_gru,
   size_t compute_interval)
-  : BaseType{std::move(name)},
+  : TrainingAlgorithm{std::move(name)},
     m_stopping_criteria{std::move(stop)},
     m_damping_act_params{std::move(damping_act_params)},
     m_damping_err_params{std::move(damping_err_params)},
@@ -89,49 +89,6 @@ KFAC::KFAC(
     m_learning_rate_factor_gru{learning_rate_factor_gru},
     m_compute_interval{compute_interval}
 {}
-
-KFAC::KFAC(KFAC const& other)
-  : BaseType(other.get_name()),
-    m_stopping_criteria{other.m_stopping_criteria->clone()},
-    m_damping_act_params{other.m_damping_act_params},
-    m_damping_err_params{other.m_damping_err_params},
-    m_damping_bn_act_params{other.m_damping_bn_act_params},
-    m_damping_bn_err_params{other.m_damping_bn_err_params},
-    m_damping_warmup_steps{other.m_damping_warmup_steps},
-    m_kronecker_decay{other.m_kronecker_decay},
-    m_print_time{other.m_print_time},
-    m_print_matrix{other.m_print_matrix},
-    m_print_matrix_summary{other.m_print_matrix_summary},
-    m_use_pi{other.m_use_pi},
-    m_update_intervals{other.m_update_intervals},
-    m_update_interval_steps{other.m_update_interval_steps},
-    m_inverse_strategy{other.m_inverse_strategy},
-    m_disable_layers{other.m_disable_layers},
-    m_learning_rate_factor{other.m_learning_rate_factor},
-    m_compute_interval{other.m_compute_interval}
-{}
-
-KFAC& KFAC::operator=(KFAC const& other) {
-  BaseType::operator=(other);
-  m_stopping_criteria = other.m_stopping_criteria->clone();
-  m_damping_act_params = other.m_damping_act_params;
-  m_damping_err_params = other.m_damping_err_params;
-  m_damping_bn_act_params = other.m_damping_bn_act_params;
-  m_damping_bn_err_params = other.m_damping_bn_err_params;
-  m_damping_warmup_steps = other.m_damping_warmup_steps;
-  m_kronecker_decay = other.m_kronecker_decay;
-  m_print_time = other.m_print_time;
-  m_print_matrix = other.m_print_matrix;
-  m_print_matrix_summary = other.m_print_matrix_summary;
-  m_use_pi = other.m_use_pi;
-  m_update_intervals = other.m_update_intervals;
-  m_update_interval_steps = other.m_update_interval_steps;
-  m_inverse_strategy = other.m_inverse_strategy;
-  m_disable_layers = other.m_disable_layers;
-  m_learning_rate_factor = other.m_learning_rate_factor;
-  m_compute_interval = other.m_compute_interval;
-  return *this;
-}
 
 std::string KFAC::get_type() const { return "KFAC"; }
 

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -40,24 +40,6 @@
 
 namespace lbann {
 
-SGDTrainingAlgorithm::SGDTrainingAlgorithm(
-  SGDTrainingAlgorithm const& other)
-  : BaseType(other.get_name()),
-    m_stopping_criteria{other.m_stopping_criteria->clone()},
-    m_validation_context{execution_mode::validation, 1UL},
-    m_validation_epochs{1UL}
-{}
-
-SGDTrainingAlgorithm&
-SGDTrainingAlgorithm::operator=(SGDTrainingAlgorithm const& other)
-{
-  BaseType::operator=(other);
-  m_stopping_criteria = other.m_stopping_criteria->clone();
-  m_validation_context = SGDExecutionContext{execution_mode::validation, 1UL};
-  m_validation_epochs = 1UL;
-  return *this;
-}
-
 ////////////////////////////////////////////////////////////
 // Evaluation and training
 ////////////////////////////////////////////////////////////

--- a/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
+++ b/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
@@ -140,11 +140,6 @@ TEST_CASE("Building training algorithm from the factory",
 
     REQUIRE(sgd->get_type() == "sgd");
     REQUIRE(sgd->get_name() == "my sgd algo");
-
-    // I don't really think we should have cloneable training algos, but:
-    auto sgd2 = sgd->clone();
-    REQUIRE(sgd2->get_type() == "sgd");
-    REQUIRE(sgd2->get_name() == "my sgd algo");
   }
 
   SECTION("Building with an invalid message type fails")


### PR DESCRIPTION
There's no practical reason to clone a training algorithm. Namely, *users* will never clone a training algorithm as there's no way to implement that operation in the front-end. Moreover, it complicates semantics. Where training algorithms are given unique identifiers, which is valuable for user-friendly output, how should that be propagated to the clone? If there are two instances of the algorithm with the same name, it is no longer unique.

Additionally, it's telling that I changed literally no other code outside the class definitions (and the SGD test)...