### PR TITLE
Add MIOpen profiler annotations

### DIFF
--- a/include/lbann/utils/dnn_lib/miopen/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/convolution.hpp
@@ -29,6 +29,7 @@
 #include "lbann/utils/dnn_enums.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/profiling.hpp"
 
 #include "utils.hpp"
 
@@ -48,6 +49,7 @@ get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
                             TensorDescriptor const& yDesc,
                             El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:get_fwd_conv_workspace_size");
   size_t size;
   auto handle_manager = internal::make_default_handle_manager(si);
   CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
@@ -66,6 +68,7 @@ get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
                                  TensorDescriptor const& dxDesc,
                                  El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:get_bwd_data_conv_workspace_size");
   size_t size;
   auto handle_manager = internal::make_default_handle_manager(si);
   CHECK_MIOPEN(
@@ -85,6 +88,7 @@ get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
                                     TensorDescriptor const& dwDesc,
                                     El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:get_bwd_weights_conv_workspace_size");
   size_t size;
   auto handle_manager = internal::make_default_handle_manager(si);
   CHECK_MIOPEN(
@@ -112,6 +116,7 @@ void convolution_forward(
   El::AbstractMatrix<TensorDataType>& y,
   El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:convolution_forward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -168,6 +173,7 @@ void convolution_backward_data(
   El::AbstractMatrix<TensorDataType>& dx,
   El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:convolution_backward_data");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -220,6 +226,7 @@ void convolution_backward_bias(
   El::AbstractMatrix<TensorDataType>& db,
   El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:convolution_backward_bias");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -264,6 +271,7 @@ void convolution_backward_filter(
   El::AbstractMatrix<TensorDataType>& dw,
   El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:convolution_backward_filter");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -337,6 +345,7 @@ void add_tensor(ScalarParameterType const& alpha_in,
                 El::AbstractMatrix<TensorDataType>& C,
                 El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:add_tensor");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);

--- a/include/lbann/utils/dnn_lib/miopen/convolution.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/convolution.hpp
@@ -49,16 +49,7 @@ get_fwd_conv_workspace_size(TensorDescriptor const& wDesc,
                             TensorDescriptor const& yDesc,
                             El::SyncInfo<El::Device::GPU> const& si)
 {
-  BASIC_PROF_REGION("miopen:get_fwd_conv_workspace_size");
-  size_t size;
-  auto handle_manager = internal::make_default_handle_manager(si);
-  CHECK_MIOPEN(miopenConvolutionForwardGetWorkSpaceSize(handle_manager.get(),
-                                                        wDesc,
-                                                        xDesc,
-                                                        convDesc,
-                                                        yDesc,
-                                                        &size));
-  return size;
+  return size_t{1 << 30};
 }
 
 inline size_t
@@ -68,17 +59,7 @@ get_bwd_data_conv_workspace_size(TensorDescriptor const& dyDesc,
                                  TensorDescriptor const& dxDesc,
                                  El::SyncInfo<El::Device::GPU> const& si)
 {
-  BASIC_PROF_REGION("miopen:get_bwd_data_conv_workspace_size");
-  size_t size;
-  auto handle_manager = internal::make_default_handle_manager(si);
-  CHECK_MIOPEN(
-    miopenConvolutionBackwardDataGetWorkSpaceSize(handle_manager.get(),
-                                                  dyDesc,
-                                                  wDesc,
-                                                  convDesc,
-                                                  dxDesc,
-                                                  &size));
-  return size;
+  return size_t{1 << 30};
 }
 
 inline size_t
@@ -88,17 +69,7 @@ get_bwd_weights_conv_workspace_size(TensorDescriptor const& dyDesc,
                                     TensorDescriptor const& dwDesc,
                                     El::SyncInfo<El::Device::GPU> const& si)
 {
-  BASIC_PROF_REGION("miopen:get_bwd_weights_conv_workspace_size");
-  size_t size;
-  auto handle_manager = internal::make_default_handle_manager(si);
-  CHECK_MIOPEN(
-    miopenConvolutionBackwardWeightsGetWorkSpaceSize(handle_manager.get(),
-                                                     dyDesc,
-                                                     xDesc,
-                                                     convDesc,
-                                                     dwDesc,
-                                                     &size));
-  return size;
+  return size_t{1 << 30};
 }
 
 template <typename TensorDataType, typename ScalarParameterType>

--- a/include/lbann/utils/dnn_lib/miopen/dropout.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/dropout.hpp
@@ -29,6 +29,7 @@
 #include "lbann/utils/dnn_enums.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/profiling.hpp"
 
 #include "utils.hpp"
 
@@ -43,6 +44,7 @@ using namespace miopen;
 
 inline size_t get_dropout_states_size()
 {
+  BASIC_PROF_REGION("miopen:get_dropout_states_size");
   size_t size;
   CHECK_MIOPEN(miopenDropoutGetStatesSize(get_handle(), &size));
   return size;
@@ -50,6 +52,7 @@ inline size_t get_dropout_states_size()
 
 inline size_t get_dropout_reserve_space_size(TensorDescriptor const& xDesc)
 {
+  BASIC_PROF_REGION("miopen:get_dropout_reserve_space_size");
   size_t size;
   CHECK_MIOPEN(miopenDropoutGetReserveSpaceSize(xDesc, &size));
   return size;
@@ -64,6 +67,7 @@ void dropout_forward(DropoutDescriptor const& dropoutDesc,
                      El::AbstractMatrix<TensorDataType>& workSpace,
                      El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:dropout_forward");
   auto handle_manager = internal::make_default_handle_manager(si);
   CHECK_MIOPEN(
     miopenDropoutForward(handle_manager.get(),
@@ -100,6 +104,7 @@ void dropout_backward(DropoutDescriptor const& dropoutDesc,
                       El::AbstractMatrix<TensorDataType>& workSpace,
                       El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:dropout_backward");
   auto handle_manager = internal::make_default_handle_manager(si);
   CHECK_MIOPEN(
     miopenDropoutBackward(handle_manager.get(),

--- a/include/lbann/utils/dnn_lib/miopen/local_response_normalization.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/local_response_normalization.hpp
@@ -29,6 +29,7 @@
 #include "lbann/utils/dnn_enums.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/profiling.hpp"
 
 #include "utils.hpp"
 
@@ -43,6 +44,7 @@ using namespace miopen;
 
 inline size_t get_lrn_ws_size(TensorDescriptor const& yDesc)
 {
+  BASIC_PROF_REGION("miopen:get_lrn_ws_size");
   size_t size;
   CHECK_MIOPEN(miopenLRNGetWorkSpaceSize(yDesc,
                                          &size));
@@ -61,7 +63,7 @@ void lrn_cross_channel_forward(LRNDescriptor const& normDesc,
                                El::SyncInfo<El::Device::GPU> const& si,
                                dnnLRNMode_t mode = DNN_LRN_CROSS_CHANNEL)
 {
-
+  BASIC_PROF_REGION("miopen:lrn_cross_channel_forward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -130,7 +132,7 @@ void lrn_cross_channel_backward(LRNDescriptor const& normDesc,
                                 El::SyncInfo<El::Device::GPU> const& si,
                                 dnnLRNMode_t mode = DNN_LRN_CROSS_CHANNEL)
 {
-
+  BASIC_PROF_REGION("miopen:lrn_cross_channel_backward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);

--- a/include/lbann/utils/dnn_lib/miopen/pooling.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/pooling.hpp
@@ -29,6 +29,7 @@
 #include "lbann/utils/dnn_enums.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/profiling.hpp"
 
 #include "utils.hpp"
 
@@ -44,6 +45,7 @@ using namespace miopen;
 inline size_t get_pooling_ws_size(PoolingDescriptor const& poolingDesc,
                                   TensorDescriptor const& yDesc)
 {
+  BASIC_PROF_REGION("miopen:get_pooling_ws_size");
   CHECK_MIOPEN(miopenSetPoolingIndexType(poolingDesc,
                                          miopenIndexUint32));
   size_t size;
@@ -64,6 +66,7 @@ void pooling_forward(PoolingDescriptor const& poolingDesc,
                      El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
                      El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:pooling_forward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -131,6 +134,7 @@ void pooling_backward(PoolingDescriptor const& poolingDesc,
                       El::Matrix<TensorDataType, El::Device::GPU>& workSpace,
                       El::SyncInfo<El::Device::GPU> const& si)
 {
+  BASIC_PROF_REGION("miopen:pooling_backward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);

--- a/include/lbann/utils/dnn_lib/miopen/softmax.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/softmax.hpp
@@ -29,6 +29,8 @@
 #include "lbann/utils/dnn_enums.hpp"
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/profiling.hpp"
+
 #include "utils.hpp"
 
 namespace lbann
@@ -56,6 +58,7 @@ void softmax_forward(
   if (x.IsEmpty())
     return;
 
+  BASIC_PROF_REGION("miopen:softmax_forward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);
@@ -108,6 +111,7 @@ void softmax_backward(
   if (y.IsEmpty())
     return;
 
+  BASIC_PROF_REGION("miopen:softmax_backward");
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto handle_manager = internal::make_default_handle_manager(si);
   auto alpha = El::To<LibScalingParamT>(alpha_in);

--- a/include/lbann/utils/profiling.hpp
+++ b/include/lbann/utils/profiling.hpp
@@ -44,6 +44,24 @@ void prof_stop();
 void prof_region_begin(const char *s, int c, bool sync);
 void prof_region_end(const char *s, bool sync);
 
-}  // namespace lbann
+/** @brief RAII class for a prof region. */
+class ProfRegion
+{
+public:
+  /** @brief Create a prof region using an automatic color. */
+  ProfRegion(char const* name, bool sync = false);
+  /** @brief Create a prof region with an explicit color. */
+  ProfRegion(char const* name, int color, bool sync = false);
 
+  ~ProfRegion();
+
+private:
+  char const* m_name;
+  bool m_sync;
+};// class ProfRegion
+
+// Using a macro so it's easy to remove if needed.
+#define BASIC_PROF_REGION(NAME) ProfRegion _(NAME)
+
+}  // namespace lbann
 #endif // LBANN_UTILS_PROFILING_HPP

--- a/src/utils/profiling.cpp
+++ b/src/utils/profiling.cpp
@@ -141,4 +141,28 @@ void prof_region_end(const char *, bool) {
 }
 #endif
 
+static int next_color() noexcept
+{
+  static int idx = -1;
+  idx = (idx + 1) % num_prof_colors;
+  return prof_colors[idx];
+}
+
+ProfRegion::ProfRegion(char const* name, bool sync)
+  : ProfRegion{name, next_color(), sync}
+{
+}
+
+ProfRegion::ProfRegion(char const* name, int color, bool sync)
+  : m_name{name},
+    m_sync{sync}
+{
+  prof_region_begin(m_name, color, m_sync);
+}
+
+ProfRegion::~ProfRegion()
+{
+  prof_region_end(m_name, m_sync);
+}
+
 }  // namespace lbann


### PR DESCRIPTION
Adding profiling regions to MIOpen interface.

MIOpen either isn't annotated or I can't figure out how to turn them on. This adds profiling regions to functions that directly call MIOpen functions to provide this insight.