### PR TITLE
Fixed NVSHMEM-enabled gather include

### DIFF
--- a/include/lbann/layers/transform/gather.hpp
+++ b/include/lbann/layers/transform/gather.hpp
@@ -34,7 +34,7 @@
 
 #if defined(LBANN_HAS_DISTCONV) && defined(LBANN_HAS_NVSHMEM)
 #include "lbann/layers/data_type_distconv_adapter.hpp"
-#include "lbann/layers/transform/distconv/distconv_scatter.hpp"
+#include "lbann/layers/transform/distconv/distconv_gather.hpp"
 #include "lbann/utils/nvshmem.hpp"
 #endif // LBANN_HAS_DISTCONV && LBANN_HAS_NVSHMEM
 


### PR DESCRIPTION
Fix the include in gather to point to the distconv gather kernel.   