### PR TITLE
Move protobuf headers to `lbann/proto`

### DIFF
--- a/include/lbann/layers/activations/elu.hpp
+++ b/include/lbann/layers/activations/elu.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/activations/leaky_relu.hpp
+++ b/include/lbann/layers/activations/leaky_relu.hpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/activations/log_softmax.hpp
+++ b/include/lbann/layers/activations/log_softmax.hpp
@@ -32,7 +32,7 @@
 #if defined LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // LBANN_HAS_DNN_LIB
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #ifdef LBANN_HAS_DISTCONV
 #include "distconv/dnn_backend/relu.hpp"

--- a/include/lbann/layers/activations/softmax.hpp
+++ b/include/lbann/layers/activations/softmax.hpp
@@ -36,7 +36,7 @@
 #include "lbann/utils/dnn_lib/softmax.hpp"
 #endif // defined LBANN_HAS_DNN_LIB
 #include "lbann/utils/dnn_lib/softmax.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 // Threshold outputs to a minimum value.
 

--- a/include/lbann/layers/image/bilinear_resize.hpp
+++ b/include/lbann/layers/image/bilinear_resize.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/learning/channelwise_scale_bias.hpp
+++ b/include/lbann/layers/learning/channelwise_scale_bias.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/exception.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/learning/embedding.hpp
+++ b/include/lbann/layers/learning/embedding.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/memory.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/learning/entrywise_scale_bias.hpp
+++ b/include/lbann/layers/learning/entrywise_scale_bias.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/exception.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/categorical_accuracy.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/cross_entropy.hpp
+++ b/include/lbann/layers/loss/cross_entropy.hpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/l1_norm.hpp
+++ b/include/lbann/layers/loss/l1_norm.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/l2_norm2.hpp
+++ b/include/lbann/layers/loss/l2_norm2.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/mean_absolute_error.hpp
+++ b/include/lbann/layers/loss/mean_absolute_error.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/mean_squared_error.hpp
+++ b/include/lbann/layers/loss/mean_squared_error.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
+++ b/include/lbann/layers/loss/top_k_categorical_accuracy.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/channelwise_mean.hpp
+++ b/include/lbann/layers/misc/channelwise_mean.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/channelwise_softmax.hpp
+++ b/include/lbann/layers/misc/channelwise_softmax.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/covariance.hpp
+++ b/include/lbann/layers/misc/covariance.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/dft_abs.hpp
+++ b/include/lbann/layers/misc/dft_abs.hpp
@@ -30,7 +30,7 @@
 #include "lbann_config.hpp"
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 // This layer is only supported if LBANN has FFTW support.
 #ifdef LBANN_HAS_FFTW

--- a/include/lbann/layers/misc/dist_embedding.hpp
+++ b/include/lbann/layers/misc/dist_embedding.hpp
@@ -36,7 +36,7 @@
 #include "lbann/weights/weights_helpers.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/memory.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/one_hot.hpp
+++ b/include/lbann/layers/misc/one_hot.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/rowwise_weights_norms.hpp
+++ b/include/lbann/layers/misc/rowwise_weights_norms.hpp
@@ -31,7 +31,7 @@
 #include "lbann/weights/weights_helpers.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/uniform_hash.hpp
+++ b/include/lbann/layers/misc/uniform_hash.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/misc/variance.hpp
+++ b/include/lbann/layers/misc/variance.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/operator_layer_impl.hpp
+++ b/include/lbann/layers/operator_layer_impl.hpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/exception.hpp"
 
 #include <cereal/types/base_class.hpp>
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include <memory>
 
 namespace lbann {

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -32,7 +32,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/entrywise_batch_normalization.hpp
@@ -32,7 +32,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/memory.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/regularizers/instance_norm.hpp
+++ b/include/lbann/layers/regularizers/instance_norm.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/regularizers/layer_norm.hpp
+++ b/include/lbann/layers/regularizers/layer_norm.hpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include <memory>
 
 namespace lbann {

--- a/include/lbann/layers/transform/concatenate.hpp
+++ b/include/lbann/layers/transform/concatenate.hpp
@@ -35,7 +35,7 @@
 
 #include <lbann/proto/proto_common.hpp>
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/crop.hpp
+++ b/include/lbann/layers/transform/crop.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/gather.hpp
+++ b/include/lbann/layers/transform/gather.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/in_top_k.hpp
+++ b/include/lbann/layers/transform/in_top_k.hpp
@@ -32,7 +32,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/scatter.hpp
+++ b/include/lbann/layers/transform/scatter.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -35,7 +35,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/trainers/trainer.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/sort.hpp
+++ b/include/lbann/layers/transform/sort.hpp
@@ -30,7 +30,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -32,7 +32,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/distconv.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/layers/transform/tessellate.hpp
+++ b/include/lbann/layers/transform/tessellate.hpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/layer.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -51,7 +51,7 @@
 // complete type. Sigh. (The greater implication of this is that you
 // cannot have `unique_ptr<IncompleteType>` as a drop-in for
 // `IncompleteType*`, which is annoying.)
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 #include <string>
 #include <unordered_map>

--- a/include/lbann/operators/builder_macros.hpp
+++ b/include/lbann/operators/builder_macros.hpp
@@ -29,7 +29,7 @@
 #include "lbann/operators/operator.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <memory>
 

--- a/include/lbann/operators/declare_stateless_op.hpp
+++ b/include/lbann/operators/declare_stateless_op.hpp
@@ -30,7 +30,7 @@
 #include "lbann/operators/operator.hpp"
 #include "lbann/utils/cloneable.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 // These are all single-type operators.
 

--- a/include/lbann/operators/math/abs.hpp
+++ b/include/lbann/operators/math/abs.hpp
@@ -33,7 +33,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/cloneable.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <h2/meta/Core.hpp>
 

--- a/include/lbann/operators/math/binary_with_constant.hpp
+++ b/include/lbann/operators/math/binary_with_constant.hpp
@@ -32,7 +32,7 @@
 #include "lbann/operators/elementwise_operator.hpp"
 #include "lbann/utils/cloneable.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 /** @file
  *
@@ -48,7 +48,7 @@
 #include "lbann/operators/operator.hpp"
 #include "lbann/utils/cloneable.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 // These are all single-type operators.
 

--- a/include/lbann/operators/math/clamp.hpp
+++ b/include/lbann/operators/math/clamp.hpp
@@ -32,7 +32,7 @@
 #include "lbann/operators/elementwise_operator.hpp"
 #include "lbann/utils/cloneable.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <h2/meta/Core.hpp>
 

--- a/include/lbann/operators/math/math_builders_impl.hpp
+++ b/include/lbann/operators/math/math_builders_impl.hpp
@@ -35,7 +35,7 @@
 #include "lbann/operators/math/unary.hpp"
 
 #include "lbann/proto/datatype_helpers.hpp"
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 template <typename DataT, El::Device D>
 std::unique_ptr<lbann::Operator<DataT, DataT, D>>

--- a/include/lbann/operators/operator.hpp
+++ b/include/lbann/operators/operator.hpp
@@ -36,7 +36,7 @@
 #include "lbann/utils/tensor.hpp"
 #include "lbann/utils/typename.hpp"
 
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <h2/meta/Core.hpp>
 #include <h2/meta/TypeList.hpp>

--- a/include/lbann/optimizers/adagrad.hpp
+++ b/include/lbann/optimizers/adagrad.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/optimizers/adam.hpp
+++ b/include/lbann/optimizers/adam.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/include/lbann/optimizers/hypergradient_adam.hpp
+++ b/include/lbann/optimizers/hypergradient_adam.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/optimizers/rmsprop.hpp
+++ b/include/lbann/optimizers/rmsprop.hpp
@@ -30,7 +30,7 @@
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include <sys/stat.h>
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/optimizers/sgd.hpp
+++ b/include/lbann/optimizers/sgd.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/io/persist.hpp"
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 

--- a/include/lbann/proto/datatype_helpers.hpp
+++ b/include/lbann/proto/datatype_helpers.hpp
@@ -29,7 +29,7 @@
 
 #include "lbann/base.hpp"
 
-#include <datatype.pb.h>
+#include "lbann/proto/datatype.pb.h"
 
 namespace lbann {
 namespace proto {

--- a/include/lbann/trainers/trainer.hpp
+++ b/include/lbann/trainers/trainer.hpp
@@ -37,7 +37,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/utils/hash.hpp"
 #include "lbann/utils/threads/thread_pool.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/include/lbann/utils/dnn_lib/dnn_lib.hpp
+++ b/include/lbann/utils/dnn_lib/dnn_lib.hpp
@@ -34,7 +34,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include <vector>
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #ifdef LBANN_HAS_DNN_LIB
 

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -35,8 +35,8 @@
 #include "lbann/utils/dnn_lib/helpers.hpp"
 #endif // LBANN_DNN_LIB
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <cstdlib>
 

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -31,8 +31,8 @@
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <cstdlib>
 

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -31,8 +31,8 @@
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <cstdlib>
 

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -31,8 +31,8 @@
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <cstdlib>
 

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -31,8 +31,8 @@
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/utils/argument_parser.hpp"
 
-#include <lbann.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <dirent.h>
 

--- a/src/callbacks/alternate_updates.cpp
+++ b/src/callbacks/alternate_updates.cpp
@@ -31,7 +31,7 @@
 
 #include "callback_helpers.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <string>
 #include <vector>

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/serialize.hpp"
 #include <h2/patterns/multimethods/SwitchDispatcher.hpp>
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <cmath>
 #include <iostream>

--- a/src/callbacks/check_metric.cpp
+++ b/src/callbacks/check_metric.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/serialize.hpp"
 #include <cereal/types/set.hpp>
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <set>
 #include <string>

--- a/src/callbacks/checkpoint.cpp
+++ b/src/callbacks/checkpoint.cpp
@@ -33,7 +33,7 @@
 #include "lbann/models/model.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <memory>
 #include <string>

--- a/src/callbacks/compute_model_size.cpp
+++ b/src/callbacks/compute_model_size.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 
 namespace lbann {

--- a/src/callbacks/confusion_matrix.cpp
+++ b/src/callbacks/confusion_matrix.cpp
@@ -28,7 +28,7 @@
 #include "lbann/callbacks/confusion_matrix.hpp"
 #include "lbann/layers/data_type_layer.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <fstream>
 #include <memory>

--- a/src/callbacks/debug.cpp
+++ b/src/callbacks/debug.cpp
@@ -31,7 +31,7 @@
 #include "lbann/weights/data_type_weights.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include "callbacks.pb.h"
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/debug_io.cpp
+++ b/src/callbacks/debug_io.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 #include <iostream>
 #include <memory>
 

--- a/src/callbacks/dump_error_signals.cpp
+++ b/src/callbacks/dump_error_signals.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/data_type_layer.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/dump_gradients.cpp
+++ b/src/callbacks/dump_gradients.cpp
@@ -30,7 +30,7 @@
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <vector>
 

--- a/src/callbacks/dump_minibatch_sample_indices.cpp
+++ b/src/callbacks/dump_minibatch_sample_indices.cpp
@@ -32,7 +32,7 @@
 #include "lbann/data_coordinator/data_coordinator.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <iomanip>
 #include <cstdlib>

--- a/src/callbacks/dump_outputs.cpp
+++ b/src/callbacks/dump_outputs.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #ifdef LBANN_HAS_CNPY
 #include <cnpy.h>

--- a/src/callbacks/dump_weights.cpp
+++ b/src/callbacks/dump_weights.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/trainer_file_utils.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <string>
 

--- a/src/callbacks/early_stopping.cpp
+++ b/src/callbacks/early_stopping.cpp
@@ -29,7 +29,7 @@
 #include "lbann/callbacks/early_stopping.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <iostream>
 

--- a/src/callbacks/export_onnx.cpp
+++ b/src/callbacks/export_onnx.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/callbacks/export_onnx.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <fstream>
 #include <iostream>

--- a/src/callbacks/hang.cpp
+++ b/src/callbacks/hang.cpp
@@ -27,7 +27,7 @@
 #include "lbann/callbacks/hang.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/imcomm.cpp
+++ b/src/callbacks/imcomm.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/timer.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <typeinfo>
 #include <typeindex>

--- a/src/callbacks/learning_rate.cpp
+++ b/src/callbacks/learning_rate.cpp
@@ -34,7 +34,7 @@
 
 #include "callback_helpers.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <cmath> // std::pow

--- a/src/callbacks/load_model.cpp
+++ b/src/callbacks/load_model.cpp
@@ -35,8 +35,8 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/callbacks.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <cstdlib>
 #include <fstream>

--- a/src/callbacks/ltfb.cpp
+++ b/src/callbacks/ltfb.cpp
@@ -39,7 +39,7 @@
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <numeric>

--- a/src/callbacks/mixup.cpp
+++ b/src/callbacks/mixup.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <unordered_set>
 

--- a/src/callbacks/monitor_io.cpp
+++ b/src/callbacks/monitor_io.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/perturb_adam.cpp
+++ b/src/callbacks/perturb_adam.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <cmath>

--- a/src/callbacks/perturb_dropout.cpp
+++ b/src/callbacks/perturb_dropout.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/perturb_learning_rate.cpp
+++ b/src/callbacks/perturb_learning_rate.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <cmath>

--- a/src/callbacks/perturb_weights.cpp
+++ b/src/callbacks/perturb_weights.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 

--- a/src/callbacks/print_model_description.cpp
+++ b/src/callbacks/print_model_description.cpp
@@ -27,7 +27,7 @@
 #include "lbann/callbacks/print_model_description.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/utils/serialize.hpp"
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/print_statistics.cpp
+++ b/src/callbacks/print_statistics.cpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/lbann_library.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <iomanip>

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/profiling.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #ifdef LBANN_NVPROF
 #include "nvToolsExt.h"

--- a/src/callbacks/replace_weights.cpp
+++ b/src/callbacks/replace_weights.cpp
@@ -31,7 +31,7 @@
 
 #include "callback_helpers.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <string>
 #include <vector>

--- a/src/callbacks/save_images.cpp
+++ b/src/callbacks/save_images.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/protobuf.hpp"
 #include <cereal/types/polymorphic.hpp>
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #ifdef LBANN_HAS_OPENCV
 #include <opencv2/imgcodecs.hpp>

--- a/src/callbacks/save_model.cpp
+++ b/src/callbacks/save_model.cpp
@@ -31,8 +31,8 @@
 #include "lbann/execution_algorithms/training_algorithm.hpp"
 #include "lbann/weights/data_type_weights.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/callbacks.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/io/coded_stream.h>

--- a/src/callbacks/save_topk_models.cpp
+++ b/src/callbacks/save_topk_models.cpp
@@ -29,7 +29,7 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/callbacks/save_topk_models.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <functional>

--- a/src/callbacks/set_weights_value.cpp
+++ b/src/callbacks/set_weights_value.cpp
@@ -28,7 +28,7 @@
 #include "lbann/weights/data_type_weights.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 
 namespace lbann {

--- a/src/callbacks/summarize_images.cpp
+++ b/src/callbacks/summarize_images.cpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/utils/summary_impl.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <iostream>
 

--- a/src/callbacks/summary.cpp
+++ b/src/callbacks/summary.cpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/profiling.hpp"
 #include "lbann/utils/summary_impl.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <algorithm>
 #include <string>

--- a/src/callbacks/sync_layers.cpp
+++ b/src/callbacks/sync_layers.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 namespace lbann {
 namespace callback {

--- a/src/callbacks/timeline.cpp
+++ b/src/callbacks/timeline.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/timer.hpp"
 #include "lbann/utils/serialize.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <fstream>
 #include <string>

--- a/src/callbacks/variable_minibatch.cpp
+++ b/src/callbacks/variable_minibatch.cpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/io/input_layer.hpp"
 #include "lbann/utils/exception.hpp"
 
-#include <callbacks.pb.h>
+#include "lbann/proto/callbacks.pb.h"
 
 #include <iostream>
 #include <utility>

--- a/src/data_coordinator/unit_test/data_coordinator_HDF5_hrrl_public_api.cpp
+++ b/src/data_coordinator/unit_test/data_coordinator_HDF5_hrrl_public_api.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/utils/threads/thread_utils.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <conduit/conduit.hpp>
 #include <cstdlib>

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_data_test.cpp
@@ -29,7 +29,7 @@
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <conduit/conduit.hpp>
 #include <cstdlib>

--- a/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_hrrl_public_api.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/threads/thread_pool.hpp"
 #include "lbann/utils/threads/thread_utils.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <conduit/conduit.hpp>
 #include <cstdlib>

--- a/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_sample_list_test.cpp
@@ -32,7 +32,7 @@
 #include "lbann/data_readers/sample_list_impl.hpp"
 #include "lbann/data_readers/sample_list_open_files_impl.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <lbann/base.hpp>
 
 namespace {

--- a/src/data_readers/unit_test/data_reader_HDF5_test.cpp
+++ b/src/data_readers/unit_test/data_reader_HDF5_test.cpp
@@ -30,7 +30,7 @@
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <cstdlib>
 #include <errno.h>

--- a/src/data_readers/unit_test/data_reader_common_catch2.hpp
+++ b/src/data_readers/unit_test/data_reader_common_catch2.hpp
@@ -35,7 +35,7 @@
 #include <lbann/base.hpp>
 
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 namespace pb = ::google::protobuf;
 
 /** create a directory in /tmp; returns the pathname to the directory */

--- a/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_fetch_datum_test.cpp
@@ -37,7 +37,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/file_utils.hpp"
 
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <google/protobuf/text_format.h>
 

--- a/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_sample_list_test.cpp
@@ -30,7 +30,7 @@
 #include "MPITestHelpers.hpp"
 
 #include "lbann/proto/proto_common.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <google/protobuf/text_format.h>
 
 // The code being tested

--- a/src/data_readers/unit_test/data_reader_smiles_test.cpp
+++ b/src/data_readers/unit_test/data_reader_smiles_test.cpp
@@ -29,7 +29,7 @@
 #include "TestHelpers.hpp"
 
 #include "lbann/proto/proto_common.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <google/protobuf/text_format.h>
 
 // The code being tested

--- a/src/data_readers/unit_test/data_reader_synthetic_test.cpp
+++ b/src/data_readers/unit_test/data_reader_synthetic_test.cpp
@@ -29,7 +29,7 @@
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <cstdlib>
 #include <errno.h>

--- a/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
+++ b/src/data_readers/unit_test/data_reader_synthetic_test_public_api.cpp
@@ -30,7 +30,7 @@
 #include "TestHelpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 #include <cstdlib>
 #include <errno.h>

--- a/src/execution_algorithms/factory.cpp
+++ b/src/execution_algorithms/factory.cpp
@@ -32,7 +32,7 @@
 
 #include <google/protobuf/message.h>
 #include <memory>
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 namespace {
 

--- a/src/execution_algorithms/kfac.cpp
+++ b/src/execution_algorithms/kfac.cpp
@@ -43,7 +43,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/profiling.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <cstddef>
 #include <limits>

--- a/src/execution_algorithms/ltfb.cpp
+++ b/src/execution_algorithms/ltfb.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/output_helpers.hpp"
 #include "lbann/utils/timer_map.hpp"
 
-#include "training_algorithm.pb.h"
+#include "lbann/proto/training_algorithm.pb.h"
 
 // FIXME (trb 04/14/21): This code is copied with only minimal
 // modification from the LTFB callback implementation. It should be

--- a/src/execution_algorithms/ltfb/meta_learning_strategy.cpp
+++ b/src/execution_algorithms/ltfb/meta_learning_strategy.cpp
@@ -31,7 +31,7 @@
 #include "lbann/utils/protobuf.hpp"
 
 #include <google/protobuf/message.h>
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 namespace {
 

--- a/src/execution_algorithms/ltfb/mutation_strategy.cpp
+++ b/src/execution_algorithms/ltfb/mutation_strategy.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include "lbann/layers/activations/elu.hpp"
 #include "lbann/layers/activations/leaky_relu.hpp"

--- a/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
+++ b/src/execution_algorithms/ltfb/random_pairwise_exchange.cpp
@@ -37,7 +37,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <algorithm>
 #include <iterator>

--- a/src/execution_algorithms/ltfb/regularized_evolution.cpp
+++ b/src/execution_algorithms/ltfb/regularized_evolution.cpp
@@ -39,7 +39,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/weights/data_type_weights_impl.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <algorithm>
 #include <iterator>

--- a/src/execution_algorithms/ltfb/truncation_selection_exchange.cpp
+++ b/src/execution_algorithms/ltfb/truncation_selection_exchange.cpp
@@ -37,7 +37,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/weights/data_type_weights_impl.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <algorithm>
 #include <iterator>

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer_map.hpp"
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <iostream>
 #include <memory>

--- a/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
+++ b/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
@@ -34,7 +34,7 @@
 #include <lbann/models/model.hpp>
 #include <lbann/utils/lbann_library.hpp>
 
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <google/protobuf/text_format.h>
 
 namespace pb = ::google::protobuf;

--- a/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
+++ b/src/execution_algorithms/unit_test/training_algorithm_factory_test.cpp
@@ -34,7 +34,7 @@
 #include <google/protobuf/stubs/logging.h>
 #include <lbann/execution_algorithms/factory.hpp>
 
-#include <training_algorithm.pb.h>
+#include "lbann/proto/training_algorithm.pb.h"
 
 #include <google/protobuf/text_format.h>
 

--- a/src/layers/activations/activation_layer_builders.cpp
+++ b/src/layers/activations/activation_layer_builders.cpp
@@ -33,7 +33,7 @@
 #include "lbann/layers/activations/relu.hpp"
 #include "lbann/layers/activations/softmax.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/activations/identity.cpp
+++ b/src/layers/activations/identity.cpp
@@ -27,7 +27,7 @@
 #define LBANN_IDENTITY_LAYER_INSTANTIATE
 #include "lbann/layers/activations/identity.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/image/composite_image_transformation.cpp
+++ b/src/layers/image/composite_image_transformation.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/image/composite_image_transformation.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include <math.h>
 
 namespace lbann {

--- a/src/layers/image/cutout.cpp
+++ b/src/layers/image/cutout.cpp
@@ -28,8 +28,8 @@
 #include "lbann/layers/image/cutout.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 #include <math.h>
 #include <algorithm>

--- a/src/layers/image/image_layer_builders.cpp
+++ b/src/layers/image/image_layer_builders.cpp
@@ -31,7 +31,7 @@
 #include "lbann/layers/image/rotation.hpp"
 #include "lbann/layers/image/cutout.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer> lbann::build_bilinear_resize_layer_from_pbuf(

--- a/src/layers/image/rotation.cpp
+++ b/src/layers/image/rotation.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/image/rotation.hpp"
 
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include <math.h>
 
 namespace lbann {

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -36,7 +36,7 @@
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/utils/serialize.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/summary_impl.hpp"
 #include "lbann/utils/timer.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <algorithm>
 #include <functional>

--- a/src/layers/learning/channelwise_fully_connected.cpp
+++ b/src/layers/learning/channelwise_fully_connected.cpp
@@ -31,7 +31,7 @@
 #include "lbann/weights/variance_scaling_initializers.hpp"
 
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann
 {

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -33,7 +33,7 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #ifdef LBANN_HAS_ONNX
 #include <onnx/onnx_pb.h>

--- a/src/layers/learning/deconvolution.cpp
+++ b/src/layers/learning/deconvolution.cpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <sstream>
 #include <string>

--- a/src/layers/learning/embedding_builder.cpp
+++ b/src/layers/learning/embedding_builder.cpp
@@ -27,7 +27,7 @@
 #include "lbann/layers/learning/embedding.hpp"
 
 #include <lbann/proto/proto_common.hpp>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -32,7 +32,7 @@
 
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <string>
 #include <sstream>

--- a/src/layers/learning/gru.cpp
+++ b/src/layers/learning/gru.cpp
@@ -35,7 +35,7 @@
 #include "lbann/utils/sync_info_helpers.hpp"
 
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/loss/loss_layer_builders.cpp
+++ b/src/layers/loss/loss_layer_builders.cpp
@@ -34,7 +34,7 @@
 #include "lbann/layers/loss/mean_squared_error.hpp"
 #include "lbann/layers/loss/top_k_categorical_accuracy.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/math/math_builders.cpp
+++ b/src/layers/math/math_builders.cpp
@@ -28,7 +28,7 @@
 #include <lbann/layers/math/matmul.hpp>
 
 #include <lbann/proto/proto_common.hpp>
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann
 {

--- a/src/layers/math/matmul.cpp
+++ b/src/layers/math/matmul.cpp
@@ -30,7 +30,7 @@
 #ifdef LBANN_HAS_GPU
 #include "lbann/utils/gpu/helpers.hpp"
 #endif // LBANN_HAS_GPU
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include<iostream>
 namespace lbann 
 {

--- a/src/layers/misc/argmax.cpp
+++ b/src/layers/misc/argmax.cpp
@@ -27,7 +27,7 @@
 #define LBANN_ARGMAX_LAYER_INSTANTIATE
 #include "lbann/layers/misc/argmax.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <algorithm>
 

--- a/src/layers/misc/argmin.cpp
+++ b/src/layers/misc/argmin.cpp
@@ -27,7 +27,7 @@
 #define LBANN_ARGMIN_LAYER_INSTANTIATE
 #include "lbann/layers/misc/argmin.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <algorithm>
 

--- a/src/layers/misc/dist_embedding.cpp
+++ b/src/layers/misc/dist_embedding.cpp
@@ -29,7 +29,7 @@
 #include "lbann/weights/weights_helpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 // =========================================================
 // CPU layer implementation

--- a/src/layers/misc/mini_batch_index.cpp
+++ b/src/layers/misc/mini_batch_index.cpp
@@ -27,7 +27,7 @@
 #define LBANN_MINI_BATCH_INDEX_LAYER_INSTANTIATE
 #include "lbann/layers/misc/mini_batch_index.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/misc/mini_batch_size.cpp
+++ b/src/layers/misc/mini_batch_size.cpp
@@ -27,7 +27,7 @@
 #define LBANN_MINI_BATCH_SIZE_LAYER_INSTANTIATE
 #include "lbann/layers/misc/mini_batch_size.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/misc/misc_builders.cpp
+++ b/src/layers/misc/misc_builders.cpp
@@ -45,7 +45,7 @@
 #include "lbann/layers/misc/dft_abs.hpp"
 #endif // LBANN_HAS_FFTW
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <memory>
 #include <type_traits>

--- a/src/layers/regularizers/batch_normalization_builder.cpp
+++ b/src/layers/regularizers/batch_normalization_builder.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/layers/regularizers/batch_normalization.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 #include <type_traits>
 
 template <typename T, lbann::data_layout L, El::Device D>

--- a/src/layers/regularizers/dropout.cpp
+++ b/src/layers/regularizers/dropout.cpp
@@ -27,7 +27,7 @@
 #define LBANN_DROPOUT_LAYER_INSTANTIATE
 #include "lbann/layers/regularizers/dropout.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/regularizers/entrywise_batch_normalization_builder.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization_builder.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/layers/regularizers/entrywise_batch_normalization.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/regularizers/layer_norm_builder.cpp
+++ b/src/layers/regularizers/layer_norm_builder.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/layers/regularizers/layer_norm.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/regularizers/local_response_normalization.cpp
+++ b/src/layers/regularizers/local_response_normalization.cpp
@@ -27,7 +27,7 @@
 #define LBANN_LOCAL_RESPONSE_NORMALIZATION_LAYER_INSTANTIATE
 #include "lbann/layers/regularizers/local_response_normalization.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 namespace {

--- a/src/layers/regularizers/selu_dropout.cpp
+++ b/src/layers/regularizers/selu_dropout.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/regularizers/selu_dropout.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>

--- a/src/layers/transform/batchwise_reduce_sum.cpp
+++ b/src/layers/transform/batchwise_reduce_sum.cpp
@@ -27,7 +27,7 @@
 #define LBANN_BATCHWISE_REDUCE_SUM_LAYER_INSTANTIATE
 #include "lbann/layers/transform/batchwise_reduce_sum.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/bernoulli.cpp
+++ b/src/layers/transform/bernoulli.cpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/categorical_random.cpp
+++ b/src/layers/transform/categorical_random.cpp
@@ -27,7 +27,7 @@
 #define LBANN_CATEGORICAL_RANDOM_LAYER_INSTANTIATE
 #include "lbann/layers/transform/categorical_random.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 namespace {

--- a/src/layers/transform/constant.cpp
+++ b/src/layers/transform/constant.cpp
@@ -32,8 +32,8 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
-#include <lbann.pb.h>
+#include "lbann/proto/layers.pb.h"
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/cross_grid_sum.cpp
+++ b/src/layers/transform/cross_grid_sum.cpp
@@ -31,8 +31,8 @@
 #include <lbann/proto/proto_common.hpp>
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/cross_grid_sum_slice.cpp
+++ b/src/layers/transform/cross_grid_sum_slice.cpp
@@ -30,8 +30,8 @@
 #include <lbann/proto/proto_common.hpp>
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/discrete_random.cpp
+++ b/src/layers/transform/discrete_random.cpp
@@ -29,7 +29,7 @@
 
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include "lbann/proto/datatype_helpers.hpp"
 

--- a/src/layers/transform/dummy.cpp
+++ b/src/layers/transform/dummy.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/transform/dummy.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include <lbann/utils/memory.hpp>
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -35,7 +35,7 @@
 #ifdef LBANN_HAS_GPU
 #include "lbann/utils/gpu/helpers.hpp"
 #endif // LBANN_HAS_GPU
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/gaussian.cpp
+++ b/src/layers/transform/gaussian.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/transform/gaussian.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/hadamard.cpp
+++ b/src/layers/transform/hadamard.cpp
@@ -30,8 +30,8 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include <lbann/proto/proto_common.hpp>
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/identity_zero.cpp
+++ b/src/layers/transform/identity_zero.cpp
@@ -31,7 +31,7 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/permute.cpp
+++ b/src/layers/transform/permute.cpp
@@ -34,8 +34,8 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 #include <memory>
 #include <sstream>

--- a/src/layers/transform/pooling.cpp
+++ b/src/layers/transform/pooling.cpp
@@ -31,8 +31,8 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
-#include <lbann.pb.h>
+#include "lbann/proto/layers.pb.h"
+#include "lbann/proto/lbann.pb.h"
 
 namespace lbann {
 namespace {

--- a/src/layers/transform/reduction.cpp
+++ b/src/layers/transform/reduction.cpp
@@ -29,7 +29,7 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/reshape.cpp
+++ b/src/layers/transform/reshape.cpp
@@ -28,7 +28,7 @@
 #include "lbann/layers/transform/reshape.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/stop_gradient.cpp
+++ b/src/layers/transform/stop_gradient.cpp
@@ -30,8 +30,8 @@
 #include "lbann/proto/datatype_helpers.hpp"
 #include <lbann/proto/proto_common.hpp>
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/transform_builders.cpp
+++ b/src/layers/transform/transform_builders.cpp
@@ -43,7 +43,7 @@
 
 #include "lbann/utils/protobuf.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer> lbann::build_batchwise_reduce_sum_layer_from_pbuf(

--- a/src/layers/transform/uniform.cpp
+++ b/src/layers/transform/uniform.cpp
@@ -29,7 +29,7 @@
 #include "lbann/layers/transform/uniform.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 #include "lbann/utils/protobuf.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/unpooling.cpp
+++ b/src/layers/transform/unpooling.cpp
@@ -27,7 +27,7 @@
 #define LBANN_UNPOOLING_LAYER_INSTANTIATE
 #include "lbann/layers/transform/unpooling.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/weighted_sum.cpp
+++ b/src/layers/transform/weighted_sum.cpp
@@ -31,8 +31,8 @@
 #include "lbann/proto/proto_common.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/layers/transform/weights.cpp
+++ b/src/layers/transform/weights.cpp
@@ -32,8 +32,8 @@
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/proto/datatype_helpers.hpp"
 
-#include <lbann.pb.h>
-#include <layers.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -48,8 +48,8 @@
 #include "lbann/utils/summary_impl.hpp"
 #include "lbann/utils/onnx_utils.hpp"
 
-#include <model.pb.h>
-#include <optimizers.pb.h>
+#include "lbann/proto/model.pb.h"
+#include "lbann/proto/optimizers.pb.h"
 
 #include <algorithm>
 #include <fstream>

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -37,7 +37,7 @@
 #include <lbann/utils/lbann_library.hpp>
 #include <lbann/proto/factories.hpp>
 
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <google/protobuf/text_format.h>
 
 namespace pb = ::google::protobuf;

--- a/src/models/unit_test/modify_test.cpp
+++ b/src/models/unit_test/modify_test.cpp
@@ -36,7 +36,7 @@
 #include <lbann/utils/lbann_library.hpp>
 
 #include <google/protobuf/text_format.h>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 using namespace lbann;
 

--- a/src/objective_functions/layer_term.cpp
+++ b/src/objective_functions/layer_term.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/utils/serialize.hpp"
-#include <objective_functions.pb.h>
+#include "lbann/proto/objective_functions.pb.h"
 
 namespace lbann {
 

--- a/src/objective_functions/weight_regularization/l2.cpp
+++ b/src/objective_functions/weight_regularization/l2.cpp
@@ -33,7 +33,7 @@
 #include "lbann/weights/data_type_weights.hpp"
 #include "lbann/utils/serialize.hpp"
 #include <h2/patterns/multimethods/SwitchDispatcher.hpp>
-#include <objective_functions.pb.h>
+#include "lbann/proto/objective_functions.pb.h"
 
 namespace lbann {
 

--- a/src/operators/math/unit_test/abs_test.cpp
+++ b/src/operators/math/unit_test/abs_test.cpp
@@ -48,7 +48,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/add_constant_test.cpp
+++ b/src/operators/math/unit_test/add_constant_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/add_test.cpp
+++ b/src/operators/math/unit_test/add_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/clamp_test.cpp
+++ b/src/operators/math/unit_test/clamp_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/constant_subtract_test.cpp
+++ b/src/operators/math/unit_test/constant_subtract_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/cos_test.cpp
+++ b/src/operators/math/unit_test/cos_test.cpp
@@ -48,7 +48,7 @@
 #include <matrices.hpp>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <math.h>
 #if defined M_PI

--- a/src/operators/math/unit_test/equal_constant_test.cpp
+++ b/src/operators/math/unit_test/equal_constant_test.cpp
@@ -47,7 +47,7 @@
 #include <matrices.hpp>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/multiply_test.cpp
+++ b/src/operators/math/unit_test/multiply_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/not_equal_constant_test.cpp
+++ b/src/operators/math/unit_test/not_equal_constant_test.cpp
@@ -47,7 +47,7 @@
 #include <matrices.hpp>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/scale_test.cpp
+++ b/src/operators/math/unit_test/scale_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/sin_test.cpp
+++ b/src/operators/math/unit_test/sin_test.cpp
@@ -47,7 +47,7 @@
 #include <h2/meta/core/Lazy.hpp>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 #include <math.h>
 #if defined M_PI_2

--- a/src/operators/math/unit_test/subtract_constant_test.cpp
+++ b/src/operators/math/unit_test/subtract_constant_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/operators/math/unit_test/subtract_test.cpp
+++ b/src/operators/math/unit_test/subtract_test.cpp
@@ -46,7 +46,7 @@
 #include <functional>
 #include <memory>
 #include <numeric>
-#include <operators.pb.h>
+#include "lbann/proto/operators.pb.h"
 
 using namespace lbann;
 

--- a/src/optimizers/hypergradient_adam.cpp
+++ b/src/optimizers/hypergradient_adam.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/memory.hpp"
 
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace lbann {
 

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -51,15 +51,15 @@ if (LBANN_HAS_PROTOBUF)
 
   foreach (proto IN LISTS PROTO_INPUTS)
     get_filename_component(name "${proto}" NAME_WE)
-    list(APPEND PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/${name}.pb.cc")
-    list(APPEND PROTO_HDRS "${CMAKE_CURRENT_BINARY_DIR}/${name}.pb.h")
+    list(APPEND PROTO_SRCS "${CMAKE_CURRENT_BINARY_DIR}/lbann/proto/${name}.pb.cc")
+    list(APPEND PROTO_HDRS "${CMAKE_CURRENT_BINARY_DIR}/lbann/proto/${name}.pb.h")
 if (LBANN_HAS_PYTHON_FRONTEND)
     list(APPEND PROTO_PY "${CMAKE_CURRENT_BINARY_DIR}/${name}_pb2.py")
 endif (LBANN_HAS_PYTHON_FRONTEND)
   endforeach ()
   add_custom_command(
     COMMAND protobuf::protoc
-    "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}"
+    "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}/lbann/proto"
     $<$<BOOL:${LBANN_HAS_PYTHON_FRONTEND}>:--python_out=${CMAKE_CURRENT_BINARY_DIR}>
     "-I" "${CMAKE_CURRENT_SOURCE_DIR}"
     "${PROTO_INPUTS}"
@@ -76,6 +76,8 @@ endif (LBANN_HAS_PYTHON_FRONTEND)
   target_link_libraries(LbannProto PUBLIC protobuf::libprotobuf)
   target_include_directories(LbannProto SYSTEM PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+  target_include_directories(LbannProto PRIVATE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/lbann/proto>)
   target_include_directories(LbannProto PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
@@ -91,7 +93,7 @@ endif (LBANN_HAS_PYTHON_FRONTEND)
     )
 
   # Install the newly built headers
-  install(FILES ${PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(FILES ${PROTO_HDRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lbann/proto)
 
 if (LBANN_HAS_PYTHON_FRONTEND)
   # Install the Python module into the site-packages directory

--- a/src/proto/factories/callback_factory.cpp
+++ b/src/proto/factories/callback_factory.cpp
@@ -81,8 +81,8 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <callbacks.pb.h>
-#include <model.pb.h>
+#include "lbann/proto/callbacks.pb.h"
+#include "lbann/proto/model.pb.h"
 
 #include <google/protobuf/message.h>
 

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -43,7 +43,7 @@
 
 #include "lbann/data_coordinator/data_coordinator_metadata.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 namespace lbann {
 

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -30,8 +30,8 @@
 
 #include "lbann/layers/learning/fully_connected.hpp"
 
-#include <model.pb.h>
-#include <trainer.pb.h>
+#include "lbann/proto/model.pb.h"
+#include "lbann/proto/trainer.pb.h"
 
 #include <string>
 #include <unordered_map>

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -32,8 +32,8 @@
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/objective_functions/weight_regularization/l2.hpp"
 
-#include <model.pb.h>
-#include <objective_functions.pb.h>
+#include "lbann/proto/model.pb.h"
+#include "lbann/proto/objective_functions.pb.h"
 
 #include <memory>
 #include <string>

--- a/src/proto/factories/objective_function_factory.cpp
+++ b/src/proto/factories/objective_function_factory.cpp
@@ -31,7 +31,7 @@
 #include "lbann/objective_functions/layer_term.hpp"
 #include "lbann/objective_functions/weight_regularization/l2.hpp"
 
-#include <objective_functions.pb.h>
+#include "lbann/proto/objective_functions.pb.h"
 
 namespace lbann {
 namespace proto {

--- a/src/proto/factories/optimizer_factory.cpp
+++ b/src/proto/factories/optimizer_factory.cpp
@@ -37,7 +37,7 @@
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/utils/factory.hpp"
 
-#include <optimizers.pb.h>
+#include "lbann/proto/optimizers.pb.h"
 
 namespace {
 

--- a/src/proto/factories/trainer_factory.cpp
+++ b/src/proto/factories/trainer_factory.cpp
@@ -31,7 +31,7 @@
 #include "lbann/data_coordinator/buffered_data_coordinator.hpp"
 #include "lbann/execution_algorithms/factory.hpp"
 
-#include <trainer.pb.h>
+#include "lbann/proto/trainer.pb.h"
 
 namespace lbann {
 namespace proto {

--- a/src/proto/factories/transform_factory.cpp
+++ b/src/proto/factories/transform_factory.cpp
@@ -53,8 +53,8 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <reader.pb.h>
-#include <transforms.pb.h>
+#include "lbann/proto/reader.pb.h"
+#include "lbann/proto/transforms.pb.h"
 
 namespace {
 

--- a/src/proto/factories/weights_factory.cpp
+++ b/src/proto/factories/weights_factory.cpp
@@ -34,7 +34,7 @@
 #include "lbann/utils/factory.hpp"
 #include "lbann/utils/protobuf.hpp"
 
-#include <weights.pb.h>
+#include "lbann/proto/weights.pb.h"
 
 namespace {
 

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -36,7 +36,7 @@
 #endif // LBANN_HAS_OPENCV
 #include "lbann/data_readers/data_reader_mnist.hpp"
 
-#include <reader.pb.h>
+#include "lbann/proto/reader.pb.h"
 
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -37,8 +37,8 @@
 #include "lbann/data_readers/data_reader_HDF5.hpp"
 #include "lbann/utils/options.hpp"
 
-#include <lbann.pb.h>
-#include <reader.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/reader.pb.h"
 
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>

--- a/src/trainers/trainer.cpp
+++ b/src/trainers/trainer.cpp
@@ -40,7 +40,7 @@
 #include "lbann/utils/serialize.hpp"
 
 // LBANN proto
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 
 // STL
 #include <functional>

--- a/src/transforms/normalize.cpp
+++ b/src/transforms/normalize.cpp
@@ -28,7 +28,7 @@
 
 #include "lbann/proto/proto_common.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/scale.cpp
+++ b/src/transforms/scale.cpp
@@ -26,7 +26,7 @@
 
 #include "lbann/transforms/scale.hpp"
 #include "lbann/utils/memory.hpp"
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/adjust_brightness.cpp
+++ b/src/transforms/vision/adjust_brightness.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/adjust_contrast.cpp
+++ b/src/transforms/vision/adjust_contrast.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/adjust_saturation.cpp
+++ b/src/transforms/vision/adjust_saturation.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/center_crop.cpp
+++ b/src/transforms/vision/center_crop.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <cmath>
 

--- a/src/transforms/vision/color_jitter.cpp
+++ b/src/transforms/vision/color_jitter.cpp
@@ -32,7 +32,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <algorithm>
 

--- a/src/transforms/vision/cutout.cpp
+++ b/src/transforms/vision/cutout.cpp
@@ -28,7 +28,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/horizontal_flip.cpp
+++ b/src/transforms/vision/horizontal_flip.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/normalize_to_lbann_layout.cpp
+++ b/src/transforms/vision/normalize_to_lbann_layout.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/pad.cpp
+++ b/src/transforms/vision/pad.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/random_affine.cpp
+++ b/src/transforms/vision/random_affine.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/random_crop.cpp
+++ b/src/transforms/vision/random_crop.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/transforms/vision/random_resized_crop.cpp
+++ b/src/transforms/vision/random_resized_crop.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.cpp
+++ b/src/transforms/vision/random_resized_crop_with_fixed_aspect_ratio.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/resize.cpp
+++ b/src/transforms/vision/resize.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/resized_center_crop.cpp
+++ b/src/transforms/vision/resized_center_crop.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 #include <opencv2/imgproc.hpp>
 

--- a/src/transforms/vision/vertical_flip.cpp
+++ b/src/transforms/vision/vertical_flip.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/opencv.hpp"
 
-#include <transforms.pb.h>
+#include "lbann/proto/transforms.pb.h"
 
 namespace lbann {
 namespace transform {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -42,9 +42,9 @@
 #include "lbann/utils/argument_parser.hpp"
 
 #include <cstdlib>
-#include <lbann.pb.h>
+#include "lbann/proto/lbann.pb.h"
 #include <memory>
-#include <model.pb.h>
+#include "lbann/proto/model.pb.h"
 
 namespace lbann {
 

--- a/src/utils/protobuf_utils.cpp
+++ b/src/utils/protobuf_utils.cpp
@@ -29,7 +29,7 @@
 #include "lbann/utils/protobuf_utils.hpp"
 #include "lbann/proto/proto_common.hpp"
 
-#include <lbann.pb.h> // Actually use LbannPB here
+#include "lbann/proto/lbann.pb.h" // Actually use LbannPB here
 
 /**
  * all methods in protobuf_utils are static

--- a/src/utils/unit_test/protobuf_utils_test.cpp
+++ b/src/utils/unit_test/protobuf_utils_test.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/protobuf/impl.hpp"
 
 #include <google/protobuf/descriptor.h>
-#include "lbann/proto/protobuf_utils_test_messages.pb.h"
+#include "protobuf_utils_test_messages.pb.h"
 
 #include <string>
 

--- a/src/utils/unit_test/protobuf_utils_test.cpp
+++ b/src/utils/unit_test/protobuf_utils_test.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/protobuf/impl.hpp"
 
 #include <google/protobuf/descriptor.h>
-#include <protobuf_utils_test_messages.pb.h>
+#include "lbann/proto/protobuf_utils_test_messages.pb.h"
 
 #include <string>
 

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -36,8 +36,8 @@
 #include "lbann/utils/options.hpp"
 #include "lbann/utils/onnx_utils.hpp"
 
-#include <layers.pb.h>
-#include <weights.pb.h>
+#include "lbann/proto/layers.pb.h"
+#include "lbann/proto/weights.pb.h"
 
 #include <algorithm>
 #include <sstream>

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -33,7 +33,7 @@
 #include "lbann/utils/protobuf.hpp"
 #include "lbann/utils/random.hpp"
 
-#include <weights.pb.h>
+#include "lbann/proto/weights.pb.h"
 #ifdef LBANN_HAS_CNPY
 #include <cnpy.h>
 #endif // LBANN_HAS_CNPY

--- a/src/weights/variance_scaling_initializers.cpp
+++ b/src/weights/variance_scaling_initializers.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/memory.hpp"
 #include <h2/patterns/multimethods/SwitchDispatcher.hpp>
 
-#include <weights.pb.h>
+#include "lbann/proto/weights.pb.h"
 
 namespace lbann {
 namespace {

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -30,7 +30,7 @@
 #include "lbann/utils/serialize.hpp"
 #include "lbann/io/file_io.hpp"
 
-#include <layers.pb.h>
+#include "lbann/proto/layers.pb.h"
 
 #include <algorithm>
 #include <sstream>

--- a/tests/test_shuffled_indices.cpp
+++ b/tests/test_shuffled_indices.cpp
@@ -29,8 +29,8 @@
 #include "lbann/lbann.hpp"
 #include "lbann/proto/proto_common.hpp"
 
-#include <lbann.pb.h>
-#include <reader.pb.h>
+#include "lbann/proto/lbann.pb.h"
+#include "lbann/proto/reader.pb.h"
 
 #include <string>
 


### PR DESCRIPTION
As part of installation, the `*.pb.h` files are found in the top-level directory, which might cause name clashes. This PR moves those files into the lbann/proto include subdirectory.

@benson31 @bvanessen 