### PR TITLE
Clean up compiler warnings

### DIFF
--- a/data_utils/hdf5/generate_schema_and_sample_list.cpp
+++ b/data_utils/hdf5/generate_schema_and_sample_list.cpp
@@ -33,8 +33,8 @@
 
 #include <conduit/conduit.hpp>
 #include <conduit/conduit_relay.hpp>
-#include <conduit/conduit_relay_hdf5.hpp>
 #include <conduit/conduit_relay_io.hpp>
+#include <conduit/conduit_relay_io_hdf5.hpp>
 #include <conduit/conduit_relay_io_identify_protocol_api.hpp>
 #include <conduit/conduit_schema.hpp>
 #include <conduit/conduit_utils.hpp>

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -218,7 +218,7 @@ inline std::ostream &operator<<(std::ostream &os,
   return os;
 }
 
-static std::ostream &print_parallel_strategy_header(std::ostream &os) {
+inline std::ostream &print_parallel_strategy_header(std::ostream &os) {
   os << "Axis over which DistConv can parallelize:\n"
      << "\tSamples in the mini-batch (N)\n"
      << "\tDepth, Height, and Width (D x H x W)\n"

--- a/src/callbacks/alternate_updates.cpp
+++ b/src/callbacks/alternate_updates.cpp
@@ -49,7 +49,7 @@ void alternate_updates::on_batch_begin(model *m) {
   const auto& c = m->get_execution_context();
   const auto& step = c.get_step();
 
-  if(step % m_iters_tot == 0 || step % m_iters_tot == m_iters_1) {
+  if(step % m_iters_tot == 0ul || step % m_iters_tot == (unsigned long) m_iters_1) {
     for(size_t i = 0; i < freeze_layers.size(); i++){
       if(!freeze_layers[i])
         LBANN_ERROR("Layer pointer is null.");

--- a/src/data_readers/data_reader_npz_ras_lipid.cpp
+++ b/src/data_readers/data_reader_npz_ras_lipid.cpp
@@ -304,19 +304,27 @@ bool ras_lipid_conduit_data_reader::fetch_datum(Mat& X, int data_id, int mb_idx)
     X(j, mb_idx) = data[j];
   }
 
-#if 0
-Notes from Adam:
-The keras model that I gave you only looks at the density_sig1 data as input data and it uses the states data as labels.  We'll want to also extract bbs to merge that with density_sig1 in various ways as input data in future models that we're putting together.
+/*
+  Notes from Adam:
 
- The probs field can be useful as an alternate label if building a regression model instead of a classification model.  I've also been using the probs field as a filter on the training data to only consider those input data whose state probability exceeds some threshold.
+  The keras model that I gave you only looks at the density_sig1 data
+  as input data and it uses the states data as labels.  We'll want to
+  also extract bbs to merge that with density_sig1 in various ways as
+  input data in future models that we're putting together.
+
+  The probs field can be useful as an alternate label if building a
+  regression model instead of a classification model.  I've also been
+  using the probs field as a filter on the training data to only
+  consider those input data whose state probability exceeds some
+  threshold.
 
   So that works out to:
 
    bb, density_sig1 - datum
    states           - label
    probs            - used as a filter to include/exclude certain samples
+*/
 
-#endif
   return true;
 }
 

--- a/src/layers/image/image_layer_builders.cpp
+++ b/src/layers/image/image_layer_builders.cpp
@@ -45,6 +45,7 @@ std::unique_ptr<lbann::Layer> lbann::build_bilinear_resize_layer_from_pbuf(
                                                                params.height(),
                                                                params.width());
   }
+  (void) comm;
   LBANN_ERROR(
     "bilinear resize layer is only supported with a data-parallel layout");
   return nullptr;
@@ -72,6 +73,7 @@ lbann::build_composite_image_transformation_layer_from_pbuf(
                   "\"float\" and \"double\".");
   }
   else {
+    (void) comm;
     LBANN_ERROR("composite image transformation layer is only supported with "
                 "a data-parallel layout and on CPU");
     return nullptr;
@@ -92,10 +94,13 @@ lbann::build_rotation_layer_from_pbuf(lbann_comm* comm,
       return std::make_unique<
         rotation_layer<double, data_layout::DATA_PARALLEL, El::Device::CPU>>(
         comm);
-    else
+    else {
+      (void) comm;
       LBANN_ERROR(
         "rotation_layer is only supported for \"float\" and \"double\".");
+    }
   else {
+    (void) comm;
     LBANN_ERROR("rotation layer is only supported with a data-parallel layout "
                 "and on CPU");
     return nullptr;
@@ -105,7 +110,7 @@ lbann::build_rotation_layer_from_pbuf(lbann_comm* comm,
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>
 lbann::build_cutout_layer_from_pbuf(lbann_comm* comm,
-                                      lbann_data::Layer const&)
+                                    lbann_data::Layer const&)
 {
   if constexpr (L == data_layout::DATA_PARALLEL && D == El::Device::CPU)
     if constexpr (std::is_same_v<T, float>)
@@ -116,10 +121,13 @@ lbann::build_cutout_layer_from_pbuf(lbann_comm* comm,
       return std::make_unique<
         cutout_layer<double, data_layout::DATA_PARALLEL, El::Device::CPU>>(
         comm);
-    else
+    else {
+      (void) comm;
       LBANN_ERROR(
         "cutout_layer is only supported for \"float\" and \"double\".");
+    }
   else {
+    (void) comm;
     LBANN_ERROR("cutout layer is only supported with a data-parallel layout "
                 "and on CPU");
     return nullptr;

--- a/src/layers/io/input_layer.cpp
+++ b/src/layers/io/input_layer.cpp
@@ -46,6 +46,7 @@ lbann::build_input_layer_from_pbuf(lbann_comm* comm,
   const auto& params = proto_layer.input();
   const auto& data_field = params.data_field();
   if constexpr (L != data_layout::DATA_PARALLEL) {
+    (void) comm;
     LBANN_ERROR("input layer is only supported with "
                 "a data-parallel layout");
   }
@@ -55,6 +56,7 @@ lbann::build_input_layer_from_pbuf(lbann_comm* comm,
       input_layer<DataType, data_layout::DATA_PARALLEL, D>>(comm, data_field);
   }
   else {
+    (void) comm;
     LBANN_ERROR("Input layers are only valid with "
                 "TensorDataType == DataType and Layout == DATA_PARALLEL");
   }

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1155,7 +1155,7 @@ void base_convolution_adapter<TensorDataType, Device>::setup_fp_tensors() {
   dc::util::print_vector(ss, kernel_dims.begin(), kernel_dims.end());
 
   // assumes no partitioning on channel/filter dimensions
-  assert_eq(input_dist.get_split_shape()[-2], 1);
+  assert_eq(input_dist.get_split_shape()[-2], 1ul);
   auto shared_dist = dc::Dist::make_shared_distribution(
     input_dist.get_locale_shape());
 

--- a/src/layers/misc/misc_builders.cpp
+++ b/src/layers/misc/misc_builders.cpp
@@ -162,6 +162,7 @@ lbann::build_argmax_layer_from_pbuf(lbann_comm* comm,
     return std::make_unique<
       argmax_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>>(comm);
   else {
+    (void) comm;
     LBANN_ERROR(
       "argmax layer is only supported with a data-parallel layout and on CPU");
     return nullptr;
@@ -177,6 +178,7 @@ lbann::build_argmin_layer_from_pbuf(lbann_comm* comm,
     return std::make_unique<
       argmin_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>>(comm);
   else {
+    (void) comm;
     LBANN_ERROR(
       "argmin layer is only supported with a data-parallel layout and on CPU");
     return nullptr;
@@ -193,6 +195,7 @@ std::unique_ptr<lbann::Layer> lbann::build_channelwise_mean_layer_from_pbuf(
       channelwise_mean_layer<T, data_layout::DATA_PARALLEL, D>>(comm);
   }
   else {
+    (void) comm;
     LBANN_ERROR("channel-wise mean layer is only supported with "
                 "a data-parallel layout");
     return nullptr;
@@ -212,6 +215,7 @@ lbann::build_channelwise_softmax_layer_from_pbuf(lbann_comm* comm,
       return std::make_unique<
         channelwise_softmax_layer<double, data_layout::DATA_PARALLEL, D>>(comm);
   }
+  (void) comm;
   LBANN_ERROR("Attempted to construct channelwise_softmax_layer ",
               "with invalid parameters ",
               "(TensorDataType=",
@@ -243,6 +247,7 @@ lbann::build_dft_abs_layer_from_pbuf(lbann_comm* comm, lbann_data::Layer const&)
   if constexpr (L == data_layout::DATA_PARALLEL)
     return build_dft_layer<T, D>(comm);
   else {
+    (void) comm;
     LBANN_ERROR("dft_abs layers are only supported in DATA_PARALLEL. "
                 "Requested layout: ",
                 to_string(L));

--- a/src/layers/transform/transform_builders.cpp
+++ b/src/layers/transform/transform_builders.cpp
@@ -47,7 +47,7 @@
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer> lbann::build_batchwise_reduce_sum_layer_from_pbuf(
-  lbann_comm* comm,
+  lbann_comm* /*comm*/,
   lbann_data::Layer const& proto_layer)
 {
   if constexpr (L == data_layout::DATA_PARALLEL)
@@ -88,6 +88,7 @@ lbann::build_crop_layer_from_pbuf(lbann_comm* comm,
       protobuf::to_vector<int>(params.dims()));
   }
   else {
+    (void) comm;
     LBANN_ERROR("Attempted to instantiate \"crop\" layer with "
                 "Layout=",
                 to_string(L),
@@ -111,6 +112,7 @@ std::unique_ptr<lbann::Layer> lbann::build_discrete_random_layer_from_pbuf(
       protobuf::to_vector<int>(params.dims()));
   }
   else {
+    (void) comm;
     LBANN_ERROR("discrete random layer is only supported on CPU");
     return nullptr;
   }
@@ -118,7 +120,7 @@ std::unique_ptr<lbann::Layer> lbann::build_discrete_random_layer_from_pbuf(
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>
-lbann::build_gather_layer_from_pbuf(lbann_comm* comm,
+lbann::build_gather_layer_from_pbuf(lbann_comm* /*comm*/,
                                     lbann_data::Layer const& proto_layer)
 {
   if constexpr (L == data_layout::DATA_PARALLEL) {
@@ -166,7 +168,7 @@ lbann::build_in_top_k_layer_from_pbuf(lbann_comm* comm,
 
 template <typename T, lbann::data_layout L, El::Device D>
 std::unique_ptr<lbann::Layer>
-lbann::build_scatter_layer_from_pbuf(lbann_comm* comm,
+lbann::build_scatter_layer_from_pbuf(lbann_comm* /*comm*/,
                                      lbann_data::Layer const& proto_layer)
 {
   if constexpr (L == data_layout::DATA_PARALLEL) {
@@ -249,6 +251,7 @@ lbann::build_sort_layer_from_pbuf(lbann_comm* comm,
       proto_layer.sort().descending());
   }
   else {
+    (void) comm;
     LBANN_ERROR("sort layer is only supported with "
                 "a data-parallel layout");
     return nullptr;
@@ -295,6 +298,7 @@ lbann::build_unpooling_layer_from_pbuf(lbann_comm* comm,
       unpooling_layer<T, data_layout::DATA_PARALLEL, El::Device::CPU>>(comm);
   }
   else {
+    (void) comm;
     LBANN_ERROR("unpooling layer is only supported with "
                 "a data-parallel layout and on CPU");
     return nullptr;

--- a/src/operators/math/abs.cpp
+++ b/src/operators/math/abs.cpp
@@ -41,11 +41,11 @@ void do_abs_bp(El::Matrix<RealT, El::Device::CPU> const& x,
   internal::EntrywiseZipInto(x,
                              gradient_wrt_output,
                              gradient_wrt_input,
-                             [](RealT const& x, RealT const& dy) {
-                               return (x > El::TypeTraits<RealT>::Zero()
-                                         ? dy
-                                         : (x < El::TypeTraits<RealT>::Zero()
-                                              ? -dy
+                             [](RealT const& x_, RealT const& dy_) {
+                               return (x_ > El::TypeTraits<RealT>::Zero()
+                                         ? dy_
+                                         : (x_ < El::TypeTraits<RealT>::Zero()
+                                              ? -dy_
                                               : El::TypeTraits<RealT>::Zero()));
                              });
 }

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -279,6 +279,8 @@ std::unique_ptr<Layer> construct_layer(lbann_comm* comm,
         num_parallel_readers,
         proto_layer);
     else {
+      (void) training_dr_linearized_data_size;
+      (void) num_parallel_readers;
       LBANN_ERROR("Currently, layers of type \"",
                   msg.GetDescriptor()->name(),
                   "\" are not constructible with any type other than the "

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -28,8 +28,6 @@ syntax = "proto3";
 
 package lbann_data;
 
-import "datatype.proto";
-
 import "callbacks.proto";
 
 import "training_algorithm.proto";

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -197,6 +197,7 @@ bool is_p2p_shuffle_feasible(const Tensor &tensor) {
   return true;
 }
 
+#ifdef DISTCONV_HAS_P2P
 void *shuffler_src_buf = nullptr;
 size_t shuffler_src_buf_size = 0;
 void *shuffler_dst_buf = nullptr;
@@ -249,6 +250,7 @@ void delete_shuffler_buffers() {
     shuffler_dst_buf = nullptr;
   }
 }
+#endif
 } // namespace
 
 int get_strided_mpi_rank(MPI_Comm comm) {
@@ -312,7 +314,9 @@ void finalize() {
     delete backend_instance;
     backend_instance = nullptr;
     initialized = false;
+#ifdef DISTCONV_HAS_P2P
     delete_shuffler_buffers();
+#endif
   }
 }
 


### PR DESCRIPTION
This covers Clang builds on Pascal and GCC builds on Lassen. There are still some `-Wdeprecated-declarations` warnings, but those aren't as trivial to squash.