### PR TITLE
Transformers apply LayerNorm with affine transform

### DIFF
--- a/applications/nlp/transformer/evaluate.py
+++ b/applications/nlp/transformer/evaluate.py
@@ -166,6 +166,10 @@ def load_transformer(weights_prefix):
         layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias.txt')
         layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix.txt')
         layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias.txt')
+        layer.norm1.weight = load_parameter(f'{prefix}_norm1_weight.txt')
+        layer.norm1.bias = load_parameter(f'{prefix}_norm1_bias.txt')
+        layer.norm2.weight = load_parameter(f'{prefix}_norm2_weight.txt')
+        layer.norm2.bias = load_parameter(f'{prefix}_norm2_bias.txt')
 
     # Load weights for decoder
     for i, layer in enumerate(transformer.decoder.layers):
@@ -202,6 +206,12 @@ def load_transformer(weights_prefix):
         layer.linear1.bias = load_parameter(f'{prefix}_fc1_bias.txt')
         layer.linear2.weight = load_parameter(f'{prefix}_fc2_matrix.txt')
         layer.linear2.bias = load_parameter(f'{prefix}_fc2_bias.txt')
+        layer.norm1.weight = load_parameter(f'{prefix}_norm1_weight.txt')
+        layer.norm1.bias = load_parameter(f'{prefix}_norm1_bias.txt')
+        layer.norm2.weight = load_parameter(f'{prefix}_norm2_weight.txt')
+        layer.norm2.bias = load_parameter(f'{prefix}_norm2_bias.txt')
+        layer.norm3.weight = load_parameter(f'{prefix}_norm3_weight.txt')
+        layer.norm3.bias = load_parameter(f'{prefix}_norm3_bias.txt')
 
     return transformer
 

--- a/python/lbann/models/transformer.py
+++ b/python/lbann/models/transformer.py
@@ -13,7 +13,54 @@ import numpy as np
 
 import lbann
 import lbann.modules
-from lbann.util import str_list
+from lbann.util import str_list, make_iterable
+
+class LayerNorm(lbann.modules.Module):
+    """See https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html"""
+
+    global_count = 0  # Static counter, used for default names
+
+    def __init__(
+            self,
+            normalized_shape,
+            name=None,
+    ):
+        super().__init__()
+        LayerNorm.global_count += 1
+        self.normalized_shape = make_iterable(normalized_shape)
+        self.name = (name
+                     if name
+                     else f'layernorm{LayerNorm.global_count}')
+
+        # Initialize weights
+        self.weight = lbann.Weights(
+            initializer=lbann.ConstantInitializer(value=1),
+            name=f'{self.name}_weight',
+        )
+        self.bias = lbann.Weights(
+            initializer=lbann.ConstantInitializer(value=0),
+            name=f'{self.name}_bias',
+        )
+
+    def forward(self, x):
+
+        # Normalization
+        x = lbann.InstanceNorm(x)
+
+        # Affine transform
+        s = lbann.WeightsLayer(
+            weights=self.weight,
+            dims=f'1 {str_list(self.normalized_shape)}',
+        )
+        s = lbann.Tessellate(s, hint_layer=x)
+        b = lbann.WeightsLayer(
+            weights=self.bias,
+            dims=f'1 {str_list(self.normalized_shape)}',
+        )
+        b = lbann.Tessellate(b, hint_layer=x)
+        x = lbann.Add(lbann.Multiply(s,x), b)
+        return x
+
 
 class TransformerEncoderLayer(lbann.modules.Module):
     """Building block for encoder in Transformer model.
@@ -60,6 +107,8 @@ class TransformerEncoderLayer(lbann.modules.Module):
             num_heads,
             name=f'{self.name}_attention'
         )
+        self.norm1 = LayerNorm(self.embed_dim, name=f'{self.name}_norm1')
+        self.norm2 = LayerNorm(self.embed_dim, name=f'{self.name}_norm2')
 
         # Weights for fully-connected layers
         self.fc1_weights = [
@@ -98,7 +147,7 @@ class TransformerEncoderLayer(lbann.modules.Module):
                 name=f'{name}_drop1',
             )
         z = lbann.Sum(x, y, name=f'{name}_sum1')
-        z = lbann.InstanceNorm(z, name=f'{name}_norm1')
+        z = self.norm1(z)
         x = z
 
         # Feedforward network with residual connection
@@ -128,7 +177,7 @@ class TransformerEncoderLayer(lbann.modules.Module):
                 name=f'{name}_drop3',
             )
         z = lbann.Sum(x, y, name=f'{name}_sum2')
-        z = lbann.InstanceNorm(z, name=f'{name}_norm2')
+        z = self.norm2(z)
         return z
 
 class TransformerDecoderLayer(lbann.modules.Module):
@@ -182,6 +231,9 @@ class TransformerDecoderLayer(lbann.modules.Module):
             num_heads,
             name=f'{self.name}_attention2'
         )
+        self.norm1 = LayerNorm(self.embed_dim, name=f'{self.name}_norm1')
+        self.norm2 = LayerNorm(self.embed_dim, name=f'{self.name}_norm2')
+        self.norm3 = LayerNorm(self.embed_dim, name=f'{self.name}_norm3')
 
         # Weights for fully-connected layers
         self.fc1_weights = [
@@ -226,7 +278,7 @@ class TransformerDecoderLayer(lbann.modules.Module):
                 name=f'{name}_drop1',
             )
         z = lbann.Sum(x, y, name=f'{name}_sum1')
-        z = lbann.InstanceNorm(z, name=f'{name}_norm1')
+        z = self.norm1(z)
         x = z
 
         # Attention on encoder output with residual connection
@@ -238,7 +290,7 @@ class TransformerDecoderLayer(lbann.modules.Module):
                 name=f'{name}_drop2',
             )
         z = lbann.Sum(x, y, name=f'{name}_sum2')
-        z = lbann.InstanceNorm(z, name=f'{name}_norm2')
+        z = self.norm2(z)
         x = z
 
         # Feedforward network with residual connection
@@ -268,7 +320,7 @@ class TransformerDecoderLayer(lbann.modules.Module):
                 name=f'{name}_drop4',
             )
         z = lbann.Sum(x, y, name=f'{name}_sum3')
-        z = lbann.InstanceNorm(z, name=f'{name}_norm3')
+        z = self.norm3(z)
         return z
 
 class Transformer(lbann.modules.Module):


### PR DESCRIPTION
This is a quick implementation of LayerNorm that matches the [PyTorch implementation](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html). In particular, it applies an entry-wise affine transform after normalizing the data. This is similar to the LayerNorm implementation in [lbann.modules.pytorch](https://github.com/LLNL/lbann/blob/8b89deb062b1730463e994c20c708d3634617692/python/lbann/modules/pytorch.py#L60), but doesn't require passing in the sequence length. It may be worthwhile changing that implementation to this one.

I can verify that the model runs and that I can import it into PyTorch, but I haven't evaluated with full training. Pinging @tnat410.

As an aside, LBANN's usage of LayerNorm and InstanceNorm is somewhat inconsistent with PyTorch:
- [lbann.LayerNorm](https://lbann.readthedocs.io/en/latest/layers/regularization_layers.html#layernorm): `y = (x - mean(x)) / stdev(x)`
- [torch.nn.LayerNorm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html): `y[...,:] = (x[...,:] - mean(x[...,:])) / stdev(x[...,:]) * scale + bias`
- [lbann.InstanceNorm](https://lbann.readthedocs.io/en/latest/layers/regularization_layers.html#instancenorm): `y[i,:] = (x[i,:] - mean(x[i,:])) / stdev(x[i,:])`
- [torch.nn.InstanceNorm2d](https://pytorch.org/docs/stable/generated/torch.nn.InstanceNorm2d.html#torch.nn.InstanceNorm1d): `y[i,:] = y[i,:] = (x[i,:] - mean(x[i,:])) / stdev(x[i,:]) * scale[i] + bias[i]`

LBANN's InstanceNorm matches PyTorch's when the affine transform is disabled.