### PR TITLE
Add a way to specify weekly-ness of testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,8 @@ stages:
 
 catalyst testing:
   stage: run-all-clusters
+  variables:
+    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/catalyst/pipeline.yml
@@ -45,18 +47,24 @@ catalyst testing:
 
 lassen testing:
   stage: run-all-clusters
+  variables:
+    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/lassen/pipeline.yml
 
 pascal testing:
   stage: run-all-clusters
+  variables:
+    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/pascal/pipeline.yml
 
 ray testing:
   stage: run-all-clusters
+  variables:
+    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/ray/pipeline.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -24,7 +24,7 @@
 ## permissions and limitations under the license.
 ################################################################################
 
-# Note: This configuration is specifically for LLNL compute
+But # Note: This configuration is specifically for LLNL compute
 # clusters. To run testing locally, consult the README in the ci_test
 # directory.
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@
 ## permissions and limitations under the license.
 ################################################################################
 
-But # Note: This configuration is specifically for LLNL compute
+# Note: This configuration is specifically for LLNL compute
 # clusters. To run testing locally, consult the README in the ci_test
 # directory.
 
@@ -34,13 +34,15 @@ stages:
 catalyst testing:
   stage: run-all-clusters
   variables:
-    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/catalyst/pipeline.yml
 
 # corona testing:
 #   stage: run-all-clusters
+#   variables:
+#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
 #   trigger:
 #     strategy: depend
 #     include: .gitlab/corona/pipeline.yml
@@ -48,7 +50,7 @@ catalyst testing:
 lassen testing:
   stage: run-all-clusters
   variables:
-    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/lassen/pipeline.yml
@@ -56,7 +58,7 @@ lassen testing:
 pascal testing:
   stage: run-all-clusters
   variables:
-    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/pascal/pipeline.yml
@@ -64,7 +66,7 @@ pascal testing:
 ray testing:
   stage: run-all-clusters
   variables:
-    LBANN_CI_RUN_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
   trigger:
     strategy: depend
     include: .gitlab/ray/pipeline.yml

--- a/.gitlab/catalyst/pipeline.yml
+++ b/.gitlab/catalyst/pipeline.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -133,7 +133,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
+    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/catalyst/pipeline.yml
+++ b/.gitlab/catalyst/pipeline.yml
@@ -48,7 +48,9 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - salloc --exclusive -N 2 -p pbatch -t 120 --no-shell -J ${JOB_NAME}
+    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
+    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
+    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # This replaces "test_compiler.py". This has the advantage that it
@@ -252,6 +254,10 @@ release allocation:
     # allowed in pipeline files either, which is why this is not an
     # absolute path).
     RESULTS_DIR: results-${CI_PIPELINE_ID}
+
+    # This needs to be imported here, too. Failure to do so causes
+    # problems if it's not set.
+    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
 
   tags:
     - catalyst

--- a/.gitlab/catalyst/pipeline.yml
+++ b/.gitlab/catalyst/pipeline.yml
@@ -48,9 +48,10 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
-    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
-    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
+    - echo "${WITH_WEEKLY:+Running with --weekly}"
+    - export TEST_TIME=$([[ -n "${WITH_WEEKLY}" ]] && echo "120" || echo "90")
+    - export LBANN_NNODES=$([[ -n "${WITH_WEEKLY}" ]] && echo "4" || echo "2")
+    - salloc --exclusive -N ${LBANN_NNODES} -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # This replaces "test_compiler.py". This has the advantage that it
@@ -133,9 +134,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
-    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
-    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
+    - export WEEKLY_FLAG=${WITH_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/catalyst/pipeline.yml
+++ b/.gitlab/catalyst/pipeline.yml
@@ -131,7 +131,7 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 --junitxml=results.xml
+    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/common/run-catch-tests.sh
+++ b/.gitlab/common/run-catch-tests.sh
@@ -1,3 +1,29 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+
 #!/bin/bash
 
 # Just in case

--- a/.gitlab/corona/pipeline.yml
+++ b/.gitlab/corona/pipeline.yml
@@ -108,7 +108,7 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 --junitxml=results.xml
+    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/corona/pipeline.yml
+++ b/.gitlab/corona/pipeline.yml
@@ -46,7 +46,9 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - salloc --exclusive -N 2 -p pbatch -t 120 --no-shell -J ${JOB_NAME}
+    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
+    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "90" || echo "30")
+    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # Build LBANN and establish the Spack environment for this pipeline.
@@ -65,7 +67,7 @@ build and install:
     - export JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - export BUILD_TASKS=$(($(nproc) + 2))
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
-    - srun --jobid=${JOB_ID} -N 1 -t 20 ./scripts/build_lbann.sh -d
+    - srun --jobid=${JOB_ID} -N 1 -t 30 ./scripts/build_lbann.sh -d
       -l ${SPACK_ENV_NAME} --test --clean-build -j ${BUILD_TASKS} --
       +deterministic +vision +numpy ${SPACK_SPECS}
     - export TEST_TASKS_PER_NODE=4
@@ -194,6 +196,10 @@ release allocation:
 
     # Catch2 output.
     RESULTS_DIR: results-${CI_PIPELINE_ID}
+
+    # This needs to be imported here, too. Failure to do so causes
+    # problems if it's not set.
+    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
 
   tags:
     - corona

--- a/.gitlab/corona/pipeline.yml
+++ b/.gitlab/corona/pipeline.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -110,7 +110,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
+    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/corona/pipeline.yml
+++ b/.gitlab/corona/pipeline.yml
@@ -46,9 +46,10 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
-    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "90" || echo "30")
-    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
+    - echo "${WITH_WEEKLY:+Running with --weekly}"
+    - export TEST_TIME=$([[ -n "${WITH_WEEKLY}" ]] && echo "120" || echo "90")
+    - export LBANN_NNODES=$([[ -n "${WITH_WEEKLY}" ]] && echo "4" || echo "2")
+    - salloc --exclusive -N ${LBANN_NNODES} -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # Build LBANN and establish the Spack environment for this pipeline.
@@ -110,9 +111,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
-    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
-    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
+    - export WEEKLY_FLAG=${WITH_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/lassen/pipeline.yml
+++ b/.gitlab/lassen/pipeline.yml
@@ -48,7 +48,7 @@ build and test everything:
     - echo "== BUILDING AND TESTING LBANN =="
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - lalloc 2 -W 90 -q pbatch ci_test/run.sh
+    - lalloc 2 -W 90 -q pbatch ci_test/run.sh ${LBANN_CI_RUN_WEEKLY:+--weekly}
   artifacts:
     when: always
     paths:

--- a/.gitlab/lassen/pipeline.yml
+++ b/.gitlab/lassen/pipeline.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/.gitlab/lassen/pipeline.yml
+++ b/.gitlab/lassen/pipeline.yml
@@ -46,12 +46,13 @@ build and test everything:
   stage: everything
   script:
     - echo "== BUILDING AND TESTING LBANN =="
-    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
+    - echo "${WITH_WEEKLY:+Running with --weekly}"
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - export TEST_WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
-    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
-    - lalloc 2 -W ${TEST_TIME} -q pbatch ci_test/run.sh ${TEST_WEEKLY}
+    - export TEST_TIME=$([[ -n "${WITH_WEEKLY}" ]] && echo "120" || echo "90")
+    - export LBANN_NNODES=$([[ -n "${WITH_WEEKLY}" ]] && echo "4" || echo "2")
+    - export WEEKLY_FLAG=${WITH_WEEKLY:+--weekly}
+    - lalloc ${LBANN_NNODES} -W ${TEST_TIME} -q pbatch ci_test/run.sh ${WEEKLY_FLAG}
   artifacts:
     when: always
     paths:

--- a/.gitlab/lassen/pipeline.yml
+++ b/.gitlab/lassen/pipeline.yml
@@ -46,9 +46,12 @@ build and test everything:
   stage: everything
   script:
     - echo "== BUILDING AND TESTING LBANN =="
+    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - lalloc 2 -W 90 -q pbatch ci_test/run.sh ${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - export TEST_WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
+    - lalloc 2 -W ${TEST_TIME} -q pbatch ci_test/run.sh ${TEST_WEEKLY}
   artifacts:
     when: always
     paths:
@@ -93,6 +96,11 @@ remove spack environment:
 
     # This is needed to ensure that we run as lbannusr.
     LLNL_SERVICE_USER: lbannusr
+
+    # This needs to be imported here, too. Failure to do so causes
+    # problems if it's not set.
+    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
+
   tags:
     - lassen
     - shell

--- a/.gitlab/pascal/pipeline.yml
+++ b/.gitlab/pascal/pipeline.yml
@@ -109,7 +109,7 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 --junitxml=results.xml
+    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/pascal/pipeline.yml
+++ b/.gitlab/pascal/pipeline.yml
@@ -46,7 +46,9 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - salloc --exclusive -N 2 -p pbatch -t 120 --no-shell -J ${JOB_NAME}
+    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
+    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
+    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # Build LBANN and establish the Spack environment for this pipeline.
@@ -193,6 +195,10 @@ release allocation:
 
     # Catch2 output.
     RESULTS_DIR: results-${CI_PIPELINE_ID}
+
+    # This needs to be imported here, too. Failure to do so causes
+    # problems if it's not set.
+    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
 
   tags:
     - pascal

--- a/.gitlab/pascal/pipeline.yml
+++ b/.gitlab/pascal/pipeline.yml
@@ -46,9 +46,10 @@ allocate lc resources:
     GIT_STRATEGY: none
   script:
     - echo "== ACQUIRING SLURM RESOURCES =="
-    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
-    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
-    - salloc --exclusive -N 2 -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
+    - echo "${WITH_WEEKLY:+Running with --weekly}"
+    - export TEST_TIME=$([[ -n "${WITH_WEEKLY}" ]] && echo "120" || echo "90")
+    - export LBANN_NNODES=$([[ -n "${WITH_WEEKLY}" ]] && echo "4" || echo "2")
+    - salloc --exclusive -N ${LBANN_NNODES} -p pbatch -t ${TEST_TIME} --no-shell -J ${JOB_NAME}
   timeout: 6h
 
 # Build LBANN and establish the Spack environment for this pipeline.
@@ -111,9 +112,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
-    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
-    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
+    - export WEEKLY_FLAG=${WITH_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY_FLAG} --junitxml=results.xml
   artifacts:
     when: always
     paths:
@@ -197,10 +198,6 @@ release allocation:
 
     # Catch2 output.
     RESULTS_DIR: results-${CI_PIPELINE_ID}
-
-    # This needs to be imported here, too. Failure to do so causes
-    # problems if it's not set.
-    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
 
   tags:
     - pascal

--- a/.gitlab/pascal/pipeline.yml
+++ b/.gitlab/pascal/pipeline.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -111,7 +111,9 @@ integration tests:
     - export OMP_NUM_THREADS=10
     - export SLURM_JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
     - cd ci_test/integration_tests
-    - python3 -m pytest -s -vv --durations=0 ${LBANN_CI_RUN_WEEKLY:+--weekly} --junitxml=results.xml
+    - export WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - echo "python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml"
+    - python3 -m pytest -s -vv --durations=0 ${WEEKLY} --junitxml=results.xml
   artifacts:
     when: always
     paths:

--- a/.gitlab/ray/pipeline.yml
+++ b/.gitlab/ray/pipeline.yml
@@ -48,7 +48,7 @@ build and test everything:
     - echo "== BUILDING AND TESTING LBANN =="
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - lalloc 2 -W 90 -q pbatch ci_test/run.sh
+    - lalloc 2 -W 90 -q pbatch ci_test/run.sh ${LBANN_CI_RUN_WEEKLY:+--weekly}
   artifacts:
     when: always
     paths:

--- a/.gitlab/ray/pipeline.yml
+++ b/.gitlab/ray/pipeline.yml
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2021, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/.gitlab/ray/pipeline.yml
+++ b/.gitlab/ray/pipeline.yml
@@ -46,12 +46,13 @@ build and test everything:
   stage: everything
   script:
     - echo "== BUILDING AND TESTING LBANN =="
-    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
+    - echo "${WITH_WEEKLY:+Running with --weekly}"
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - export TEST_WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
-    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
-    - lalloc 2 -W ${TEST_TIME} -q pbatch ci_test/run.sh ${TEST_WEEKLY}
+    - export TEST_TIME=$([[ -n "${WITH_WEEKLY}" ]] && echo "120" || echo "90")
+    - export LBANN_NNODES=$([[ -n "${WITH_WEEKLY}" ]] && echo "4" || echo "2")
+    - export WEEKLY_FLAG=${WITH_WEEKLY:+--weekly}
+    - lalloc ${LBANN_NNODES} -W ${TEST_TIME} -q pbatch ci_test/run.sh ${WEEKLY_FLAG}
   artifacts:
     when: always
     paths:

--- a/.gitlab/ray/pipeline.yml
+++ b/.gitlab/ray/pipeline.yml
@@ -46,9 +46,12 @@ build and test everything:
   stage: everything
   script:
     - echo "== BUILDING AND TESTING LBANN =="
+    - echo "LBANN_CI_RUN_WEEKLY=${LBANN_CI_RUN_WEEKLY}"
     - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
     - export SPACK_ENV_NAME=${SPACK_ENV_NAME}
-    - lalloc 2 -W 90 -q pbatch ci_test/run.sh ${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - export TEST_WEEKLY=${LBANN_CI_RUN_WEEKLY:+--weekly}
+    - export TEST_TIME=$([[ -n "${LBANN_CI_RUN_WEEKLY}" ]] && echo "120" || echo "90")
+    - lalloc 2 -W ${TEST_TIME} -q pbatch ci_test/run.sh ${TEST_WEEKLY}
   artifacts:
     when: always
     paths:
@@ -93,6 +96,11 @@ remove spack environment:
 
     # This is needed to ensure that we run as lbannusr.
     LLNL_SERVICE_USER: lbannusr
+
+    # This needs to be imported here, too. Failure to do so causes
+    # problems if it's not set.
+    LBANN_CI_RUN_WEEKLY: ${LBANN_CI_RUN_WEEKLY}
+
   tags:
     - ray
     - shell


### PR DESCRIPTION
When running Gitlab CI manually or via a schedule, simply set `LBANN_CI_RUN_WEEKLY` via the web interface to any non-null value.