### PR TITLE
Skip dft_abs and gru tests when not supported by the build

### DIFF
--- a/ci_test/unit_tests/test_unit_layer_dft_abs.py
+++ b/ci_test/unit_tests/test_unit_layer_dft_abs.py
@@ -76,6 +76,11 @@ def setup_experiment(lbann, weekly):
         lbann (module): Module for LBANN Python frontend
 
     """
+    if not lbann.has_feature('FFTW'):
+        message = f'{os.path.basename(__file__)} requires FFT support'
+        print('Skip - ' + message)
+        pytest.skip(message)
+
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)
     model = construct_model(lbann)

--- a/ci_test/unit_tests/test_unit_layer_dft_abs.py
+++ b/ci_test/unit_tests/test_unit_layer_dft_abs.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import sys
 import numpy as np
+import pytest
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)

--- a/ci_test/unit_tests/test_unit_layer_gru.py
+++ b/ci_test/unit_tests/test_unit_layer_gru.py
@@ -84,13 +84,17 @@ def setup_experiment(lbann, weekly):
 
     """
 
-    # Skip test on non-GPU systems
-    # Note: Test requires cuDNN (on GPU) or oneDNN (on CPU).
-    ### @todo Assume LBANN has been built with oneDNN?
-    if not tools.gpus_per_node(lbann):
-        message = f'{os.path.basename(__file__)} requires cuDNN or oneDNN'
-        print('Skip - ' + message)
-        pytest.skip(message)
+    # Skip test when not supported.    
+    if not tools.gpus_per_node(lbann):   # CPU system
+        if not lbann.has_feature('ONEDNN_CPU'):
+            message = f'{os.path.basename(__file__)} requires oneDNN on CPU'
+            print('Skip - ' + message)
+            pytest.skip(message)
+    else:                                # GPU system
+        if not (lbann.has_feature('CUDA') and lbann.has_feature('CUDNN')):
+            message = f'{os.path.basename(__file__)} requires CUDA and cuDNN on GPU'
+            print('Skip - ' + message)
+            pytest.skip(message)
 
     mini_batch_size = num_samples() // 2
     trainer = lbann.Trainer(mini_batch_size)


### PR DESCRIPTION
These tests are not always supported; the features check allows us to skip them when they cannot run.
