### PR TITLE
Bugfix in Spack for compiler specification

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ pascal testing:
 pascal compiler testing:
   stage: run-all-clusters
   variables:
-    SPACK_SPECS: "%gcc@8.3.1 +cuda +half +fft"
+    SPACK_SPECS: "\%gcc@8.3.1 +cuda +half +fft"
     BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
   trigger:
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ stages:
 pascal compiler testing:
   stage: run-all-clusters
   variables:
-    SPACK_SPECS: "\\%gcc@8.3.1 +cuda +half +fft"
+    SPACK_SPECS: "\\%gcc\\@8.3.1 +cuda +half +fft"
     BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
   trigger:
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,6 +63,15 @@ pascal testing:
     strategy: depend
     include: .gitlab/pascal/pipeline.yml
 
+pascal testing (compilers):
+  stage: run-all-clusters
+  variables:
+    SPACK_SPECS: "%gcc@8.3.1 +cuda +half +fft"
+    BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
+  trigger:
+    strategy: depend
+    include: .gitlab/pascal/pipeline_compiler_tests.yml
+
 ray testing:
   stage: run-all-clusters
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ stages:
 pascal compiler testing:
   stage: run-all-clusters
   variables:
-    SPACK_SPECS: "\\%gcc\\@8.3.1 +cuda +half +fft"
+    SPACK_SPECS: "+cuda +half +fft"
     BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
   trigger:
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ stages:
 pascal compiler testing:
   stage: run-all-clusters
   variables:
-    SPACK_SPECS: "\%gcc@8.3.1 +cuda +half +fft"
+    SPACK_SPECS: "\\%gcc@8.3.1 +cuda +half +fft"
     BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
   trigger:
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,13 +31,13 @@
 stages:
   - run-all-clusters
 
-# catalyst testing:
-#   stage: run-all-clusters
-#   variables:
-#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-#   trigger:
-#     strategy: depend
-#     include: .gitlab/catalyst/pipeline.yml
+catalyst testing:
+  stage: run-all-clusters
+  variables:
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+  trigger:
+    strategy: depend
+    include: .gitlab/catalyst/pipeline.yml
 
 # corona testing:
 #   stage: run-all-clusters
@@ -47,21 +47,21 @@ stages:
 #     strategy: depend
 #     include: .gitlab/corona/pipeline.yml
 
-# lassen testing:
-#   stage: run-all-clusters
-#   variables:
-#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-#   trigger:
-#     strategy: depend
-#     include: .gitlab/lassen/pipeline.yml
+lassen testing:
+  stage: run-all-clusters
+  variables:
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+  trigger:
+    strategy: depend
+    include: .gitlab/lassen/pipeline.yml
 
-# pascal testing:
-#   stage: run-all-clusters
-#   variables:
-#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-#   trigger:
-#     strategy: depend
-#     include: .gitlab/pascal/pipeline.yml
+pascal testing:
+  stage: run-all-clusters
+  variables:
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+  trigger:
+    strategy: depend
+    include: .gitlab/pascal/pipeline.yml
 
 pascal compiler testing:
   stage: run-all-clusters
@@ -72,10 +72,10 @@ pascal compiler testing:
     strategy: depend
     include: .gitlab/pascal/pipeline_compiler_tests.yml
 
-# ray testing:
-#   stage: run-all-clusters
-#   variables:
-#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-#   trigger:
-#     strategy: depend
-#     include: .gitlab/ray/pipeline.yml
+ray testing:
+  stage: run-all-clusters
+  variables:
+    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+  trigger:
+    strategy: depend
+    include: .gitlab/ray/pipeline.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ pascal testing:
     strategy: depend
     include: .gitlab/pascal/pipeline.yml
 
-pascal testing (compilers):
+pascal compiler testing:
   stage: run-all-clusters
   variables:
     SPACK_SPECS: "%gcc@8.3.1 +cuda +half +fft"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,7 +67,7 @@ pascal compiler testing:
   stage: run-all-clusters
   variables:
     SPACK_SPECS: "%gcc@8.3.1 +cuda +half +fft"
-    BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
+    BUILD_SCRIPT_OPTIONS: "--no-default-mirrors"
   trigger:
     strategy: depend
     include: .gitlab/pascal/pipeline_compiler_tests.yml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ stages:
 pascal compiler testing:
   stage: run-all-clusters
   variables:
-    SPACK_SPECS: "+cuda +half +fft"
+    SPACK_SPECS: "%gcc@8.3.1 +cuda +half +fft"
     BUILD_SCRIPT_OPTIONS: "--no-default-mirror"
   trigger:
     strategy: depend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,13 +31,13 @@
 stages:
   - run-all-clusters
 
-catalyst testing:
-  stage: run-all-clusters
-  variables:
-    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-  trigger:
-    strategy: depend
-    include: .gitlab/catalyst/pipeline.yml
+# catalyst testing:
+#   stage: run-all-clusters
+#   variables:
+#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+#   trigger:
+#     strategy: depend
+#     include: .gitlab/catalyst/pipeline.yml
 
 # corona testing:
 #   stage: run-all-clusters
@@ -47,21 +47,21 @@ catalyst testing:
 #     strategy: depend
 #     include: .gitlab/corona/pipeline.yml
 
-lassen testing:
-  stage: run-all-clusters
-  variables:
-    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-  trigger:
-    strategy: depend
-    include: .gitlab/lassen/pipeline.yml
+# lassen testing:
+#   stage: run-all-clusters
+#   variables:
+#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+#   trigger:
+#     strategy: depend
+#     include: .gitlab/lassen/pipeline.yml
 
-pascal testing:
-  stage: run-all-clusters
-  variables:
-    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-  trigger:
-    strategy: depend
-    include: .gitlab/pascal/pipeline.yml
+# pascal testing:
+#   stage: run-all-clusters
+#   variables:
+#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+#   trigger:
+#     strategy: depend
+#     include: .gitlab/pascal/pipeline.yml
 
 pascal compiler testing:
   stage: run-all-clusters
@@ -72,10 +72,10 @@ pascal compiler testing:
     strategy: depend
     include: .gitlab/pascal/pipeline_compiler_tests.yml
 
-ray testing:
-  stage: run-all-clusters
-  variables:
-    WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
-  trigger:
-    strategy: depend
-    include: .gitlab/ray/pipeline.yml
+# ray testing:
+#   stage: run-all-clusters
+#   variables:
+#     WITH_WEEKLY: "${LBANN_CI_RUN_WEEKLY}"
+#   trigger:
+#     strategy: depend
+#     include: .gitlab/ray/pipeline.yml

--- a/.gitlab/pascal/pipeline_compiler_tests.yml
+++ b/.gitlab/pascal/pipeline_compiler_tests.yml
@@ -60,6 +60,7 @@ build and install:
       - spack-build-*/build.ninja
       - spack-build-*/spack-*.txt
       - ${RESULTS_DIR}/*
+      - build_script.bash
   script:
     - echo "== BUILDING LBANN =="
     - export JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")

--- a/.gitlab/pascal/pipeline_compiler_tests.yml
+++ b/.gitlab/pascal/pipeline_compiler_tests.yml
@@ -60,7 +60,6 @@ build and install:
       - spack-build-*/build.ninja
       - spack-build-*/spack-*.txt
       - ${RESULTS_DIR}/*
-      - build_script.bash
   script:
     - echo "== BUILDING LBANN =="
     - export JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
@@ -69,7 +68,7 @@ build and install:
     - srun --jobid=${JOB_ID} -N 1 -t 30 ./scripts/build_lbann.sh -d
       -l ${SPACK_ENV_NAME} --test --clean-build -j ${BUILD_TASKS}
       -e ./scripts/common_spack_packages/ci_spack_packages.sh
-      $(BUILD_SCRIPT_OPTIONS} -- 
+      ${BUILD_SCRIPT_OPTIONS} -- 
       +deterministic +vision +numpy ${SPACK_SPECS}
     - export TEST_TASKS_PER_NODE=2
     - export TEST_MPIBIND_FLAG="--mpibind=off"

--- a/.gitlab/pascal/pipeline_compiler_tests.yml
+++ b/.gitlab/pascal/pipeline_compiler_tests.yml
@@ -1,0 +1,160 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+
+# This is the testing pipeline for the Pascal cluster at LLNL. This
+# cluster builds the LBANN applications and libraries using a single
+# compiler toolchain and then runs a collection of tests. Testing
+# output is in JUnit format and parsed by the pipeline for web
+# viewing.
+
+# See the Catalyst pipeline for more thorough documentation.
+
+stages:
+  - allocate
+  - build
+  - test
+  - deallocate
+
+# Get LC resources.
+allocate lc resources:
+  stage: allocate
+  extends: .pascal common
+  variables:
+    GIT_STRATEGY: none
+  script:
+    - echo "== ACQUIRING SLURM RESOURCES =="
+    - salloc --exclusive -N 1 -p pbatch -t 45 --no-shell -J ${JOB_NAME}
+  timeout: 6h
+
+# Build LBANN and establish the Spack environment for this pipeline.
+build and install:
+  extends: .pascal common
+  stage: build
+  artifacts:
+    paths:
+      - spack-*.txt
+      - spack-build-*/CMakeCache.txt
+      - spack-build-*/build.ninja
+      - spack-build-*/spack-*.txt
+      - ${RESULTS_DIR}/*
+  script:
+    - echo "== BUILDING LBANN =="
+    - export JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
+    - export BUILD_TASKS=$(($(nproc) + 2))
+    - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
+    - srun --jobid=${JOB_ID} -N 1 -t 30 ./scripts/build_lbann.sh -d
+      -l ${SPACK_ENV_NAME} --test --clean-build -j ${BUILD_TASKS}
+      -e ./scripts/common_spack_packages/ci_spack_packages.sh
+      $(BUILD_SCRIPT_OPTIONS} -- 
+      +deterministic +vision +numpy ${SPACK_SPECS}
+    - export TEST_TASKS_PER_NODE=2
+    - export TEST_MPIBIND_FLAG="--mpibind=off"
+    - .gitlab/common/run-catch-tests.sh
+
+# This is a dummy job that checks the Catch2 testing.
+check catch2 tests:
+  extends:
+    - .pascal common
+  stage: test
+  dependencies:
+    - build and install
+  script:
+    - ([[ $(find ${RESULTS_DIR} -name "catch-tests-failed.txt" | wc -l) -eq 0 ]])
+  artifacts:
+    reports:
+      junit: ${RESULTS_DIR}/*.xml
+
+# Cleanup the pipeline's Spack environment.
+remove spack environment:
+  extends: .pascal common
+  stage: deallocate
+  variables:
+    GIT_STRATEGY: none
+  when: always
+  script:
+    - echo "== CLEANING UP SPACK RESOURCES =="
+    - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
+    - export SPACK_ARCH_TARGET=$(spack arch -t)
+    - export FULL_ENV_NAME=lbann-${SPACK_ENV_NAME}-${SPACK_ARCH_TARGET}
+    - |
+      if [[ -n "$(spack env list | grep -e ${FULL_ENV_NAME})" ]] ;
+      then
+        spack env rm --yes-to-all ${FULL_ENV_NAME}
+      fi
+
+# Free the allocation we obtained in "allocate lc resources".
+release allocation:
+  stage: deallocate
+  extends: .pascal common
+  variables:
+    GIT_STRATEGY: none
+  when: always
+  script:
+    - echo "== RELEASING RESOURCES =="
+    - export JOB_ID=$(squeue -h -n "${JOB_NAME}" -o "%A")
+    - ([[ -n "${JOB_ID}" ]] && scancel ${JOB_ID})
+
+# Load the spack shell integration and load the environment.
+.uses spack environment:
+  before_script:
+    - source ${HOME}/${SPACK_REPO}/share/spack/setup-env.sh
+    - export SPACK_ARCH=$(spack arch)
+    - export SPACK_ARCH_TARGET=$(spack arch -t)
+    - spack env activate lbann-${SPACK_ENV_NAME}-${SPACK_ARCH_TARGET}
+    - spack load lbann@${SPACK_ENV_NAME}-${SPACK_ARCH_TARGET} arch=${SPACK_ARCH}
+
+# Variables for Pascal.
+.pascal common:
+  variables:
+    # Just the obvious identifier. Which specific node doesn't matter.
+    SYSTEM_NAME: pascal
+    SPACK_REPO: spack_repos/spack_${SYSTEM_NAME}.git
+
+    # This is based on the assumption that each runner will only ever
+    # be able to run one pipeline on a given cluster at one time.
+    SPACK_ENV_NAME: gitlab-${CI_PIPELINE_ID}
+
+    # These are system-specific specs that should be forwarded to the
+    # build script
+    BUILD_SCRIPT_OPTIONS:
+    
+    # These are system-specific specs that should be forwarded to the
+    # build script
+    SPACK_SPECS: "+cuda +half +fft"
+
+    # This variable is the name used to identify the job in the Slurm
+    # queue. We need this to be able to access the correct jobid.
+    JOB_NAME: ${CI_PROJECT_NAME}_${CI_PIPELINE_ID}
+
+    # This is needed to ensure that we run as lbannusr.
+    LLNL_SERVICE_USER: lbannusr
+
+    # Catch2 output.
+    RESULTS_DIR: results-${CI_PIPELINE_ID}
+
+  tags:
+    - pascal
+    - shell

--- a/.gitlab/pascal/pipeline_compiler_tests.yml
+++ b/.gitlab/pascal/pipeline_compiler_tests.yml
@@ -139,11 +139,11 @@ release allocation:
 
     # These are system-specific specs that should be forwarded to the
     # build script
-    BUILD_SCRIPT_OPTIONS:
+#    BUILD_SCRIPT_OPTIONS: ""
     
     # These are system-specific specs that should be forwarded to the
     # build script
-    SPACK_SPECS: "+cuda +half +fft"
+#    SPACK_SPECS: "+cuda +half +fft"
 
     # This variable is the name used to identify the job in the Slurm
     # queue. We need this to be able to access the correct jobid.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@
 cmake_minimum_required(VERSION 3.21)
 cmake_policy(VERSION 3.21)
 
-project(LBANN CXX)
+project(LBANN C CXX)
 
 # Prevent in-source builds
 if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)

--- a/applications/ATOM/external_packages_atom.sh
+++ b/applications/ATOM/external_packages_atom.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Add packages used by the ATOM project
-spack add py-pandas
-spack add python@3.9.1:
-spack add py-torch@1.7.1 ${DEPENDENT_PACKAGES_GPU_VARIANTS}
-spack add py-scikit-learn
-spack add py-tqdm
-spack add py-nltk
-spack add rdkit
+spack add py-pandas ${CENTER_COMPILER}
+spack add python@3.9.1: ${CENTER_COMPILER}
+spack add py-torch@1.7.1 ${CENTER_COMPILER} ${DEPENDENT_PACKAGES_GPU_VARIANTS}
+spack add py-scikit-learn ${CENTER_COMPILER}
+spack add py-tqdm ${CENTER_COMPILER}
+spack add py-nltk ${CENTER_COMPILER}
+spack add rdkit ${CENTER_COMPILER}

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -498,7 +498,6 @@ if [[ "${CENTER_COMPILER}" =~ .*"%gcc".* ]]; then
     CENTER_LINKER_FLAGS="+gold"
 fi
 
-
 GPU_VARIANTS_ARRAY=('+cuda' '+rocm')
 DEPENDENT_PACKAGES_GPU_VARIANTS=
 for GPU_VARIANTS in ${GPU_VARIANTS_ARRAY[@]}
@@ -536,11 +535,22 @@ if [[ ! -n "${SKIP_MODULES:-}" ]]; then
     # Activate modules
     MODULE_CMD=
     set_center_specific_modules ${CENTER} ${SPACK_ARCH_TARGET}
+    if [[ "${CENTER_COMPILER}" =~ .*"%clang".* && -n "${MODULE_CMD_CLANG}" && -z "${MODULE_CMD}" ]]; then
+        # If the compiler is clang use the specificed set of modules
+        MODULE_CMD=${MODULE_CMD_CLANG}
+    fi
+
+    if [[ "${CENTER_COMPILER}" =~ .*"%gcc".* && -n "${MODULE_CMD_GCC}" && -z "${MODULE_CMD}" ]]; then
+        # If the compiler is gcc use the specificed set of modules
+        MODULE_CMD=${MODULE_CMD_GCC}
+    fi
+
     if [[ -n ${MODULE_CMD} ]]; then
         echo ${MODULE_CMD} | tee -a ${LOG}
         [[ -z "${DRY_RUN:-}" ]] && { eval ${MODULE_CMD} || exit_on_failure "${MODULE_CMD}"; }
     fi
 fi
+
 
 # If the dependencies are being installed then you should clean things up
 if [[ -n "${INSTALL_DEPS:-}" ]]; then

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -70,6 +70,7 @@ Options:
   ${C}-l | --label <LABEL>${N}       LBANN version label prefix: (default label is local-<SPACK_ARCH_TARGET>,
                              and is built and installed in the spack environment lbann-<label>-<SPACK_ARCH_TARGET>
   ${C}-m | --mirror <PATH>${N}       Specify a Spack mirror (and buildcache)
+  ${C}--no-default-mirrors>${N}      Disable the default set of mirrors
   ${C}--no-modules${N}               Don't try to load any modules (use the existing users environment)
   ${C}-p | --pkg <PACKAGE>${N}       Add package PACKAGE to the Spack environment in addition to LBANN (Flag can be repeated)
   ${C}--pip <requirements.txt>${N}   PIP install Python packages in requirements.txt with the version of Python used by LBANN (Flag can be repeated)
@@ -152,6 +153,9 @@ while :; do
                 echo "\"${1}\" option requires a non-empty option argument" >&2
                 exit 1
             fi
+            ;;
+        --no-default-mirrors)
+            SKIP_MIRRORS="TRUE"
             ;;
         --no-modules)
             SKIP_MODULES="TRUE"
@@ -296,6 +300,7 @@ if [ -n "${SPACK_ROOT}" ]; then
     else
         echo "ERROR: Spack needs at least commit ${MIN_SPACK_COMMIT}."
         echo "ERROR: Please update spack."
+        exit 1
     fi
     popd
 else

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -281,10 +281,23 @@ function uninstall_specific_versions()
     fi
 }
 
+# This should be a commit hash (NOT a tag) that needs to exist in the
+# spack repository that is checked out. It's a minimum version, so
+# more commits is fine.
+MIN_SPACK_COMMIT=c06f69d0bffad688f668db41cb6acad894a745ac
+
 # "spack" is just a shell function; it may not be exported to this
 # scope. Just to be sure, reload the shell integration.
 if [ -n "${SPACK_ROOT}" ]; then
-    source ${SPACK_ROOT}/share/spack/setup-env.sh
+    pushd ${SPACK_ROOT}
+    if git merge-base --is-ancestor ${MIN_SPACK_COMMIT} HEAD &> /dev/null;
+    then
+        source ${SPACK_ROOT}/share/spack/setup-env.sh
+    else
+        echo "ERROR: Spack needs at least commit ${MIN_SPACK_COMMIT}."
+        echo "ERROR: Please update spack."
+    fi
+    popd
 else
     echo "Spack required.  Please set SPACK_ROOT environment variable"
     exit 1

--- a/scripts/common_spack_packages/aux_tools_spack_packages.sh
+++ b/scripts/common_spack_packages/aux_tools_spack_packages.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 # Add Python packages used by the LBANN auxiliary tools
-spack add py-configparser
-spack add py-graphviz@0.10.1:
-spack add py-matplotlib@3.0.0:
-spack add py-numpy@1.16.0:
-spack add py-onnx@1.3.0:
-spack add py-pandas@0.24.1:
-spack add py-texttable@1.4.0:
+spack add py-configparser ${CENTER_COMPILER}
+spack add py-graphviz@0.10.1: ${CENTER_COMPILER}
+spack add py-matplotlib@3.0.0: ${CENTER_COMPILER}
+spack add py-numpy@1.16.0: ${CENTER_COMPILER}
+spack add py-onnx@1.3.0: ${CENTER_COMPILER}
+spack add py-pandas@0.24.1: ${CENTER_COMPILER}
+spack add py-texttable@1.4.0: ${CENTER_COMPILER}

--- a/scripts/common_spack_packages/ci_spack_packages.sh
+++ b/scripts/common_spack_packages/ci_spack_packages.sh
@@ -3,7 +3,7 @@
 # Add packages used by the LBANN CI and applications
 # Note that py-numpy@1.16.0: is explicitly added by the build_lbann.sh
 # script when the lbann+python variant is enabled
-spack add python
-spack add py-pytest
-spack add py-scipy
-spack add py-tqdm
+spack add python ${CENTER_COMPILER}
+spack add py-pytest ${CENTER_COMPILER}
+spack add py-scipy ${CENTER_COMPILER}
+spack add py-tqdm ${CENTER_COMPILER}

--- a/scripts/common_spack_packages/docs_spack_packages.sh
+++ b/scripts/common_spack_packages/docs_spack_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Add packages used by the LBANN documentation
-spack add py-breathe
-spack add py-sphinx-rtd-theme
-spack add doxygen
-spack add py-m2r
+spack add py-breathe ${CENTER_COMPILER}
+spack add py-sphinx-rtd-theme ${CENTER_COMPILER}
+spack add doxygen ${CENTER_COMPILER}
+spack add py-m2r ${CENTER_COMPILER}

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -104,7 +104,8 @@ set_center_specific_modules()
                 # MODULE_CMD="module --force unload StdEnv; module load clang/12.0.1 cuda/11.1.1 spectrum-mpi/rolling-release python/3.7.2 essl/6.2.1"
                 ;;
             "broadwell" | "haswell" | "sandybridge") # Pascal, RZHasGPU, Surface
-                MODULE_CMD="module --force unload StdEnv; module load clang/12.0.1 cuda/11.4.1 mvapich2/2.3.6 python/3.7.2"
+                MODULE_CMD_GCC="module --force unload StdEnv; module load gcc/8.3.1 cuda/11.4.1 mvapich2/2.3 python/3.7.2"
+                MODULE_CMD_CLANG="module --force unload StdEnv; module load clang/12.0.1 cuda/11.4.1 mvapich2/2.3.6 python/3.7.2"
                 ;;
             "ivybridge" | "cascadelake") # Catalyst, Ruby
                 MODULE_CMD="module --force unload StdEnv; module load gcc/10.2.1 mvapich2/2.3 python/3.7.2"

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -158,13 +158,15 @@ set_center_specific_spack_dependencies()
     local spack_arch_target="$2"
 
     if [[ ${center} = "llnl_lc" ]]; then
-        POSSIBLE_MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
-        for m in ${POSSIBLE_MIRRORS}
-        do
-            if [[ -r "${m}" ]]; then
-                MIRRORS="${m} $MIRRORS"
-            fi
-        done
+        if [[ -z "${SKIP_MIRRORS:-}" ]]; then
+            POSSIBLE_MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
+            for m in ${POSSIBLE_MIRRORS}
+            do
+                if [[ -r "${m}" ]]; then
+                    MIRRORS="${m} $MIRRORS"
+                fi
+            done
+        fi
         # MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
         case ${spack_arch_target} in
             "power9le") # Lassen

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -106,7 +106,7 @@ set_center_specific_modules()
             "broadwell" | "haswell" | "sandybridge") # Pascal, RZHasGPU, Surface
                 MODULE_CMD="module --force unload StdEnv; module load clang/12.0.1 cuda/11.4.1 mvapich2/2.3.6 python/3.7.2"
                 ;;
-            "ivybridge") # Catalyst
+            "ivybridge" | "cascadelake") # Catalyst, Ruby
                 MODULE_CMD="module --force unload StdEnv; module load gcc/10.2.1 mvapich2/2.3 python/3.7.2"
                 ;;
             "zen" | "zen2") # Corona
@@ -167,35 +167,35 @@ set_center_specific_spack_dependencies()
         # MIRRORS="/p/vast1/lbann/spack/mirror /p/vast1/atom/spack/mirror"
         case ${spack_arch_target} in
             "power9le") # Lassen
+                CENTER_COMPILER="%gcc"
                 CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105 ^libtool@2.4.2 ^python@3.9.10"
-                CENTER_FLAGS="+gold"
                 CENTER_BLAS_LIBRARY="blas=openblas"
-                # CENTER_DEPENDENCIES="%clang ^spectrum-mpi ^cuda@11.1.105 ^libtool@2.4.2 ^python@3.9.10"
-                # CENTER_FLAGS="+lld"
+                # CENTER_COMPILER="%clang"
+                # CENTER_DEPENDENCIES="^spectrum-mpi ^cuda@11.1.105 ^libtool@2.4.2 ^python@3.9.10"
                 # CENTER_BLAS_LIBRARY="blas=essl"
                 ;;
             "power8le") # Ray
+                CENTER_COMPILER="%gcc"
                 CENTER_DEPENDENCIES="^spectrum-mpi ^openblas@0.3.12 threads=openmp ^cuda@11.1.105 ^libtool@2.4.2 ^python@3.9.10"
-                CENTER_FLAGS="+gold"
                 CENTER_BLAS_LIBRARY="blas=openblas"
+                # CENTER_COMPILER="%clang"
                 # CENTER_DEPENDENCIES="%clang ^spectrum-mpi ^cuda@11.1.105 ^libtool@2.4.2 ^py-packaging@17.1 ^python@3.9.10 ^py-scipy@1.6.3"
-                # CENTER_FLAGS="+lld"
                 # CENTER_BLAS_LIBRARY="blas=essl"
                 ;;
             "broadwell" | "haswell" | "sandybridge") # Pascal, RZHasGPU, Surface
                 # On LC the mvapich2 being used is built against HWLOC v1
-               CENTER_DEPENDENCIES="%clang ^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10"
-               CENTER_FLAGS="+lld"
+                CENTER_COMPILER="%clang"
+                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10"
                 ;;
-            "ivybridge") # Catalyst
+            "ivybridge" | "cascadelake") # Catalyst, Ruby
                 # On LC the mvapich2 being used is built against HWLOC v1
-               CENTER_DEPENDENCIES="%gcc ^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10"
-               CENTER_FLAGS="+gold"
+                CENTER_COMPILER="%gcc"
+                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10"
                 ;;
             "zen" | "zen2") # Corona
                 # On LC the mvapich2 being used is built against HWLOC v1
+                CENTER_COMPILER="%clang"
                 CENTER_DEPENDENCIES="^openmpi ^hwloc@2.3.0"
-                CENTER_FLAGS="+lld"
                 ;;
             *)
                 echo "No center-specified CENTER_DEPENDENCIES for ${spack_arch_target} at ${center}."
@@ -216,7 +216,8 @@ set_center_specific_spack_dependencies()
                 CENTER_DEPENDENCIES="^openmpi"
                 ;;
             "zen3") # Perlmutter
-                CENTER_DEPENDENCIES="%cce@13.0.0 ^mpich@8.1.12 ^python@3.9.4 ^cuda+allow-unsupported-compilers"
+                CENTER_COMPILER="%cce@13.0.0"
+                CENTER_DEPENDENCIES="^mpich@8.1.12 ^python@3.9.4 ^cuda+allow-unsupported-compilers"
                 CENTER_BLAS_LIBRARY="blas=libsci"
                 ;;
             *)


### PR DESCRIPTION
Separated out the spack compiler flag from the rest of the variants
and dependent packages.  This ensures that the compiler is propagated
to the top level LBANN package as well as any co-concretized
packages. Pulled out the high speed linker into a conditional block to
make sure it is only set if the compiler is compatible.  Added the
option to override the compiler from the command line.

Added a spack variant of the host architecture to make sure that spack
builds for the intended system and not some other microarchitecture.