### PR TITLE
Fix Cereal error for distributed embedding

### DIFF
--- a/src/layers/misc/cereal_registration/dist_embedding.cpp
+++ b/src/layers/misc/cereal_registration/dist_embedding.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "lbann/utils/serialize.hpp"
 #include <lbann/layers/misc/dist_embedding.hpp>
+#include "lbann/layers/data_type_layer.hpp"
 
 #if defined(LBANN_HAS_SHMEM) || defined(LBANN_HAS_NVSHMEM)
 
@@ -54,19 +55,19 @@ void dist_embedding_layer<TensorDataType,Layout,Device>::serialize(ArchiveT& ar)
 // permutations of supported data and device types
 #include <lbann/macros/common_cereal_registration.hpp>
 #define LBANN_COMMA ,
-#define PROTO_DEVICE(TYPE, DEVICE)                                      \
-  LBANN_ADD_ALL_SERIALIZE_ETI(::lbann::dist_embedding_layer<TYPE LBANN_COMMA DEVICE>); \
+#define PROTO_DEVICE(TYPE, LAYOUT, DEVICE)                                      \
+  LBANN_ADD_ALL_SERIALIZE_ETI(::lbann::dist_embedding_layer<TYPE LBANN_COMMA LAYOUT LBANN_COMMA DEVICE>); \
   CEREAL_REGISTER_TYPE_WITH_NAME(                                       \
-    ::lbann::dist_embedding_layer<TYPE LBANN_COMMA DEVICE>,             \
-    "dist_embedding_layer (" #TYPE "," #DEVICE ")");
+    ::lbann::dist_embedding_layer<TYPE LBANN_COMMA LAYOUT LBANN_COMMA DEVICE>,             \
+    "dist_embedding_layer (" #TYPE "," #LAYOUT"," #DEVICE ")");
 
 #ifdef LBANN_HAS_SHMEM
-PROTO_DEVICE(float, El::Device::CPU)
-PROTO_DEVICE(double, El::Device::CPU)
+PROTO_DEVICE(float, lbann::data_layout::DATA_PARALLEL, El::Device::CPU)
+PROTO_DEVICE(double, lbann::data_layout::DATA_PARALLEL, El::Device::CPU)
 #endif // LBANN_HAS_SHMEM
 #ifdef LBANN_HAS_NVSHMEM
-PROTO_DEVICE(float, El::Device::GPU)
-PROTO_DEVICE(double, El::Device::GPU)
+PROTO_DEVICE(float, lbann::data_layout::DATA_PARALLEL, El::Device::GPU)
+PROTO_DEVICE(double, lbann::data_layout::DATA_PARALLEL, El::Device::GPU)
 #endif // LBANN_HAS_NVSHMEM
 
 LBANN_REGISTER_DYNAMIC_INIT(dist_embedding_layer);


### PR DESCRIPTION
PR #2066 didn't solve the compilation error with nvshmem and distconv enabled. The dist_embedding layer required the layout template parameter. This fix just instantiates with lbann::data_layout::DATA_PARALLEL 

Pinging @timmoon10 