### PR TITLE
Allow Catch2 version 3 to be used in addition to version 2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,12 +554,20 @@ if (LBANN_WITH_ONNX)
 endif ()
 
 if (LBANN_WITH_UNIT_TESTING)
-  find_package(Catch2 2.0.0 CONFIG REQUIRED)
+  # LBANN allows for Catch2 v2.* or v3.*
+    find_package(Catch2 3.0.0 CONFIG QUIET)
+  if (NOT Catch2_FOUND)
+    find_package(Catch2 2.0.0 CONFIG REQUIRED)
+    set(LBANN_USE_CATCH2_V3 FALSE)
+  else ()
+    set(LBANN_USE_CATCH2_V3 TRUE)
+  endif ()
+  message(STATUS "Found Catch2: Version ${Catch2_VERSION}")
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "ROCMClang")
     set_target_properties(Catch2::Catch2
       PROPERTIES INTERFACE_COMPILE_FEATURES "cxx_std_17")
-  endif()
+  endif ()
 
   # Now that Catch2 has been found, start adding the unit tests
   include(CTest)

--- a/data_utils/hdf5/CMakeLists.txt
+++ b/data_utils/hdf5/CMakeLists.txt
@@ -19,14 +19,20 @@ install(TARGETS generate_schema_and_sample_list
 
 # Testing
 if (LBANN_WITH_UNIT_TESTING)
-  add_executable(helpers_tests test_main.cpp test_helpers.cpp helpers.cpp)
+  add_executable(helpers_tests
+    $<$<NOT:$<BOOL:${LBANN_USE_CATCH2_V3}>>:test_main.cpp>
+    test_helpers.cpp
+    helpers.cpp)
   set_target_properties(helpers_tests
     PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/unit_test)
   target_link_libraries(helpers_tests
     PRIVATE
     conduit::conduit
-    Catch2::Catch2)
+    $<IF:$<BOOL:${LBANN_USE_CATCH2_V3}>,Catch2::Catch2WithMain,Catch2::Catch2>)
+  if (LBANN_USE_CATCH2_V3)
+    target_compile_definitions(helpers_tests PRIVATE LBANN_USE_CATCH2_V3)
+  endif ()
   if ("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     target_compile_features(helpers_tests PRIVATE cxx_std_17)
   else ()

--- a/data_utils/hdf5/test_helpers.cpp
+++ b/data_utils/hdf5/test_helpers.cpp
@@ -1,4 +1,34 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifdef LBANN_USE_CATCH2_V3
+#include <catch2/catch_all.hpp>
+#else
 #include <catch2/catch.hpp>
+#endif // LBANN_USE_CATCH2_V3
+
 #include <conduit/conduit_error.hpp>
 #include <regex>
 

--- a/data_utils/hdf5/test_main.cpp
+++ b/data_utils/hdf5/test_main.cpp
@@ -1,2 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+// ONLY COMPILED WHEN CATCH IS V2.*
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>

--- a/src/callbacks/unit_test/print_statistics_test.cpp
+++ b/src/callbacks/unit_test/print_statistics_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/data_coordinator/unit_test/data_coordinator_HDF5_hrrl_public_api.cpp
+++ b/src/data_coordinator/unit_test/data_coordinator_HDF5_hrrl_public_api.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_HDF5_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/data_readers/unit_test/data_reader_smiles_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 

--- a/src/data_readers/unit_test/data_reader_synthetic_test.cpp
+++ b/src/data_readers/unit_test/data_reader_synthetic_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"

--- a/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
+++ b/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
+++ b/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
@@ -23,11 +23,12 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
+#include "Catch2BasicSupport.hpp"
+
 #include "lbann/execution_algorithms/sgd_training_algorithm.hpp"
 #include "lbann/execution_algorithms/training_algorithm.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/make_abstract.hpp"
-#include <catch2/catch.hpp>
 
 #include <exception>
 #include <google/protobuf/stubs/logging.h>
@@ -38,6 +39,13 @@
 #include <google/protobuf/text_format.h>
 
 namespace pb = ::google::protobuf;
+
+#ifdef LBANN_USE_CATCH2_V3
+static Catch::Matchers::StringContainsMatcher Contains(std::string const& str)
+{
+  return Catch::Matchers::ContainsSubstring(str, Catch::CaseSensitive::Yes);
+}
+#endif // LBANN_USE_CATCH2_V3
 
 TEST_CASE("Parsing training algorithm prototext", "[factory][algorithm][proto]")
 {
@@ -153,6 +161,6 @@ TEST_CASE("Building training algorithm from the factory",
 
     REQUIRE_THROWS_WITH(
       lbann::make_abstract<lbann::TrainingAlgorithm>(algo_msg),
-      Catch::Contains("Unknown id \"TerminationCriteria\" detected"));
+      Contains("Unknown id \"TerminationCriteria\" detected"));
   }
 }

--- a/src/layers/activations/unit_test/identity_test.cpp
+++ b/src/layers/activations/unit_test/identity_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/layers/learning/unit_test/convolution_test.cpp
+++ b/src/layers/learning/unit_test/convolution_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/layers/regularizers/unit_test/batch_normalization_test.cpp
+++ b/src/layers/regularizers/unit_test/batch_normalization_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/layers/transform/unit_test/cutensor_permute_test.cpp
+++ b/src/layers/transform/unit_test/cutensor_permute_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "../permute/cutensor_permuteimpl.hpp"
 #include "lbann/utils/dim_helpers.hpp"

--- a/src/layers/transform/unit_test/cutt_permute_test.cpp
+++ b/src/layers/transform/unit_test/cutt_permute_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "../permute/cutt_permuteimpl.hpp"
 #include "lbann/utils/dim_helpers.hpp"

--- a/src/layers/transform/unit_test/permute_layer_test.cpp
+++ b/src/layers/transform/unit_test/permute_layer_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/layers/transform/unit_test/tensor_dims_utils_test.cpp
+++ b/src/layers/transform/unit_test/tensor_dims_utils_test.cpp
@@ -25,11 +25,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <algorithm>
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "../permute/tensor_dims_utils.hpp"
 
+#include <algorithm>
 #include <sstream>
 
 template <typename T>

--- a/src/layers/unit_test/operator_layer_test.cpp
+++ b/src/layers/unit_test/operator_layer_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/base.hpp"
 #include "lbann/layers/data_type_layer.hpp"

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/models/unit_test/modify_test.cpp
+++ b/src/models/unit_test/modify_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/operators/math/unit_test/abs_test.cpp
+++ b/src/operators/math/unit_test/abs_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/add_constant_test.cpp
+++ b/src/operators/math/unit_test/add_constant_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/add_test.cpp
+++ b/src/operators/math/unit_test/add_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/clamp_test.cpp
+++ b/src/operators/math/unit_test/clamp_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/constant_subtract_test.cpp
+++ b/src/operators/math/unit_test/constant_subtract_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/cos_test.cpp
+++ b/src/operators/math/unit_test/cos_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/equal_constant_test.cpp
+++ b/src/operators/math/unit_test/equal_constant_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/multiply_test.cpp
+++ b/src/operators/math/unit_test/multiply_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/not_equal_constant_test.cpp
+++ b/src/operators/math/unit_test/not_equal_constant_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/scale_test.cpp
+++ b/src/operators/math/unit_test/scale_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/sin_test.cpp
+++ b/src/operators/math/unit_test/sin_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/subtract_constant_test.cpp
+++ b/src/operators/math/unit_test/subtract_constant_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/operators/math/unit_test/subtract_test.cpp
+++ b/src/operators/math/unit_test/subtract_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Testing framework stuff
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "MatrixHelpers.hpp"

--- a/src/optimizers/unit_test/test_adagrad.cpp
+++ b/src/optimizers/unit_test/test_adagrad.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/optimizers/adagrad.hpp>
 
 #include "optimizer_common.hpp"

--- a/src/optimizers/unit_test/test_adam.cpp
+++ b/src/optimizers/unit_test/test_adam.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/optimizers/adam.hpp>
 
 #include "optimizer_common.hpp"

--- a/src/optimizers/unit_test/test_hypergradient_adam.cpp
+++ b/src/optimizers/unit_test/test_hypergradient_adam.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/optimizers/hypergradient_adam.hpp>
 
 #include "optimizer_common.hpp"

--- a/src/optimizers/unit_test/test_rmsprop.cpp
+++ b/src/optimizers/unit_test/test_rmsprop.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/optimizers/rmsprop.hpp>
 
 #include "optimizer_common.hpp"

--- a/src/optimizers/unit_test/test_sgd.cpp
+++ b/src/optimizers/unit_test/test_sgd.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // Must include this for all the Catch2 machinery
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // Some common infrastructure for testing optimizers
 #include "optimizer_common.hpp"

--- a/src/proto/unit_test/parse_list_test.cpp
+++ b/src/proto/unit_test/parse_list_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/base.hpp>
 #include <lbann/proto/proto_common.hpp>

--- a/src/proto/unit_test/parse_set_test.cpp
+++ b/src/proto/unit_test/parse_set_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/base.hpp>
 #include <lbann/proto/proto_common.hpp>

--- a/src/proto/unit_test/trim_test.cpp
+++ b/src/proto/unit_test/trim_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/proto/proto_common.hpp>
 

--- a/src/transforms/unit_test/normalize_test.cpp
+++ b/src/transforms/unit_test/normalize_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/normalize.hpp>

--- a/src/transforms/unit_test/sample_normalize_test.cpp
+++ b/src/transforms/unit_test/sample_normalize_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/sample_normalize.hpp>

--- a/src/transforms/unit_test/scale_test.cpp
+++ b/src/transforms/unit_test/scale_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/scale.hpp>

--- a/src/transforms/unit_test/transform_pipeline_test.cpp
+++ b/src/transforms/unit_test/transform_pipeline_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/transform_pipeline.hpp>

--- a/src/transforms/vision/unit_test/center_crop_test.cpp
+++ b/src/transforms/vision/unit_test/center_crop_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/center_crop.hpp>

--- a/src/transforms/vision/unit_test/colorize_test.cpp
+++ b/src/transforms/vision/unit_test/colorize_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/colorize.hpp>

--- a/src/transforms/vision/unit_test/grayscale_test.cpp
+++ b/src/transforms/vision/unit_test/grayscale_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/grayscale.hpp>

--- a/src/transforms/vision/unit_test/horizontal_flip_test.cpp
+++ b/src/transforms/vision/unit_test/horizontal_flip_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/horizontal_flip.hpp>

--- a/src/transforms/vision/unit_test/random_affine_test.cpp
+++ b/src/transforms/vision/unit_test/random_affine_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/random_affine.hpp>

--- a/src/transforms/vision/unit_test/random_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_crop_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/random_crop.hpp>

--- a/src/transforms/vision/unit_test/random_resized_crop_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/random_resized_crop.hpp>

--- a/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
+++ b/src/transforms/vision/unit_test/random_resized_crop_with_fixed_aspect_ratio_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.hpp>

--- a/src/transforms/vision/unit_test/resize_test.cpp
+++ b/src/transforms/vision/unit_test/resize_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/resize.hpp>

--- a/src/transforms/vision/unit_test/resized_center_crop_test.cpp
+++ b/src/transforms/vision/unit_test/resized_center_crop_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/resized_center_crop.hpp>

--- a/src/transforms/vision/unit_test/to_lbann_layout_test.cpp
+++ b/src/transforms/vision/unit_test/to_lbann_layout_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/to_lbann_layout.hpp>

--- a/src/transforms/vision/unit_test/transform_pipeline_test.cpp
+++ b/src/transforms/vision/unit_test/transform_pipeline_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/transform_pipeline.hpp>

--- a/src/transforms/vision/unit_test/vertical_flip_test.cpp
+++ b/src/transforms/vision/unit_test/vertical_flip_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/transforms/vision/vertical_flip.hpp>

--- a/src/utils/unit_test/argument_parser_test.cpp
+++ b/src/utils/unit_test/argument_parser_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/utils/argument_parser.hpp"
 

--- a/src/utils/unit_test/beta_distribution_test.cpp
+++ b/src/utils/unit_test/beta_distribution_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/beta.hpp>

--- a/src/utils/unit_test/cloneable_test.cpp
+++ b/src/utils/unit_test/cloneable_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include "TestHelpers.hpp"
 #include "lbann/utils/cloneable.hpp"
 #include <memory>

--- a/src/utils/unit_test/cufft_test.cpp
+++ b/src/utils/unit_test/cufft_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/base.hpp>
 #include <lbann/utils/exception.hpp>

--- a/src/utils/unit_test/dim_helpers_test.cpp
+++ b/src/utils/unit_test/dim_helpers_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/utils/dim_helpers.hpp>
 

--- a/src/utils/unit_test/dnn_lib_test.cpp
+++ b/src/utils/unit_test/dnn_lib_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/utils/dnn_enums.hpp>
 #include <lbann/utils/dnn_lib/helpers.hpp>

--- a/src/utils/unit_test/environment_variable_test.cpp
+++ b/src/utils/unit_test/environment_variable_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/utils/environment_variable.hpp"
 

--- a/src/utils/unit_test/factory_test.cpp
+++ b/src/utils/unit_test/factory_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // Be sure to include this!
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // The code being tested
 #include <lbann/utils/factory.hpp>

--- a/src/utils/unit_test/fftw_test.cpp
+++ b/src/utils/unit_test/fftw_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/base.hpp>
 #include <lbann/utils/exception.hpp>

--- a/src/utils/unit_test/file_utils_test.cpp
+++ b/src/utils/unit_test/file_utils_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/file_utils.hpp>

--- a/src/utils/unit_test/from_string_test.cpp
+++ b/src/utils/unit_test/from_string_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/from_string.hpp>

--- a/src/utils/unit_test/hash_test.cpp
+++ b/src/utils/unit_test/hash_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/hash.hpp>

--- a/src/utils/unit_test/image_test.cpp
+++ b/src/utils/unit_test/image_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/image.hpp>

--- a/src/utils/unit_test/onednn_infrastructure_test.cpp
+++ b/src/utils/unit_test/onednn_infrastructure_test.cpp
@@ -25,7 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/utils/dnn_lib/onednn.hpp>
 

--- a/src/utils/unit_test/onnx_utils_test.cpp
+++ b/src/utils/unit_test/onnx_utils_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 #include "TestHelpers.hpp"

--- a/src/utils/unit_test/output_helpers_test.cpp
+++ b/src/utils/unit_test/output_helpers_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/utils/output_helpers.hpp>
 

--- a/src/utils/unit_test/protobuf_utils_test.cpp
+++ b/src/utils/unit_test/protobuf_utils_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/utils/protobuf/decl.hpp"
@@ -59,6 +59,13 @@ static_assert(lbann::protobuf::details::PBCppType<lbann_testing::SimpleMesg> ==
 static_assert(lbann::protobuf::details::PBCppType<lbann_testing::MyEnum> ==
               google::protobuf::FieldDescriptor::CPPTYPE_ENUM);
 
+#ifdef LBANN_USE_CATCH2_V3
+static Catch::Matchers::StringContainsMatcher Contains(std::string const& str)
+{
+  return Catch::Matchers::ContainsSubstring(str, Catch::CaseSensitive::Yes);
+}
+#endif // LBANN_USE_CATCH2_V3
+
 TEST_CASE("Basic utilities", "[protobuf][utils]")
 {
   lbann_testing::SimpleMesg msg;
@@ -89,17 +96,17 @@ another_field: false
   CHECK(lbann::protobuf::which_oneof(msg, "my_oneof") == "my_uint64");
   CHECK_THROWS_WITH(
     lbann::protobuf::get_oneof_message(msg, "my_oneof"),
-    Catch::Contains("Oneof \"my_oneof\" has field \"my_uint64\" set but it is "
-                    "not of message type."));
+    Contains("Oneof \"my_oneof\" has field \"my_uint64\" set but it is "
+             "not of message type."));
 
   CHECK_NOTHROW(lbann::protobuf::text::fill(msg_NO_ONEOF_str, msg));
   CHECK_THROWS_WITH(
     lbann::protobuf::which_oneof(msg, "my_oneof"),
-    Catch::Contains("Oneof field \"my_oneof\" in message has not been set."));
+    Contains("Oneof field \"my_oneof\" in message has not been set."));
 
   CHECK_THROWS_WITH(
     lbann::protobuf::get_oneof_message(msg, "my_oneof"),
-    Catch::Contains("Oneof field \"my_oneof\" in message has not been set."));
+    Contains("Oneof field \"my_oneof\" in message has not been set."));
 }
 
 TEST_CASE("Complex oneof manipulation", "[protobuf][utils]")
@@ -161,7 +168,7 @@ my_enums: TWO
   {
     CHECK_THROWS_WITH(
       lbann::protobuf::as_vector<lbann::protobuf::uint64>(msg, "my_int64s"),
-      Catch::Contains("Field has incompatible type"));
+      Contains("Field has incompatible type"));
   }
 
   SECTION("As vector - static field")

--- a/src/utils/unit_test/python_test.cpp
+++ b/src/utils/unit_test/python_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/python.hpp>

--- a/src/utils/unit_test/random_fill_test.cpp
+++ b/src/utils/unit_test/random_fill_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/base.hpp>
 #include <lbann/utils/random.hpp>
 #include <h2/patterns/multimethods/SwitchDispatcher.hpp>

--- a/src/utils/unit_test/random_test.cpp
+++ b/src/utils/unit_test/random_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/random.hpp>

--- a/src/utils/unit_test/rooted_archive_test.cpp
+++ b/src/utils/unit_test/rooted_archive_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 

--- a/src/utils/unit_test/serialize_distmatrix_test.cpp
+++ b/src/utils/unit_test/serialize_distmatrix_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/base.hpp>
 
 #include <lbann/utils/serialize.hpp>

--- a/src/utils/unit_test/serialize_enum_test.cpp
+++ b/src/utils/unit_test/serialize_enum_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/src/utils/unit_test/serialize_half_test.cpp
+++ b/src/utils/unit_test/serialize_half_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include <lbann/base.hpp> // half stuff is here.
 #include <lbann/utils/serialize.hpp>

--- a/src/utils/unit_test/serialize_matrix_test.cpp
+++ b/src/utils/unit_test/serialize_matrix_test.cpp
@@ -23,7 +23,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 #include <lbann/base.hpp>
 #include <lbann/utils/serialize.hpp>
 #include <h2/patterns/multimethods/SwitchDispatcher.hpp>

--- a/src/utils/unit_test/statistics_test.cpp
+++ b/src/utils/unit_test/statistics_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/utils/running_statistics.hpp"
 

--- a/src/utils/unit_test/timer_test.cpp
+++ b/src/utils/unit_test/timer_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "lbann/utils/accumulating_timer.hpp"
 #include "lbann/utils/argument_parser.hpp"

--- a/src/utils/unit_test/type_erased_matrix_test.cpp
+++ b/src/utils/unit_test/type_erased_matrix_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 // MUST include this
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 // File being tested
 #include <lbann/utils/type_erased_matrix.hpp>

--- a/src/weights/unit_test/weights_proxy_test.cpp
+++ b/src/weights/unit_test/weights_proxy_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "MPITestHelpers.hpp"
 

--- a/src/weights/unit_test/weights_test.cpp
+++ b/src/weights/unit_test/weights_test.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include "Catch2BasicSupport.hpp"
 
 #include "TestHelpers.hpp"
 #include "MPITestHelpers.hpp"

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -24,7 +24,13 @@ add_subdirectory(example)
 add_executable(mpi-catch-tests
   MPICatchMain.cpp "${LBANN_MPI_CATCH2_TEST_FILES}")
 target_link_libraries(mpi-catch-tests
-  PRIVATE unit_test_utilities lbann Catch2::Catch2)
-
+  PRIVATE
+  unit_test_utilities
+  lbann
+  Catch2::Catch2)
+if (LBANN_USE_CATCH2_V3)
+  target_compile_definitions(seq-catch-tests PRIVATE LBANN_USE_CATCH2_V3)
+  target_compile_definitions(mpi-catch-tests PRIVATE LBANN_USE_CATCH2_V3)
+endif ()
 # TODO: Some "magical" way to automatically run tests if a parallel
 # environment is detected at CTest time

--- a/unit_test/MPICatchMain.cpp
+++ b/unit_test/MPICatchMain.cpp
@@ -24,8 +24,16 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef LBANN_USE_CATCH2_V3
+#include <catch2/catch_session.hpp>
+#include <catch2/internal/catch_clara.hpp>
+using Catch::Clara::Opt;
+#else
+// VERSION 2 ONLY
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+using Catch::clara::Opt;
+#endif // LBANN_USE_CATCH2_V3
 
 // Utilities
 #include "MPITestHelpers.hpp"
@@ -57,7 +65,7 @@ int main(int argc, char* argv[])
 
   int hang_rank = -1;
   auto cli =
-    session.cli() | Catch::clara::Opt(hang_rank, "Rank to hang")["--hang-rank"](
+    session.cli() | Opt(hang_rank, "Rank to hang")["--hang-rank"](
                       "Hang this rank to attach a debugger.");
   session.cli(cli);
 
@@ -90,7 +98,11 @@ int main(int argc, char* argv[])
 
   // Manipulate output file if needed.
   auto& config_data = session.configData();
+#ifdef LBANN_USE_CATCH2_V3
+  auto& output_file = config_data.defaultOutputFilename;
+#else
   auto& output_file = config_data.outputFilename;
+#endif
   if (output_file.size() > 0) {
     lbann::utils::SystemInfo sys_info;
     output_file = replace_escapes(output_file, sys_info);

--- a/unit_test/SequentialCatchMain.cpp
+++ b/unit_test/SequentialCatchMain.cpp
@@ -24,8 +24,14 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
+#ifdef LBANN_USE_CATCH2_V3
+#include <catch2/catch_session.hpp>
+#else
+// VERSION 2 ONLY
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>
+#endif // LBANN_USE_CATCH2_V3
+
 #include <lbann/utils/dnn_lib/helpers.hpp>
 #include <lbann/utils/options.hpp>
 #include <lbann/utils/random_number_generators.hpp>

--- a/unit_test/utilities/CMakeLists.txt
+++ b/unit_test/utilities/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Add the library
 add_library(unit_test_utilities
+  # Catch2 version abstraction
+  Catch2BasicSupport.hpp
+
   # Headers
   MPITestHelpers.hpp
   ReplaceEscapes.hpp

--- a/unit_test/utilities/Catch2BasicSupport.hpp
+++ b/unit_test/utilities/Catch2BasicSupport.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 // the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -23,36 +23,29 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UNIT_TEST_UTILITIES_CATCH2BASICSUPPORT_HPP_INCLUDED
+#define LBANN_UNIT_TEST_UTILITIES_CATCH2BASICSUPPORT_HPP_INCLUDED
 
-#include <Catch2BasicSupport.hpp>
+/** @file
+ *
+ *  This header is used to allow easy compile-time switching between
+ *  Catch2 v2.* and v3.*.
+ *
+ *  The v3 support includes the basic test macros and all of the
+ *  matchers and generators, as well as the Approx class.. Additional
+ *  components may be added piecemeal by the tests that require them
+ *  checking if the LBANN_USE_CATCH2_V3 preprocessing macro is
+ *  defined.
+ */
 
-#include <lbann/comm_impl.hpp>
-
-#include "MPITestHelpers.hpp"
-
-TEST_CASE("Example: test of Broadcast", "[mpi][example]")
-{
-  auto& world_comm = unit_test::utilities::current_world_comm();
-  int rank_in_world = world_comm.get_rank_in_world();
-
-  SECTION("Scalar broadcast")
-  {
-    int value = (rank_in_world == 0 ? 13 : -1);
-    world_comm.world_broadcast(0, value);
-
-    REQUIRE(value == 13);
-  }
-
-  SECTION("Vector broadcast")
-  {
-    std::vector<float> true_values = {1.f, 2.f, 3.f, 4.f};
-    std::vector<float> values =
-      (rank_in_world == 0
-       ? true_values
-       : std::vector<float>(4, -1.f));
-
-    world_comm.world_broadcast(0, values.data(), values.size());
-
-    REQUIRE(values == true_values);
-  }
-}
+#ifdef LBANN_USE_CATCH2_V3
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_all.hpp>
+using Catch::Approx;
+#else
+#include <catch2/catch.hpp>
+#endif // LBANN_USE_CATCH2_V3
+#endif // LBANN_UNIT_TEST_UTILITIES_CATCH2BASICSUPPORT_HPP_INCLUDED

--- a/unit_test/utilities/unit_test/test_replace_escapes.cpp
+++ b/unit_test/utilities/unit_test/test_replace_escapes.cpp
@@ -24,7 +24,7 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <catch2/catch.hpp>
+#include <Catch2BasicSupport.hpp>
 
 #include "ReplaceEscapes.hpp"
 


### PR DESCRIPTION
This will hold us over for a transition period. I'd like to get to Catch2 v3 in general, though, as it's better factored. (I can do that now, but I know @bvanessen just put work in to make sure we only use Catch2 v2...)