### PR TITLE
Enable on demand (nightly) integration tests

### DIFF
--- a/ci_test/common_python/tools.py
+++ b/ci_test/common_python/tools.py
@@ -679,7 +679,7 @@ def create_tests(setup_func,
         # Make sure test name is prefixed with 'test_'
         test_name_base = 'test_' + test_name_base
 
-    def test_func(cluster, dirname):
+    def test_func(cluster, dirname, weekly):
         """Function that can interact with PyTest.
 
         Returns a dict containing log files and other output data.
@@ -696,7 +696,7 @@ def create_tests(setup_func,
         import lbann.contrib.launcher
 
         # Setup LBANN experiment
-        trainer, model, data_reader, optimizer = setup_func(lbann)
+        trainer, model, data_reader, optimizer = setup_func(lbann, weekly)
 
         # Configure kwargs to LBANN launcher
         _kwargs = copy.deepcopy(kwargs)

--- a/ci_test/common_python/tools.py
+++ b/ci_test/common_python/tools.py
@@ -696,7 +696,10 @@ def create_tests(setup_func,
         import lbann.contrib.launcher
 
         # Setup LBANN experiment
-        trainer, model, data_reader, optimizer = setup_func(lbann, weekly)
+        trainer, model, data_reader, optimizer, req_num_nodes = setup_func(lbann, weekly)
+
+        if req_num_nodes:
+            kwargs['nodes'] = req_num_nodes
 
         # Configure kwargs to LBANN launcher
         _kwargs = copy.deepcopy(kwargs)

--- a/ci_test/integration_tests/test_integration_alexnet.py
+++ b/ci_test/integration_tests/test_integration_alexnet.py
@@ -20,8 +20,6 @@ import data.imagenet
 # ==============================================
 
 # Training options
-num_nodes = 2
-#num_nodes = 4
 imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 
 # Top-5 classification accuracy (percent)
@@ -32,14 +30,13 @@ imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 ################################################################################
 # Weekly training options and targets
 ################################################################################
-# Reconstruction loss
 weekly_options_and_targets = {
+    'num_nodes': 4,
     'num_epochs': 5,
     'mini_batch_size': 256,
     'expected_train_accuracy_range': (9, 15),
     'expected_test_accuracy_range': (15, 24),
     'percent_of_data_to_use': imagenet_fraction,
-    # Weekly operates on 4 compute nodes
     'expected_mini_batch_times': {
         'pascal': 0.154, # 0.100,
         'lassen': 0.050,
@@ -51,15 +48,15 @@ weekly_options_and_targets = {
 # Nightly training options and targets
 ################################################################################
 nightly_options_and_targets = {
+    'num_nodes': 2,
     'num_epochs': 3,
     'mini_batch_size': 256,
-    'expected_train_accuracy_range': (.6, 0.7),
+    'expected_train_accuracy_range': (.6, 1.1),
     'expected_test_accuracy_range': (0.45, 0.6),
     'percent_of_data_to_use': imagenet_fraction * 0.01,
-    # Nightly operates on 2 compute nodes
     'expected_mini_batch_times': {
-        'pascal': 0.900, # 0.100,
-        'lassen': 0.050,
+        'pascal': 1.574,
+        'lassen': 0.070,
         'ray':    0.075,
     }
 }
@@ -91,7 +88,7 @@ def setup_experiment(lbann, weekly):
     data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, options['num_nodes']
 
 def construct_model(lbann, num_epochs):
     """Construct LBANN model.
@@ -220,6 +217,5 @@ def augment_test_func(test_func):
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment,
                                      __file__,
-                                     nodes=num_nodes,
                                      lbann_args=['--load_full_sample_list_once']):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_alexnet.py
+++ b/ci_test/integration_tests/test_integration_alexnet.py
@@ -20,48 +20,80 @@ import data.imagenet
 # ==============================================
 
 # Training options
-num_epochs = 5
-mini_batch_size = 256
-num_nodes = 4
+num_nodes = 2
+#num_nodes = 4
 imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 
 # Top-5 classification accuracy (percent)
-expected_train_accuracy_range = (9, 15)
-expected_test_accuracy_range = (15, 24)
-
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
 # Commented out times are prior to thread safe RNGs
-expected_mini_batch_times = {
-    'pascal': 0.154, # 0.100,
-    'lassen': 0.050,
-    'ray':    0.075,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+# Reconstruction loss
+weekly_options_and_targets = {
+    'num_epochs': 5,
+    'mini_batch_size': 256,
+    'expected_train_accuracy_range': (9, 15),
+    'expected_test_accuracy_range': (15, 24),
+    'percent_of_data_to_use': imagenet_fraction,
+    # Weekly operates on 4 compute nodes
+    'expected_mini_batch_times': {
+        'pascal': 0.154, # 0.100,
+        'lassen': 0.050,
+        'ray':    0.075,
+    }
+}
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_epochs': 3,
+    'mini_batch_size': 256,
+    'expected_train_accuracy_range': (.6, 0.7),
+    'expected_test_accuracy_range': (0.45, 0.6),
+    'percent_of_data_to_use': imagenet_fraction * 0.01,
+    # Nightly operates on 2 compute nodes
+    'expected_mini_batch_times': {
+        'pascal': 0.900, # 0.100,
+        'lassen': 0.050,
+        'ray':    0.075,
+    }
 }
 
 # ==============================================
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
         lbann (module): Module for LBANN Python frontend
 
     """
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
-    model = construct_model(lbann)
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'])
+    model = construct_model(lbann, options['num_epochs'])
+
     # Setup data reader
     data_reader = data.imagenet.make_data_reader(lbann, num_classes=1000)
     # We train on a subset of ImageNet
-    data_reader.reader[0].percent_of_data_to_use = imagenet_fraction
+    data_reader.reader[0].percent_of_data_to_use = options['percent_of_data_to_use']
     # Only evaluate on ImageNet validation set at end of training
     data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
     return trainer, model, data_reader, optimizer
 
-def construct_model(lbann):
+def construct_model(lbann, num_epochs):
     """Construct LBANN model.
 
     Args:
@@ -132,14 +164,17 @@ def augment_test_func(test_func):
     # Define test function
     def func(cluster, dirname, weekly):
 
-        # Skip test with nightly builds and on CPU systems
-        if not weekly:
-            pytest.skip('only run {} with weekly builds'.format(test_name))
+        # Skip test on CPU systems
         if cluster in ('catalyst', 'corona'):
             pytest.skip('only run {} on GPU systems'.format(test_name))
 
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
+
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_accuracy = None
@@ -158,24 +193,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training accuracy is within expected range
-        assert (expected_train_accuracy_range[0]
+        assert (targets['expected_train_accuracy_range'][0]
                 < train_accuracy
-                < expected_train_accuracy_range[1]), \
+                < targets['expected_train_accuracy_range'][1]), \
                 'train accuracy is outside expected range'
 
         # Check if testing accuracy is within expected range
-        assert (expected_test_accuracy_range[0]
+        assert (targets['expected_test_accuracy_range'][0]
                 < test_accuracy
-                < expected_test_accuracy_range[1]), \
+                < targets['expected_test_accuracy_range'][1]), \
                 'test accuracy is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function

--- a/ci_test/integration_tests/test_integration_atom_wae.py
+++ b/ci_test/integration_tests/test_integration_atom_wae.py
@@ -49,8 +49,8 @@ nightly_options_and_targets = {
     'num_nodes': 2,
     'num_epochs': 10,
     'mini_batch_size': 512,
-    'expected_train_recon_range': (1.16, 1.175),
-    'expected_test_recon_range': (1.11, 1.13),
+    'expected_train_recon_range': (1.16, 1.21),
+    'expected_test_recon_range': (1.11, 1.15),
     'percent_of_data_to_use': 0.01,
     'expected_mini_batch_times': {
         'lassen':   0.20,

--- a/ci_test/integration_tests/test_integration_atom_wae.py
+++ b/ci_test/integration_tests/test_integration_atom_wae.py
@@ -48,8 +48,8 @@ weekly_options_and_targets = {
 # Nightly training options and targets
 ################################################################################
 nightly_options_and_targets = {
-    'expected_train_recon_range': (1.16, 1.17),
-    'expected_test_recon_range': (1.11, 1.12),
+    'expected_train_recon_range': (1.16, 1.175),
+    'expected_test_recon_range': (1.11, 1.13),
     'percent_of_data_to_use': 0.01,
     # Nightly operates on 2 compute nodes
     'expected_mini_batch_times': {

--- a/ci_test/integration_tests/test_integration_atom_wae.py
+++ b/ci_test/integration_tests/test_integration_atom_wae.py
@@ -24,16 +24,39 @@ mini_batch_size = 512
 num_nodes = 2
 num_decoder_layers = 3
 
-# Reconstruction loss
-expected_train_recon_range = (0.500, 0.555)
-expected_test_recon_range = (0.500, 0.525)
-
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
 # Commented out times are prior to thread safe RNGs
-expected_mini_batch_times = {
-    'lassen':   0.20,
-    'pascal':   0.365,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+# Reconstruction loss
+weekly_options_and_targets = {
+    'expected_train_recon_range': (0.500, 0.555),
+    'expected_test_recon_range': (0.500, 0.525),
+    'percent_of_data_to_use': 1.0,
+    # Weekly operates on 4 compute nodes
+    'expected_mini_batch_times': {
+        'lassen':   0.20,
+        'pascal':   0.365,
+        'ray':   0.185,
+    }
+}
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'expected_train_recon_range': (1.16, 1.17),
+    'expected_test_recon_range': (1.11, 1.12),
+    'percent_of_data_to_use': 0.01,
+    # Nightly operates on 2 compute nodes
+    'expected_mini_batch_times': {
+        'lassen':   0.20,
+        'pascal':   0.460,
+        'ray':   0.185,
+    }
 }
 
 #@todo: add other cluster if need be
@@ -46,7 +69,7 @@ vocab_loc = {
 def list2str(l):
     return ' '.join(l)
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -65,6 +88,14 @@ def setup_experiment(lbann):
     #     for data_reader prototext
     import data.atom
     data_reader = data.atom.make_data_reader(lbann)
+
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    # Use less training data for the integration test
+    data_reader.reader[0].percent_of_data_to_use = options['percent_of_data_to_use']
 
     opt = lbann.Adam(learn_rate=3e-4, beta1=0.9, beta2=0.99, eps=1e-8)
     return trainer, model, data_reader, opt
@@ -184,13 +215,15 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname,weekly):
+    def func(cluster, dirname, weekly):
 
-        if not weekly:
-            pytest.skip('This app runs {} with weekly builds only'.format(test_name))
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_recon = None
@@ -209,24 +242,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training reconstruction is within expected range
-        assert (expected_train_recon_range[0]
+        assert (targets['expected_train_recon_range'][0]
                 < train_recon
-                < expected_train_recon_range[1]), \
+                < targets['expected_train_recon_range'][1]), \
                 'train reconstruction loss is outside expected range'
 
         # Check if testing reconstruction  is within expected range
-        assert (expected_test_recon_range[0]
+        assert (targets['expected_test_recon_range'][0]
                 < test_recon
-                < expected_test_recon_range[1]), \
+                < targets['expected_test_recon_range'][1]), \
                 'test reconstruction loss is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function

--- a/ci_test/integration_tests/test_integration_atom_wae.py
+++ b/ci_test/integration_tests/test_integration_atom_wae.py
@@ -28,7 +28,6 @@ num_decoder_layers = 3
 ################################################################################
 # Weekly training options and targets
 ################################################################################
-# Reconstruction loss
 weekly_options_and_targets = {
     'num_nodes': 2,
     'num_epochs': 10,

--- a/ci_test/integration_tests/test_integration_atom_wae_app.py
+++ b/ci_test/integration_tests/test_integration_atom_wae_app.py
@@ -219,7 +219,7 @@ def augment_test_func(test_func):
     def func(cluster, dirname,weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_recon = None

--- a/ci_test/integration_tests/test_integration_atom_wae_app.py
+++ b/ci_test/integration_tests/test_integration_atom_wae_app.py
@@ -28,17 +28,44 @@ mini_batch_size = 512
 num_nodes = 2
 num_decoder_layers = 3
 
-# Reconstruction loss
-expected_train_recon_range = (0.95, 0.97)
-expected_test_recon_range = (0.925, 0.94)
-
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
 # Commented out times are prior to thread safe RNGs
-expected_mini_batch_times = {
-    'lassen':   0.157,
-    'pascal':   0.365,
-    'ray':   0.185,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+weekly_options_and_targets = {
+    'num_nodes': 2,
+    'num_epochs': 10,
+    'mini_batch_size': 512,
+    'num_decoder_layers': 3,
+    'expected_train_recon_range': (0.95, 0.97),
+    'expected_test_recon_range': (0.925, 0.94),
+    'percent_of_data_to_use': 0.01,
+    'expected_mini_batch_times': {
+        'lassen':   0.157,
+        'pascal':   0.365,
+        'ray':   0.185,
+    }
+}
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_nodes': 2,
+    'num_epochs': 10,
+    'mini_batch_size': 512,
+    'num_decoder_layers': 3,
+    'expected_train_recon_range': (0.95, 0.97),
+    'expected_test_recon_range': (0.925, 0.94),
+    'percent_of_data_to_use': 0.01,
+    'expected_mini_batch_times': {
+        'lassen':   0.157,
+        'pascal':   0.365,
+        'ray':   0.185,
+    }
 }
 
 #@todo: add other cluster if need be
@@ -51,7 +78,7 @@ vocab_loc = {
 def list2str(l):
     return ' '.join(l)
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -63,7 +90,12 @@ def setup_experiment(lbann):
       print('Skip - ' + message)
       pytest.skip(message)
 
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'])
     import atom_models
     pad_index = 40
     sequence_length = 100
@@ -89,17 +121,17 @@ def setup_experiment(lbann):
                                                  lambda_=lambda_,
                                                  lr=learn_rate,
                                                  batch_size=mini_batch_size,
-                                                 num_epochs=num_epochs,
+                                                 num_epochs=options['num_epochs'],
                                                  CPU_only=True)
 
     #see: <LBANN>ci_test/common_python/data/atom/data_reader_mpro.prototext
     import data.atom
     data_reader = data.atom.make_data_reader(lbann)
     # Use less training data for the integration test
-    data_reader.reader[0].percent_of_data_to_use = 0.01
+    data_reader.reader[0].percent_of_data_to_use = options['percent_of_data_to_use']
 
     opt = lbann.Adam(learn_rate=3e-4, beta1=0.9, beta2=0.99, eps=1e-8)
-    return trainer, model, data_reader, opt
+    return trainer, model, data_reader, opt, options['num_nodes']
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -216,7 +248,12 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname,weekly):
+    def func(cluster, dirname, weekly):
+
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
 
         # Run LBANN experiment
         experiment_output = test_func(cluster, dirname, weekly)
@@ -238,24 +275,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training reconstruction is within expected range
-        assert (expected_train_recon_range[0]
+        assert (targets['expected_train_recon_range'][0]
                 < train_recon
-                < expected_train_recon_range[1]), \
+                < targets['expected_train_recon_range'][1]), \
                 'train reconstruction loss is outside expected range'
 
         # Check if testing reconstruction  is within expected range
-        assert (expected_test_recon_range[0]
+        assert (targets['expected_test_recon_range'][0]
                 < test_recon
-                < expected_test_recon_range[1]), \
+                < targets['expected_test_recon_range'][1]), \
                 'test reconstruction loss is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function
@@ -266,6 +303,5 @@ m_lbann_args=f"--vocab={vocab_loc['vast']} --sequence_length=100 --use_data_stor
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment,
                                      __file__,
-                                     lbann_args=[m_lbann_args],
-                                     nodes=num_nodes):
+                                     lbann_args=[m_lbann_args]):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_jag_wae.py
+++ b/ci_test/integration_tests/test_integration_jag_wae.py
@@ -21,9 +21,6 @@ sys.path.append(app_path)
 # ==============================================
 
 # Training options
-num_epochs = 10
-mini_batch_size = 128
-num_nodes = 1
 procs_per_node = 2 # Only use 2 GPUs to ensure comparable testing between lassen and pascal
                    # this model is very sensitive to differences in how it is initialized
                    # and parallelized
@@ -39,22 +36,47 @@ metadata_prototext = join(model_zoo_dir,
 y_dim = 16399 # image+scalar dim (default: 64*64*4+15=16399)
 z_dim = 20 # latent space dim (default: 20)
 
-# Reconstruction loss
-expected_train_pc_range = (20.0, 20.2)
-expected_test_pc_range = (19.2, 19.4)
-
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
 # Commented out times are prior to thread safe RNGs
-expected_mini_batch_times = {
-    'lassen':   0.0530066,
-    'pascal':   0.044,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+weekly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 10,
+    'mini_batch_size': 128,
+    'expected_train_pc_range': (7.7, 7.9),
+    'expected_test_pc_range': (8.0, 8.2),
+    'percent_of_data_to_use': 0.1,
+    'expected_mini_batch_times': {
+        'lassen':   0.0530066,
+        'pascal':   0.044,
+    }
 }
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 10,
+    'mini_batch_size': 128,
+    'expected_train_pc_range': (20.0, 20.2),
+    'expected_test_pc_range': (19.2, 19.4),
+    'percent_of_data_to_use': 0.01,
+    'expected_mini_batch_times': {
+        'lassen':   0.0530066,
+        'pascal':   0.044,
+    }
+}
+
 # ==============================================
 # Setup LBANN experiment
 # ==============================================
 
-def make_data_reader(lbann):
+def make_data_reader(lbann, percent_of_data_to_use):
     """Make Protobuf message for HRRL  data reader.
 
     """
@@ -67,12 +89,12 @@ def make_data_reader(lbann):
     message = message.data_reader
 
     # Use less training data for the integration test
-    message.reader[0].percent_of_data_to_use = 0.01
+    message.reader[0].percent_of_data_to_use = percent_of_data_to_use
 
     # Set paths
     return message
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -84,21 +106,26 @@ def setup_experiment(lbann):
       print('Skip - ' + message)
       pytest.skip(message)
 
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size,
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'],
                             serialize_io=True)
     import jag_models
     dump_models = 'dump_models'
     ltfb_batch_interval = 0
     model = jag_models.construct_jag_wae_model(y_dim=y_dim,
                                                z_dim=z_dim,
-                                               num_epochs=num_epochs)
+                                               num_epochs=options['num_epochs'])
 
     # Setup optimizer
     opt = lbann.Adam(learn_rate=0.0001,beta1=0.9,beta2=0.99,eps=1e-8)
     # Load data reader from prototext
-    data_reader = make_data_reader(lbann)
+    data_reader = make_data_reader(lbann, options['percent_of_data_to_use'])
 
-    return trainer, model, data_reader, opt
+    return trainer, model, data_reader, opt, options['num_nodes']
 
 # ==============================================
 # Setup PyTest
@@ -129,13 +156,15 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname,weekly):
+    def func(cluster, dirname, weekly):
 
-#        if not weekly:
-#            pytest.skip('This app runs {} with weekly builds only'.format(test_name))
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_pc = None
@@ -154,24 +183,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training reconstruction is within expected range
-        assert (expected_train_pc_range[0]
+        assert (targets['expected_train_pc_range'][0]
                 < train_pc
-                < expected_train_pc_range[1]), \
+                < targets['expected_train_pc_range'][1]), \
                 'train reconstruction error is outside expected range'
 
         # Check if testing reconstruction  is within expected range
-        assert (expected_test_pc_range[0]
+        assert (targets['expected_test_pc_range'][0]
                 < test_pc
-                < expected_test_pc_range[1]), \
+                < targets['expected_test_pc_range'][1]), \
                 'test reconstruction error is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function
@@ -183,6 +212,5 @@ m_lbann_args=f"--use_data_store --preload_data_store --metadata={metadata_protot
 for _test_func in tools.create_tests(setup_experiment,
                                      __file__,
                                      lbann_args=[m_lbann_args],
-                                     procs_per_node=procs_per_node,
-                                     nodes=num_nodes):
+                                     procs_per_node=procs_per_node):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_lenet.py
+++ b/ci_test/integration_tests/test_integration_lenet.py
@@ -43,7 +43,7 @@ expected_mini_batch_times = {
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -120,10 +120,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_accuracy = None

--- a/ci_test/integration_tests/test_integration_lenet.py
+++ b/ci_test/integration_tests/test_integration_lenet.py
@@ -35,7 +35,7 @@ expected_mini_batch_times = {
     'pascal':   0.0020, # Changed as of 1/18/22 0.0014, # 0.0013,
     'catalyst': 0.0073, # 0.0055,
     'lassen':   0.0022,
-    'ray':      0.0025,
+    'ray':      0.0029, # Changed as of 3/22/22 0.0025,
     'corona':   0.0117, # 0.0075,
 }
 

--- a/ci_test/integration_tests/test_integration_lenet.py
+++ b/ci_test/integration_tests/test_integration_lenet.py
@@ -58,7 +58,7 @@ def setup_experiment(lbann, weekly):
     data_reader.reader[0].validation_percent = 0
 
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, num_nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -168,6 +168,5 @@ def augment_test_func(test_func):
 
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment,
-                                     __file__,
-                                     nodes=num_nodes):
+                                     __file__):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_probiesnet.py
+++ b/ci_test/integration_tests/test_integration_probiesnet.py
@@ -31,10 +31,10 @@ weekly_options_and_targets = {
     'num_epochs': 10,
     'mini_batch_size': 32,
     'expected_train_pc_range': (0.89, 0.92),
-    'expected_test_pc_range': (0.90, 0.925),
+    'expected_test_pc_range': (0.90, 0.931),
     'percent_of_data_to_use': 1.0,
     'expected_mini_batch_times': {
-        'lassen':   0.0051,
+        'lassen':   0.0069, # Old as of 3/21/2022 0.0051,
         'pascal':   0.2267, # Old as of 3/21/2022 0.0146,
     }
 }
@@ -50,7 +50,7 @@ nightly_options_and_targets = {
     'expected_test_pc_range': (0.66, 0.68),
     'percent_of_data_to_use': 0.01,
     'expected_mini_batch_times': {
-        'lassen':   0.0051,
+        'lassen':   0.0069,
         'pascal':   0.172,
     }
 }

--- a/ci_test/integration_tests/test_integration_probiesnet.py
+++ b/ci_test/integration_tests/test_integration_probiesnet.py
@@ -19,29 +19,49 @@ import tools
 # Options
 # ==============================================
 
-# Training options
-num_epochs = 10
-mini_batch_size = 32
-num_nodes = 1
-
-# Reconstruction loss
-expected_train_pc_range = (0.89, 0.92)
-expected_test_pc_range = (0.90, 0.925)
-
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
 # Commented out times are prior to thread safe RNGs
-expected_mini_batch_times = {
-    'lassen':   0.0051,
-    'pascal':   0.0146,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+weekly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 10,
+    'mini_batch_size': 32,
+    'expected_train_pc_range': (0.89, 0.92),
+    'expected_test_pc_range': (0.90, 0.925),
+    'percent_of_data_to_use': 1.0,
+    'expected_mini_batch_times': {
+        'lassen':   0.0051,
+        'pascal':   0.2267, # Old as of 3/21/2022 0.0146,
+    }
 }
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 10,
+    'mini_batch_size': 32,
+    'expected_train_pc_range': (0.57, 0.59),
+    'expected_test_pc_range': (0.66, 0.68),
+    'percent_of_data_to_use': 0.01,
+    'expected_mini_batch_times': {
+        'lassen':   0.0051,
+        'pascal':   0.172,
+    }
+}
+
 # ==============================================
 # Setup LBANN experiment
 # ==============================================
 def list2str(l):
     return ' '.join(l)
 
-def make_data_reader(lbann):
+def make_data_reader(lbann, percent_of_data_to_use):
     """Make Protobuf message for HRRL  data reader.
 
     """
@@ -56,10 +76,12 @@ def make_data_reader(lbann):
         google.protobuf.text_format.Merge(f.read(), message)
     message = message.data_reader
 
+    message.reader[0].percent_of_data_to_use = percent_of_data_to_use
+
     # Set paths
     return message
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -71,15 +93,20 @@ def setup_experiment(lbann):
       print('Skip - ' + message)
       pytest.skip(message)
 
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
-    model = construct_model(lbann)
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
 
-    data_reader = make_data_reader(lbann)
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'])
+    model = construct_model(lbann, options['num_epochs'])
+
+    data_reader = make_data_reader(lbann, options['percent_of_data_to_use'])
 
     opt = lbann.Adam(learn_rate=0.0002,beta1=0.9,beta2=0.99,eps=1e-8)
-    return trainer, model, data_reader, opt
+    return trainer, model, data_reader, opt, options['num_nodes']
 
-def construct_model(lbann):
+def construct_model(lbann, num_epochs):
     """Construct LBANN model.
     Args:
         lbann (module): Module for LBANN Python frontend
@@ -167,13 +194,15 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname,weekly):
+    def func(cluster, dirname, weekly):
 
-        if not weekly:
-            pytest.skip('This app runs {} with weekly builds only'.format(test_name))
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_pc = None
@@ -192,24 +221,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training reconstruction is within expected range
-        assert (expected_train_pc_range[0]
+        assert (targets['expected_train_pc_range'][0]
                 < train_pc
-                < expected_train_pc_range[1]), \
+                < targets['expected_train_pc_range'][1]), \
                 'train pearson correlation is outside expected range'
 
         # Check if testing reconstruction  is within expected range
-        assert (expected_test_pc_range[0]
+        assert (targets['expected_test_pc_range'][0]
                 < test_pc
-                < expected_test_pc_range[1]), \
+                < targets['expected_test_pc_range'][1]), \
                 'test pearson correlation is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function
@@ -220,6 +249,5 @@ m_lbann_args=f"--use_data_store --preload_data_store"
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment,
                                      __file__,
-                                     lbann_args=[m_lbann_args],
-                                     nodes=num_nodes):
+                                     lbann_args=[m_lbann_args]):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -50,7 +50,7 @@ nightly_options_and_targets = {
     'num_epochs': 3,
     'mini_batch_size': 256,
     'expected_train_accuracy_range': (3, 4),
-    'expected_test_accuracy_range': (1.5, 2),
+    'expected_test_accuracy_range': (1.5, 2.1),
     'percent_of_data_to_use': imagenet_fraction * 0.01,
     'expected_mini_batch_times': {
         'pascal': 0.78,

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -55,7 +55,7 @@ nightly_options_and_targets = {
     'expected_mini_batch_times': {
         'pascal': 0.43,
         'lassen': 0.15,
-        'ray':    0.15,
+        'ray':    0.23,
     }
 }
 

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -20,46 +20,75 @@ import data.imagenet
 # ==============================================
 
 # Training options
-num_epochs = 5
-mini_batch_size = 256
-num_nodes = 4
+num_nodes = 2 #4
 imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 
 # Top-5 classification accuracy (percent)
-expected_train_accuracy_range = (45, 50)
-expected_test_accuracy_range = (40, 55)
 
-# Average mini-batch time (in sec) for each LC system
-expected_mini_batch_times = {
-    'pascal': 0.25,
-    'lassen': 0.10,
-    'ray':    0.15,
+################################################################################
+# Weekly training options and targets
+################################################################################
+# Reconstruction loss
+weekly_options_and_targets = {
+    'num_epochs': 5,
+    'mini_batch_size': 256,
+    'expected_train_accuracy_range': (45, 50),
+    'expected_test_accuracy_range': (40, 55),
+    'percent_of_data_to_use': imagenet_fraction,
+    # Weekly operates on 4 compute nodes
+    'expected_mini_batch_times': {
+        'pascal': 0.25,
+        'lassen': 0.10,
+        'ray':    0.15,
+    }
+}
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_epochs': 3,
+    'mini_batch_size': 256,
+    'expected_train_accuracy_range': (45, 50),
+    'expected_test_accuracy_range': (40, 55),
+    'percent_of_data_to_use': imagenet_fraction * 0.01,
+    # Weekly operates on 2 compute nodes
+    'expected_mini_batch_times': {
+        'pascal': 0.25,
+        'lassen': 0.10,
+        'ray':    0.15,
+    }
 }
 
 # ==============================================
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
         lbann (module): Module for LBANN Python frontend
 
     """
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
-    model = construct_model(lbann)
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'])
+    model = construct_model(lbann, options['num_epochs'])
     # Setup data reader
     data_reader = data.imagenet.make_data_reader(lbann, num_classes=1000)
     # We train on a subset of ImageNet
-    data_reader.reader[0].percent_of_data_to_use = imagenet_fraction
+    data_reader.reader[0].percent_of_data_to_use = options['percent_of_data_to_use']
     # Only evaluate on ImageNet validation set at end of training
     data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.1, momentum=0.9)
     return trainer, model, data_reader, optimizer
 
-def construct_model(lbann):
+def construct_model(lbann, num_epochs):
     """Construct LBANN model.
 
     Args:
@@ -130,14 +159,17 @@ def augment_test_func(test_func):
     # Define test function
     def func(cluster, dirname, weekly):
 
-        # Skip test with nightly builds and on CPU systems
-        if not weekly:
-            pytest.skip('only run {} with weekly builds'.format(test_name))
+        # Skip test on CPU systems
         if cluster in ('catalyst', 'corona'):
             pytest.skip('only run {} on GPU systems'.format(test_name))
 
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
+
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_accuracy = None
@@ -156,24 +188,24 @@ def augment_test_func(test_func):
                     mini_batch_times.append(float(match.group(1)))
 
         # Check if training accuracy is within expected range
-        assert (expected_train_accuracy_range[0]
+        assert (targets['expected_train_accuracy_range'][0]
                 < train_accuracy
-                < expected_train_accuracy_range[1]), \
+                < targets['expected_train_accuracy_range'][1]), \
                 'train accuracy is outside expected range'
 
         # Check if testing accuracy is within expected range
-        assert (expected_test_accuracy_range[0]
+        assert (targets['expected_test_accuracy_range'][0]
                 < test_accuracy
-                < expected_test_accuracy_range[1]), \
+                < targets['expected_test_accuracy_range'][1]), \
                 'test accuracy is outside expected range'
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         mini_batch_times = mini_batch_times[1:]
         mini_batch_time = sum(mini_batch_times) / len(mini_batch_times)
-        assert (0.75 * expected_mini_batch_times[cluster]
+        assert (0.75 * targets['expected_mini_batch_times'][cluster]
                 < mini_batch_time
-                < 1.25 * expected_mini_batch_times[cluster]), \
+                < 1.25 * targets['expected_mini_batch_times'][cluster]), \
                 'average mini-batch time is outside expected range'
 
     # Return test function from factory function

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -53,7 +53,7 @@ nightly_options_and_targets = {
     'expected_test_accuracy_range': (1.5, 2),
     'percent_of_data_to_use': imagenet_fraction * 0.01,
     'expected_mini_batch_times': {
-        'pascal': 0.25,
+        'pascal': 0.78,
         'lassen': 0.15,
         'ray':    0.15,
     }

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -53,7 +53,7 @@ nightly_options_and_targets = {
     'expected_test_accuracy_range': (1.5, 2.1),
     'percent_of_data_to_use': imagenet_fraction * 0.01,
     'expected_mini_batch_times': {
-        'pascal': 0.78,
+        'pascal': 0.43,
         'lassen': 0.15,
         'ray':    0.15,
     }

--- a/ci_test/integration_tests/test_integration_resnet50.py
+++ b/ci_test/integration_tests/test_integration_resnet50.py
@@ -20,7 +20,6 @@ import data.imagenet
 # ==============================================
 
 # Training options
-num_nodes = 2 #4
 imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 
 # Top-5 classification accuracy (percent)
@@ -30,12 +29,12 @@ imagenet_fraction = 0.280994  # Train with 360K out of 1.28M samples
 ################################################################################
 # Reconstruction loss
 weekly_options_and_targets = {
+    'num_nodes': 4,
     'num_epochs': 5,
     'mini_batch_size': 256,
     'expected_train_accuracy_range': (45, 50),
     'expected_test_accuracy_range': (40, 55),
     'percent_of_data_to_use': imagenet_fraction,
-    # Weekly operates on 4 compute nodes
     'expected_mini_batch_times': {
         'pascal': 0.25,
         'lassen': 0.10,
@@ -47,15 +46,15 @@ weekly_options_and_targets = {
 # Nightly training options and targets
 ################################################################################
 nightly_options_and_targets = {
+    'num_nodes': 2,
     'num_epochs': 3,
     'mini_batch_size': 256,
-    'expected_train_accuracy_range': (45, 50),
-    'expected_test_accuracy_range': (40, 55),
+    'expected_train_accuracy_range': (3, 4),
+    'expected_test_accuracy_range': (1.5, 2),
     'percent_of_data_to_use': imagenet_fraction * 0.01,
-    # Weekly operates on 2 compute nodes
     'expected_mini_batch_times': {
         'pascal': 0.25,
-        'lassen': 0.10,
+        'lassen': 0.15,
         'ray':    0.15,
     }
 }
@@ -86,7 +85,7 @@ def setup_experiment(lbann, weekly):
     data_reader.reader[1].role = 'test'
 
     optimizer = lbann.SGD(learn_rate=0.1, momentum=0.9)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, options['num_nodes']
 
 def construct_model(lbann, num_epochs):
     """Construct LBANN model.
@@ -215,6 +214,5 @@ def augment_test_func(test_func):
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment,
                                      __file__,
-                                     nodes=num_nodes,
                                      lbann_args=['--load_full_sample_list_once']):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_roberta.py
+++ b/ci_test/integration_tests/test_integration_roberta.py
@@ -67,7 +67,7 @@ nightly_options_and_targets = {
     'num_nodes': 1,
     'num_epochs': 0,
     'mini_batch_size': 16,
-    'expected_test_loss_range': (6.8, 7.1),
+    'expected_test_loss_range': (6.75, 7.1),
     'percent_of_data_to_use': 0.01,
     'expected_mini_batch_times': {
         "pascal": 0.925, # Weird performance behavior 3/21/2022 - 0.1225,

--- a/ci_test/integration_tests/test_integration_roberta.py
+++ b/ci_test/integration_tests/test_integration_roberta.py
@@ -70,7 +70,7 @@ nightly_options_and_targets = {
     'expected_test_loss_range': (6.8, 7.1),
     'percent_of_data_to_use': 0.01,
     'expected_mini_batch_times': {
-        "pascal": 0.1225,
+        "pascal": 0.925, # Weird performance behavior 3/21/2022 - 0.1225,
         "lassen": 0.808, # Weird performance regression 3/21/2022 - 0.0440,
         "ray" : 0.0607,
         "catalyst" : 7.45,

--- a/ci_test/integration_tests/test_integration_roberta.py
+++ b/ci_test/integration_tests/test_integration_roberta.py
@@ -39,20 +39,42 @@ config.vocab_size = 50265
 weights_dir = "/p/vast1/lbann/pretrained_weights/RoBERTa/"
 
 # Training options
-num_epochs = 0
-mini_batch_size = 16
-num_nodes = 1
-
-# Classification loss
-expected_test_loss_range = (6.8, 7.1)
 
 # Average mini-batch time (in sec) for each LC system
 # Note that run times are with LBANN_DETERMINISTIC set
-expected_mini_batch_times = {
-    "pascal": 0.1225,
-    "lassen": 0.0440,
-    "ray" : 0.0607,
-    "catalyst" : 7.45,
+
+################################################################################
+# Weekly training options and targets
+################################################################################
+weekly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 0,
+    'mini_batch_size': 16,
+    'expected_test_loss_range': (6.8, 7.1),
+    'percent_of_data_to_use': 1.0,
+    'expected_mini_batch_times': {
+        "pascal": 0.1225,
+        "lassen": 0.0440,
+        "ray" : 0.0607,
+        "catalyst" : 7.45,
+    }
+}
+
+################################################################################
+# Nightly training options and targets
+################################################################################
+nightly_options_and_targets = {
+    'num_nodes': 1,
+    'num_epochs': 0,
+    'mini_batch_size': 16,
+    'expected_test_loss_range': (6.8, 7.1),
+    'percent_of_data_to_use': 0.01,
+    'expected_mini_batch_times': {
+        "pascal": 0.1225,
+        "lassen": 0.808, # Weird performance regression 3/21/2022 - 0.0440,
+        "ray" : 0.0607,
+        "catalyst" : 7.45,
+    }
 }
 
 # ==============================================
@@ -60,23 +82,29 @@ expected_mini_batch_times = {
 # ==============================================
 
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
         lbann (module): Module for LBANN Python frontend
 
     """
-    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
-    model = construct_model(lbann)
+    if weekly:
+        options = weekly_options_and_targets
+    else:
+        options = nightly_options_and_targets
+
+    trainer = lbann.Trainer(mini_batch_size=options['mini_batch_size'])
+    model = construct_model(lbann, options['num_epochs'])
 
     data_reader = data.iur.make_data_reader(lbann)
+    data_reader.reader[0].percent_of_data_to_use = options['percent_of_data_to_use']
 
     optimizer = lbann.Adam(learn_rate=1e-3, beta1=0.9, beta2=0.99, eps=1e-8)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, options['num_nodes']
 
 
-def construct_model(lbann):
+def construct_model(lbann, num_epochs):
     """Construct LBANN model.
 
     Args:
@@ -146,10 +174,15 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
+
+        if weekly:
+            targets = weekly_options_and_targets
+        else:
+            targets = nightly_options_and_targets
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         test_loss = None
@@ -167,15 +200,17 @@ def augment_test_func(test_func):
 
         # Check if testing accuracy is within expected range
         assert (
-            expected_test_loss_range[0] < test_loss < expected_test_loss_range[1]
+            targets['expected_test_loss_range'][0]
+            < test_loss
+            < targets['expected_test_loss_range'][1]
         ), "test loss is outside expected range"
 
         # Check if mini-batch time is within expected range
         # Note: Skip first epoch since its runtime is usually an outlier
         assert (
-            0.75 * expected_mini_batch_times[cluster]
+            0.75 * targets['expected_mini_batch_times'][cluster]
             < mini_batch_time
-            < 1.25 * expected_mini_batch_times[cluster]
+            < 1.25 * targets['expected_mini_batch_times'][cluster]
         ), "average mini-batch time is outside expected range"
 
     # Return test function from factory function
@@ -184,5 +219,5 @@ def augment_test_func(test_func):
 
 
 # Create test functions that can interact with PyTest
-for _test_func in tools.create_tests(setup_experiment, __file__, nodes=num_nodes):
+for _test_func in tools.create_tests(setup_experiment, __file__):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/integration_tests/test_integration_roberta.py
+++ b/ci_test/integration_tests/test_integration_roberta.py
@@ -72,7 +72,7 @@ nightly_options_and_targets = {
     'expected_mini_batch_times': {
         "pascal": 0.925, # Weird performance behavior 3/21/2022 - 0.1225,
         "lassen": 0.808, # Weird performance regression 3/21/2022 - 0.0440,
-        "ray" : 0.0607,
+        "ray" : 0.578,
         "catalyst" : 7.45,
     }
 }

--- a/ci_test/integration_tests/test_integration_train_macc_surrogate.py
+++ b/ci_test/integration_tests/test_integration_train_macc_surrogate.py
@@ -144,13 +144,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname,weekly):
-
-#        if not weekly:
-#            pytest.skip('This app runs {} with weekly builds only'.format(test_name))
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         train_pc = None

--- a/ci_test/unit_tests/test_unit_algo_kfac.py
+++ b/ci_test/unit_tests/test_unit_algo_kfac.py
@@ -59,7 +59,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -70,7 +70,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_trainer(lbann, ):
     """Construct LBANN trainer and training algorithm.

--- a/ci_test/unit_tests/test_unit_algo_kfac_conv.py
+++ b/ci_test/unit_tests/test_unit_algo_kfac_conv.py
@@ -39,7 +39,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -50,7 +50,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_trainer(lbann, ):
     """Construct LBANN trainer and training algorithm.

--- a/ci_test/unit_tests/test_unit_algo_ltfb.py
+++ b/ci_test/unit_tests/test_unit_algo_ltfb.py
@@ -53,7 +53,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -77,7 +77,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -181,10 +181,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         num_trainers = None

--- a/ci_test/unit_tests/test_unit_algo_ltfb_trunc_selection.py
+++ b/ci_test/unit_tests/test_unit_algo_ltfb_trunc_selection.py
@@ -54,7 +54,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -79,7 +79,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -172,10 +172,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         num_trainers = None

--- a/ci_test/unit_tests/test_unit_callback_ltfb.py
+++ b/ci_test/unit_tests/test_unit_callback_ltfb.py
@@ -173,10 +173,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         num_trainers = None

--- a/ci_test/unit_tests/test_unit_callback_ltfb.py
+++ b/ci_test/unit_tests/test_unit_callback_ltfb.py
@@ -53,7 +53,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -64,7 +64,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_callback_ltfb_data.py
+++ b/ci_test/unit_tests/test_unit_callback_ltfb_data.py
@@ -46,7 +46,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -57,7 +57,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_callback_poly_learning_rate.py
+++ b/ci_test/unit_tests/test_unit_callback_poly_learning_rate.py
@@ -30,7 +30,7 @@ lr_end = 0.1
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -42,7 +42,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.SGD(learn_rate=lr_start)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -120,10 +120,10 @@ def augment_test_func(test_func):
     test_name = test_func.__name__
 
     # Define test function
-    def func(cluster, dirname):
+    def func(cluster, dirname, weekly):
 
         # Run LBANN experiment
-        experiment_output = test_func(cluster, dirname)
+        experiment_output = test_func(cluster, dirname, weekly)
 
         # Parse LBANN log file
         lr_list = []

--- a/ci_test/unit_tests/test_unit_callback_set_weights_value.py
+++ b/ci_test/unit_tests/test_unit_callback_set_weights_value.py
@@ -33,7 +33,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -44,7 +44,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_checkpoint_lenet.py
+++ b/ci_test/unit_tests/test_unit_checkpoint_lenet.py
@@ -32,7 +32,7 @@ checkpoint_dir='ckpt'
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -54,7 +54,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -167,7 +167,7 @@ def create_test_func(test_func):
         print('\n################################################################################')
         print('Running baseline model')
         print('################################################################################\n')
-        baseline_test_output = test_func(cluster, dirname)
+        baseline_test_output = test_func(cluster, dirname, weekly)
         baseline_training_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         baseline_validation_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'validation objective function')
         baseline_test_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'test objective function')
@@ -185,7 +185,7 @@ def create_test_func(test_func):
             lbann_args=['--disable_cuda' + ' --num_epochs='+str(num_ckpt_epochs)],
         )
 
-        checkpoint_test_output = test_func_checkpoint[0](cluster, dirname)
+        checkpoint_test_output = test_func_checkpoint[0](cluster, dirname, weekly)
         checkpoint_training_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         checkpoint_validation_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'validation objective function')
         checkpoint_test_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'test objective function')
@@ -206,7 +206,7 @@ def create_test_func(test_func):
         )
 
         # Restart LBANN model and run to completion
-        restart_test_output = test_func_restart[0](cluster, dirname)
+        restart_test_output = test_func_restart[0](cluster, dirname, weekly)
         restart_training_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         restart_validation_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'validation objective function')
         restart_test_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'test objective function')

--- a/ci_test/unit_tests/test_unit_datareader_python.py
+++ b/ci_test/unit_tests/test_unit_datareader_python.py
@@ -34,7 +34,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -46,7 +46,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_argmax.py
+++ b/ci_test/unit_tests/test_unit_layer_argmax.py
@@ -40,7 +40,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -52,7 +52,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_argmin.py
+++ b/ci_test/unit_tests/test_unit_layer_argmin.py
@@ -40,7 +40,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -52,7 +52,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_batch_normalization.py
+++ b/ci_test/unit_tests/test_unit_layer_batch_normalization.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_batched_matmul.py
+++ b/ci_test/unit_tests/test_unit_layer_batched_matmul.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_batchwise_reduce_sum.py
+++ b/ci_test/unit_tests/test_unit_layer_batchwise_reduce_sum.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected.py
@@ -38,7 +38,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -50,7 +50,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected_distconv.py
@@ -43,7 +43,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -55,7 +55,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 
 def create_parallel_strategy(num_channel_groups):

--- a/ci_test/unit_tests/test_unit_layer_channelwise_gru_cell.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_gru_cell.py
@@ -66,7 +66,7 @@ def numpy_gru_cell(x, h, w):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -87,7 +87,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.SGD()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_channelwise_scale_bias.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_scale_bias.py
@@ -38,7 +38,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -50,7 +50,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_channelwise_softmax.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_softmax.py
@@ -48,7 +48,7 @@ def numpy_channelwise_softmax(x):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -60,7 +60,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_clamp.py
+++ b/ci_test/unit_tests/test_unit_layer_clamp.py
@@ -41,7 +41,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -53,7 +53,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_concatenate.py
+++ b/ci_test/unit_tests/test_unit_layer_concatenate.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_convolution.py
+++ b/ci_test/unit_tests/test_unit_layer_convolution.py
@@ -110,7 +110,7 @@ def pytorch_convolution(data,
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -122,7 +122,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_convolution_distconv.py
@@ -112,7 +112,7 @@ def pytorch_convolution(data,
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -124,7 +124,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}

--- a/ci_test/unit_tests/test_unit_layer_covariance.py
+++ b/ci_test/unit_tests/test_unit_layer_covariance.py
@@ -33,7 +33,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -45,7 +45,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_cross_entropy.py
+++ b/ci_test/unit_tests/test_unit_layer_cross_entropy.py
@@ -62,7 +62,7 @@ def numpy_cross_entropy(x, xhat):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -74,7 +74,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_deconvolution.py
+++ b/ci_test/unit_tests/test_unit_layer_deconvolution.py
@@ -113,7 +113,7 @@ def pytorch_deconvolution(
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -125,7 +125,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_dft_abs.py
+++ b/ci_test/unit_tests/test_unit_layer_dft_abs.py
@@ -69,7 +69,7 @@ _sample_dims = [3, 8, 8]
 _sample_size = np.prod(_sample_dims);
 _samples = make_nice_data_array([_num_samples] + _sample_dims, 13)
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -81,7 +81,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_dist_embedding.py
+++ b/ci_test/unit_tests/test_unit_layer_dist_embedding.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_elu.py
+++ b/ci_test/unit_tests/test_unit_layer_elu.py
@@ -39,7 +39,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -51,7 +51,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_embedding.py
+++ b/ci_test/unit_tests/test_unit_layer_embedding.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_entrywise_batch_normalization.py
+++ b/ci_test/unit_tests/test_unit_layer_entrywise_batch_normalization.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_entrywise_scale_bias.py
+++ b/ci_test/unit_tests/test_unit_layer_entrywise_scale_bias.py
@@ -38,7 +38,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -50,7 +50,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_erf.py
+++ b/ci_test/unit_tests/test_unit_layer_erf.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_erfinv.py
+++ b/ci_test/unit_tests/test_unit_layer_erfinv.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_fully_connected.py
+++ b/ci_test/unit_tests/test_unit_layer_fully_connected.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_gather.py
+++ b/ci_test/unit_tests/test_unit_layer_gather.py
@@ -42,7 +42,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -54,7 +54,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_gru.py
+++ b/ci_test/unit_tests/test_unit_layer_gru.py
@@ -76,7 +76,7 @@ def numpy_gru(x, h, w):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -97,7 +97,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.SGD()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_identity.py
+++ b/ci_test/unit_tests/test_unit_layer_identity.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_identity_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_distconv.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}

--- a/ci_test/unit_tests/test_unit_layer_instance_norm.py
+++ b/ci_test/unit_tests/test_unit_layer_instance_norm.py
@@ -48,7 +48,7 @@ def numpy_instance_norm(x, epsilon=1e-5):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -60,7 +60,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_l1_norm.py
+++ b/ci_test/unit_tests/test_unit_layer_l1_norm.py
@@ -39,7 +39,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -51,7 +51,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_layer_norm.py
+++ b/ci_test/unit_tests/test_unit_layer_layer_norm.py
@@ -46,7 +46,7 @@ def numpy_layer_norm(x, epsilon=1e-5):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -58,7 +58,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_leaky_relu.py
+++ b/ci_test/unit_tests/test_unit_layer_leaky_relu.py
@@ -39,7 +39,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -51,7 +51,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_leaky_relu_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_leaky_relu_distconv.py
@@ -40,7 +40,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -52,7 +52,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}

--- a/ci_test/unit_tests/test_unit_layer_log_sigmoid.py
+++ b/ci_test/unit_tests/test_unit_layer_log_sigmoid.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_log_softmax.py
+++ b/ci_test/unit_tests/test_unit_layer_log_softmax.py
@@ -50,7 +50,7 @@ def numpy_log_softmax(x):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -62,7 +62,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_matmul.py
+++ b/ci_test/unit_tests/test_unit_layer_matmul.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_mean_absolute_error.py
+++ b/ci_test/unit_tests/test_unit_layer_mean_absolute_error.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_mean_squared_error.py
+++ b/ci_test/unit_tests/test_unit_layer_mean_squared_error.py
@@ -33,7 +33,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -45,7 +45,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_one_hot.py
+++ b/ci_test/unit_tests/test_unit_layer_one_hot.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_pooling.py
+++ b/ci_test/unit_tests/test_unit_layer_pooling.py
@@ -96,7 +96,7 @@ def pytorch_pooling(data,
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -108,7 +108,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_pooling_distconv.py
@@ -97,7 +97,7 @@ def pytorch_pooling(data,
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -109,7 +109,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}

--- a/ci_test/unit_tests/test_unit_layer_reduction.py
+++ b/ci_test/unit_tests/test_unit_layer_reduction.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_relu.py
+++ b/ci_test/unit_tests/test_unit_layer_relu.py
@@ -39,7 +39,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -51,7 +51,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_relu_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_relu_distconv.py
@@ -40,7 +40,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -52,7 +52,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}

--- a/ci_test/unit_tests/test_unit_layer_rowwise_weights_norms.py
+++ b/ci_test/unit_tests/test_unit_layer_rowwise_weights_norms.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_scatter.py
+++ b/ci_test/unit_tests/test_unit_layer_scatter.py
@@ -42,7 +42,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -54,7 +54,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_selu.py
+++ b/ci_test/unit_tests/test_unit_layer_selu.py
@@ -55,7 +55,7 @@ def numpy_selu(x):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -67,7 +67,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_sigmoid.py
+++ b/ci_test/unit_tests/test_unit_layer_sigmoid.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_sigmoid_binary_cross_entropy.py
+++ b/ci_test/unit_tests/test_unit_layer_sigmoid_binary_cross_entropy.py
@@ -36,7 +36,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -48,7 +48,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_slice.py
+++ b/ci_test/unit_tests/test_unit_layer_slice.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_softmax.py
+++ b/ci_test/unit_tests/test_unit_layer_softmax.py
@@ -51,7 +51,7 @@ def numpy_softmax(x):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -63,7 +63,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_softplus.py
+++ b/ci_test/unit_tests/test_unit_layer_softplus.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_softsign.py
+++ b/ci_test/unit_tests/test_unit_layer_softsign.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_squared_difference.py
+++ b/ci_test/unit_tests/test_unit_layer_squared_difference.py
@@ -33,7 +33,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -45,7 +45,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_tessellate.py
+++ b/ci_test/unit_tests/test_unit_layer_tessellate.py
@@ -37,7 +37,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -49,7 +49,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_uniform_hash.py
+++ b/ci_test/unit_tests/test_unit_layer_uniform_hash.py
@@ -47,7 +47,7 @@ def uniform_hash(x):
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -66,7 +66,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_layer_variance.py
+++ b/ci_test/unit_tests/test_unit_layer_variance.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_lbann_invocation.py
+++ b/ci_test/unit_tests/test_unit_lbann_invocation.py
@@ -25,7 +25,7 @@ def get_file_names(dir_name, test_name):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_no_params_bad'
-def test_unit_no_params_bad(cluster, dirname):
+def test_unit_no_params_bad(cluster, dirname, weekly):
     print('TESTING: run lbann with no params; lbann should throw exception\n')
     (output_file_name, error_file_name) = get_file_names(dirname, 'no_params_bad')
     command = tools.get_command(
@@ -42,7 +42,7 @@ def test_unit_no_params_bad(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_one_model_bad'
-def test_unit_one_model_bad(cluster, dirname):
+def test_unit_one_model_bad(cluster, dirname, weekly):
     print('TESTING: run lbann with no optimizer or reader; lbann should throw exception\n')
     (_, model_path, _) = get_default_parameters(dirname, two_models=False)
     (output_file_name, error_file_name) = get_file_names(dirname, 'one_model_bad')
@@ -61,7 +61,7 @@ def test_unit_one_model_bad(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_two_models'
-def test_unit_two_models(cluster, dirname):
+def test_unit_two_models(cluster, dirname, weekly):
     print('TESTING: run lbann with two models; lbann should throw exception\n')
     (data_reader_path, model_path, optimizer_path) = get_default_parameters(dirname)
     (output_file_name, error_file_name) = get_file_names(dirname, 'two_models')
@@ -82,7 +82,7 @@ def test_unit_two_models(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_missing_optimizer'
-def test_unit_missing_optimizer(cluster, dirname):
+def test_unit_missing_optimizer(cluster, dirname, weekly):
     print('TESTING: run lbann with model, reader, but no optimizer; lbann should throw exception\n')
     (data_reader_path, model_path, _) = get_default_parameters(dirname, two_models=False)
     (output_file_name, error_file_name) = get_file_names(dirname, 'missing_optimizer')
@@ -102,7 +102,7 @@ def test_unit_missing_optimizer(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_missing_reader'
-def test_unit_missing_reader(cluster, dirname):
+def test_unit_missing_reader(cluster, dirname, weekly):
     print('TESTING: run lbann with model, optimizer, but no reader; lbann should throw exception\n')
     (_, model_path, optimizer_path) = get_default_parameters(dirname, two_models=False)
     (output_file_name, error_file_name) = get_file_names(dirname, 'missing_reader')
@@ -121,7 +121,7 @@ def test_unit_missing_reader(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_bad_params'
-def test_unit_bad_params(cluster, dirname):
+def test_unit_bad_params(cluster, dirname, weekly):
     exe = shutil.which('lbann')
     print('TESTING: run lbann with ill-formed param (exit_after_setup should have `--` not `-`) lbann should throw exception\n')
     (data_reader_path, model_path, optimizer_path) = get_default_parameters(
@@ -143,7 +143,7 @@ def test_unit_bad_params(cluster, dirname):
 
 
 # Run with python3 -m pytest -s test_unit_lbann_invocation.py -k 'test_unit_should_work'
-def test_unit_should_work(cluster, dirname):
+def test_unit_should_work(cluster, dirname, weekly):
     print('TESTING: run lbann with model, reader, and optimizer; lbann should NOT throw exception\n')
     (data_reader_path, model_path, optimizer_path) = get_default_parameters(
         dirname, two_models=False)

--- a/ci_test/unit_tests/test_unit_load_weights_lenet.py
+++ b/ci_test/unit_tests/test_unit_load_weights_lenet.py
@@ -34,7 +34,7 @@ save_model_dir='model_weights'
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -56,7 +56,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.SGD(learn_rate=0.01, momentum=0.9)
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.
@@ -171,7 +171,7 @@ def create_test_func(test_func):
         print('\n################################################################################')
         print('Running model halfway ')
         print('################################################################################\n')
-        baseline_test_output = test_func(cluster, dirname)
+        baseline_test_output = test_func(cluster, dirname, weekly)
         baseline_training_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         baseline_validation_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'validation objective function')
         baseline_test_metrics = tools.collect_metrics_from_log_func(baseline_test_output['stdout_log_file'], 'test objective function')
@@ -191,7 +191,7 @@ def create_test_func(test_func):
                         '--load_model_weights_dir='+ os.path.join(baseline_test_output['work_dir'], checkpoint_dir, 'trainer0')],
         )
 
-        checkpoint_test_output = test_func_checkpoint[0](cluster, dirname)
+        checkpoint_test_output = test_func_checkpoint[0](cluster, dirname, weekly)
         checkpoint_training_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         checkpoint_validation_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'validation objective function')
         checkpoint_test_metrics = tools.collect_metrics_from_log_func(checkpoint_test_output['stdout_log_file'], 'test objective function')
@@ -212,7 +212,7 @@ def create_test_func(test_func):
         )
 
         # Restart LBANN model and run to completion
-        restart_test_output = test_func_restart[0](cluster, dirname)
+        restart_test_output = test_func_restart[0](cluster, dirname, weekly)
         restart_training_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'training epoch [0-9]+ objective function')
         restart_validation_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'validation objective function')
         restart_test_metrics = tools.collect_metrics_from_log_func(restart_test_output['stdout_log_file'], 'test objective function')

--- a/ci_test/unit_tests/test_unit_module_fully_connected.py
+++ b/ci_test/unit_tests/test_unit_module_fully_connected.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid.py
+++ b/ci_test/unit_tests/test_unit_subgrid.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid_concat.py
+++ b/ci_test/unit_tests/test_unit_subgrid_concat.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid_cross_grid_sum.py
+++ b/ci_test/unit_tests/test_unit_subgrid_cross_grid_sum.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid_slice.py
+++ b/ci_test/unit_tests/test_unit_subgrid_slice.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid_split.py
+++ b/ci_test/unit_tests/test_unit_subgrid_split.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_subgrid_sum.py
+++ b/ci_test/unit_tests/test_unit_subgrid_sum.py
@@ -35,7 +35,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -47,7 +47,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.

--- a/ci_test/unit_tests/test_unit_weights_numpy_initializer.py
+++ b/ci_test/unit_tests/test_unit_weights_numpy_initializer.py
@@ -38,7 +38,7 @@ def sample_dims():
 # Setup LBANN experiment
 # ==============================================
 
-def setup_experiment(lbann):
+def setup_experiment(lbann, weekly):
     """Construct LBANN experiment.
 
     Args:
@@ -50,7 +50,7 @@ def setup_experiment(lbann):
     model = construct_model(lbann)
     data_reader = construct_data_reader(lbann)
     optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
 
 def construct_model(lbann):
     """Construct LBANN model.


### PR DESCRIPTION
Updating the CI testing framework so that the weekly flag is passed
into the setup_experiment function so that tests, especially
integration, tests can be run in both a quick mode (i.e. nightly) and
a more extensive tests (i.e. weekly).

Updated the ATOM integration test to use both nightly and weekly modes.