### PR TITLE
Bugfixes for CI and Spack

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -60,8 +60,6 @@ def make_batch_script(
     # touch the wrong GPU while figuring out ownership.
     if scheduler == 'slurm' and has_gpu(system):
         launcher_args.extend(['--mpibind=off'])
-        if system != 'corona':
-            launcher_args.extend(['--nvidia_compute_mode=default'])
 
     # Optimized thread affinity for Pascal
     # Note: Both GPUs are on socket 0, so we only use cores on that

--- a/scripts/build_lbann.sh
+++ b/scripts/build_lbann.sh
@@ -692,12 +692,12 @@ if [[ -n "${INSTALL_DEPS:-}" ]]; then
     [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
 
     # Limit the scope of the external search to minimize overhead time
-    CRAY_MANIFEST="/opt/cray/pe/cpe-descriptive-manifest"
-    if [[ -e ${CRAY_MANIFEST} ]]; then
-       CMD="spack external read-cray-manifest --directory ${CRAY_MANIFEST} --fail-on-error"
-       echo ${CMD} | tee -a ${LOG}
-       [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
-    fi
+    # CRAY_MANIFEST="/opt/cray/pe/cpe-descriptive-manifest"
+    # if [[ -e ${CRAY_MANIFEST} ]]; then
+    #    CMD="spack external read-cray-manifest --directory ${CRAY_MANIFEST} --fail-on-error"
+    #    echo ${CMD} | tee -a ${LOG}
+    #    [[ -z "${DRY_RUN:-}" ]] && { ${CMD} || exit_on_failure "${CMD}"; }
+    # fi
 
     # Use standard tags for common packages
     CMD="spack external find --scope env:${LBANN_ENV} --tag core-packages --tag build-tools --tag rocm"

--- a/scripts/customize_build_env.sh
+++ b/scripts/customize_build_env.sh
@@ -100,11 +100,11 @@ set_center_specific_modules()
                 MODULE_CMD_CLANG="module --force unload StdEnv; module load clang/10.0.1-gcc-8.3.1 cuda/11.6.1 spectrum-mpi/rolling-release python/3.7.2 essl/6.3.0.1"
                 ;;
             "broadwell" | "haswell" | "sandybridge") # Pascal, RZHasGPU, Surface
-                MODULE_CMD_GCC="module load gcc/10.3.1-magic cuda/11.8.0 openmpi/4.1.2 python/3.9.12"
+                MODULE_CMD_GCC="module load gcc/10.3.1-magic cuda/11.8.0 mvapich2/2.3.6 python/3.9.12"
                 MODULE_CMD_CLANG="module --force unload StdEnv; module load clang/12.0.1 cuda/11.6.1 mvapich2/2.3.6 python/3.7.2"
                 ;;
             "ivybridge" | "cascadelake") # Catalyst, Ruby
-                MODULE_CMD="module --force unload StdEnv; module load gcc/10.2.1 mvapich2/2.3 python/3.7.2"
+                MODULE_CMD="module --force unload StdEnv; module load gcc/10.2.1 mvapich2/2.3.6 python/3.7.2"
                 ;;
             "zen" | "zen2") # Corona
                 MODULE_CMD="module load StdEnv gcc-tce/10.3.1 cmake/3.23.1 openmpi-tce/4.1.2 rocm/5.4.1"
@@ -181,13 +181,13 @@ set_center_specific_spack_dependencies()
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_COMPILER="%gcc"
 #                CENTER_COMPILER="%clang"
-                CENTER_DEPENDENCIES="^openmpi@4.1.2"
+                CENTER_DEPENDENCIES="^mvapich2@2.3.6"
 #                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10 ^protobuf@3.10.0 ^py-protobuf@3.10.0"
                 ;;
             "ivybridge" | "cascadelake") # Catalyst, Ruby
                 # On LC the mvapich2 being used is built against HWLOC v1
                 CENTER_COMPILER="%gcc"
-                CENTER_DEPENDENCIES="^mvapich2 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10 ^protobuf@3.10.0 ^py-protobuf@3.10.0"
+                CENTER_DEPENDENCIES="^mvapich2@2.3.6 ^hwloc@1.11.13 ^libtool@2.4.2 ^python@3.9.10 ^protobuf@3.10.0 ^py-protobuf@3.10.0"
                 ;;
             "zen" | "zen2") # Corona
                 # On LC the mvapich2 being used is built against HWLOC v1
@@ -197,7 +197,7 @@ set_center_specific_spack_dependencies()
                 ;;
             "zen3") # Tioga, RZVernal
                 CENTER_COMPILER="%rocmcc@5.4.3"
-                CENTER_DEPENDENCIES="^cray-mpich@8.1.21 ^hip@5.4.3 ^python@3.9.12"
+                CENTER_DEPENDENCIES="^cray-mpich@8.1.24 ^hip@5.4.3 ^python@3.9.12"
                 CENTER_BLAS_LIBRARY="blas=libsci"
                 # Override the conduit variants for the cray compilers
                 CONDUIT_VARIANTS="~hdf5_compat~fortran~parmetis~blt_find_mpi"
@@ -383,21 +383,23 @@ cat <<EOF  >> ${yaml}
     cray-libsci:
       buildable: False
       version:
-      - 22.08.1.1
+      - 23.02.1.1
       externals:
-      - spec: cray-libsci@22.08.1.1 arch=${spack_arch}
+      - spec: cray-libsci@23.02.1.1 %rocmcc arch=${spack_arch}
         modules:
-        - cray-libsci/22.08.1.1
+        - amd/5.4.3 PrgEnv-amd/8.3.3 cray-libsci/23.02.1.1
     cray-mpich:
       buildable: False
       version:
-      - 8.1.21
+      - 8.1.24
       externals:
-      - spec: cray-mpich@8.1.21 arch=${spack_arch}
+      - spec: cray-mpich@8.1.24 %rocmcc arch=${spack_arch}
         modules:
-        - cray-mpich/8.1.21
-#      - spec: cray-mpich@8.1.21 +wrappers arch=${spack_arch}
-#        prefix: /opt/cray/pe/mpich/8.1.21/ofi/crayclang/10.0/
+        - amd/5.4.3 PrgEnv-amd/8.3.3 cray-mpich/8.1.24
+      # - spec: cray-mpich@8.1.24 +wrappers %cc arch=${spack_arch}
+      #   prefix: /opt/cray/pe/mpich/8.1.24/ofi/crayclang/10.0/
+      # - spec: cray-mpich@8.1.24 +wrappers %rocmcc arch=${spack_arch}
+      #   prefix: /opt/cray/pe/mpich/8.1.24/ofi/amd/5.0/
 EOF
                 ;;
             *)


### PR DESCRIPTION
Removed a deprecated slurm wrapper command to bind GPUs on Pascal.

Disabled the spack import of the cray manifest since it is not kept up to date.

Fixed the external definitions of the cray-mpich and cray-libsci spack packages.  Note that this should fix the bug where CMake is unable to find MPI.