### PR TITLE
Replace Relu with LeakyRelu in Unet3d app.

### DIFF
--- a/applications/segmentation/unet3d/unet3d_network_architectures.py
+++ b/applications/segmentation/unet3d/unet3d_network_architectures.py
@@ -122,7 +122,7 @@ class UNet3DConvBlock(lm.Module):
                 3,
                 stride=1,
                 padding=1,
-                activation=lbann.Relu,
+                activation=lbann.LeakyRelu,
                 bias=False,
                 name="{}_conv_block_{}".format(self.name, i+1)))
 
@@ -173,7 +173,7 @@ class Convolution3dBNModule(lm.Module):
                 self.name,
                 self.instance))
         if self.activation is not None:
-            x = self.activation(x)
+            x = self.activation(x, negative_slope=0.0)
 
         return x
 


### PR DESCRIPTION
This PR replaces Relu() with LeakyRelu() in the Unet 3d model because the current Relu implementation in distconv does not work in this context.
Specifically, the distconv's ReLU activation function uses cuDNN's ReLU implementation, and it requires the same stride sizes in the tensors.