### PR TITLE
Add guards on distconv CI tests

### DIFF
--- a/ci_test/unit_tests/test_unit_layer_batched_matmul_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_batched_matmul_distconv.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import sys
 import numpy as np
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -47,6 +48,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_channelwise_fully_connected_distconv.py
@@ -50,6 +50,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)   
+    
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_convolution_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_convolution_distconv.py
@@ -119,6 +119,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+    
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_identity_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_distconv.py
@@ -43,6 +43,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_leaky_relu_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_leaky_relu_distconv.py
@@ -47,6 +47,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)   
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_pooling_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_pooling_distconv.py
@@ -104,6 +104,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+    
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_relu_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_relu_distconv.py
@@ -47,6 +47,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if (not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_scatter_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_scatter_distconv.py
@@ -211,6 +211,6 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for _test_func in tools.create_tests(setup_experiment, __file__):
-                                    #  environment=tools.get_distconv_environment()):
+for _test_func in tools.create_tests(setup_experiment, __file__,
+                                    environment=tools.get_distconv_environment()):
     globals()[_test_func.__name__] = _test_func


### PR DESCRIPTION
Adds guards on the Distconv-enabled layer CI tests to check for LBANN Distconv feature or skip the tests. 