### PR TITLE
Reformat LBANN code base for protobuf files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -162,4 +162,7 @@ StatementMacros:
 TabWidth:        8
 UseCRLF:         false
 UseTab:          Never
+---
+Language: Proto
+BasedOnStyle: Google
 ...

--- a/src/proto/callbacks.proto
+++ b/src/proto/callbacks.proto
@@ -59,7 +59,8 @@ message Callback {
     CallbackLTFB ltfb = 24;
     CallbackDebugIO debug_io = 25;
     CallbackMinibatchSchedule minibatch_schedule = 26;
-    CallbackOptimizerwiseAdaptiveLearningRate optimizerwise_adaptive_learning_rate = 27;
+    CallbackOptimizerwiseAdaptiveLearningRate
+        optimizerwise_adaptive_learning_rate = 27;
     CallbackCheckpoint checkpoint = 28;
     CallbackSaveModel save_model = 29;
     CallbackPolyLearningRate poly_learning_rate = 30;
@@ -90,44 +91,46 @@ message Callback {
   message CallbackLTFB {
     int64 batch_interval = 1;
     string metric = 2;
-    string weights = 3;       // default: all weights
+    string weights = 3;  // default: all weights
     bool low_score_wins = 4;
-    string communication_algorithm = 5;   // default: "sendrecv_weights"
+    string communication_algorithm = 5;  // default: "sendrecv_weights"
     bool exchange_hyperparameters = 6;
     string checkpoint_basedir = 7;
   }
 
   message CallbackStepLearningRate {
-    string weights = 1; //default: all weights
+    string weights = 1;  // default: all weights
     int64 step = 2;
     double amt = 3;
   }
 
   message CallbackSetLearningRate {
-    string weights = 1; //default: all weights
+    string weights = 1;  // default: all weights
     int64 step = 2;
     double val = 3;
   }
 
   message CallbackCustomLearningRate {
-    //don't know how to support this, since it takes an std::function as an argument
+    // don't know how to support this, since it takes an std::function as an
+    // argument
   }
 
   message CallbackAdaptiveLearningRate {
-    string weights = 1; //default: all weights
+    string weights = 1;  // default: all weights
     int64 patience = 2;
     double amt = 3;
   }
 
   message CallbackSaveImages {
-    string layers       = 1; // Layer outputs to save as images
-    string image_format = 2; // Image format (e.g. jpg, png, pgm)
-    string image_prefix = 3; // Prefix for saved image files
+    string layers = 1;        // Layer outputs to save as images
+    string image_format = 2;  // Image format (e.g. jpg, png, pgm)
+    string image_prefix = 3;  // Prefix for saved image files
   }
 
   message CallbackPrint {
-    int64 interval = 1; //default in lbann_callback_print.hpp is 1
-    bool  print_global_stat_only = 2; //useful in large scale multi-trainer, default is false
+    int64 interval = 1;  // default in lbann_callback_print.hpp is 1
+    bool print_global_stat_only =
+        2;  // useful in large scale multi-trainer, default is false
   }
 
   message CallbackProfiler {
@@ -135,12 +138,11 @@ message Callback {
     bool skip_init = 2;
   }
 
-  message CallbackTimer {
-  }
+  message CallbackTimer {}
 
   message CallbackSummary {
-    int64 batch_interval = 2; //default in lbann_callback_summary.hpp is 1
-    int64 mat_interval = 3; //default in lbann_callback_summary.hpp is 25
+    int64 batch_interval = 2;  // default in lbann_callback_summary.hpp is 1
+    int64 mat_interval = 3;    // default in lbann_callback_summary.hpp is 25
   }
 
   /** @brief Dump weights to files.
@@ -155,18 +157,19 @@ message Callback {
    *  on each process' local data.
    */
   message CallbackDumpWeights {
-    string directory = 1;       // Directory for weight files
-    int64  epoch_interval = 2;  // Frequency for weight dumping
-                                // (default: after each training epoch)
-    string format = 3;          // Options: text (default), binary, distributed_binary
+    string directory = 1;      // Directory for weight files
+    int64 epoch_interval = 2;  // Frequency for weight dumping
+                               // (default: after each training epoch)
+    string format = 3;  // Options: text (default), binary, distributed_binary
   }
 
   message CallbackDumpOutputs {
-    string layers = 1;          // Default: all layers
-    string execution_modes = 2; // Default: all modes
-    int64 batch_interval = 3;   // Frequency for output dumping (default: all steps)
-    string directory = 4;       // Directory for output files
-    string format = 5;          // Options: csv, tsv, npy, npz (default: csv)
+    string layers = 1;           // Default: all layers
+    string execution_modes = 2;  // Default: all modes
+    int64 batch_interval =
+        3;                 // Frequency for output dumping (default: all steps)
+    string directory = 4;  // Directory for output files
+    string format = 5;     // Options: csv, tsv, npy, npz (default: csv)
   }
 
   message CallbackDumpErrorSignals {
@@ -184,7 +187,7 @@ message Callback {
   }
 
   message CallbackDispIOStats {
-    string layers = 1; //e.g: "2 4 5"; use "10000" to apply to all layers
+    string layers = 1;  // e.g: "2 4 5"; use "10000" to apply to all layers
   }
 
   message CallbackImComm {
@@ -193,7 +196,7 @@ message Callback {
   }
 
   message CallbackDebug {
-    string phase = 1; //should be called "modes"
+    string phase = 1;  // should be called "modes"
   }
 
   message CallbackDebugIO {
@@ -201,14 +204,11 @@ message Callback {
     int32 lvl = 2;
   }
 
-  message CallbackCheckSmall {
-  }
+  message CallbackCheckSmall {}
 
-  message CallbackCheckNaN {
-  }
+  message CallbackCheckNaN {}
 
-  message CallbackCheckDataset {
-  }
+  message CallbackCheckDataset {}
 
   message CallbackHang {
     int64 rank = 1;
@@ -261,16 +261,16 @@ message Callback {
   message CallbackCheckGradients {
     double step_size = 1;
     bool verbose = 2;
-    bool error_on_failure = 3; // Throw error if gradient check fails
-    string execution_modes = 4; // Default: all modes
+    bool error_on_failure = 3;   // Throw error if gradient check fails
+    string execution_modes = 4;  // Default: all modes
   }
 
   message CallbackCheckMetric {
     string metric = 1;
     double lower_bound = 2;
     double upper_bound = 3;
-    bool error_on_failure = 4;  // Throw error if metric check fails
-    string execution_modes = 5; // Default: all modes
+    bool error_on_failure = 4;   // Throw error if metric check fails
+    string execution_modes = 5;  // Default: all modes
   }
 
   message CallbackCheckpoint {
@@ -284,7 +284,6 @@ message Callback {
     int64 ckpt_dist_steps = 7;
   }
 
-
   message CallbackSaveModel {
     string dir = 1;
     string extension = 2;
@@ -292,17 +291,16 @@ message Callback {
   }
 
   message CallbackLoadModel {
-    string dirs = 1;  //director(ies) to load pretrained model(s)
+    string dirs = 1;  // director(ies) to load pretrained model(s)
     string extension = 2;
   }
 
   message CallbackReplaceWeights {
-    string source_layers = 1; //set of layers to copy weights from
-    string destination_layers = 2;  //set of layers to copy weights to
+    string source_layers = 1;       // set of layers to copy weights from
+    string destination_layers = 2;  // set of layers to copy weights to
     int64 batch_interval = 3;
   }
-  message CallbackGPUMemoryUsage {
-  }
+  message CallbackGPUMemoryUsage {}
 
   message CallbackSyncLayers {
     bool sync_gpus = 1;
@@ -311,31 +309,38 @@ message Callback {
   }
 
   message CallbackConfusionMatrix {
-    string prediction = 1; // Prediction layer
-    string label = 2;      // Label layer
-    string prefix = 3;     // Prefix for output files
+    string prediction = 1;  // Prediction layer
+    string label = 2;       // Label layer
+    string prefix = 3;      // Prefix for output files
   }
 
   message CallbackPerturbAdam {
-    float learning_rate_factor = 1;   // Learning rate perturbation (in log space)
-    float beta1_factor = 2;           // beta1 perturbation (in log space)
-    float beta2_factor = 3;           // beta2 perturbation (in log space)
-    float eps_factor = 4;             // eps perturbation (in log space)
-    bool perturb_during_training = 5; // Whether to periodically perturb during training
-    int64 batch_interval = 6;         // Frequency of perturbation if perturb_during_training is true
-    string weights = 7;               // Weights with Adam optimizer
+    float learning_rate_factor =
+        1;                   // Learning rate perturbation (in log space)
+    float beta1_factor = 2;  // beta1 perturbation (in log space)
+    float beta2_factor = 3;  // beta2 perturbation (in log space)
+    float eps_factor = 4;    // eps perturbation (in log space)
+    bool perturb_during_training =
+        5;  // Whether to periodically perturb during training
+    int64 batch_interval =
+        6;  // Frequency of perturbation if perturb_during_training is true
+    string weights = 7;  // Weights with Adam optimizer
   }
 
   message CallbackPerturbDropout {
-    float keep_dropout_factor = 1; //Keep dropout prob perturbation (in log space)
-    string layers = 2; // dropout layers to perturb keep prob, all dropout layers by default
+    float keep_dropout_factor =
+        1;              // Keep dropout prob perturbation (in log space)
+    string layers = 2;  // dropout layers to perturb keep prob, all dropout
+                        // layers by default
   }
 
   message CallbackSaveTopKModels {
-    string dir = 1;  //directory to save model
-    int32  k = 2;    //number of (top) models to save
-    string metric = 3; //metrics to use in evaluating models
-    bool  ascending_ordering = 4; //whether to sort metrics per model in ascending order, descending order is default
+    string dir = 1;     // directory to save model
+    int32 k = 2;        // number of (top) models to save
+    string metric = 3;  // metrics to use in evaluating models
+    bool ascending_ordering =
+        4;  // whether to sort metrics per model in
+            // ascending order, descending order is default
   }
 
   message CallbackMixup {
@@ -343,8 +348,7 @@ message Callback {
     float alpha = 2;
   }
 
-  message CallbackCheckInit {
-  }
+  message CallbackCheckInit {}
 
   message CallbackEarlyStopping {
     int64 patience = 1;
@@ -359,8 +363,7 @@ message Callback {
   // Message is printed when the model has finished setup. The
   // description includes information on the model's layers, weights,
   // and callbacks.
-  message CallbackPrintModelDescription {
-  }
+  message CallbackPrintModelDescription {}
 
   /** @brief Set values in a weights object at a given training step */
   message CallbackSetWeightsValue {
@@ -370,19 +373,17 @@ message Callback {
   }
 
   message CallbackSummarizeImages {
-
     message SelectionStrategy {
-
       oneof strategy_type {
         CategoricalAccuracyStrategy categorical_accuracy = 1;
         TrackSampleIDsStrategy track_sample_ids = 2;
       }
 
       message CategoricalAccuracyStrategy {
-        enum MatchType{
-          NOMATCH = 0;//NOMATCH = dump failed categorization
-          MATCH = 1;//MATCH = dump successful categorization
-          ALL = 2;//ALL = dump all
+        enum MatchType {
+          NOMATCH = 0;  // NOMATCH = dump failed categorization
+          MATCH = 1;    // MATCH = dump successful categorization
+          ALL = 2;      // ALL = dump all
         }
         string accuracy_layer_name = 1;
         MatchType match_type = 2;
@@ -394,23 +395,26 @@ message Callback {
         uint64 num_tracked_images = 2;
       }
 
-    }// message SelectionStrategy
+    }  // message SelectionStrategy
 
     SelectionStrategy selection_strategy = 1;
     string image_source_layer_name = 2;
     uint64 epoch_interval = 3;
-  }// message CallbackSummarizeImages
+  }  // message CallbackSummarizeImages
 
   message CallbackDumpModelGraph {
-    string basename = 1; // default: "model.dot"
+    string basename = 1;  // default: "model.dot"
     bool print = 2;
   }
 
   message CallbackPerturbLearningRate {
-    float learning_rate_factor = 1;   // Learning rate perturbation (in log space)
-    bool perturb_during_training = 2; // Whether to periodically perturb during training (default: False)
-    int64 batch_interval = 3;         // Frequency of perturbation if perturb_during_training is true
-    string weights = 4;               // Optimizer weights with lr to perturb (default: All)
+    float learning_rate_factor =
+        1;  // Learning rate perturbation (in log space)
+    bool perturb_during_training =
+        2;  // Whether to periodically perturb during training (default: False)
+    int64 batch_interval =
+        3;  // Frequency of perturbation if perturb_during_training is true
+    string weights = 4;  // Optimizer weights with lr to perturb (default: All)
   }
 
   message CallbackComputeModelSize {
@@ -419,24 +423,25 @@ message Callback {
   }
 
   message CallbackPerturbWeights {
-    float upper = 1; // Upper bound for weight value
-    float lower = 2; // Lower bound for weight value
-    float scale = 3; // Scale of normal distribution N(1,0)
-    float perturb_probability = 4; // Probability of perturbing the weight
+    float upper = 1;                // Upper bound for weight value
+    float lower = 2;                // Lower bound for weight value
+    float scale = 3;                // Scale of normal distribution N(1,0)
+    float perturb_probability = 4;  // Probability of perturbing the weight
     string output_name = 5;
     int64 batch_interval = 6;
   }
 
   /** @brief Export trained model in onnx format */
   message CallbackExportOnnx {
-    string output_filename = 1; // name of onnx output file
-    string debug_string_filename = 2; // print debug string to file
+    string output_filename = 1;        // name of onnx output file
+    string debug_string_filename = 2;  // print debug string to file
   }
 
   message CallbackAlternateUpdates {
-    string layers_1 = 1; // first set of layers to be trained
+    string layers_1 = 1;  // first set of layers to be trained
     string layers_2 = 2;  // second set of layers to be trained
-    int64 iters_1 = 3; // number of training iterations for first set of layers
-    int64 iters_2 = 4; // number of training iterations for second set of layers
+    int64 iters_1 = 3;  // number of training iterations for first set of layers
+    int64 iters_2 =
+        4;  // number of training iterations for second set of layers
   }
 }

--- a/src/proto/data_coordinator.proto
+++ b/src/proto/data_coordinator.proto
@@ -34,13 +34,14 @@ import "datatype.proto";
 
 message TransformDataField {
   string data_field = 1;
-  string execution_phase = 2; // train, validation, test, tournament
+  string execution_phase = 2;           // train, validation, test, tournament
   repeated Transform transforms = 600;  // Ordered list of transforms to apply.
 }
 
 message DataCoordinator {
   DataType datatype = 1;
-  string io_buffer = 2;         // Options: "partitioned" (default)
+  string io_buffer = 2;  // Options: "partitioned" (default)
 
-  repeated TransformDataField transforms = 600;  // Ordered list of transforms to apply.
+  repeated TransformDataField transforms =
+      600;  // Ordered list of transforms to apply.
 }

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -62,7 +62,6 @@ enum ConvTensorOpsMode {
  *  zero-like unless otherwise stated.
  */
 message Layer {
-
   // ===========================================
   // Basic layer options
   // ===========================================
@@ -133,12 +132,11 @@ message Layer {
   // inheritance.
 
   oneof layer_type {
-
     // Input layer
     Input input = 20;
 
     // Operator layer
-    OperatorLayer operator_layer = 21; // Name chosen to avoid collision
+    OperatorLayer operator_layer = 21;  // Name chosen to avoid collision
 
     // Transform layers
     Reshape reshape = 50;
@@ -170,8 +168,8 @@ message Layer {
     BatchwiseReduceSum batchwise_reduce_sum = 76;
     TensorPermute permute = 77;
     IdentityZero identity_zero = 78;
-    CategoricalRandom categorical_random = 406; // Deprecated
-    DiscreteRandom discrete_random = 407; // Deprecated
+    CategoricalRandom categorical_random = 406;  // Deprecated
+    DiscreteRandom discrete_random = 407;        // Deprecated
 
     // Learning layers
     FullyConnected fully_connected = 100;
@@ -467,7 +465,6 @@ message Layer {
     double bias_init = 3;
     /// Deprecated
     string stats_aggregation = 5;
-
   }
 
   /** @brief Entry-wise batch normalization
@@ -626,7 +623,6 @@ message Layer {
    *  window and applies a reduction operation.
    */
   message Pooling {
-
     /** @brief Pooling operation
      *
      *  Options: max, average, average_no_pad
@@ -683,7 +679,6 @@ message Layer {
      *  Used when @c has_vectors is disabled.
      */
     int64 pool_strides_i = 9;
-
   }
 
   /** @brief Transpose of pooling layer
@@ -720,7 +715,6 @@ message Layer {
    *  points, and each child layer recieves one piece.
    */
   message Slice {
-
     /// Tensor dimension to slice along
     int64 axis = 1;
     /** @brief Positions at which to slice tensor
@@ -748,27 +742,23 @@ message Layer {
    *  PyTorch or TensorFlow. The name refers to splits in the compute
    *  graph.
    */
-  message Split {
-  }
+  message Split {}
 
   /** @brief Add multiple tensors */
-  message Sum {
-  }
+  message Sum {}
 
   /** @brief Add tensors over multiple sub-grids and slice
    *
    *  This is experimental functionality for use with sub-grid
    *  parallelism.
    */
-  message Cross_Grid_Sum_Slice {
-  }
+  message Cross_Grid_Sum_Slice {}
   /** @brief Add tensors over multiple sub-grids
    *
    *  This is experimental functionality for use with sub-grid
    *  parallelism.
    */
-  message Cross_Grid_Sum {
-  }
+  message Cross_Grid_Sum {}
 
   /** @brief Add tensors with scaling factors */
   message WeightedSum {
@@ -779,8 +769,7 @@ message Layer {
   }
 
   /** @brief Entry-wise tensor product */
-  message Hadamard {
-  }
+  message Hadamard {}
 
   /** @brief Output tensor filled with a single value */
   message Constant {
@@ -805,8 +794,7 @@ message Layer {
    *  Rarely needed by users. Evaluation layers are automatically
    *  created when needed in the compute graph.
    */
-  message Evaluation {
-  }
+  message Evaluation {}
 
   /** @brief Random tensor with Gaussian/normal distribution */
   message Gaussian {
@@ -878,8 +866,7 @@ message Layer {
    *  Rarely needed by users. This layer is used internally to handle
    *  cases where a layer has no child layers.
    */
-  message Dummy {
-  }
+  message Dummy {}
 
   /** @brief Block error signals during back propagation
    *
@@ -889,8 +876,7 @@ message Layer {
    *  means that computed gradients in preceeding layers are not exact
    *  gradients of the objective function.
    */
-  message StopGradient {
-  }
+  message StopGradient {}
 
   /** @brief One-hot vector indicating top-k entries
    *
@@ -950,26 +936,26 @@ message Layer {
   }
 
   /** @brief Scatter values to specified tensor indices
-    *
-    *  Expects two input tensors: an @f$ N @f$-D data tensor and a 1D
-    *  index vector. For 1D data:
-    *  @f[
-    *    y[\text{ind}[i]] = x[i]
-    *  @f]
-    *  Out-of-range indices are ignored.
-    *
-    *  For higher-dimensional data, the layer performs a scatter along
-    *  one dimension. For example, with 2D data and axis=1,
-    *  @f[
-    *    y[i,\text{ind}[j]] = x[i,j]
-    *  @f]
-    *  Currently, only 1D and 2D data is supported.
-    *
-    *  The size of the index vector must match the size of the data
-    *  tensor along the scatter dimension.
-    *
-    *  @todo Support higher-dimensional data
-    */
+   *
+   *  Expects two input tensors: an @f$ N @f$-D data tensor and a 1D
+   *  index vector. For 1D data:
+   *  @f[
+   *    y[\text{ind}[i]] = x[i]
+   *  @f]
+   *  Out-of-range indices are ignored.
+   *
+   *  For higher-dimensional data, the layer performs a scatter along
+   *  one dimension. For example, with 2D data and axis=1,
+   *  @f[
+   *    y[i,\text{ind}[j]] = x[i,j]
+   *  @f]
+   *  Currently, only 1D and 2D data is supported.
+   *
+   *  The size of the index vector must match the size of the data
+   *  tensor along the scatter dimension.
+   *
+   *  @todo Support higher-dimensional data
+   */
   message Scatter {
     /** @brief Output tensor dimensions
      *
@@ -982,37 +968,37 @@ message Layer {
   }
 
   /** @brief Gather values from specified tensor indices
-    *
-    *  Expects two input tensors: an @f$ N @f$-D data tensor and a 1D
-    *  index vector. For 1D data:
-    *  @f[
-    *    y[i] = x[\text{ind}[i]]
-    *  @f]
-    *  If an index is out-of-range, the corresponding output is set to
-    *  zero.
-    *
-    *  For higher-dimensional data, the layer performs a gather along
-    *  one dimension. For example, with 2D data and axis=1,
-    *  @f[
-    *    y[i,j] = x[i,\text{ind}[j]]
-    *  @f]
-    *  Currently, only 1D and 2D data is supported.
-    *
-    *  The size of the the output tensor along the gather dimension is
-    *  equal to the size of the index vector. The remaining dimensions
-    *  of the output tensor are identical to the data tensor.
-    *
-    *  @todo Support higher-dimensional data
-    */
+   *
+   *  Expects two input tensors: an @f$ N @f$-D data tensor and a 1D
+   *  index vector. For 1D data:
+   *  @f[
+   *    y[i] = x[\text{ind}[i]]
+   *  @f]
+   *  If an index is out-of-range, the corresponding output is set to
+   *  zero.
+   *
+   *  For higher-dimensional data, the layer performs a gather along
+   *  one dimension. For example, with 2D data and axis=1,
+   *  @f[
+   *    y[i,j] = x[i,\text{ind}[j]]
+   *  @f]
+   *  Currently, only 1D and 2D data is supported.
+   *
+   *  The size of the the output tensor along the gather dimension is
+   *  equal to the size of the index vector. The remaining dimensions
+   *  of the output tensor are identical to the data tensor.
+   *
+   *  @todo Support higher-dimensional data
+   */
   message Gather {
     /// Dimension to gather along
     google.protobuf.UInt64Value axis = 1;
   }
 
   /** @brief Sum of tensor entries over batch dimension
-    *
-    *  Output tensor has same shape as input tensor.
-    */
+   *
+   *  Output tensor has same shape as input tensor.
+   */
   message BatchwiseReduceSum {}
 
   /** @brief Permute a tensor's indices ("tensor transpose")
@@ -1028,16 +1014,14 @@ message Layer {
   }
 
   /** @brief Toggle identity or zero function.
-   *  
-   *  Outputs zeros when the layer is frozen or acts as the identity function 
+   *
+   *  Outputs zeros when the layer is frozen or acts as the identity function
    *  otherwise.
    */
-  message IdentityZero {
-  }
+  message IdentityZero {}
 
   /// Deprecated
-  message CategoricalRandom {
-  }
+  message CategoricalRandom {}
   /// Deprecated
   message DiscreteRandom {
     repeated double values = 1;
@@ -1088,7 +1072,6 @@ message Layer {
    *  the bias weights are initialized to zero.
    */
   message Convolution {
-
     /** @brief Number of spatial dimensions
      *
      *  The first data dimension is treated as the channel dimension,
@@ -1145,7 +1128,6 @@ message Layer {
      *  @details Ignored for non-GPU layers.
      */
     ConvTensorOpsMode conv_tensor_op_mode = 14;
-
   }
 
   /** @brief Convolution transpose
@@ -1159,7 +1141,6 @@ message Layer {
    *  used in the deep learning is actually cross-correlation.
    */
   message Deconvolution {
-
     /// Number of spatial dimensions
     int64 num_dims = 1;
 
@@ -1201,7 +1182,6 @@ message Layer {
      *  @details Ignored for non-GPU layers.
      */
     ConvTensorOpsMode conv_tensor_op_mode = 10;
-
   }
 
   /** @brief Lookup table to embedding vectors.
@@ -1346,7 +1326,8 @@ message Layer {
    */
   message Rotation {}
 
-  /** @brief Rotate a image clockwise around its center, then shear , then translate
+  /** @brief Rotate a image clockwise around its center, then shear , then
+   * translate
    *
    *  Expects 4 inputs: a 3D image tensor in CHW format, a scalar
    *  rotation angle, a tensor for (X,Y) shear factor, a tensor
@@ -1424,10 +1405,10 @@ message Layer {
 
   /** @brief Create layer from an external library
    *
-   *  Expects any number of input tensors. Invokes a shared object (e.g., .so file)
-   *  to call the layer.
+   *  Expects any number of input tensors. Invokes a shared object (e.g., .so
+   * file) to call the layer.
    */
-   message External {
+  message External {
     /// Library filename or path
     string filename = 1;
 
@@ -1472,7 +1453,6 @@ message Layer {
    *  @todo Sparse SGD with optimizer class
    */
   message DistEmbedding {
-
     /** Size of dictionary of embeddings. */
     int64 num_embeddings = 1;
     /** Size of embedding vectors. */
@@ -1498,7 +1478,6 @@ message Layer {
      *  @todo Think of a way to avoid this synchronization.
      */
     bool barrier_in_forward_prop = 5;
-
   }
 
   /** @brief Apply a hash function to get uniformly distributed values
@@ -1526,7 +1505,7 @@ message Layer {
    */
   message RowwiseWeightsNorms {}
 
-} // message Layer
+}  // message Layer
 
 //========================================================================
 // Parallel strategies for generalized layer-wise parallelism
@@ -1534,7 +1513,6 @@ message Layer {
 
 /** @brief Configuration for advanced parallelization strategies */
 message ParallelStrategy {
-
   // ---------------------------
   // distconv
   // ---------------------------
@@ -1572,7 +1550,6 @@ message ParallelStrategy {
   int64 sub_branch_resource_percentage = 16;
   /// @todo Remove
   bool enable_subgraph = 17;
-
 }
 
 // =============================================
@@ -1589,15 +1566,16 @@ message WeightsData {
   string name = 1;
   int64 height = 2;
   int64 width = 3;
-  repeated float data = 4 [packed=true];
+  repeated float data = 4 [packed = true];
   Imcomm imcomm = 55;
 }
 /// Deprecated
 enum Imcomm {
-  DEFAULT = 0; //add Layer to Imcomm callback if all_learning_layers = true in
-               //the CallbackImComm
-  EXCLUDE = 1; //*do not* add Layer to Imcomm callback if all_learning_layers = true in
-               //the CallbackImComm
-  INCLUDE = 2;  //add Layer to Imcomm callback regardless of whether all_learning_layers
-                //in the CallbackImComm is set to true or false
+  DEFAULT = 0;  // add Layer to Imcomm callback if all_learning_layers = true in
+                // the CallbackImComm
+  EXCLUDE = 1;  //*do not* add Layer to Imcomm callback if all_learning_layers =
+                //true in the CallbackImComm
+  INCLUDE =
+      2;  // add Layer to Imcomm callback regardless of whether
+          // all_learning_layers in the CallbackImComm is set to true or false
 }

--- a/src/proto/metrics.proto
+++ b/src/proto/metrics.proto
@@ -29,7 +29,6 @@ syntax = "proto3";
 package lbann_data;
 
 message Metric {
-
   message LayerMetric {
     string layer = 1;
     string name = 2;

--- a/src/proto/model.proto
+++ b/src/proto/model.proto
@@ -53,16 +53,15 @@ message Model {
   string data_layout = 6;
 
   int64 num_epochs = 4;
-  int64 super_steps = 121; //multiple steps/epochs currently use in GAN
-  int64 num_batches = 122; //multiple batches/sub epoch
+  int64 super_steps = 121;  // multiple steps/epochs currently use in GAN
+  int64 num_batches = 122;  // multiple batches/sub epoch
   int64 evaluation_frequency = 54;
 
-
-  SubGraphCommunication subgraph_communication = 13;  //Subgrid communication flag
+  SubGraphCommunication subgraph_communication =
+      13;  // Subgrid communication flag
   bool enable_subgraph_topology = 27;
-  int64 subgraph_parent_grid_resources = 29; //Num resources for parent grid (0: use all resources)
-
-
+  int64 subgraph_parent_grid_resources =
+      29;  // Num resources for parent grid (0: use all resources)
 
   bool disable_cuda = 8;
 

--- a/src/proto/objective_functions.proto
+++ b/src/proto/objective_functions.proto
@@ -29,7 +29,6 @@ syntax = "proto3";
 package lbann_data;
 
 message ObjectiveFunction {
-
   message LayerTerm {
     double scale_factor = 1;
     string layer = 2;

--- a/src/proto/operators.proto
+++ b/src/proto/operators.proto
@@ -125,22 +125,22 @@ message MinConstantOperator {
   double constant = 1;
 }
 message NotEqualConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 message EqualConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 message LessEqualConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 message LessConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 message GreaterEqualConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 message GreaterConstantOperator {
-    double constant = 1;
+  double constant = 1;
 }
 
 /// @}

--- a/src/proto/optimizers.proto
+++ b/src/proto/optimizers.proto
@@ -42,33 +42,33 @@ message Optimizer {
 
   message AdaGrad {
     double learn_rate = 1;
-    double eps = 2;           // Suggested: 1e-8
+    double eps = 2;  // Suggested: 1e-8
   }
 
   message Adam {
     double learn_rate = 1;
-    double beta1 = 6;         // Suggested: 0.9
-    double beta2 = 7;         // Suggested: 0.99
-    double eps = 8;           // Suggested: 1e-8
+    double beta1 = 6;  // Suggested: 0.9
+    double beta2 = 7;  // Suggested: 0.99
+    double eps = 8;    // Suggested: 1e-8
   }
 
   message HypergradientAdam {
     double init_learning_rate = 1;
-    double hyper_learning_rate = 2;   // Suggested: 1e-7
-    double beta1 = 6;                 // Suggested: 0.9
-    double beta2 = 7;                 // Suggested: 0.99
-    double eps = 8;                   // Suggested: 1e-8
+    double hyper_learning_rate = 2;  // Suggested: 1e-7
+    double beta1 = 6;                // Suggested: 0.9
+    double beta2 = 7;                // Suggested: 0.99
+    double eps = 8;                  // Suggested: 1e-8
   }
 
   message RMSprop {
     double learn_rate = 1;
     double decay_rate = 2;
-    double eps = 3;           // Suggested: 1e-8
+    double eps = 3;  // Suggested: 1e-8
   }
 
   message SGD {
     double learn_rate = 1;
-    double momentum = 2;      // Set to zero for vanilla SGD
+    double momentum = 2;  // Set to zero for vanilla SGD
     bool nesterov = 4;
   }
 }

--- a/src/proto/reader.proto
+++ b/src/proto/reader.proto
@@ -37,11 +37,12 @@ message DataReader {
 }
 
 message Reader {
-  string name = 1; //mnist, nci, nci_regression, numpy, imagenet, synthetic, merge_samples
-  string role = 3; //train, validation, test, tournament
+  string name = 1;  // mnist, nci, nci_regression, numpy, imagenet, synthetic,
+                    // merge_samples
+  string role = 3;  // train, validation, test, tournament
   bool shuffle = 4;
   string data_filedir = 5;
-  string data_local_filedir = 50; //to support data_store
+  string data_local_filedir = 50;  // to support data_store
   string data_filename = 6;
   string label_filename = 7;
   string sample_list = 8;
@@ -54,15 +55,15 @@ message Reader {
   // for SMILES data reader
   string metadata_filename = 13;
 
-  //for GAN model
+  // for GAN model
   bool gan_labelling = 201;
   int32 gan_label_value = 202;
 
-  int32 num_labels = 99; //for imagenet and synthetic
-  int64 num_samples = 100; //only for synthetic
-  string synth_dimensions = 101; //only for synthetic
-  string synth_response_dimensions = 115; //only for synthetic
-  //csv attributes
+  int32 num_labels = 99;                   // for imagenet and synthetic
+  int64 num_samples = 100;                 // only for synthetic
+  string synth_dimensions = 101;           // only for synthetic
+  string synth_response_dimensions = 115;  // only for synthetic
+  // csv attributes
   string separator = 102;
   int32 skip_cols = 103;
   int32 skip_rows = 104;
@@ -73,20 +74,21 @@ message Reader {
   bool disable_responses = 109;
   bool enable_labels = 99108;
   bool enable_responses = 99109;
-  string format = 110; // numpy, csv
+  string format = 110;  // numpy, csv
   string data_file_pattern = 111;
-  int64 num_neighbors = 112; // pilot2_molecular_reader
-  int64 max_neighborhood = 113; // pilot2_molecular_reader
-  int32 num_image_srcs = 114; // data_reader_multi_images
-  float scaling_factor_int16 = 116; // for numpy_npz_reader with int16 data
+  int64 num_neighbors = 112;         // pilot2_molecular_reader
+  int64 max_neighborhood = 113;      // pilot2_molecular_reader
+  int32 num_image_srcs = 114;        // data_reader_multi_images
+  float scaling_factor_int16 = 116;  // for numpy_npz_reader with int16 data
 
   int32 max_files_to_load = 1000;
 
   //------------- start of only for sample lists ------------------
   bool sample_list_per_trainer = 400;
-  bool sample_list_per_model   = 401;
-  // For testing and validation, keep the loaded sample order same as that in the file
-  bool sample_list_keep_order  = 402;
+  bool sample_list_per_model = 401;
+  // For testing and validation, keep the loaded sample order same as that in
+  // the file
+  bool sample_list_keep_order = 402;
   //------------- end of only for sample lists ------------------
 
   PythonDataReader python = 501;
@@ -95,8 +97,8 @@ message Reader {
   repeated Transform transforms = 600;  // Ordered list of transforms to apply.
 
   //------------- start of only for HDF5 data reader ------------------
-  string hdf5_key_data      = 700;
-  string hdf5_key_labels    = 701;
+  string hdf5_key_data = 700;
+  string hdf5_key_labels = 701;
   string hdf5_key_responses = 702;
   bool hdf5_hyperslab_labels = 703;
   int32 num_responses = 704;
@@ -106,7 +108,6 @@ message Reader {
   string data_schema_filename = 800;
   string experiment_schema_filename = 801;
   //-------- end of only for new (generalized) HDF5 data reader -------------
-
 }
 
 message PythonDataReader {
@@ -114,7 +115,8 @@ message PythonDataReader {
   string module_dir = 2;            // Directory containing Python module
   string sample_function = 3;       // Function that gets data sample
   string num_samples_function = 4;  // Function that gets number of data samples
-  string sample_dims_function = 5;  // Function that gets dimensions of data sample
+  string sample_dims_function =
+      5;  // Function that gets dimensions of data sample
 }
 
 message Node2VecDataReader {
@@ -151,10 +153,10 @@ message DataSetMetaData {
     repeated JagKeyPrefixFilter jag_input_prefix_filters = 96;
 
     enum JAG_Data {
-      Undefined  = 0;
-      JAG_Image  = 1;
+      Undefined = 0;
+      JAG_Image = 1;
       JAG_Scalar = 2;
-      JAG_Input  = 3;
+      JAG_Input = 3;
     }
     message JAGDataSlice {
       repeated JAG_Data pieces = 1;

--- a/src/proto/trainer.proto
+++ b/src/proto/trainer.proto
@@ -35,7 +35,6 @@ import "training_algorithm.proto";
 import "data_coordinator.proto";
 
 message Trainer {
-
   // Unique identifier
   string name = 1;
 
@@ -44,7 +43,7 @@ message Trainer {
   // These threads are typically used to perform data ingestion in the
   // background.
   int64 num_parallel_readers = 3;
-  bool  serialize_io = 101;
+  bool serialize_io = 101;
 
   repeated Callback callback = 20;
   int64 mini_batch_size = 12;
@@ -53,7 +52,8 @@ message Trainer {
   // Advanced options
   // -------------------------------
 
-  // If false, trainers will have their trainer rank mixed into their random seed.
+  // If false, trainers will have their trainer rank mixed into their random
+  // seed.
   bool random_init_trainers_identically = 4;
 
   // Set a random seed for the entire trainer

--- a/src/proto/training_algorithm.proto
+++ b/src/proto/training_algorithm.proto
@@ -55,7 +55,7 @@ message SGD {
   TerminationCriteria stopping_criteria = 1;
   // This is temporary
   bool suppress_timer_output = 489;
-}// message SGD
+}  // message SGD
 
 // Is-a TrainingAlgorithm
 message LTFB {
@@ -69,20 +69,16 @@ message LTFB {
 
   // This is temporary
   bool suppress_timer_output = 489;
-}// message LTFB
+}  // message LTFB
 
 message MutationStrategy {
-  message NullMutation {
-  }
+  message NullMutation {}
 
-  message ReplaceActivation {
-  }
+  message ReplaceActivation {}
 
-  message ReplaceConvolution {
-  }
+  message ReplaceConvolution {}
 
-  message HybridMutation {
-  }
+  message HybridMutation {}
 
   oneof strategy {
     NullMutation null_mutation = 1;
@@ -90,7 +86,7 @@ message MutationStrategy {
     ReplaceConvolution replace_convolution = 3;
     HybridMutation hybrid_mutation = 4;
   }
-} //message Mutation Strategy
+}  // message Mutation Strategy
 
 // The classic LTFB algorithm. Implements MetaLearningStrategy.
 message RandomPairwiseExchange {
@@ -122,8 +118,8 @@ message RandomPairwiseExchange {
       CheckpointBinary checkpoint_binary = 3;
       CheckpointFile checkpoint_file = 4;
     }
-  }// message ExchangeStrategy
-}// message RandomPairwiseExchange
+  }  // message ExchangeStrategy
+}  // message RandomPairwiseExchange
 
 // Truncation selection strategy Implements MetaLearningStrategy.
 message TruncationSelectionExchange {
@@ -133,8 +129,8 @@ message TruncationSelectionExchange {
   }
 
   map<string, MetricStrategy> metric_name_strategy_map = 1;
-  uint64 truncation_k = 2; //what should be default, 1?
-}// message TruncationSelectionExchange
+  uint64 truncation_k = 2;  // what should be default, 1?
+}  // message TruncationSelectionExchange
 
 // Regularized Evolution strategy Implements MetaLearningStrategy.
 message RegularizedEvolution {
@@ -147,10 +143,9 @@ message RegularizedEvolution {
   MetricStrategy metric_strategy = 2;
   MutationStrategy mutation_strategy = 3;
   uint64 sample_size = 4;
-}// message RegularizedEvolution
+}  // message RegularizedEvolution
 
 message KFAC {
-
   SGD sgd = 1;
 
   // Space-separated pairs of the initial and the target damping value.
@@ -162,37 +157,39 @@ message KFAC {
   string damping_bn_err = 5;
   string kfac_use_interval = 21;
 
-  uint64 damping_warmup_steps = 6; // default: damping_warmup_steps_default
-  double kronecker_decay = 7; // default: callback::kfac::kronecker_decay_default
+  uint64 damping_warmup_steps = 6;  // default: damping_warmup_steps_default
+  double kronecker_decay =
+      7;  // default: callback::kfac::kronecker_decay_default
 
-  bool print_time = 8; // default: false
-  bool print_matrix = 9; // default: false
-  bool print_matrix_summary = 10; // default: false
+  bool print_time = 8;             // default: false
+  bool print_matrix = 9;           // default: false
+  bool print_matrix_summary = 10;  // default: false
 
-  bool use_pi = 11; // default: false
+  bool use_pi = 11;  // default: false
 
   // Space-separated pairs of the initial and the target update intervals.
   // If only one value is specified, it will be used throughout training.
-  string update_intervals = 12; // default: "1"
-  uint64 update_interval_steps = 13; // default: 0
+  string update_intervals = 12;       // default: "1"
+  uint64 update_interval_steps = 13;  // default: 0
 
-  string inverse_strategy = 14; // Options: all, each, root (default: all)
+  string inverse_strategy = 14;  // Options: all, each, root (default: all)
 
-  string disable_layers = 15; // List of layers to be ignored by the callback
+  string disable_layers = 15;  // List of layers to be ignored by the callback
 
-  float learning_rate_factor = 16; // Factor to be multiplied to the learning rate
+  float learning_rate_factor =
+      16;  // Factor to be multiplied to the learning rate
   // Factor to be multiplied to the learning rate for GRU layers
   // (default: learning_rate_factor)
   float learning_rate_factor_gru = 17;
 
-  int64 compute_interval = 18; // default:1
+  int64 compute_interval = 18;  // default:1
 
-  bool distribute_precondition_compute = 19; // default: false
+  bool distribute_precondition_compute = 19;  // default: false
 
-  bool use_eigen_decomposition = 20; // default: false
+  bool use_eigen_decomposition = 20;  // default: false
 
-  bool enable_copy_errors = 22; // default: false
+  bool enable_copy_errors = 22;  // default: false
 
-  bool enable_copy_activations = 23; // default: false
+  bool enable_copy_activations = 23;  // default: false
 
-}//message KFAC
+}  // message KFAC

--- a/src/proto/transforms.proto
+++ b/src/proto/transforms.proto
@@ -128,7 +128,8 @@ message Transform {
     uint64 height = 1;
     uint64 width = 2;
   }
-  // Resize to height x width then crop to crop_height x crop_width at the center.
+  // Resize to height x width then crop to crop_height x crop_width at the
+  // center.
   message ResizedCenterCrop {
     uint64 height = 1;
     uint64 width = 2;
@@ -136,7 +137,7 @@ message Transform {
     uint64 crop_width = 4;
   }
   // Convert from an image to LBANN data.
-  message ToLBANNLayout { }
+  message ToLBANNLayout {}
   // Vertical flip with probability p.
   message VerticalFlip {
     float p = 1;
@@ -157,7 +158,8 @@ message Transform {
     RandomAffine random_affine = 105;
     RandomCrop random_crop = 106;
     RandomResizedCrop random_resized_crop = 107;
-    RandomResizedCropWithFixedAspectRatio random_resized_crop_with_fixed_aspect_ratio = 108;
+    RandomResizedCropWithFixedAspectRatio
+        random_resized_crop_with_fixed_aspect_ratio = 108;
     Resize resize = 109;
     ResizedCenterCrop resized_center_crop = 110;
     ToLBANNLayout to_lbann_layout = 111;

--- a/src/utils/unit_test/protobuf_utils_test_messages.proto
+++ b/src/utils/unit_test/protobuf_utils_test_messages.proto
@@ -36,16 +36,14 @@ enum MyEnum {
   TWO = 2;
 }
 
-message SimpleMesg
-{
+message SimpleMesg {
   int32 my_int32 = 1;
   float my_float = 2;
   string my_string = 3;
   MyEnum my_enum = 4;
 }
 
-message HasAOneofField
-{
+message HasAOneofField {
   oneof my_oneof {
     uint64 my_uint64 = 1;
     int32 my_int32 = 2;
@@ -55,8 +53,7 @@ message HasAOneofField
   bool another_field = 10;
 }
 
-message HasRepeatedPODFields
-{
+message HasRepeatedPODFields {
   repeated float my_floats = 1;
   repeated double my_doubles = 2;
   repeated uint32 my_uint32s = 3;
@@ -64,14 +61,12 @@ message HasRepeatedPODFields
   repeated MyEnum my_enums = 5;
 }
 
-message HasRepeatedPtrFields
-{
+message HasRepeatedPtrFields {
   repeated SimpleMesg my_simple_msgs = 1;
   repeated string my_strings = 2;
 }
 
-message HasAnyField
-{
+message HasAnyField {
   google.protobuf.Any my_any = 1;
   int32 my_non_any = 2;
 }


### PR DESCRIPTION
A follow-up of #2220 for protobuf files, this PR adds a proto formatter to the `clang-format` configuration and formats all proto files in the repository.

The following command was used to reformat the codebase:
`clang-format -i $(git ls-files src include | grep -E "proto$")`

@bvanessen @benson31 