### PR TITLE
Enabling tensor copy on distconv-enabled ID

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -29,6 +29,7 @@ Support for new layers:
 - Added distributed tensor parallelism with channelwise decomposition for channelwise fully connected layer
 - Added "binary-with-constant" operators
 - Updated deconvolution layer to match PyTorch's API
+- Updated identity layer to copy tensors to enable tensor parallelism in subsequent layers in the compute graph
 
 Python front-end:
  - Added support for buidling and launching jobs on Fugaku

--- a/ci_test/unit_tests/test_unit_layer_identity_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_distconv.py
@@ -53,6 +53,10 @@ def setup_experiment(lbann, weekly):
 def create_parallel_strategy(num_height_groups):
     return {"height_groups": num_height_groups}
 
+def channelwise_parallel_strategy(num_channel_groups):
+    return {"channel_groups": num_channel_groups,
+            "filter_groups": num_channel_groups}
+
 def construct_model(lbann):
     """Construct LBANN model.
 
@@ -114,7 +118,41 @@ def construct_model(lbann):
         upper_bound=val+tol,
         error_on_failure=True,
         execution_modes='test'))
+    
+    # ------------------------------------------
+    # Data-parallel layout with DC and activation
+    # ------------------------------------------
 
+    x = x_lbann
+    x = lbann.Identity(x, dims=[48, 1, 1])
+    _data = lbann.Identity(_data,
+                           name="input_data_distconv",
+                           parallel_strategy=channelwise_parallel_strategy(NUM_GROUPS))
+    _data = lbann.Relu(_data,
+                       name="distconv_activation",
+                       parallel_strategy=channelwise_parallel_strategy(NUM_GROUPS))
+    
+    _data = lbann.Reshape(_data, dims=[48])
+    z = lbann.L2Norm2(_data)
+    obj.append(z)
+    metrics.append(lbann.Metric(z, name='data-parallel w activation'))
+    
+    # Numpy implementation
+    vals = []
+    for i in range(num_samples()):
+        x = get_sample(i).astype(np.float64)
+        y = x
+        z = tools.numpy_l2norm2(y)
+        vals.append(z)
+    val = np.mean(vals)
+    tol = 8 * val * np.finfo(np.float32).eps
+    callbacks.append(lbann.CallbackCheckMetric(
+        metric=metrics[-1].name,
+        lower_bound=val-tol,
+        upper_bound=val+tol,
+        error_on_failure=True,
+        execution_modes='test'))
+    
     # ------------------------------------------
     # Model-parallel layout
     # ------------------------------------------

--- a/ci_test/unit_tests/test_unit_layer_identity_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_distconv.py
@@ -177,14 +177,14 @@ def construct_model(lbann):
         metric=metrics[-1].name,
         lower_bound=val-tol,
         upper_bound=val+tol,
-        error_on_failure=False,
+        error_on_failure=True,
         execution_modes='test'))
     
     # ------------------------------------------
     # Gradient checking
     # ------------------------------------------
 
-    # callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
+    callbacks.append(lbann.CallbackCheckGradients(error_on_failure=True))
 
     # ------------------------------------------
     # Construct model

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -82,9 +82,11 @@ protected:
     #ifdef LBANN_HAS_DISTCONV
     // Copy activations when distconv is enabled
     
-    data_type_layer<TensorDataType>::fp_setup_outputs(mini_batch_size);
+    if (this->distconv_enabled()){
+        data_type_layer<TensorDataType>::fp_setup_outputs(mini_batch_size);
    
-    return ;
+        return ;
+    }
     #endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_activations(), this->get_prev_activations());
   }
@@ -92,11 +94,11 @@ protected:
     #ifdef LBANN_HAS_DISTCONV
     // Copy gradients wrt inputs when distconv is enabled
     
-
-    data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(mini_batch_size);
+    if (this->distconv_enabled()){
+        data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(mini_batch_size);
     
-    return ;
-    
+        return ;
+    }
     #endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_error_signals(), this->get_prev_error_signals());
   }

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -79,9 +79,25 @@ protected:
     this->set_output_dims(this->get_input_dims());
   }
   void fp_setup_outputs(El::Int mini_batch_size) override {
+    #ifdef LBANN_HAS_DISTCONV
+    // Copy activations when distconv is enabled
+    
+    data_type_layer<TensorDataType>::fp_setup_outputs(mini_batch_size);
+   
+    return ;
+    #endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_activations(), this->get_prev_activations());
   }
   void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
+    #ifdef LBANN_HAS_DISTCONV
+    // Copy gradients wrt inputs when distconv is enabled
+    
+
+    data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(mini_batch_size);
+    
+    return ;
+    
+    #endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_error_signals(), this->get_prev_error_signals());
   }
   void fp_compute() override {}

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -79,27 +79,28 @@ protected:
     this->set_output_dims(this->get_input_dims());
   }
   void fp_setup_outputs(El::Int mini_batch_size) override {
-    #ifdef LBANN_HAS_DISTCONV
+#ifdef LBANN_HAS_DISTCONV
     // Copy activations when distconv is enabled
-    
-    if (this->distconv_enabled()){
-        data_type_layer<TensorDataType>::fp_setup_outputs(mini_batch_size);
-   
-        return ;
+
+    if (this->distconv_enabled()) {
+      data_type_layer<TensorDataType>::fp_setup_outputs(mini_batch_size);
+
+      return;
     }
-    #endif // LBANN_HAS_DISTCONV
+#endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_activations(), this->get_prev_activations());
   }
   void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override {
-    #ifdef LBANN_HAS_DISTCONV
+#ifdef LBANN_HAS_DISTCONV
     // Copy gradients wrt inputs when distconv is enabled
-    
-    if (this->distconv_enabled()){
-        data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(mini_batch_size);
-    
-        return ;
+
+    if (this->distconv_enabled()) {
+      data_type_layer<TensorDataType>::bp_setup_gradient_wrt_inputs(
+        mini_batch_size);
+
+      return;
     }
-    #endif // LBANN_HAS_DISTCONV
+#endif // LBANN_HAS_DISTCONV
     El::LockedView(this->get_error_signals(), this->get_prev_error_signals());
   }
   void fp_compute() override {}


### PR DESCRIPTION
A possible fix for Issue #2126 is to fall back to `data_type_layer::fp_setup_outputs` and   `data_type_layer::bp_setup_gradient_wrt_inputs`. 