### PR TITLE
Add image layer for cutout operation.

### DIFF
--- a/include/lbann/layers/image/CMakeLists.txt
+++ b/include/lbann/layers/image/CMakeLists.txt
@@ -28,6 +28,7 @@ set_full_path(THIS_DIR_HEADERS
   bilinear_resize.hpp
   rotation.hpp
   composite_image_transformation.hpp
+  cutout.hpp
   )
 
 # Propagate the files up the tree

--- a/include/lbann/layers/image/cutout.hpp
+++ b/include/lbann/layers/image/cutout.hpp
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef LBANN_LAYERS_IMAGE_CUTOUT_HPP_INCLUDED
+#define LBANN_LAYERS_IMAGE_CUTOUT_HPP_INCLUDED
+
+#include "lbann/layers/data_type_layer.hpp"
+#include "lbann/layers/layer.hpp"
+
+namespace lbann {
+
+/** @brief Cutout a square from an image
+ *
+ *  Expects two inputs: a 3D image tensor in CHW format and a scalar
+ *  length of the cutout square.
+ */
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+class cutout_layer : public data_type_layer<TensorDataType> {
+  static_assert(Layout == data_layout::DATA_PARALLEL,
+                "cutout_layer only supports DATA_PARALLEL");
+  static_assert(Device == El::Device::CPU,
+                "cutou_layer only supports CPU");
+public:
+  /** @name Public Types */
+  ///@{
+
+  /** @brief The tensor type expected in this object. */
+  using AbsDistMatrixType = El::AbstractDistMatrix<TensorDataType>;
+
+  ///@}
+
+
+public:
+
+  cutout_layer(lbann_comm *comm)
+    : data_type_layer<TensorDataType>(comm) {
+		 this->m_expected_num_parent_layers = 2;
+  }
+
+  cutout_layer* copy() const override {
+    return new cutout_layer(*this);
+  }
+
+  /** @name Serialization */
+  ///@{
+
+  template <typename ArchiveT>
+  void serialize(ArchiveT& ar);
+
+  ///@}
+
+  std::string get_type() const override { return "cutout"; }
+  data_layout get_data_layout() const override { return Layout; }
+  El::Device get_device_allocation() const override { return Device; }
+
+  void fp_compute() override;
+
+protected:
+
+  friend class cereal::access;
+  cutout_layer()
+    : cutout_layer(nullptr)
+  {}
+
+  void setup_dims(DataReaderMetaData& dr_metadata) override {
+    data_type_layer<TensorDataType>::setup_dims(dr_metadata);
+
+    // Get input dimensions
+    auto dims = this->get_input_dims(0);
+    const auto& cutout_length = this->get_input_dims(1);
+
+    // Check that dimensions are valid
+    if (dims.size() != 3) {
+      std::ostringstream ss;
+      for (size_t i = 0; i < dims.size(); ++i) {
+        ss << (i > 0 ? " x " : "") << dims[i];
+      }
+      LBANN_ERROR(this->get_type()," layer \"",this->get_name(),"\" ",
+        "expects a 3D input in CHW format, ",
+        "but input dimensions are ",ss.str());
+    }
+    if (cutout_length.size() > 1 || cutout_length[0] != 1) {
+      std::ostringstream ss;
+      for (size_t i = 0; i < cutout_length.size(); ++i) {
+        ss << (i > 0 ? " x " : "") << cutout_length[i];
+      }
+      LBANN_ERROR(
+        this->get_type()," layer \"",this->get_name(),"\" ",
+        "expects a scalar input for the cutout length, ",
+        "but input dimensions are ",ss.str());
+    }
+  }
+};
+
+#ifndef LBANN_CUTOUT_LAYER_INSTANTIATE
+#define PROTO(T) \
+  extern template class cutout_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>
+
+#include "lbann/macros/instantiate.hpp"
+#undef PROTO
+#endif // LBANN_CUTOUT_LAYER_INSTANTIATE
+
+} // namespace lbann
+
+#endif // LBANN_LAYERS_IMAGE_CUTOUT_HPP_INCLUDED

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -444,6 +444,7 @@ CEREAL_FORCE_DYNAMIC_INIT(convolution_layer);
 CEREAL_FORCE_DYNAMIC_INIT(covariance_layer);
 CEREAL_FORCE_DYNAMIC_INIT(crop_layer);
 CEREAL_FORCE_DYNAMIC_INIT(cross_entropy_layer);
+CEREAL_FORCE_DYNAMIC_INIT(cutout_layer);
 CEREAL_FORCE_DYNAMIC_INIT(deconvolution_layer);
 CEREAL_FORCE_DYNAMIC_INIT(discrete_random_layer);
 CEREAL_FORCE_DYNAMIC_INIT(dropout_layer);

--- a/src/layers/image/CMakeLists.txt
+++ b/src/layers/image/CMakeLists.txt
@@ -28,6 +28,7 @@ set_full_path(THIS_DIR_SOURCES
   bilinear_resize.cpp
   rotation.cpp
   composite_image_transformation.cpp
+  cutout.cpp
 
   image_layer_builders.cpp
 )

--- a/src/layers/image/cereal_registration/CMakeLists.txt
+++ b/src/layers/image/cereal_registration/CMakeLists.txt
@@ -28,6 +28,7 @@ set_full_path(THIS_DIR_SOURCES
   bilinear_resize.cpp
   rotation.cpp
   composite_image_transformation.cpp
+  cutout.cpp
   )
 
 # Propagate the files up the tree

--- a/src/layers/image/cereal_registration/cutout.cpp
+++ b/src/layers/image/cereal_registration/cutout.cpp
@@ -23,17 +23,23 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
-#ifndef LBANN_LAYERS_IMAGE_IMAGE_LAYER_BUILDERS_HPP_INCLUDED
-#define LBANN_LAYERS_IMAGE_IMAGE_LAYER_BUILDERS_HPP_INCLUDED
-
-#include "lbann/layers/layer.hpp"
+#include "lbann/utils/serialize.hpp"
+#include <lbann/layers/image/cutout.hpp>
 
 namespace lbann {
 
-LBANN_DEFINE_LAYER_BUILDER(bilinear_resize);
-LBANN_DEFINE_LAYER_BUILDER(composite_image_transformation);
-LBANN_DEFINE_LAYER_BUILDER(rotation);
-LBANN_DEFINE_LAYER_BUILDER(cutout);
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+template <typename ArchiveT>
+void
+cutout_layer<TensorDataType,Layout,Device>
+::serialize(ArchiveT& ar)
+{
+  using DataTypeLayer = data_type_layer<TensorDataType>;
+  ar(::cereal::make_nvp("DataTypeLayer",
+                        ::cereal::base_class<DataTypeLayer>(this)));
+}
 
 } // namespace lbann
-#endif // LBANN_LAYERS_IMAGE_IMAGE_LAYER_BUILDERS_HPP_INCLUDED
+
+#define LBANN_LAYER_NAME cutout_layer
+#include <lbann/macros/register_layer_with_cereal_data_parallel_cpu_only.hpp>

--- a/src/layers/image/cutout.cpp
+++ b/src/layers/image/cutout.cpp
@@ -1,0 +1,109 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#define LBANN_CUTOUT_LAYER_INSTANTIATE
+#include "lbann/layers/image/cutout.hpp"
+
+#include <math.h>
+#include <algorithm>
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout Layout, El::Device Device>
+void cutout_layer<TensorDataType, Layout, Device>::fp_compute() {
+
+  // Useful constants
+  constexpr DataType zero = 0;
+  constexpr DataType one = 1;
+
+  // Input and output tensors
+  const auto& local_input = this->get_local_prev_activations();
+  auto& local_output = this->get_local_activations();
+
+  // Tensor dimensions
+  const auto& input_dims = this->get_input_dims(0);
+  const auto& num_samples = local_input.Width();
+  const El::Int num_channels = input_dims[0];
+  const El::Int input_height = input_dims[1];
+  const El::Int input_width = input_dims[2];
+
+  // Get cutout length
+  const auto& cutouts = this->get_local_prev_activations(1);
+
+  // RNG
+  std::random_device rd;  
+  std::mt19937 gen(rd());
+  std::uniform_real_distribution<DataType> uni(zero,one);
+
+  const El::Int col_center = uni(gen)*input_width;
+  const El::Int row_center = uni(gen)*input_height;
+
+  // Perform cutout
+  LBANN_OMP_PARALLEL_FOR_COLLAPSE4
+  for (El::Int sample = 0; sample < num_samples; ++sample) {
+    for (El::Int channel = 0; channel < num_channels; ++channel) {
+      for (El::Int output_row = 0; output_row < input_height; ++output_row) {
+        for (El::Int output_col = 0; output_col < input_width; ++output_col) {
+
+          const auto& cutout = cutouts.Get(0,sample);
+
+          const El::Int col_start = std::max(static_cast<El::Int>(col_center - cutout / 2), El::Int(0));
+          const El::Int col_end = std::min(static_cast<El::Int>(col_start + cutout), input_width-1);
+
+          const El::Int row_start = std::max(static_cast<El::Int>(row_center - cutout / 2), El::Int(0));
+          const El::Int row_end = std::min(static_cast<El::Int>(row_start + cutout), input_height-1);
+
+          // Find input pixels
+          const auto input_col = output_col;
+          const auto input_row = output_row;
+
+          // Input and output pixels
+          auto& pixel_output = local_output(channel * input_height * input_width
+                                                + input_row * input_width
+                                                + input_col,
+                                                sample);
+
+	  if((input_col >= col_start && input_col < col_end) && (input_row >= row_start && input_row < row_end)){
+          	pixel_output = zero; 
+	  }
+	  else{
+          	pixel_output = local_input(channel * input_height * input_width
+                                                + input_row * input_width
+                                                + input_col,
+                                                sample);
+	  }
+        }
+      }
+    }
+  }
+}
+
+#define PROTO(T) \
+  template class cutout_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>
+
+#include "lbann/macros/instantiate.hpp"
+
+} // namespace lbann

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -194,6 +194,7 @@ private:
     LBANN_REGISTER_BUILDER(CompositeImageTransformation,
                            composite_image_transformation);
     LBANN_REGISTER_BUILDER(Rotation, rotation);
+    LBANN_REGISTER_BUILDER(Cutout, cutout);
 
     // Miscellaneous layers
     LBANN_REGISTER_BUILDER(Argmax, argmax);

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -216,6 +216,7 @@ message Layer {
     BilinearResize bilinear_resize = 200;
     Rotation rotation = 201;
     CompositeImageTransformation composite_image_transformation = 202;
+    Cutout cutout = 203;
 
     // Miscellaneous layers
     Covariance covariance = 300;
@@ -1343,6 +1344,13 @@ message Layer {
    *  for (X,Y) translate.
    */
   message CompositeImageTransformation {}
+
+  /** @brief Cutout a random square from an image
+   *
+   *  Expects two inputs: a 3D image tensor in CHW format and a scalar
+   *  length of the cutout square.
+   */
+  message Cutout {}
 
   // ---------------------------
   // Miscellaneous layers


### PR DESCRIPTION
The cutout layer applies a fixed-size zero mask to a random location of each input image.
The cutout layer selects a pixel coordinate within the image as a center point and then places the cutout mask around that location.
The cutout layer only has one square patch as the cutout region.