### PR TITLE
Enforce consistent GPU targets in spack environment

### DIFF
--- a/applications/ATOM/external_packages_atom.sh
+++ b/applications/ATOM/external_packages_atom.sh
@@ -3,9 +3,8 @@
 # Add packages used by the ATOM project
 spack add py-pandas ${CENTER_COMPILER}
 spack add python@3.9.1: ${CENTER_COMPILER}
-spack add py-torch@1.7.1 ${CENTER_COMPILER} ${DEPENDENT_PACKAGES_GPU_VARIANTS}
+spack add py-torch@1.7.1: ${CENTER_COMPILER} ${DEPENDENT_PACKAGES_GPU_VARIANTS}
 spack add py-scikit-learn ${CENTER_COMPILER}
-spack add py-scipy@1.3.3 ${CENTER_COMPILER}
 spack add py-tqdm ${CENTER_COMPILER}
 spack add py-nltk ${CENTER_COMPILER}
 spack add rdkit ${CENTER_COMPILER}

--- a/applications/ATOM/external_packages_atom.sh
+++ b/applications/ATOM/external_packages_atom.sh
@@ -5,6 +5,7 @@ spack add py-pandas ${CENTER_COMPILER}
 spack add python@3.9.1: ${CENTER_COMPILER}
 spack add py-torch@1.7.1 ${CENTER_COMPILER} ${DEPENDENT_PACKAGES_GPU_VARIANTS}
 spack add py-scikit-learn ${CENTER_COMPILER}
+spack add py-scipy@1.3.3 ${CENTER_COMPILER}
 spack add py-tqdm ${CENTER_COMPILER}
 spack add py-nltk ${CENTER_COMPILER}
 spack add rdkit ${CENTER_COMPILER}

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -188,7 +188,7 @@ while :; do
         -s|--stable-defaults)
             # Use the latest released version
             HYDROGEN_VER=
-            ALUMINUM_VER=
+            ALUMINUM_VER="@1.0.0-lbann"
             DIHYDROGEN_VER=
             ;;
         --test)
@@ -638,6 +638,11 @@ if [[ -n "${INSTALL_DEPS:-}" ]]; then
     CMD="set_center_specific_externals ${CENTER} ${SPACK_ARCH_TARGET} ${SPACK_ARCH} ${SPACK_ENV_YAML_FILE}"
     echo ${CMD} | tee -a ${LOG}
     [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+
+    # Force the environment to concretize with the same set of GPU variants
+    CMD="spack config add packages:all:variants:'${DEPENDENT_PACKAGES_GPU_VARIANTS}'"
+    echo ${CMD} | tee -a ${LOG}
+    [[ -z "${DRY_RUN:-}" ]] && { `spack config add packages:all:variants:"${DEPENDENT_PACKAGES_GPU_VARIANTS}"` || exit_on_failure "${CMD}"; }
 
     CMD="spack compiler find --scope env:${LBANN_ENV}"
     echo ${CMD} | tee -a ${LOG}


### PR DESCRIPTION
There is a poor behavior in Spack environments where PyTorch is
concretizing some of its dependents with different GPU architectures
than what LBANN and the rest of the environment are using.  This
forces all packages in the environment to use a common set of GPU
architecture variants.

Also add the Aluminum v1.0.0-lbann as the stable default version.