### PR TITLE
Move LC paths in PFE

### DIFF
--- a/python/lbann/contrib/lc/paths.py
+++ b/python/lbann/contrib/lc/paths.py
@@ -13,7 +13,7 @@ def parallel_file_system_path(system = system()):
     elif system == 'ray':
         return '/p/gscratchr/'
     else:
-        return '/p/lustre2/'
+        return '/p/vast1/'
 
 def mnist_dir(system = system()):
     """MNIST directory on LC system.
@@ -24,11 +24,11 @@ def mnist_dir(system = system()):
     from http://yann.lecun.com/exdb/mnist/ and uncompressing.
 
     """
-    return parallel_file_system_path(system) + 'brainusr/datasets/MNIST'
+    return parallel_file_system_path(system) + 'lbann/datasets/MNIST'
 
 def cifar10_dir(system = system()):
     """CIFAR10 directory on LC systems."""
-    return parallel_file_system_path(system) + 'brainusr/datasets/cifar10-bin'
+    return parallel_file_system_path(system) + 'lbann/datasets/cifar10-bin'
 
 def imagenet_dir(system = system(), data_set = 'training',
                  num_classes = 1000):
@@ -50,7 +50,7 @@ def imagenet_dir(system = system(), data_set = 'training',
 
     """
     base_path = parallel_file_system_path(system)
-    base_path += 'brainusr/datasets/ILSVRC2012/original/'
+    base_path += 'lbann/datasets/ILSVRC2012/'
     if data_set.lower() in ('train', 'training'):
         return base_path + 'train/'
     elif data_set.lower() in ('val', 'validation'):
@@ -81,9 +81,9 @@ def imagenet_labels(system = system(), data_set = 'train',
     """
     label_dir = parallel_file_system_path(system)
     if system in ('lassen', 'sierra'):
-        label_dir += 'brainusr/datasets/ILSVRC2012/original/labels/'
+        label_dir += 'lbann/datasets/ILSVRC2012/labels/'
     else:
-        label_dir += 'brainusr/datasets/ILSVRC2012/labels/'
+        label_dir += 'lbann/datasets/ILSVRC2012/labels/'
     suffixes = {1000: '', 10: '_c0-9', 100: '_c0-99',
                 200: '_c100-299', 300: '_c0-299'}
     if data_set.lower() in ('train', 'training'):
@@ -128,9 +128,9 @@ def imagenet_sample_list(system = system(), data_set = 'train',
     """
     slist_dir = parallel_file_system_path(system)
     if system in ('lassen', 'sierra'):
-        slist_dir += 'brainusr/datasets/ILSVRC2012/sample_list/'
+        slist_dir += 'lbann/datasets/ILSVRC2012/sample_list/'
     else:
-        slist_dir += 'brainusr/datasets/ILSVRC2012/sample_list/'
+        slist_dir += 'lbann/datasets/ILSVRC2012/sample_list/'
     suffixes = {1000: '', 10: '_c0-9', 100: '_c0-99',
                 200: '_c100-299', 300: '_c0-299'}
     if data_set.lower() in ('train', 'training'):

--- a/python/lbann/contrib/lc/paths.py
+++ b/python/lbann/contrib/lc/paths.py
@@ -24,11 +24,11 @@ def mnist_dir(system = system()):
     from http://yann.lecun.com/exdb/mnist/ and uncompressing.
 
     """
-    return parallel_file_system_path(system) + 'lbann/datasets/MNIST'
+    return parallel_file_system_path(system) + 'lbann/datasets/mnist'
 
 def cifar10_dir(system = system()):
     """CIFAR10 directory on LC systems."""
-    return parallel_file_system_path(system) + 'lbann/datasets/cifar10-bin'
+    return parallel_file_system_path(system) + 'lbann/datasets/cifar10'
 
 def imagenet_dir(system = system(), data_set = 'training',
                  num_classes = 1000):


### PR DESCRIPTION
Previous paths required a user to be in the `brain` group in order to access `/p/lustre2/brainusr`. With these changes I was able to run `lbann/applications/vision/resnet.py` without having been added to the brain group.