### PR TITLE
Fix buffer overflow in SMILES data reader

### DIFF
--- a/include/lbann/data_readers/data_reader_smiles.hpp
+++ b/include/lbann/data_readers/data_reader_smiles.hpp
@@ -44,7 +44,7 @@ namespace lbann {
 class smiles_data_reader : public data_reader_sample_list<sample_list_ifstream<long long>> {
 public:
   // Types for mapping a sample id to an <offset,length> locator
-  using offset_t = std::pair<long long, short>;
+  using offset_t = std::pair<long long, unsigned short>;
   using offset_map_t = std::unordered_map<size_t, offset_t>;
 
   smiles_data_reader(const bool shuffle);
@@ -79,7 +79,7 @@ public:
     const size_t index_in,
     std::string& filename_out,
     size_t& offset_out,
-    short& length_out) const;
+    unsigned short& length_out) const;
 
   /** This method is for use during testing and development.
    *  Returns the set of indices whose samples are cached in
@@ -90,7 +90,7 @@ public:
   /** This method made public for use during testing.
    *  Convert SMILES string to a vector of shorts
    */
-  bool encode_smiles(const char *smiles, short size, std::vector<unsigned short> &data);
+  bool encode_smiles(const char *smiles, unsigned short size, std::vector<unsigned short> &data);
   /** This method made public for use during testing.
    *  Convert SMILES string to a vector of shorts
    */
@@ -113,7 +113,7 @@ public:
    *  Insert an entry into a map: index -> (offset, length),
    *  where 'index' is an alias for an entry in the shuffled_indices
    */
-  void set_offset(size_t index, long long offset, short length);
+  void set_offset(size_t index, long long offset, unsigned short length);
 
   /** This method made public for use during testing. */
   void load_list_of_samples(const std::string sample_list_file);
@@ -136,17 +136,17 @@ private:
   int m_sequence_length = 0;
 
   const size_t OffsetBinarySize = sizeof(long long);
-  const size_t LengthBinarySize = sizeof(short);
+  const size_t LengthBinarySize = sizeof(unsigned short);
   const std::streamsize OffsetAndLengthBinarySize = OffsetBinarySize+LengthBinarySize;
 
   struct SampleData {
     SampleData() {}
-    SampleData(int idx, long long off, short len)
+    SampleData(int idx, long long off, unsigned short len)
       : index(idx),  offset(off), length(len) {
     }
     size_t index;
     long long offset;
-    short length;
+    unsigned short length;
   };
 
   int m_linearized_data_size = 0;

--- a/src/data_readers/data_reader_smiles.cpp
+++ b/src/data_readers/data_reader_smiles.cpp
@@ -178,7 +178,7 @@ void smiles_data_reader::do_preload_data_store() {
     const std::map<size_t, size_t>& local_to_index =  m_local_to_index[filename];
     size_t min_offset = std::numeric_limits<size_t>::max();
     size_t max_offset = 0;
-    short len_of_last_offset = 0;
+    size_t len_of_last_offset = 0;
 
     // Create local batches for fetching from a contiguous buffer
     std::map<size_t, size_t> samples_in_range;

--- a/src/data_readers/data_reader_smiles.cpp
+++ b/src/data_readers/data_reader_smiles.cpp
@@ -386,7 +386,7 @@ bool smiles_data_reader::encode_smiles(const std::string &smiles, std::vector<un
   return encode_smiles(smiles.data(), smiles.size(), data);
 }
 
-bool smiles_data_reader::encode_smiles(const char *smiles, short size, std::vector<unsigned short> &data) {
+bool smiles_data_reader::encode_smiles(const char *smiles, unsigned short size, std::vector<unsigned short> &data) {
   static int count = 0;
   bool found_all_characters_in_vocab = true;
 
@@ -582,7 +582,7 @@ void smiles_data_reader::read_offset_data(std::vector<SampleData> &data) {
   // Create a buffer for reading in each offsets file
   std::vector<char> iobuffer(buf_size);
   long long offset;
-  short length;
+  unsigned short length;
   for (size_t j=0; j<data_filenames.size(); j++) {
     if (m_filename_to_local_id_set.find(data_filenames[j]) != m_filename_to_local_id_set.end()) {
       std::ifstream in;
@@ -722,7 +722,7 @@ void smiles_data_reader::get_sample_origin(
     const size_t index_in,
     std::string& filename_out,
     size_t& offset_out,
-    short& length_out) const {
+    unsigned short& length_out) const {
 
   offset_map_t::const_iterator t2 = m_sample_offsets.find(index_in);
   if (t2 == m_sample_offsets.end()) {
@@ -738,7 +738,7 @@ void smiles_data_reader::get_sample_origin(
   filename_out = t3->second;
 }
 
-void smiles_data_reader::set_offset(size_t index, long long offset, short length) {
+void smiles_data_reader::set_offset(size_t index, long long offset, unsigned short length) {
   m_sample_offsets[index] = std::make_pair(offset, length);
 }
 


### PR DESCRIPTION
Fixed the len_of_last_offset field to use a size_t to avoid overflow,
which was triggering a bad allocation in the buffered SMILES data
reader.