### PR TITLE
Move data store exchange to primary thread

### DIFF
--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -342,7 +342,6 @@ class generic_data_reader {
   void start_data_store_mini_batch_exchange();
   void finish_data_store_mini_batch_exchange();
 
-
   /**
    * During the network's update phase, the data reader will
    * advanced the current position pointer.  If the pointer wraps

--- a/include/lbann/data_readers/data_reader.hpp
+++ b/include/lbann/data_readers/data_reader.hpp
@@ -339,6 +339,10 @@ class generic_data_reader {
     m_supported_input_types[INPUT_DATA_TYPE_RESPONSES] = b;
   }
 
+  void start_data_store_mini_batch_exchange();
+  void finish_data_store_mini_batch_exchange();
+
+
   /**
    * During the network's update phase, the data reader will
    * advanced the current position pointer.  If the pointer wraps

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -233,7 +233,8 @@ class data_store_conduit {
    */
   void preload_local_cache();
 
-  void exchange_mini_batch_data(size_t current_pos, size_t mb_size);
+  void start_exchange_mini_batch_data(size_t current_pos, size_t mb_size);
+  void finish_exchange_mini_batch_data();
 
   void set_node_sizes_vary() { m_node_sizes_vary = true; }
 
@@ -440,6 +441,9 @@ private :
   int  m_np_in_trainer;
   int  m_num_partitions_in_trainer;
 
+  /// Flag to indicate if a data exchange has started
+  bool m_mini_batch_data_exchange_started = false;
+
   /** @brief Maps an index to the processor that owns the associated data
    * First value of index is the sample ID and second value is the partiton ID
    *
@@ -508,7 +512,8 @@ private :
   // methods follow
   //=========================================================================
 
-  void exchange_data_by_sample(size_t current_pos, size_t mb_size);
+  void start_exchange_data_by_sample(size_t current_pos, size_t mb_size);
+  void finish_exchange_data_by_sample();
 
   void setup_data_store_buffers();
 

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -141,14 +141,6 @@ int buffered_data_coordinator<TensorDataType>::fetch_to_local_matrix(data_buffer
   /// Check to make sure that the local matrix has space for data
   data_buffer<IODataType>& buf = get_data_buffer(buffer_map, mode);
 
-  /// Make sure that every rank participates in the data store prior
-  /// to seeing if the local rank's position is valid.  Note that
-  /// every rank will hold data that may be used in the last mini-batch
-  if (dr->data_store_active()) {
-    dr->get_data_store().exchange_mini_batch_data(dr->get_position() - dr->get_base_offset() - dr->get_model_offset(),
-                                                  dr->get_loaded_mini_batch_size());
-  }
-
   buf.m_num_samples_fetched = 0;
   /// BVE FIXME change the guard
   if (this->m_comm->get_rank_in_trainer() < num_parallel_readers &&

--- a/src/data_coordinator/buffered_data_coordinator.cpp
+++ b/src/data_coordinator/buffered_data_coordinator.cpp
@@ -225,6 +225,11 @@ void buffered_data_coordinator<TensorDataType>::fetch_data(execution_mode mode) 
   // If there is no valid data and there is not already a background
   // thread to fetch the data, queue up the background thread
   if(active_buffer.num_samples_ready() == 0 && !active_buffer.is_data_fetched_in_background()) {
+    // Start data store exchange if necessary (this should be move
+    // earlier as a future optimization)
+    get_data_reader(mode)->start_data_store_mini_batch_exchange();
+    // Finish data store exchange before accessing samples
+    get_data_reader(mode)->finish_data_store_mini_batch_exchange();
     std::future<void> background_fetch_done = get_io_thread_pool().submit_job(
       std::bind(&buffered_data_coordinator::fetch_data_in_background, this, this->get_active_buffer_idx(mode), mode));
     active_buffer.set_data_fetch_future(std::move(background_fetch_done));
@@ -264,6 +269,11 @@ bool buffered_data_coordinator<TensorDataType>::epoch_complete(execution_mode mo
   // in epoch.  In a future PR this state should be moved to the data coordinator
   if(!m_data_set_processed && m_trainer->background_io_activity_allowed()) {
     int next_active_buffer = this->get_active_buffer_idx(mode) + 1;
+    // Start data store exchange if necessary (this should be move
+    // earlier as a future optimization)
+    get_data_reader(mode)->start_data_store_mini_batch_exchange();
+    // Finish data store exchange before accessing samples
+    get_data_reader(mode)->finish_data_store_mini_batch_exchange();
     std::future<void> background_fetch_done = get_io_thread_pool().submit_job(
       std::bind(&buffered_data_coordinator::fetch_data_in_background, this, next_active_buffer, mode));
     data_buffer_map_t& next_io_buffer_map = m_data_buffers[next_active_buffer % m_data_buffers.size()];

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -205,6 +205,29 @@ int lbann::generic_data_reader::fetch(
   return mb_size;
 }
 
+void lbann::generic_data_reader::start_data_store_mini_batch_exchange() {
+  int loaded_batch_size = get_loaded_mini_batch_size();
+
+  /// Make sure that every rank participates in the data store prior
+  /// to seeing if the local rank's position is valid.  Note that
+  /// every rank will hold data that may be used in the last mini-batch
+  if (data_store_active()) {
+    const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size), m_shuffled_indices.size());
+    m_data_store->start_exchange_mini_batch_data(m_current_pos-m_base_offset-m_model_offset, loaded_batch_size);
+  }
+  return;
+}
+
+void lbann::generic_data_reader::finish_data_store_mini_batch_exchange() {
+  /// Make sure that every rank participates in the data store prior
+  /// to seeing if the local rank's position is valid.  Note that
+  /// every rank will hold data that may be used in the last mini-batch
+  if (data_store_active()) {
+    m_data_store->finish_exchange_mini_batch_data();
+  }
+  return;
+}
+
 bool lbann::generic_data_reader::fetch_data_block(
   std::map<data_field_type, CPUMat*>& input_buffers,
   El::Int block_offset,

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -212,7 +212,6 @@ void lbann::generic_data_reader::start_data_store_mini_batch_exchange() {
   /// to seeing if the local rank's position is valid.  Note that
   /// every rank will hold data that may be used in the last mini-batch
   if (data_store_active()) {
-    const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size), m_shuffled_indices.size());
     m_data_store->start_exchange_mini_batch_data(m_current_pos-m_base_offset-m_model_offset, loaded_batch_size);
   }
   return;

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -208,9 +208,9 @@ int lbann::generic_data_reader::fetch(
 void lbann::generic_data_reader::start_data_store_mini_batch_exchange() {
   int loaded_batch_size = get_loaded_mini_batch_size();
 
-  /// Make sure that every rank participates in the data store prior
-  /// to seeing if the local rank's position is valid.  Note that
-  /// every rank will hold data that may be used in the last mini-batch
+  // Make sure that every rank participates in the data store prior
+  // to seeing if the local rank's position is valid.  Note that
+  // every rank will hold data that may be used in the last mini-batch
   if (data_store_active()) {
     m_data_store->start_exchange_mini_batch_data(m_current_pos-m_base_offset-m_model_offset, loaded_batch_size);
   }
@@ -218,9 +218,9 @@ void lbann::generic_data_reader::start_data_store_mini_batch_exchange() {
 }
 
 void lbann::generic_data_reader::finish_data_store_mini_batch_exchange() {
-  /// Make sure that every rank participates in the data store prior
-  /// to seeing if the local rank's position is valid.  Note that
-  /// every rank will hold data that may be used in the last mini-batch
+  // Make sure that every rank participates in the data store prior
+  // to seeing if the local rank's position is valid.  Note that
+  // every rank will hold data that may be used in the last mini-batch
   if (data_store_active()) {
     m_data_store->finish_exchange_mini_batch_data();
   }

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -74,6 +74,7 @@ data_store_conduit::data_store_conduit(
   m_offset_in_partition = m_rank_in_trainer%num_io_parts;
   m_np_in_trainer = m_comm->get_procs_per_trainer();
   m_num_partitions_in_trainer = m_np_in_trainer/num_io_parts; // rename this m_num_io_groups_in_trainer
+  m_mini_batch_data_exchange_started = false;
 
   open_informational_files();
 
@@ -230,6 +231,8 @@ void data_store_conduit::copy_members(const data_store_conduit& rhs) {
   m_compacted_sample_size = rhs.m_compacted_sample_size;
   m_indices_to_send = rhs.m_indices_to_send;
   m_indices_to_recv = rhs.m_indices_to_recv;
+
+  m_mini_batch_data_exchange_started = rhs.m_mini_batch_data_exchange_started;
 
   open_informational_files();
 }
@@ -471,7 +474,7 @@ void data_store_conduit::build_node_for_sending(const conduit::Node &node_in, co
   }
 }
 
-void data_store_conduit::exchange_data_by_sample(size_t current_pos, size_t mb_size) {
+void data_store_conduit::start_exchange_data_by_sample(size_t current_pos, size_t mb_size) {
   if (! m_is_setup) {
     LBANN_ERROR("setup(mb_size) has not been called");
   }
@@ -586,9 +589,11 @@ void data_store_conduit::exchange_data_by_sample(size_t current_pos, size_t mb_s
   }
 
   m_start_snd_rcv_time += (get_time() - tm5);
+}
 
+void data_store_conduit::finish_exchange_data_by_sample() {
   // wait for all msgs to complete
-  tm5 = get_time();
+  double tm5 = get_time();
   m_comm->wait_all(m_send_requests);
   m_comm->wait_all(m_recv_requests);
   m_comm->trainer_barrier();
@@ -1467,7 +1472,7 @@ void data_store_conduit::profile_timing() {
   }
 }
 
-void data_store_conduit::exchange_mini_batch_data(size_t current_pos, size_t mb_size) {
+void data_store_conduit::start_exchange_mini_batch_data(size_t current_pos, size_t mb_size) {
   if (is_local_cache() && is_fully_loaded()) {
     return;
   }
@@ -1511,7 +1516,19 @@ PROFILE("exchange_mini_batch_data; m_owner_maps_were_exchanged = true");
     */
   }
 
-  exchange_data_by_sample(current_pos, mb_size);
+  start_exchange_data_by_sample(current_pos, mb_size);
+  m_mini_batch_data_exchange_started = true;
+  m_exchange_time += (get_time() - tm1);
+}
+
+void data_store_conduit::finish_exchange_mini_batch_data() {
+  if (!m_mini_batch_data_exchange_started) {
+    return;
+  }
+
+  double tm1 = get_time();
+  finish_exchange_data_by_sample();
+  m_mini_batch_data_exchange_started = false;
   m_exchange_time += (get_time() - tm1);
 }
 


### PR DESCRIPTION
Moved the data store exchange out of the fetch_data call to allow it
to start and finish in the primary thread.  This should alleviate
issues with MPI_THREAD_MULTIPLE and background I/O.  Furthermore,
there should be no loss in performance since it is being executed in
the same sequence as before.  Additionally, split the data store calls
into two phases that are split between initiating the non-blocking
sends and receives and the subsequent wait statements.  Currently,
these calls are still executed back-to-back to provide equivalent
semantics as the prior implementation.