### PR TITLE
Fix include path and remove Python.h inclusion from headers

### DIFF
--- a/include/lbann/utils/python.hpp
+++ b/include/lbann/utils/python.hpp
@@ -30,7 +30,9 @@
 #include "lbann/base.hpp"
 #ifdef LBANN_HAS_EMBEDDED_PYTHON
 
-#include <Python.h>
+// Forward declarations of Python objects to avoid including Python.h
+struct _object;
+typedef struct _object PyObject;
 
 #include <mutex>
 #include <string>
@@ -79,14 +81,16 @@ void check_error(bool force_error = false);
  *
  *  If an Python session is not running, one is started.
  */
-class global_interpreter_lock {
+class global_interpreter_lock
+{
 public:
   global_interpreter_lock();
   ~global_interpreter_lock();
+
 private:
   global_interpreter_lock(const global_interpreter_lock&) = delete;
   global_interpreter_lock& operator=(const global_interpreter_lock&) = delete;
-  PyGILState_STATE m_gil_state;
+  int m_gil_state;
 };
 
 /** @brief Wrapper around a Python object pointer.
@@ -109,9 +113,9 @@ private:
  *
  *  for an explanation of reference counts.
  */
-class object {
+class object
+{
 public:
-
   /** @brief Take ownership of a Python object pointer.
    *  @details @a Steals the reference.
    */
@@ -136,11 +140,11 @@ public:
   ~object();
 
   /** @returns @a Borrowed reference. */
-  inline PyObject* get() noexcept                  { return m_ptr; }
+  inline PyObject* get() noexcept { return m_ptr; }
   /** @returns @a Borrowed reference. */
-  inline const PyObject* get() const noexcept      { return m_ptr; }
+  inline const PyObject* get() const noexcept { return m_ptr; }
   /** @returns @a Borrowed reference. */
-  inline operator PyObject*() noexcept             { return get(); }
+  inline operator PyObject*() noexcept { return get(); }
   /** @returns @a Borrowed reference. */
   inline operator const PyObject*() const noexcept { return get(); }
 
@@ -157,10 +161,8 @@ public:
   operator double();
 
 private:
-
   /** Python object pointer. */
   PyObject* m_ptr = nullptr;
-
 };
 
 } // namespace python

--- a/include/lbann/utils/tensor.hpp
+++ b/include/lbann/utils/tensor.hpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/typename.hpp"
 
-#include <core/DistMatrix/AbstractDistMatrix.hpp>
+#include <El/core/DistMatrix/AbstractDistMatrix.hpp>
 #include <iterator>
 #include <type_traits>
 

--- a/src/data_readers/data_reader_python.cpp
+++ b/src/data_readers/data_reader_python.cpp
@@ -30,6 +30,9 @@
 #include <cstdio>
 #include <algorithm>
 #include <regex>
+
+#include <Python.h>
+
 #include "lbann/trainers/trainer.hpp"
 #include "lbann/utils/python.hpp"
 

--- a/src/utils/python.cpp
+++ b/src/utils/python.cpp
@@ -29,6 +29,8 @@
 #include <sstream>
 #include "lbann/utils/exception.hpp"
 
+#include <Python.h>
+
 namespace lbann {
 namespace python {
 
@@ -153,7 +155,7 @@ global_interpreter_lock::global_interpreter_lock() {
 
 global_interpreter_lock::~global_interpreter_lock() {
   if (is_active()) {
-    PyGILState_Release(m_gil_state);
+    PyGILState_Release(static_cast<PyGILState_STATE>(m_gil_state));
   }
 }
 


### PR DESCRIPTION
This PR moves the inclusion of Python.h from the headers to the two .cpp files that use it. It also fixes an include path that did not include a top-level directory.