### PR TITLE
Add include guard for dist_embedding layer cerealization 

### DIFF
--- a/src/layers/misc/cereal_registration/dist_embedding.cpp
+++ b/src/layers/misc/cereal_registration/dist_embedding.cpp
@@ -50,14 +50,25 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::serialize(ArchiveT& ar)
 
 } // namespace lbann
 
-#define LBANN_LAYER_NAME dist_embedding_layer
+// Manually register the distributed embedding layer since it has many
+// permutations of supported data and device types
+#include <lbann/macros/common_cereal_registration.hpp>
+#define LBANN_COMMA ,
+#define PROTO_DEVICE(TYPE, DEVICE)                                      \
+  LBANN_ADD_ALL_SERIALIZE_ETI(::lbann::dist_embedding_layer<TYPE LBANN_COMMA DEVICE>); \
+  CEREAL_REGISTER_TYPE_WITH_NAME(                                       \
+    ::lbann::dist_embedding_layer<TYPE LBANN_COMMA DEVICE>,             \
+    "dist_embedding_layer (" #TYPE "," #DEVICE ")");
 
 #ifdef LBANN_HAS_SHMEM
-#include <lbann/macros/register_layer_with_cereal_data_parallel_cpu_only.hpp>
-#endif  // LBANN_HAS_SHMEM
-
+PROTO_DEVICE(float, El::Device::CPU)
+PROTO_DEVICE(double, El::Device::CPU)
+#endif // LBANN_HAS_SHMEM
 #ifdef LBANN_HAS_NVSHMEM
-#include <lbann/macros/register_layer_with_cereal_data_parallel_gpu_only.hpp>
-#endif  // LBANN_HAS_NVSHMEM
+PROTO_DEVICE(float, El::Device::GPU)
+PROTO_DEVICE(double, El::Device::GPU)
+#endif // LBANN_HAS_NVSHMEM
+
+LBANN_REGISTER_DYNAMIC_INIT(dist_embedding_layer);
 
 #endif // defined(LBANN_HAS_SHMEM) || defined(LBANN_HAS_NVSHMEM)

--- a/src/layers/misc/cereal_registration/dist_embedding.cpp
+++ b/src/layers/misc/cereal_registration/dist_embedding.cpp
@@ -51,6 +51,13 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::serialize(ArchiveT& ar)
 } // namespace lbann
 
 #define LBANN_LAYER_NAME dist_embedding_layer
-#include <lbann/macros/register_layer_with_cereal_data_parallel_only.hpp>
+
+#ifdef LBANN_HAS_SHMEM
+#include <lbann/macros/register_layer_with_cereal_data_parallel_cpu_only.hpp>
+#endif
+
+#ifdef LBANN_HAS_NVSHMEM
+#include <lbann/macros/register_layer_with_cereal_data_parallel_gpu_only.hpp>
+#endif
 
 #endif // defined(LBANN_HAS_SHMEM) || defined(LBANN_HAS_NVSHMEM)

--- a/src/layers/misc/cereal_registration/dist_embedding.cpp
+++ b/src/layers/misc/cereal_registration/dist_embedding.cpp
@@ -54,10 +54,10 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::serialize(ArchiveT& ar)
 
 #ifdef LBANN_HAS_SHMEM
 #include <lbann/macros/register_layer_with_cereal_data_parallel_cpu_only.hpp>
-#endif
+#endif  // LBANN_HAS_SHMEM
 
 #ifdef LBANN_HAS_NVSHMEM
 #include <lbann/macros/register_layer_with_cereal_data_parallel_gpu_only.hpp>
-#endif
+#endif  // LBANN_HAS_NVSHMEM
 
 #endif // defined(LBANN_HAS_SHMEM) || defined(LBANN_HAS_NVSHMEM)


### PR DESCRIPTION
To stop instantiation of both CPU and GPU layers if only one of LBANN_HAS_SHMEM or LBANN_HAS_NVSHMEM is defined. Otherwise, there is a linker error when building with +distconv +nvshmem via Spack