### PR TITLE
Fix an explicit path in Python Front-End

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -96,7 +96,8 @@ def make_batch_script(
         set_environment('MIOPEN_DEBUG_DISABLE_FIND_DB', '1')
         set_environment('MIOPEN_DISABLE_CACHE', '1')
         prepend_environment_path('LD_LIBRARY_PATH', os.getenv('CRAY_LD_LIBRARY_PATH'))
-        prepend_environment_path('LD_LIBRARY_PATH', '/opt/rocm-5.3.0/llvm/lib')
+        if os.getenv('ROCM_PATH') is not None:
+            prepend_environment_path('LD_LIBRARY_PATH', os.path.join(os.getenv('ROCM_PATH'), 'llvm', 'lib'))
 
     # Optimizations for Sierra-like systems
     if system in ('sierra', 'lassen', 'rzansel'):


### PR DESCRIPTION
This shouldn't code a specific ROCm version. If the user wants this, they can load the right module or set this path explicitly. Or Spack should be able to do that for them.

As a separate issue, we should talk about the `CRAY_LD_LIBRARY_PATH` addition as well, since that _also_ seems to be a Spack issue. It's not needed in any sane build.