### PR TITLE
Reduce LTFB startup overhead and reporting

### DIFF
--- a/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
+++ b/include/lbann/execution_algorithms/ltfb/random_pairwise_exchange.hpp
@@ -165,9 +165,11 @@ public:
 private:
   /** @brief Get the value of the given metric from the model. */
   std::unordered_map<std::string, EvalType>
-  evaluate_model(model& m, LTFBExecutionContext& ctxt, data_coordinator& dc) const;
+  evaluate_model(model& m,
+                 LTFBExecutionContext& ctxt,
+                 data_coordinator& dc) const;
   /** @brief Generate a new trainer partner from the comm. */
-  El::Int get_partner_trainer(lbann_comm const& c) const noexcept;
+  int get_partner_trainer(lbann_comm const& c) const noexcept;
   /** @brief Evaluate the output of two models according to the input
    *         metric strategies.
    *

--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -42,9 +42,16 @@ namespace lbann {
 #define LBANN_OPTION_DISABLE_SIGNAL_HANDLER "disable_signal_handler"
 #define LBANN_OPTION_EXIT_AFTER_SETUP "exit_after_setup"
 #define LBANN_OPTION_GENERATE_MULTI_PROTO "generate_multi_proto"
-#define LBANN_OPTION_LOAD_MODEL_WEIGHTS_DIR_IS_COMPLETE "load_model_weights_dir_is_complete"
-#define LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS "LTFB Allow global statistics"
+#define LBANN_OPTION_LOAD_MODEL_WEIGHTS_DIR_IS_COMPLETE                        \
+  "load_model_weights_dir_is_complete"
+// Deprecated -- "LTFB Callback"
+#define LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS \
+  "LTFB Allow global statistics"
+// Deprecated -- "LTFB Callback"
 #define LBANN_OPTION_LTFB_VERBOSE "ltfb_verbose"
+#define LBANN_OPTION_MULTITRAINER_VERBOSE "multitrainer_verbose"
+#define LBANN_OPTION_ALLOW_MULTITRAINER_GLOBAL_STATISTICS \
+  "Allow multitrainer global statistics"
 #define LBANN_OPTION_NO_IM_COMM "no_im_comm"
 #define LBANN_OPTION_PRELOAD_DATA_STORE "preload_data_store"
 #define LBANN_OPTION_PRINT_AFFINITY "print_affinity"

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -256,6 +256,12 @@ void restore_model_weights(
 std::string sendrecv_string(lbann_comm const& c, std::string const& src,
                             El::Int partner_trainer)
 {
+#ifdef LBANN_HAS_ALUMINUM
+  El::mpi::EnsureComm<size_t, El::Collective::SENDRECV>(
+    c.get_world_comm(),
+    El::SyncInfo<El::Device::CPU>{});
+#endif
+
   if (!c.am_trainer_master())
     return "";
 

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -196,16 +196,26 @@ El::Int get_partner_trainer(lbann_comm& comm,
   std::shuffle(trainers.begin(), trainers.end(), get_ltfb_generator());
 
   if (comm.am_world_master()) { // Root process
+    auto& arg_parser = global_argument_parser();
+    bool ltfb_verbose =
+      arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
+    bool skipped_reporting_trainers = false;
     // Print partner assignments to standard output
     std::stringstream msg;
     msg << message_prefix << "tournament partners -";
     for (El::Int i = 0; i < num_trainers; i += 2) {
-      msg << (i > 0 ? "," : "")
-          << " {" << trainers[i];
-      if (i+1 < num_trainers) {
-        msg << "," << trainers[i+1];
+      // By default only print out 3 pairs of trainer mappings unless
+      // LTFB has verbose reporting
+      if(i < 3 || i == (num_trainers-2) || i == (num_trainers-1) || ltfb_verbose) {
+        msg << (i > 0 && !skipped_reporting_trainers ? "," : "") << " {" << trainers[i];
+        if (i + 1 < num_trainers) {
+          msg << "," << trainers[i + 1];
+        }
+        msg << "}";
+      }else if(!skipped_reporting_trainers) {
+        msg << " ...";
+        skipped_reporting_trainers = true;
       }
-      msg << "}";
     }
     msg << "\n";
     std::cout << msg.str() << std::endl << std::flush;

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -196,29 +196,31 @@ El::Int get_partner_trainer(lbann_comm& comm,
   std::shuffle(trainers.begin(), trainers.end(), get_ltfb_generator());
 
   if (comm.am_world_master()) { // Root process
-    auto& arg_parser = global_argument_parser();
-    bool ltfb_verbose =
-      arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
+    auto const& arg_parser = global_argument_parser();
+    bool const ltfb_verbose = arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
     bool skipped_reporting_trainers = false;
     // Print partner assignments to standard output
-    std::stringstream msg;
+    std::ostringstream msg;
     msg << message_prefix << "tournament partners -";
     for (El::Int i = 0; i < num_trainers; i += 2) {
       // By default only print out 3 pairs of trainer mappings unless
       // LTFB has verbose reporting
-      if(i < 3 || i == (num_trainers-2) || i == (num_trainers-1) || ltfb_verbose) {
-        msg << (i > 0 && !skipped_reporting_trainers ? "," : "") << " {" << trainers[i];
+      if (i < 3 || i == (num_trainers - 2) || i == (num_trainers - 1) ||
+          ltfb_verbose) {
+        msg << (i > 0 && !skipped_reporting_trainers ? "," : "") << " {"
+            << trainers[i];
         if (i + 1 < num_trainers) {
           msg << "," << trainers[i + 1];
         }
         msg << "}";
-      }else if(!skipped_reporting_trainers) {
+      }
+      else if (!skipped_reporting_trainers) {
         msg << " ...";
         skipped_reporting_trainers = true;
       }
     }
     msg << "\n";
-    std::cout << msg.str() << std::endl << std::flush;
+    std::cout << msg.str() << std::endl;
   }
 
   // Setup partner assignments for all processes

--- a/src/execution_algorithms/ltfb/checkpoint_common.hpp
+++ b/src/execution_algorithms/ltfb/checkpoint_common.hpp
@@ -102,6 +102,12 @@ inline static std::string sendrecv_string(lbann_comm const& c,
                                           std::string const& src,
                                           El::Int partner_trainer)
 {
+#ifdef LBANN_HAS_ALUMINUM
+  El::mpi::EnsureComm<size_t, El::Collective::SENDRECV>(
+    c.get_world_comm(),
+    El::SyncInfo<El::Device::CPU>{});
+#endif
+
   if (!c.am_trainer_master())
     return "";
 

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -226,9 +226,9 @@ El::Int RandomPairwiseExchange::get_partner_trainer(
   std::shuffle(trainers.begin(), trainers.end(), get_ltfb_generator());
 
   if (comm.am_world_master()) { // Root process
-    auto& arg_parser = global_argument_parser();
-    bool ltfb_verbose =
-      arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
+    auto const& arg_parser = global_argument_parser();
+    bool const multitrainer_verbose =
+      arg_parser.get<bool>(LBANN_OPTION_MULTITRAINER_VERBOSE);
     bool skipped_reporting_trainers = false;
     // Print partner assignments to standard output
     std::ostringstream msg;
@@ -236,13 +236,16 @@ El::Int RandomPairwiseExchange::get_partner_trainer(
     for (El::Int i = 0; i < num_trainers; i += 2) {
       // By default only print out 3 pairs of trainer mappings unless
       // LTFB has verbose reporting
-      if(i < 3 || i == (num_trainers-2) || i == (num_trainers-1) || ltfb_verbose) {
-        msg << (i > 0 && !skipped_reporting_trainers ? "," : "") << " {" << trainers[i];
+      if (i < 3 || i == (num_trainers - 2) || i == (num_trainers - 1) ||
+          multitrainer_verbose) {
+        msg << (i > 0 && !skipped_reporting_trainers ? "," : "") << " {"
+            << trainers[i];
         if (i + 1 < num_trainers) {
           msg << "," << trainers[i + 1];
         }
         msg << "}";
-      }else if(!skipped_reporting_trainers) {
+      }
+      else if (!skipped_reporting_trainers) {
         msg << " ...";
         skipped_reporting_trainers = true;
       }

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -211,15 +211,15 @@ RandomPairwiseExchange::evaluate_model(model& m,
   return metric_values;
 }
 
-El::Int RandomPairwiseExchange::get_partner_trainer(
+int RandomPairwiseExchange::get_partner_trainer(
   lbann_comm const& comm) const noexcept
 {
   // Assign partner trainers
   // Note: The first trainer in 'trainers' is paired with the
   // second, the third with the fourth, and so on. If there are an
   // odd number of trainers, the last one is partnered with itself.
-  const El::Int num_trainers = comm.get_num_trainers();
-  std::vector<El::Int> trainers(num_trainers);
+  int const num_trainers = comm.get_num_trainers();
+  std::vector<int> trainers(num_trainers);
   std::iota(trainers.begin(), trainers.end(), 0);
   // Everyone use a special RNG that is only for LTFB so that they
   // can all communicate the same pairs without communication
@@ -233,7 +233,7 @@ El::Int RandomPairwiseExchange::get_partner_trainer(
     // Print partner assignments to standard output
     std::ostringstream msg;
     msg << "tournament partners -";
-    for (El::Int i = 0; i < num_trainers; i += 2) {
+    for (int i = 0; i < num_trainers; i += 2) {
       // By default only print out 3 pairs of trainer mappings unless
       // LTFB has verbose reporting
       if (i < 3 || i == (num_trainers - 2) || i == (num_trainers - 1) ||
@@ -255,10 +255,10 @@ El::Int RandomPairwiseExchange::get_partner_trainer(
   }
 
   // Setup partner assignments for all processes
-  std::vector<El::Int> send_buffer(num_trainers);
-  for (El::Int i = 0; i < num_trainers; i += 2) {
-    const auto& trainer1 = trainers[i];
-    const auto& trainer2 = (i + 1 < num_trainers) ? trainers[i + 1] : trainer1;
+  std::vector<int> send_buffer(num_trainers);
+  for (int i = 0; i < num_trainers; i += 2) {
+    auto const& trainer1 = trainers[i];
+    auto const& trainer2 = (i + 1 < num_trainers) ? trainers[i + 1] : trainer1;
     send_buffer[trainer1] = trainer2;
     send_buffer[trainer2] = trainer1;
   }
@@ -300,8 +300,8 @@ void RandomPairwiseExchange::select_next(model& m,
 
   LBANN_LOG_WORLD_MASTER(comm, message_prefix, "starting tournament...");
 
-  El::Int const local_trainer = comm.get_trainer_rank();
-  El::Int const partner_trainer = get_partner_trainer(comm);
+  int const local_trainer = comm.get_trainer_rank();
+  int const partner_trainer = get_partner_trainer(comm);
 
   LBANN_LOG_WORLD_MASTER(comm, message_prefix, "evaluating local model...");
 
@@ -321,7 +321,7 @@ void RandomPairwiseExchange::select_next(model& m,
 
   // If we win, we do nothing. The input model is the winner, so no
   // further action is required. Otherwise, swap models.
-  El::Int const tournament_winner =
+  int const tournament_winner =
     (local_is_better(local_scores, partner_scores) ? local_trainer
                                                    : partner_trainer);
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -35,6 +35,7 @@
 #include "lbann/utils/argument_parser.hpp"
 
 #include "lbann/data_readers/data_reader_HDF5.hpp"
+#include "lbann/utils/options.hpp"
 
 #include <lbann.pb.h>
 #include <reader.pb.h>
@@ -886,86 +887,89 @@ void print_parameters(const lbann_comm& comm,
     return;
   }
 
-  const lbann_data::Trainer &t = p.trainer();
-  const lbann_data::Model &m = p.model();
+  lbann_data::Trainer const& t = p.trainer();
+  lbann_data::Model const& m = p.model();
 
-  bool disable_cuda = m.disable_cuda();
-#ifndef LBANN_HAS_GPU
-  disable_cuda = true;
+#ifdef LBANN_HAS_GPU
+  bool const disable_cuda = m.disable_cuda();
+#else
+  bool const disable_cuda = true;
 #endif // LBANN_HAS_GPU
-  bool disable_cudnn = disable_cuda;
-#ifndef LBANN_HAS_CUDNN
-  disable_cudnn = true;
+#ifdef LBANN_HAS_CUDNN
+  bool const disable_cudnn = disable_cuda;
+#else
+  bool const disable_cudnn = true;
 #endif // LBANN_HAS_CUDNN
-  bool enable_determinism = false;
 #ifdef LBANN_DETERMINISTIC
-  enable_determinism = true;
+  bool const enable_determinism = true;
+#else
+  bool const enable_determinism = false;
 #endif // LBANN_DETERMINISTIC
 
-  std::cout << std::endl
-            << "Running with these parameters:\n"
+  std::cout << "\nRunning with these parameters:\n"
             << " General:\n"
-            << "  datatype size:              " << sizeof(DataType) << std::endl
-            << "  mini_batch_size:            " << t.mini_batch_size() << std::endl
-            << "  num_epochs:                 " << m.num_epochs()  << std::endl
-            << "  hydrogen_block_size:        " << t.hydrogen_block_size()  << std::endl
-            << "  procs_per_trainer:          " << comm.get_procs_per_trainer()  << std::endl
-            << "  num_parallel_readers:       " << t.num_parallel_readers()  << std::endl
-            << "  serialize_io:               " << t.serialize_io()  << std::endl
-            << "  cuda:                       " << (disable_cuda ? "disabled" : "enabled") << std::endl
-            << "  cudnn:                      " << (disable_cudnn ? "disabled" : "enabled") << std::endl;
+            << "  datatype size:              " << sizeof(DataType) << '\n'
+            << "  mini_batch_size:            " << t.mini_batch_size() << '\n'
+            << "  num_epochs:                 " << m.num_epochs() << '\n'
+            << "  hydrogen_block_size:        " << t.hydrogen_block_size()
+            << '\n'
+            << "  procs_per_trainer:          " << comm.get_procs_per_trainer()
+            << '\n'
+            << "  num_parallel_readers:       " << t.num_parallel_readers()
+            << '\n'
+            << "  serialize_io:               " << t.serialize_io() << '\n'
+            << "  cuda:                       "
+            << (disable_cuda ? "disabled" : "enabled") << '\n'
+            << "  cudnn:                      "
+            << (disable_cudnn ? "disabled" : "enabled") << std::endl;
   auto& arg_parser = global_argument_parser();
-  bool allow_global_statistics =
-    arg_parser.get<bool>(LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS);
-  bool ltfb_verbose =
-    arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
-  std::stringstream root_rng, rng, data_seq_rng;
-  for(size_t i = 0; i < random_seeds.size(); i++) {
-    int trainer_rank = comm.map_world_rank_to_trainer_rank(i);
-    int rank_in_trainer = comm.map_world_rank_to_rank_in_trainer(i);
-    if(rank_in_trainer < arg_parser.get<int>(LBANN_OPTION_MAX_RNG_SEEDS_DISPLAY)) {
-      std::stringstream id;
+  bool const allow_global_statistics =
+    arg_parser.get<bool>(LBANN_OPTION_ALLOW_MULTITRAINER_GLOBAL_STATISTICS);
+  bool const multitrainer_verbose =
+    arg_parser.get<bool>(LBANN_OPTION_MULTITRAINER_VERBOSE);
+  int const max_rng_seeds =
+    arg_parser.get<int>(LBANN_OPTION_MAX_RNG_SEEDS_DISPLAY);
+  std::ostringstream root_rng, rng, data_seq_rng;
+  for (size_t i = 0; i < random_seeds.size(); i++) {
+    int const trainer_rank = comm.map_world_rank_to_trainer_rank(i);
+    int const rank_in_trainer = comm.map_world_rank_to_rank_in_trainer(i);
+    if (rank_in_trainer < max_rng_seeds) {
+      std::ostringstream id;
       id << "[" << trainer_rank << "][" << rank_in_trainer << "]";
-      root_rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(root_random_seeds[i]) << " " ;
-      rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(random_seeds[i]) << " " ;
-      data_seq_rng << id.str() << "=" << std::setfill('0') << std::setw(10) << static_cast<unsigned int>(data_seq_random_seeds[i]) << " " ;
-    }else {
+      root_rng << id.str() << "=" << std::setfill('0') << std::setw(10)
+               << static_cast<unsigned int>(root_random_seeds[i]) << " ";
+      rng << id.str() << "=" << std::setfill('0') << std::setw(10)
+          << static_cast<unsigned int>(random_seeds[i]) << " ";
+      data_seq_rng << id.str() << "=" << std::setfill('0') << std::setw(10)
+                   << static_cast<unsigned int>(data_seq_random_seeds[i])
+                   << " ";
+    }
+    else {
       root_rng << "... ";
       rng << "... ";
       data_seq_rng << "... ";
     }
   }
-  if(!(allow_global_statistics && ltfb_verbose) && comm.get_num_trainers() > 1) {
-    std::stringstream msg;
-    if(comm.get_num_trainers() == 2) {
+  if (!(allow_global_statistics && multitrainer_verbose) &&
+      comm.get_num_trainers() > 1) {
+    std::ostringstream msg;
+    if (comm.get_num_trainers() == 2) {
       msg << "trainer 1";
-    }else {
-      msg << "trainers 1 to " << comm.get_num_trainers()-1;
+    }
+    else {
+      msg << "trainers 1 to " << comm.get_num_trainers() - 1;
     }
     root_rng << "... (Omitting RNGs from " << msg.str() << ")";
     rng << "... (Omitting RNGs from " << msg.str() << ")";
     data_seq_rng << "... (Omitting RNGs from " << msg.str() << ")";
   }
-  std::cout << "  root_random_seed[t][r]:     " << root_rng.str() << std::endl;
-  std::cout << "  random_seed[t][r]:          " << rng.str() << std::endl;
-  std::cout << "  data_seq_random_seed[t][r]: " << data_seq_rng.str() << std::endl;
-  std::cout << "  deterministic_exec:         " << (enable_determinism ? "enabled" : "disabled") << std::endl
-            << "  data_layout:                " << m.data_layout()  << std::endl
-            << "     (only used for metrics)\n";
-}
-
-void copy_file(std::string fn, std::ofstream &out)
-{
-  std::ifstream in(fn.c_str());
-  if (!in.is_open()) {
-    std::ostringstream err;
-    err << __FILE__ << " " << __LINE__
-        << " :: failed to open file for reading: " << fn;
-    throw std::runtime_error(err.str());
-  }
-  std::ostringstream s;
-  s << in.rdbuf();
-  out << s.str();
+  std::cout << "  root_random_seed[t][r]:     " << root_rng.str() << '\n'
+            << "  random_seed[t][r]:          " << rng.str() << '\n'
+            << "  data_seq_random_seed[t][r]: " << data_seq_rng.str() << '\n'
+            << "  deterministic_exec:         "
+            << (enable_determinism ? "enabled" : "disabled") << '\n'
+            << "  data_layout:                " << m.data_layout()
+            << "     (only used for metrics)" << std::endl;
 }
 
 void save_session(const lbann_comm& comm, const int argc, char * const* argv, lbann_data::LbannPB& p)

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -135,20 +135,21 @@ trainer& construct_trainer(lbann_comm* comm,
                            lbann_data::Trainer* pb_trainer,
                            lbann_data::LbannPB& pb)
 {
-  if (pb_trainer->num_parallel_readers() > comm->get_procs_per_trainer()) {
-    pb_trainer->set_num_parallel_readers(comm->get_procs_per_trainer());
+  int const procs_per_trainer = comm->get_procs_per_trainer();
+  if (pb_trainer->num_parallel_readers() > procs_per_trainer) {
+    pb_trainer->set_num_parallel_readers(procs_per_trainer);
   }
-  auto& arg_parser = global_argument_parser();
+  auto const& arg_parser = global_argument_parser();
 
   // Adjust the number of parallel readers; this may be adjusted
   // after calling split_trainers()
   // set_num_parallel_readers(*comm, pb);
 
   // Check to see if the model wants to reduce the I/O parallelism
-  bool serialized_io = false;
-  if(pb_trainer->serialize_io()) {
-    std::cout << "Trainer " << pb_trainer->name() << " serialized the I/O threads" << std::endl;
-    serialized_io = true;
+  bool const serialized_io = pb_trainer->serialize_io();
+  if (serialized_io) {
+    std::cout << "Trainer " << pb_trainer->name()
+              << " serialized the I/O threads" << std::endl;
   }
 
   // Initalize a per-trainer I/O thread pool
@@ -156,8 +157,8 @@ trainer& construct_trainer(lbann_comm* comm,
     construct_io_thread_pool(comm, serialized_io);
 
   // Setup I/O threads
-  auto io_threads_per_process = io_thread_pool->get_num_threads();
-  auto io_threads_offset = io_thread_pool->get_threads_offset();
+  auto const io_threads_per_process = io_thread_pool->get_num_threads();
+  auto const io_threads_offset = io_thread_pool->get_threads_offset();
 
   // Set algorithmic blocksize in Hydrogen
   if (pb_trainer->hydrogen_block_size() > 0) {
@@ -186,11 +187,13 @@ trainer& construct_trainer(lbann_comm* comm,
   if (arg_parser.get<std::string>(LBANN_OPTION_CKPT_DIR) != "") {
     for (auto&& c : global_trainer_->get_callbacks()) {
       {
-        auto* cb = dynamic_cast<callback::checkpoint*>(c);
-        if(cb != nullptr) {
-          cb->set_checkpoint_dir(arg_parser.get<std::string>(LBANN_OPTION_CKPT_DIR));
-          if(comm->am_trainer_master()) {
-            std::cout << "Setting the checkpoint directory to " << cb->get_checkpoint_dir() << std::endl;
+        auto* const cb = dynamic_cast<callback::checkpoint*>(c);
+        if (cb != nullptr) {
+          cb->set_checkpoint_dir(
+            arg_parser.get<std::string>(LBANN_OPTION_CKPT_DIR));
+          if (comm->am_trainer_master()) {
+            std::cout << "Setting the checkpoint directory to "
+                      << cb->get_checkpoint_dir() << std::endl;
           }
         }
       }
@@ -199,11 +202,13 @@ trainer& construct_trainer(lbann_comm* comm,
   if (arg_parser.get<std::string>(LBANN_OPTION_RESTART_DIR) != "") {
     for (auto&& c : global_trainer_->get_callbacks()) {
       {
-        auto* cb = dynamic_cast<callback::checkpoint*>(c);
-        if(cb != nullptr) {
-          cb->set_restart_dir(arg_parser.get<std::string>(LBANN_OPTION_RESTART_DIR));
-          if(comm->am_trainer_master()) {
-            std::cout << "Setting the restart directory to " << cb->get_restart_dir() << std::endl;
+        auto* const cb = dynamic_cast<callback::checkpoint*>(c);
+        if (cb != nullptr) {
+          cb->set_restart_dir(
+            arg_parser.get<std::string>(LBANN_OPTION_RESTART_DIR));
+          if (comm->am_trainer_master()) {
+            std::cout << "Setting the restart directory to "
+                      << cb->get_restart_dir() << std::endl;
           }
         }
       }
@@ -211,12 +216,9 @@ trainer& construct_trainer(lbann_comm* comm,
   }
 
   // Root of the random seed tree
-  int root_random_seed = lbann_default_random_seed;
-
-  // Change random seed if requested
-  if (pb_trainer->random_seed() > 0) {
-    root_random_seed = pb_trainer->random_seed();
-  }
+  int const root_random_seed =
+    (pb_trainer->random_seed() ? pb_trainer->random_seed()
+                               : lbann_default_random_seed);
 
   // Random seed used for the general RNGs
   int random_seed = root_random_seed;
@@ -230,16 +232,16 @@ trainer& construct_trainer(lbann_comm* comm,
     data_seq_random_seed = random_seed;
   }
 #else
-  if(comm->am_world_master()) {
-    std::cout <<
-      "--------------------------------------------------------------------------------------------------------------------\n"
-      "ALERT: executing with LBANN_DETERMINISTIC flag to minimize reduce numerical variance -- performance will be degraded\n"
-      "--------------------------------------------------------------------------------------------------------------------\n";
+  if (comm->am_world_master()) {
+    std::cout << std::string(116, '-') << '\n'
+              << "ALERT: executing with LBANN_DETERMINISTIC flag to minimize "
+                 "reduce numerical variance -- performance will be degraded\n"
+              << std::string(116, '-') << std::endl;
   }
   if (!pb_trainer->random_init_trainers_identically()) {
-    if(comm->am_trainer_master()) {
-      std::cout << "WARNING: forcing 'random_init_trainers_identically' " <<
-        "due to sequential consistency" << std::endl;
+    if (comm->am_trainer_master()) {
+      std::cout << "WARNING: forcing 'random_init_trainers_identically' "
+                << "due to sequential consistency" << std::endl;
     }
   }
 #endif
@@ -248,16 +250,18 @@ trainer& construct_trainer(lbann_comm* comm,
   init_random(random_seed, io_threads_per_process);
   init_data_seq_random(data_seq_random_seed);
   init_ltfb_random(root_random_seed);
-  global_trainer_->set_random_seeds(root_random_seed, random_seed, data_seq_random_seed);
+  global_trainer_->set_random_seeds(root_random_seed,
+                                    random_seed,
+                                    data_seq_random_seed);
 
-  bool allow_global_statistics =
-    arg_parser.get<bool>(LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS);
-  bool ltfb_verbose =
-    arg_parser.get<bool>(LBANN_OPTION_LTFB_VERBOSE);
+  bool const allow_global_statistics =
+    arg_parser.get<bool>(LBANN_OPTION_ALLOW_MULTITRAINER_GLOBAL_STATISTICS);
+  bool const multitrainer_verbose =
+    arg_parser.get<bool>(LBANN_OPTION_MULTITRAINER_VERBOSE);
   std::vector<int> root_random_seeds;
   std::vector<int> random_seeds;
   std::vector<int> data_seq_random_seeds;
-  if(allow_global_statistics && ltfb_verbose) {
+  if (allow_global_statistics && multitrainer_verbose) {
     // Collect everyone's random seeds
     root_random_seeds.resize(comm->get_procs_in_world());
     random_seeds.resize(comm->get_procs_in_world());
@@ -265,22 +269,24 @@ trainer& construct_trainer(lbann_comm* comm,
     comm->world_all_gather(root_random_seed, root_random_seeds);
     comm->world_all_gather(random_seed, random_seeds);
     comm->world_all_gather(data_seq_random_seed, data_seq_random_seeds);
-  }else {
+  }
+  else {
     // Collect random seeds from everyone in the trainer
-    root_random_seeds.resize(comm->get_procs_per_trainer());
-    random_seeds.resize(comm->get_procs_per_trainer());
-    data_seq_random_seeds.resize(comm->get_procs_per_trainer());
+    root_random_seeds.resize(procs_per_trainer);
+    random_seeds.resize(procs_per_trainer);
+    data_seq_random_seeds.resize(procs_per_trainer);
     comm->trainer_all_gather(root_random_seed, root_random_seeds);
     comm->trainer_all_gather(random_seed, random_seeds);
     comm->trainer_all_gather(data_seq_random_seed, data_seq_random_seeds);
   }
 
-  // Update the sample lists to accomodate multi-trainer / multi-model specification
+  // Update the sample lists to accomodate multi-trainer / multi-model
+  // specification
   customize_data_readers_sample_list(*comm, pb);
 
   // Initialize data readers
   //@todo: code not in place for correctly handling image preprocessing
-  std::map<execution_mode, generic_data_reader *> data_readers;
+  std::map<execution_mode, generic_data_reader*> data_readers;
   init_data_readers(comm, pb, data_readers);
 
   global_trainer_->setup(std::move(io_thread_pool), data_readers);
@@ -290,54 +296,54 @@ trainer& construct_trainer(lbann_comm* comm,
   }
 
   // Create sub-grids in block order
-  const int num_subgrids_block
-    = arg_parser.get<int>(LBANN_OPTION_NUM_SUBGRIDS_BLOCK_ORDER);
+  const int num_subgrids_block =
+    arg_parser.get<int>(LBANN_OPTION_NUM_SUBGRIDS_BLOCK_ORDER);
   if (num_subgrids_block > 0) {
 
     // Check sub-grid size
     const int trainer_size = comm->get_procs_per_trainer();
     const int subgrid_size = trainer_size / num_subgrids_block;
     if (trainer_size != subgrid_size * num_subgrids_block) {
-      LBANN_ERROR(
-        "attempted to divide a trainer grid with ",trainer_size," processes ",
-        "into ",num_subgrids_block," equally-sized sub-grids");
+      LBANN_ERROR("attempted to divide a trainer grid with ",
+                  trainer_size,
+                  " processes ",
+                  "into ",
+                  num_subgrids_block,
+                  " equally-sized sub-grids");
     }
 
     // Construct sub-grids
     std::vector<int> trainer_ranks(subgrid_size);
-    for (int root_rank=0; root_rank<trainer_size; root_rank+=subgrid_size) {
+    for (int root_rank = 0; root_rank < trainer_size;
+         root_rank += subgrid_size) {
       std::iota(trainer_ranks.begin(), trainer_ranks.end(), root_rank);
       El::mpi::Comm trainer_comm;
       El::mpi::Group trainer_group, subgrid_group;
       El::mpi::Dup(comm->get_trainer_comm(), trainer_comm);
       El::mpi::CommGroup(trainer_comm, trainer_group);
-      El::mpi::Incl(
-        trainer_group,
-        trainer_ranks.size(),
-        trainer_ranks.data(),
-        subgrid_group);
-      global_trainer_->add_grid(
-        make_unique<El::Grid>(
-          std::move(trainer_comm),
-          subgrid_group,
-          subgrid_size,
-          El::COLUMN_MAJOR));
+      El::mpi::Incl(trainer_group,
+                    trainer_ranks.size(),
+                    trainer_ranks.data(),
+                    subgrid_group);
+      global_trainer_->add_grid(make_unique<El::Grid>(std::move(trainer_comm),
+                                                      subgrid_group,
+                                                      subgrid_size,
+                                                      El::COLUMN_MAJOR));
       El::mpi::Free(trainer_group);
     }
-
   }
 
   // Report useful information
   if (comm->am_world_master()) {
-    print_lbann_configuration(comm,
-                              io_threads_per_process,
-                              io_threads_offset);
-    std::cout << "\n"
-              << global_trainer_->get_description()
-              << std::endl;
+    print_lbann_configuration(comm, io_threads_per_process, io_threads_offset);
+    std::cout << "\n" << global_trainer_->get_description() << std::endl;
 
     // User feedback
-    print_parameters(*comm, pb, root_random_seeds, random_seeds, data_seq_random_seeds);
+    print_parameters(*comm,
+                     pb,
+                     root_random_seeds,
+                     random_seeds,
+                     data_seq_random_seeds);
   }
 
   return *global_trainer_;

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -57,15 +57,26 @@ void construct_std_options()
     LBANN_OPTION_LOAD_MODEL_WEIGHTS_DIR_IS_COMPLETE,
     {"--load_model_weights_dir_is_complete"},
     "[STD] Use load_model_weights_dir as given, ignoring checkpoint hierarchy");
-  arg_parser.add_flag(LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS,
-                      {"--ltfb_allow_global_statistics"},
-                      utils::ENV("LBANN_LTFB_ALLOW_GLOBAL_STATISTICS"),
+  arg_parser.add_flag(
+    LBANN_OPTION_LTFB_ALLOW_GLOBAL_STATISTICS,
+    {"--ltfb_allow_global_statistics"},
+    utils::ENV("LBANN_LTFB_ALLOW_GLOBAL_STATISTICS"),
+    "[STD, deprecated] Allow the print_statistics callback to report "
+    "global (inter-trainer) summary statistics.");
+  arg_parser.add_flag(LBANN_OPTION_LTFB_VERBOSE,
+                      {"--ltfb_verbose"},
+                      utils::ENV("LBANN_LTFB_VERBOSE"),
+                      "[STD, deprecated] Increases number of per-trainer "
+                      "messages that are reported");
+  arg_parser.add_flag(LBANN_OPTION_ALLOW_MULTITRAINER_GLOBAL_STATISTICS,
+                      {"--ltfb_global_multitrainer_statistics"},
+                      utils::ENV("LBANN_ALLOW_MULTITRAINER_GLOBAL_STATISTICS"),
                       "[STD] Allow the print_statistics callback to report "
                       "global (inter-trainer) summary statistics.");
   arg_parser.add_flag(
-    LBANN_OPTION_LTFB_VERBOSE,
-    {"--ltfb_verbose"},
-    utils::ENV("LBANN_LTFB_VERBOSE"),
+    LBANN_OPTION_MULTITRAINER_VERBOSE,
+    {"--multitrainer_verbose"},
+    utils::ENV("LBANN_MULTITRAINER_VERBOSE"),
     "[STD] Increases number of per-trainer messages that are reported");
   arg_parser.add_flag(
     LBANN_OPTION_NO_IM_COMM,

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -65,6 +65,7 @@ void construct_std_options()
   arg_parser.add_flag(
     LBANN_OPTION_LTFB_VERBOSE,
     {"--ltfb_verbose"},
+    utils::ENV("LBANN_LTFB_VERBOSE"),
     "[STD] Increases number of per-trainer messages that are reported");
   arg_parser.add_flag(
     LBANN_OPTION_NO_IM_COMM,


### PR DESCRIPTION
Removed three global all gather collectives from LBANN's start up
unless LTFB global statistics and verbose reporting are on.  Also
limited the number of LTFB partner pairings that are reported unless
LTFB verbose reporting is enabled.