### PR TITLE
Patch for DistConv input layer

### DIFF
--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -235,7 +235,8 @@ input_distconv_adapter(
 
   // Input data is only processed when its consumer layer is also
   // enabled for distconv
-  m_is_input_processed = layer.get_child_layer().distconv_enabled();
+  m_is_input_processed = (m_data_field == INPUT_DATA_TYPE_SAMPLES)
+      || layer.get_child_layer().distconv_enabled();
 
 }
 
@@ -328,6 +329,7 @@ void input_distconv_adapter<TensorDataType, T_layout, Dev>::setup_fp_tensors() {
   }
 
   this->setup_activations();
+  this->setup_original_activations();
 }
 
 template <typename TensorDataType,


### PR DESCRIPTION
This addresses the issue @fiedorowicz1 is seeing when adding a non-distconv layer immediately after a distconv'd input layer.

In general, this situation should not arise. The (non-testing) reason for having a distconv-capable input layer is to handle sample sizes that might exceed the memory capacity of a single GPU. Thus, it does not make sense to put a regular (`DATA_PARALLEL`) layer right after such a distconv'd input layer because it will have to allocate a full sample's worth of storage. However, this shouldn't be "wrong".

While we are working to "distconvify" more of our layers, this will at least allow prototyping at smaller scales to continue.