### PR TITLE
Pin scipy at working version for Power

### DIFF
--- a/scripts/common_spack_packages/ci_spack_packages.sh
+++ b/scripts/common_spack_packages/ci_spack_packages.sh
@@ -5,5 +5,5 @@
 # script when the lbann+python variant is enabled
 spack add python ${CENTER_COMPILER}
 spack add py-pytest ${CENTER_COMPILER}
-spack add py-scipy ${CENTER_COMPILER}
+spack add py-scipy@1.8.1 ${CENTER_COMPILER}
 spack add py-tqdm ${CENTER_COMPILER}


### PR DESCRIPTION
Limit the version of py-scipy built as an external dependency to limit the challenges of building on pwoer systems.