### PR TITLE
Identified that there are multiple unnecessary calls to EL::Empty

### DIFF
--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -29,6 +29,8 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 #include "lbann/utils/dim_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
 #include "lbann/utils/exception.hpp"
@@ -267,7 +269,13 @@ void concatenate_layer<TensorDataType,Layout,Device>::fp_setup_outputs(El::Int m
 #endif // LBANN_HAS_DISTCONV
   const auto& input0 = this->get_prev_activations(0);
   auto& output = this->get_activations();
-  output.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    output.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(output);
+  }
   if (this->get_num_parents() == 1) {
     El::LockedView(output, input0);
   }

--- a/include/lbann/layers/transform/crop.hpp
+++ b/include/lbann/layers/transform/crop.hpp
@@ -28,7 +28,9 @@
 #define LBANN_LAYER_CROP_HPP_INCLUDED
 
 #include "lbann/layers/data_type_layer.hpp"
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -197,7 +199,13 @@ private:
     const auto& region_size = output_dims.back();
 
     // Get crop position
-    m_crop_pos_v->Empty(false);
+    auto& arg_parser = global_argument_parser();
+    if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+      m_crop_pos_v->Empty(false);
+    }
+    // if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    //   El::Zero(m_crop_pos_v);
+    // }
     m_crop_pos_v->AlignWith(input);
     const auto& input1 = this->get_prev_activations(1);
     if (m_crop_pos_v->DistData() == input1.DistData()) {

--- a/include/lbann/layers/transform/cross_grid_sum.hpp
+++ b/include/lbann/layers/transform/cross_grid_sum.hpp
@@ -29,6 +29,8 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -144,7 +146,13 @@ private:
     for (int i = 0; i < this->get_num_children(); ++i) {
 
       auto& output = this->get_activations(i);
-      output.Empty(false);
+      auto& arg_parser = global_argument_parser();
+      if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+        output.Empty(false);
+      }
+      if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+        El::Zero(output);
+      }
       output.Resize(this->get_output_size(i), mini_batch_size);
     }
   }

--- a/include/lbann/layers/transform/cross_grid_sum_slice.hpp
+++ b/include/lbann/layers/transform/cross_grid_sum_slice.hpp
@@ -29,6 +29,8 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/exception.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -151,7 +153,13 @@ protected:
     // Initialize output tensors
     for (int i = 0; i < this->get_num_children(); ++i) {
       auto& output = this->get_activations(i);
-      output.Empty(false);
+      auto& arg_parser = global_argument_parser();
+      if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+        output.Empty(false);
+      }
+      if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+        El::Zero(output);
+      }
       output.Resize(this->get_output_size(i), mini_batch_size);
     }
   }

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -366,10 +366,14 @@ template <typename TensorDataType, data_layout Layout, El::Device Device>
 void slice_layer<TensorDataType,Layout,Device>::bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) {
   const auto& output0_grad = this->get_prev_error_signals(0);
   auto& input_grad = this->get_error_signals();
-  input_grad.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    input_grad.Empty(false);
+  }
   input_grad.Resize(this->get_input_size(), output0_grad.Width());
-  El::Zeros(input_grad, this->get_input_size(), output0_grad.Width());
-
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zeros(input_grad, this->get_input_size(), output0_grad.Width());
+  }
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -28,6 +28,8 @@
 #define LBANN_LAYER_SUM_HPP_INCLUDED
 
 #include "lbann/layers/data_type_layer.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/distconv.hpp"
 
@@ -224,7 +226,13 @@ protected:
 #endif // LBANN_HAS_DISTCONV
 
       auto& output = this->get_activations(i);
-      output.Empty(false);
+      auto& arg_parser = global_argument_parser();
+      if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+        output.Empty(false);
+      }
+      if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+        El::Zero(output);
+      }
       if (align_outputs &&  this->get_parallel_strategy().enable_subgraph==false) { output.AlignWith(alignment_dist); }
       output.Resize(this->get_output_size(i), mini_batch_size);
       }

--- a/include/lbann/layers/transform/tessellate.hpp
+++ b/include/lbann/layers/transform/tessellate.hpp
@@ -29,6 +29,8 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -157,7 +159,13 @@ protected:
     // Get input and output data
     auto& output = this->get_activations();
     const auto& input = this->get_prev_activations();
-    m_input_v->Empty(false);
+    auto& arg_parser = global_argument_parser();
+    if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+      m_input_v->Empty(false);
+    }
+    // if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    //   El::Zero(m_input_v);
+    // }
     m_input_v->AlignWith(output);
     if (m_input_v->DistData() == input.DistData()) {
       El::LockedView(*m_input_v, input);

--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -89,6 +89,10 @@ namespace lbann {
 #define LBANN_OPTION_TRAINER_PRIMARY_GRID_SIZE "Primary Grid Size per trainer"
 #define LBANN_OPTION_NUM_SUBGRIDS_BLOCK_ORDER "Divide each trainer into equally-sized sub-grids with blocked ordering"
 
+/****** debuggin options ******/
+#define LBANN_OPTION_ZERO_INTERMEDIATE_STATE "Explicitly call El::Zero on intermediate state"
+#define LBANN_OPTION_EMPTY_INTERMEDIATE_STATE "Explicitly call El::Empty on intermediate state"
+
 /****** datastore options ******/
 // Bool flags
 #define LBANN_OPTION_DATA_STORE_CACHE "data_store_cache"

--- a/src/layers/activations/log_softmax.cpp
+++ b/src/layers/activations/log_softmax.cpp
@@ -27,6 +27,8 @@
 #define LBANN_LOG_SOFTMAX_LAYER_INSTANTIATE
 #include "lbann/comm_impl.hpp"
 #include "lbann/layers/activations/log_softmax.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -39,7 +41,13 @@ void fp(lbann_comm& comm,
         El::AbstractDistMatrix<TensorDataType>& workspace) {
 
   // Setup workspace
-  workspace.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    workspace.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(workspace);
+  }
   workspace.AlignWith(input);
   workspace.Resize(1, input.Width());
 

--- a/src/layers/activations/log_softmax.cu
+++ b/src/layers/activations/log_softmax.cu
@@ -30,6 +30,8 @@
 #ifdef LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/softmax.hpp"
 #endif // LBANN_HAS_DNN_LIB
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -291,7 +293,13 @@ void fp_compute_impl(log_softmax_layer<TensorDataType, data_layout::MODEL_PARALL
   using GPUMatType = El::Matrix<TensorDataType, El::Device::GPU>;
 
   // Setup workspace
-  l.m_workspace->Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    l.m_workspace->Empty(false);
+  }
+  /* if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) { */
+  /*   El::Zero(l.m_workspace); */
+  /* } */
   l.m_workspace->AlignWith(l.get_activations());
   l.m_workspace->Resize(1, l.get_activations().Width());
 

--- a/src/layers/activations/softmax.cpp
+++ b/src/layers/activations/softmax.cpp
@@ -30,6 +30,9 @@
 
 #include "lbann/utils/dnn_lib/softmax.hpp"
 
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
+
 namespace lbann {
 
 namespace {
@@ -47,7 +50,13 @@ void fp_model_parallel(lbann_comm& comm,
   }
 
   // Setup workspace
-  workspace.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    workspace.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(workspace);
+  }
   workspace.AlignWith(input);
   workspace.Resize(1, input.Width());
 

--- a/src/layers/activations/softmax.cu
+++ b/src/layers/activations/softmax.cu
@@ -30,6 +30,8 @@
 #ifdef LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/softmax.hpp"
 #endif // LBANN_HAS_DNN_LIB
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -343,7 +345,13 @@ void fp_compute_impl(softmax_layer<TensorDataType, data_layout::MODEL_PARALLEL, 
   }
 
   // Setup workspace
-  l.m_workspace->Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    l.m_workspace->Empty(false);
+  }
+  /* if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) { */
+  /*   El::Zero(l.m_workspace); */
+  /* } */
   l.m_workspace->AlignWith(l.get_activations());
   l.m_workspace->Resize(1, l.get_activations().Width());
 

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -868,21 +868,22 @@ fp_setup_outputs(El::Int mini_batch_size) {
 #endif // LBANN_HAS_DISTCONV
     auto& output = get_activations(i);
     auto& arg_parser = global_argument_parser();
+    if (output.Viewing()) {
+      LBANN_ERROR(get_name(),
+                  " fp_setup_outputs should be overridden",
+                  " if it needs to handle outputs that view",
+                  " other matrices");
+    }
     if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
       output.Empty(false);
     }
     if (align_outputs) {
       output.AlignWith(alignment_dist);
     }
-    El::Int old_height = output.Height();
     output.Resize(get_output_size(i), mini_batch_size);
     if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
       El::Zero(output);
     }
-    // if (old_height != get_output_size(i)) {
-    //   LBANN_MSG("I have just resized the output from ", old_height, " to new height ", get_output_size(i));
-    //   El::Zero(output);
-    // }
   }
 
 }
@@ -1100,6 +1101,12 @@ bp_setup_gradient_wrt_inputs(
 #endif // LBANN_HAS_DISTCONV
     auto& gradient_wrt_input = get_error_signals(i);
     auto& arg_parser = global_argument_parser();
+    if (gradient_wrt_input.Viewing()) {
+      LBANN_ERROR(get_name(),
+                  " bp_setup_gradient_wrt_inputs should be overridden",
+                  " if it needs to handle error signals that view other",
+                  "  matrices");
+    }
     if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
       gradient_wrt_input.Empty(false);
     }

--- a/src/layers/misc/covariance.cpp
+++ b/src/layers/misc/covariance.cpp
@@ -26,6 +26,8 @@
 
 #define LBANN_COVARIANCE_LAYER_INSTANTIATE
 #include "lbann/layers/misc/covariance.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -57,7 +59,13 @@ void fp_cpu(const El::AbstractDistMatrix<TensorDataType>& input0,
   const auto& local_width = local_input0.Width();
 
   // Compute column-wise mean
-  means.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    means.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(means);
+  }
   means.AlignWith(input0);
   means.Resize(2, width);
   LBANN_OMP_PARALLEL_FOR
@@ -74,7 +82,12 @@ void fp_cpu(const El::AbstractDistMatrix<TensorDataType>& input0,
   El::AllReduce(means, means.RedundantComm());
 
   // Compute column-wise covariance
-  workspace.Empty(false);
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    workspace.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(workspace);
+  }
   workspace.AlignWith(input0);
   workspace.Resize(1, width);
   LBANN_OMP_PARALLEL_FOR

--- a/src/layers/misc/covariance.cu
+++ b/src/layers/misc/covariance.cu
@@ -27,6 +27,8 @@
 #define LBANN_COVARIANCE_LAYER_INSTANTIATE
 #include "lbann/layers/misc/covariance.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -199,7 +201,13 @@ void fp_gpu(const El::AbstractDistMatrix<TensorDataType>& input0,
   const auto& local_width = local_input0.Width();
 
   // Compute column-wise mean
-  means.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    means.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(means);
+  }
   means.AlignWith(input0);
   El::Zeros(means, 2, width);
   if (!local_input0.IsEmpty()) {
@@ -224,7 +232,12 @@ void fp_gpu(const El::AbstractDistMatrix<TensorDataType>& input0,
   El::AllReduce(means, means.RedundantComm());
 
   // Compute column-wise covariance
-  workspace.Empty(false);
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    workspace.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(workspace);
+  }
   workspace.AlignWith(input0);
   El::Zeros(workspace, 1, width);
   if (!local_input0.IsEmpty()) {

--- a/src/layers/misc/variance.cpp
+++ b/src/layers/misc/variance.cpp
@@ -26,6 +26,8 @@
 
 #define LBANN_VARIANCE_LAYER_INSTANTIATE
 #include "lbann/layers/misc/variance.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -55,7 +57,13 @@ void fp_cpu(const El::AbstractDistMatrix<TensorDataType>& input,
   const auto& local_width = local_input.Width();
 
   // Compute column-wise mean
-  means.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    means.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(means);
+  }
   means.AlignWith(input);
   means.Resize(1, width);
   LBANN_OMP_PARALLEL_FOR
@@ -69,7 +77,12 @@ void fp_cpu(const El::AbstractDistMatrix<TensorDataType>& input,
   El::AllReduce(means, means.RedundantComm());
 
   // Compute column-wise variance
-  workspace.Empty(false);
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    workspace.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(workspace);
+  }
   workspace.AlignWith(input);
   workspace.Resize(1, width);
   LBANN_OMP_PARALLEL_FOR

--- a/src/layers/regularizers/entrywise_batch_normalization.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization.cpp
@@ -28,7 +28,10 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 
+#include "lbann/utils/argument_parser.hpp"
 #include "lbann/weights/weights_helpers.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -158,7 +161,13 @@ void fp_impl(lbann_comm& comm,
   using CPUMatType = El::Matrix<TensorDataType, El::Device::CPU>;
 
   // Make sure workspace is aligned with input tensor
-  batch_statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    batch_statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(batch_statistics);
+  }
   batch_statistics.AlignWith(input);
   batch_statistics.Resize(input.Height(), 2);
 
@@ -220,7 +229,13 @@ void bp_training_impl(lbann_comm& comm,
   using CPUMatType = El::Matrix<TensorDataType, El::Device::CPU>;
 
   // Make sure workspace is aligned with input tensor
-  gradient_wrt_statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    gradient_wrt_statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(gradient_wrt_statistics);
+  }
   gradient_wrt_statistics.AlignWith(input);
   gradient_wrt_statistics.Resize(input.Height(), 2);
 

--- a/src/layers/regularizers/entrywise_batch_normalization.cu
+++ b/src/layers/regularizers/entrywise_batch_normalization.cu
@@ -29,6 +29,8 @@
 #include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 #include "lbann/weights/weights_helpers.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -260,7 +262,13 @@ void fp_impl(lbann_comm& comm,
              El::AbstractDistMatrix<TensorDataType>& running_var) {
 
   // Make sure workspace is aligned with input tensor
-  batch_statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    batch_statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(batch_statistics);
+  }
   batch_statistics.AlignWith(input);
   batch_statistics.Resize(input.Height(), 2);
 
@@ -407,7 +415,13 @@ void bp_training_impl(lbann_comm& comm,
                       El::AbstractDistMatrix<TensorDataType>& gradient_wrt_statistics) {
 
   // Make sure workspace is aligned with input tensor
-  gradient_wrt_statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    gradient_wrt_statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(gradient_wrt_statistics);
+  }
   gradient_wrt_statistics.AlignWith(input);
   gradient_wrt_statistics.Resize(input.Height(), 2);
 

--- a/src/layers/regularizers/layer_norm.cpp
+++ b/src/layers/regularizers/layer_norm.cpp
@@ -27,6 +27,8 @@
 #define LBANN_LAYER_NORM_LAYER_INSTANTIATE
 #include "lbann/comm_impl.hpp"
 #include "lbann/layers/regularizers/layer_norm.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 namespace lbann {
 
@@ -42,7 +44,13 @@ void fp_impl(lbann_comm& comm,
   using CPUMatType = El::Matrix<TensorDataType, El::Device::CPU>;
 
   // Workspace buffer
-  statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(statistics);
+  }
   statistics.AlignWith(input);
   statistics.Resize(2, input.Width());
 
@@ -120,7 +128,13 @@ void bp_impl(lbann_comm& comm,
   using CPUMatType = El::Matrix<TensorDataType, El::Device::CPU>;
 
   // Workspace buffer
-  statistics_grad.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    statistics_grad.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(statistics_grad);
+  }
   statistics_grad.AlignWith(input);
   statistics_grad.Resize(2, input.Width());
 

--- a/src/layers/regularizers/layer_norm.cu
+++ b/src/layers/regularizers/layer_norm.cu
@@ -28,6 +28,8 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/layers/regularizers/layer_norm.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
+#include "lbann/utils/argument_parser.hpp"
+#include "lbann/utils/options.hpp"
 
 #include <thrust/pair.h>
 
@@ -181,7 +183,13 @@ void fp_impl(lbann_comm& comm,
   using GPUMatType = El::Matrix<TensorDataType, El::Device::GPU>;
 
   // Workspace buffer
-  statistics.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    statistics.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(statistics);
+  }
   statistics.AlignWith(input);
   statistics.Resize(2, input.Width());
 
@@ -394,7 +402,13 @@ void bp_impl(lbann_comm& comm,
   using GPUMatType = El::Matrix<TensorDataType, El::Device::GPU>;
 
   // Workspace buffer
-  statistics_grad.Empty(false);
+  auto& arg_parser = global_argument_parser();
+  if (arg_parser.get<bool>(LBANN_OPTION_EMPTY_INTERMEDIATE_STATE)) {
+    statistics_grad.Empty(false);
+  }
+  if (arg_parser.get<bool>(LBANN_OPTION_ZERO_INTERMEDIATE_STATE)) {
+    El::Zero(statistics_grad);
+  }
   statistics_grad.AlignWith(input);
   statistics_grad.Resize(2, input.Width());
 

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -251,6 +251,19 @@ void construct_std_options()
                         "sub-grids with blocked ordering",
                         0);
 
+  // Debugging flag
+  arg_parser.add_flag(
+    LBANN_OPTION_ZERO_INTERMEDIATE_STATE,
+    {"--zero_intermediate_state"},
+    utils::ENV("LBANN_ZERO_INTERMEDIATE_STATE"),
+    "[STD] Explicitly Zero out the activation and error signal matrices.");
+
+  arg_parser.add_flag(
+    LBANN_OPTION_EMPTY_INTERMEDIATE_STATE,
+    {"--empty_intermediate_state"},
+    utils::ENV("LBANN_EMPTY_INTERMEDIATE_STATE"),
+    "[STD] Explicitly El::Empty the activation and error signal matrices.");
+
 }
 
 void construct_datastore_options()


### PR DESCRIPTION
function when resetting matrices at the start of each forward and backward prop phases.  Currently this seems to be triggering a memory leak in Hydrogen, but they should also be unnecessary becasue there are already calls to resize the matrix and they will be overwritten.

Enable temporary performance testing by providing command line and environment options to enable application of the Empty function to intermediate state, zero'ing out that state, or just reusing dirty buffers with the understanding that the matrices will be overwritten.