### PR TITLE
Add support for changing distconv overlaps in Identity layer.

### DIFF
--- a/ci_test/unit_tests/test_unit_layer_identity_overlap_change_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_overlap_change_distconv.py
@@ -114,17 +114,17 @@ def construct_model(lbann):
 
     for num_dims in [2, 3]:
         # Convolution settings
-        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [3]*num_dims
+        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [1]*num_dims
         strides = [1]*num_dims
-        pads = [1]*num_dims
+        pads = [0]*num_dims
         dilations = [1]*num_dims
 
         kernel = np.zeros(kernel_dims)
         for i in range(len(kernel)):
             if num_dims == 2:
-                kernel[i,i,1,1] = 1
+                kernel[i,i,0,0] = 1
             else:
-                kernel[i,i,1,1,1] = 1
+                kernel[i,i,0,0,0] = 1
 
         # Apply convolution
         kernel_weights = lbann.Weights(
@@ -152,17 +152,17 @@ def construct_model(lbann):
         
 
         # Convolution settings
-        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [5]*num_dims
+        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [3]*num_dims
         strides = [1]*num_dims
-        pads = [2]*num_dims
+        pads = [1]*num_dims
         dilations = [1]*num_dims
 
         kernel = np.zeros(kernel_dims)
         for i in range(len(kernel)):
             if num_dims == 2:
-                kernel[i,i,2,2] = 1
+                kernel[i,i,1,1] = 1
             else:
-                kernel[i,i,2,2,2] = 1
+                kernel[i,i,1,1,1] = 1
 
         # Apply convolution
         kernel_weights = lbann.Weights(
@@ -294,7 +294,7 @@ def augment_test_func(test_func):
                 delimiter=','
             )
 
-            assert np.allclose(in_data, out_data, rtol=1e-3)
+            assert np.allclose(in_data, out_data)
 
     # Return test function from factory function
     func.__name__ = test_name

--- a/ci_test/unit_tests/test_unit_layer_identity_overlap_change_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_identity_overlap_change_distconv.py
@@ -6,6 +6,7 @@ import os.path
 import sys
 import numpy as np
 import pytest
+import lbann.contrib.args
 
 # Bamboo utilities
 current_file = os.path.realpath(__file__)
@@ -294,7 +295,7 @@ def augment_test_func(test_func):
                 delimiter=','
             )
 
-            assert np.allclose(in_data, out_data)
+            assert np.allclose(in_data, out_data, atol=1e-6)
 
     # Return test function from factory function
     func.__name__ = test_name
@@ -304,5 +305,5 @@ def augment_test_func(test_func):
 # Note: Create test name by removing ".py" from file name
 _test_name = os.path.splitext(os.path.basename(current_file))[0]
 for _test_func in tools.create_tests(setup_experiment, _test_name,
-                               environment=tools.get_distconv_environment()):
+                               environment=lbann.contrib.args.get_distconv_environment()):
     globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/ci_test/unit_tests/test_unit_layer_overlap_change_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_overlap_change_distconv.py
@@ -1,0 +1,308 @@
+import functools
+import math
+import operator
+import os
+import os.path
+import sys
+import numpy as np
+import pytest
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+def make_random_array(shape, seed):
+    """Hacked function to generate a random array.
+
+    NumPy's RNG produces different values with different NumPy
+    versions. This function is helpful when array values must be
+    identical across all runs, e.g. when checking against precomputed
+    metric values.
+
+    Args:
+        shape (Iterable of int): Array dimensions
+        seed (int): Parameter for RNG. Must be non-zero.
+    Returns:
+        numpy.ndarray: Array of `np.float32`. Values will be in
+            [-0.5,0.5).
+
+    """
+    size = functools.reduce(operator.mul, shape)
+    eps = np.finfo(np.float32).eps
+    x = (seed / np.linspace(math.sqrt(eps), 0.1, size)) % 1 - 0.5
+    return x.reshape(shape).astype(np.float32)
+
+# Data
+_num_samples = 1
+_sample_dims = [64,16,16]
+_sample_dims_3d = [4,16,16,16]
+_sample_size = functools.reduce(operator.mul, _sample_dims)
+_samples = make_random_array([_num_samples] + _sample_dims, 7)
+
+# Sample access functions
+def get_sample(index):
+    return _samples[index,:].reshape(-1)
+def num_samples():
+    return _num_samples
+def sample_dims():
+    return (_sample_size,)
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+def setup_experiment(lbann, weekly):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    if not lbann.has_feature('DISTCONV'):
+        message = f'{os.path.basename(__file__)} requires DISTCONV'
+        print('Skip - ' + message)
+        pytest.skip(message)
+    
+    mini_batch_size = num_samples() #// 2
+    trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer, None # Don't request any specific number of nodes
+
+def create_parallel_strategy(num_height_groups):
+    return {"height_groups": num_height_groups}
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Input data
+    x_lbann = lbann.Reshape(lbann.Input(data_field='samples'),
+                                dims=_sample_dims)
+
+    # Objects for LBANN model
+    obj = []
+    metrics = []
+    callbacks = []
+
+    # ------------------------------------------
+    # Conv -> Identity (Overlap Change) -> Conv
+    # ------------------------------------------
+    # Two distconv enabled convolutions whose weights produce the identity
+    # function. Each convolution has a different kernel size and therefore
+    # overlap. An identity layer is placed between the two convolutions to
+    # change the overlap.
+
+    num_height_groups = tools.gpus_per_node(lbann)
+    if num_height_groups == 0:
+        e = 'this test requires GPUs.'
+        print('Skip - ' + e)
+        pytest.skip(e)
+
+    for num_dims in [2, 3]:
+        # Convolution settings
+        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [3]*num_dims
+        strides = [1]*num_dims
+        pads = [1]*num_dims
+        dilations = [1]*num_dims
+
+        kernel = np.zeros(kernel_dims)
+        for i in range(len(kernel)):
+            if num_dims == 2:
+                kernel[i,i,1,1] = 1
+            else:
+                kernel[i,i,1,1,1] = 1
+
+        # Apply convolution
+        kernel_weights = lbann.Weights(
+            optimizer=lbann.SGD(),
+            initializer=lbann.ValueInitializer(values=np.nditer(kernel)),
+            name='kernel1_{}d'.format(num_dims)
+        )
+        x = x_lbann
+        if num_dims == 3:
+            x = lbann.Reshape(x, dims=_sample_dims_3d)
+        x = lbann.Identity(x, name=f'in_{num_dims}D')
+
+        x = lbann.Convolution(x,
+                              weights=(kernel_weights, ),
+                              num_dims=num_dims,
+                              out_channels=kernel_dims[0],
+                              kernel_size=kernel_dims[2:],
+                              stride=strides,
+                              padding=pads,
+                              dilation=dilations,
+                              has_bias=False,
+                              parallel_strategy=create_parallel_strategy(
+                                  num_height_groups),
+                              name=f'conv1_{num_dims}D')
+        
+
+        # Convolution settings
+        kernel_dims = [_sample_dims[0] if num_dims == 2 else _sample_dims_3d[0]]*2 + [5]*num_dims
+        strides = [1]*num_dims
+        pads = [2]*num_dims
+        dilations = [1]*num_dims
+
+        kernel = np.zeros(kernel_dims)
+        for i in range(len(kernel)):
+            if num_dims == 2:
+                kernel[i,i,2,2] = 1
+            else:
+                kernel[i,i,2,2,2] = 1
+
+        # Apply convolution
+        kernel_weights = lbann.Weights(
+            optimizer=lbann.SGD(),
+            initializer=lbann.ValueInitializer(values=np.nditer(kernel)),
+            name='kernel2_{}d'.format(num_dims)
+        )
+
+        x = lbann.Identity(x, parallel_strategy=create_parallel_strategy(
+                                  num_height_groups), name=f'ident_{num_dims}D')
+
+        x = lbann.Convolution(x,
+                              weights=(kernel_weights, ),
+                              num_dims=num_dims,
+                              out_channels=kernel_dims[0],
+                              kernel_size=kernel_dims[2:],
+                              stride=strides,
+                              padding=pads,
+                              dilation=dilations,
+                              has_bias=False,
+                              parallel_strategy=create_parallel_strategy(
+                                  num_height_groups),
+                              name=f'conv2_{num_dims}D')
+        
+        y = lbann.Identity(x, name=f'out_{num_dims}D')
+        z = lbann.L2Norm2(y)
+        obj.append(z)
+
+        # Save the inputs and outputs to check later.
+        callbacks.append(lbann.CallbackDumpOutputs(layers=f'in_{num_dims}D out_{num_dims}D', directory='outputs'))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x_lbann),
+                       objective_function=obj,
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'train'
+        )
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(
+            lbann,
+            current_file,
+            'get_sample',
+            'num_samples',
+            'sample_dims',
+            'test'
+        )
+    ])
+    return message
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+def augment_test_func(test_func):
+    """Augment test function to parse log files.
+
+    `tools.create_tests` creates functions that run an LBANN
+    experiment. This function creates augmented functions that parse
+    the log files after LBANN finishes running, e.g. to check metrics
+    or runtimes.
+
+    Note: The naive approach is to define the augmented test functions
+    in a loop. However, Python closures are late binding. In other
+    words, the function would be overwritten every time we define it.
+    We get around this overwriting problem by defining the augmented
+    function in the local scope of another function.
+
+    Args:
+        test_func (function): Test function created by
+            `tools.create_tests`.
+
+    Returns:
+        function: Test that can interact with PyTest.
+
+    """
+    test_name = test_func.__name__
+
+    # Define test function
+    def func(cluster, dirname, weekly):
+
+        # Run LBANN experiment
+        experiment_output = test_func(cluster, dirname, weekly)
+
+        # Check that the output values are close to the input values.
+        for num_dims in [2, 3]:
+            in_data = np.loadtxt(
+                os.path.join(
+                    experiment_output['work_dir'],
+                    'outputs', 'trainer0', 'model0',
+                    f'sgd.testing.epoch.0.step.0_in_{num_dims}D_output0.csv'
+                ),
+                delimiter=','
+            )
+            out_data = np.loadtxt(
+                os.path.join(
+                    experiment_output['work_dir'],
+                    'outputs', 'trainer0', 'model0',
+                    f'sgd.testing.epoch.0.step.0_out_{num_dims}D_output0.csv'
+                ),
+                delimiter=','
+            )
+
+            assert np.allclose(in_data, out_data, rtol=1e-3)
+
+    # Return test function from factory function
+    func.__name__ = test_name
+    return func
+
+# Create test functions that can interact with PyTest
+# Note: Create test name by removing ".py" from file name
+_test_name = os.path.splitext(os.path.basename(current_file))[0]
+for _test_func in tools.create_tests(setup_experiment, _test_name,
+                               environment=tools.get_distconv_environment()):
+    globals()[_test_func.__name__] = augment_test_func(_test_func)

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -164,7 +164,8 @@ protected:
                                 prev_activations.get_const_base_ptr(),
                                 beta,
                                 m_ydesc,
-                                activations.get_base_ptr());
+                                activations.get_base_ptr(),
+                                dc::get_backend().get_handle());
     }
 #endif // LBANN_HAS_DISTCONV
   }
@@ -193,7 +194,8 @@ protected:
                                 prev_error_signals.get_const_base_ptr(),
                                 beta,
                                 m_dxdesc,
-                                error_signals.get_base_ptr());
+                                error_signals.get_base_ptr(),
+                                dc::get_backend().get_handle());
     }
 #endif // LBANN_HAS_DISTCONV
   }

--- a/include/lbann/layers/activations/identity.hpp
+++ b/include/lbann/layers/activations/identity.hpp
@@ -156,8 +156,9 @@ protected:
       dc_backend::setup_tensor_descriptor(ydesc, activations,
                                           activations.get_local_shape());
 
-      TensorDataType alpha = 1;
-      TensorDataType beta = 0;
+      using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
+      LibScalingParamT alpha = 1;
+      LibScalingParamT beta = 0;
       dnn_lib::transform_tensor(alpha,
                                 m_xdesc,
                                 prev_activations.get_const_base_ptr(),
@@ -184,8 +185,9 @@ protected:
       dc_backend::setup_tensor_descriptor(dydesc, prev_error_signals,
                                           prev_error_signals.get_local_shape());
 
-      TensorDataType alpha = 1;
-      TensorDataType beta = 0;
+      using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
+      LibScalingParamT alpha = 1;
+      LibScalingParamT beta = 0;
       dnn_lib::transform_tensor(alpha,
                                 m_dydesc,
                                 prev_error_signals.get_const_base_ptr(),

--- a/include/lbann/layers/distconv_adapter.hpp
+++ b/include/lbann/layers/distconv_adapter.hpp
@@ -57,6 +57,7 @@ public:
   void mark_equivalent(dc::Dist& d1, dc::Dist& d2);
   void mark_updated(const dc::Dist& d);
   void mark_invariant(const dc::Dist& d);
+  void update_name(const dc::Dist& d, std::string name);
 
   void find_valid_overlap();
 
@@ -64,6 +65,7 @@ private:
   std::unordered_map<const dc::Dist*, dist_set> m_equivalents;
   const_dist_set m_updated;
   const_dist_set m_invariants;
+  std::unordered_map<const dc::Dist*, std::string> m_names;
 };
 
 class distconv_adapter

--- a/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
@@ -45,13 +45,14 @@ void transform_tensor(ScalarParameterType const& alpha_in,
                       const TensorDataType* x,
                       ScalarParameterType const& beta_in,
                       TensorDescriptor const& yDesc,
-                      TensorDataType* y)
+                      TensorDataType* y,
+                      dnnHandle_t handle)
 {
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto alpha = static_cast<LibScalingParamT>(alpha_in);
   auto beta = static_cast<LibScalingParamT>(beta_in);
   CHECK_CUDNN(
-    cudnnTransformTensor(get_handle(),
+    cudnnTransformTensor(handle,
                          &alpha,
                          xDesc,
                          x,

--- a/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 // the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -51,14 +51,7 @@ void transform_tensor(ScalarParameterType const& alpha_in,
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto alpha = static_cast<LibScalingParamT>(alpha_in);
   auto beta = static_cast<LibScalingParamT>(beta_in);
-  CHECK_CUDNN(
-    cudnnTransformTensor(handle,
-                         &alpha,
-                         xDesc,
-                         x,
-                         &beta,
-                         yDesc,
-                         y));
+  CHECK_CUDNN(cudnnTransformTensor(handle, &alpha, xDesc, x, &beta, yDesc, y));
 }
 
 } // namespace dnn_lib

--- a/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/cudnn/transform_tensor.hpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_CUDNN_TRANSFORM_TENSOR_HPP_
+#define LBANN_UTILS_DNN_LIB_CUDNN_TRANSFORM_TENSOR_HPP_
+
+#include "lbann/utils/dnn_enums.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
+
+#include "utils.hpp"
+
+namespace lbann {
+
+#ifdef LBANN_HAS_CUDNN
+namespace dnn_lib {
+
+using namespace cudnn;
+
+template <typename TensorDataType, typename ScalarParameterType>
+void transform_tensor(ScalarParameterType const& alpha_in,
+                      TensorDescriptor const& xDesc,
+                      const TensorDataType* x,
+                      ScalarParameterType const& beta_in,
+                      TensorDescriptor const& yDesc,
+                      TensorDataType* y)
+{
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
+  auto alpha = static_cast<LibScalingParamT>(alpha_in);
+  auto beta = static_cast<LibScalingParamT>(beta_in);
+  CHECK_CUDNN(
+    cudnnTransformTensor(get_handle(),
+                         &alpha,
+                         xDesc,
+                         x,
+                         &beta,
+                         yDesc,
+                         y));
+}
+
+} // namespace dnn_lib
+#endif // LBANN_HAS_CUDNN
+} // namespace lbann
+#endif // LBANN_UTILS_DNN_LIB_CUDNN_TRANSFORM_TENSOR_HPP_

--- a/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_MIOPEN_TRANSFORM_TENSOR_HPP_
+#define LBANN_UTILS_DNN_LIB_MIOPEN_TRANSFORM_TENSOR_HPP_
+
+#include "lbann/utils/dnn_enums.hpp"
+#include "lbann/utils/dnn_lib/helpers.hpp"
+#include "lbann/utils/gpu/helpers.hpp"
+
+#include "utils.hpp"
+
+namespace lbann {
+
+#ifdef LBANN_HAS_MIOPEN
+namespace dnn_lib {
+
+using namespace miopen;
+
+template <typename TensorDataType, typename ScalarParameterType>
+void transform_tensor(ScalarParameterType const& alpha_in,
+                      TensorDescriptor const& xDesc,
+                      const TensorDataType* x,
+                      ScalarParameterType const& beta_in,
+                      TensorDescriptor const& yDesc,
+                      TensorDataType* y)
+{
+  using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
+  auto alpha = static_cast<LibScalingParamT>(alpha_in);
+  auto beta = static_cast<LibScalingParamT>(beta_in);
+  CHECK_MIOPEN(
+    miopenTransformTensor(get_handle(),
+                         &alpha,
+                         xDesc,
+                         x,
+                         &beta,
+                         yDesc,
+                         y));
+}
+
+} // namespace dnn_lib
+#endif // LBANN_HAS_MIOPEN
+} // namespace lbann
+#endif // LBANN_UTILS_DNN_LIB_MIOPEN_TRANSFORM_TENSOR_HPP_

--- a/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 // the CONTRIBUTORS file. <lbann-dev@llnl.gov>
@@ -52,13 +52,7 @@ void transform_tensor(ScalarParameterType const& alpha_in,
   auto alpha = static_cast<LibScalingParamT>(alpha_in);
   auto beta = static_cast<LibScalingParamT>(beta_in);
   CHECK_MIOPEN(
-    miopenTransformTensor(handle,
-                          &alpha,
-                          xDesc,
-                          x,
-                          &beta,
-                          yDesc,
-                          y));
+    miopenTransformTensor(handle, &alpha, xDesc, x, &beta, yDesc, y));
 }
 
 } // namespace dnn_lib

--- a/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/miopen/transform_tensor.hpp
@@ -45,19 +45,20 @@ void transform_tensor(ScalarParameterType const& alpha_in,
                       const TensorDataType* x,
                       ScalarParameterType const& beta_in,
                       TensorDescriptor const& yDesc,
-                      TensorDataType* y)
+                      TensorDataType* y,
+                      dnnHandle_t handle)
 {
   using LibScalingParamT = dnn_lib::ScalingParamType<TensorDataType>;
   auto alpha = static_cast<LibScalingParamT>(alpha_in);
   auto beta = static_cast<LibScalingParamT>(beta_in);
   CHECK_MIOPEN(
-    miopenTransformTensor(get_handle(),
-                         &alpha,
-                         xDesc,
-                         x,
-                         &beta,
-                         yDesc,
-                         y));
+    miopenTransformTensor(handle,
+                          &alpha,
+                          xDesc,
+                          x,
+                          &beta,
+                          yDesc,
+                          y));
 }
 
 } // namespace dnn_lib

--- a/include/lbann/utils/dnn_lib/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/transform_tensor.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
 // Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 // the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/include/lbann/utils/dnn_lib/transform_tensor.hpp
+++ b/include/lbann/utils/dnn_lib/transform_tensor.hpp
@@ -1,0 +1,41 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+#ifndef LBANN_UTILS_DNN_LIB_TRANSFORM_TENSOR_HPP
+#define LBANN_UTILS_DNN_LIB_TRANSFORM_TENSOR_HPP
+
+#include "lbann_config.hpp"
+
+#if defined LBANN_HAS_CUDNN
+#include "lbann/utils/dnn_lib/cudnn/transform_tensor.hpp"
+#elif defined LBANN_HAS_MIOPEN
+#include "lbann/utils/dnn_lib/miopen/transform_tensor.hpp"
+#else
+static_assert(false,
+              "This file must be included only if there is support from a "
+              "valid DNN library.");
+#endif // LBANN_HAS_CUDNN
+
+#endif // LBANN_UTILS_DNN_LIB_TRANSFORM_TENSOR_HPP

--- a/src/layers/activations/identity.cpp
+++ b/src/layers/activations/identity.cpp
@@ -72,12 +72,12 @@ identity_distconv_adapter<TensorDataType, Layout, Device>::
 {
   assert_eq(index, 0);
 
-  const auto& prev_activations_overlap = this->get_prev_activations_dist().get_overlap();
-  const auto& activations_overlap = this->get_activations_dist().get_overlap();
+  const auto& prev_error_signals_overlap = this->get_prev_error_signals_dist().get_overlap();
+  const auto& error_signals_overlap = this->get_error_signals_dist().get_overlap();
 
-  assert_eq(prev_activations_overlap.length(), activations_overlap.length());
-  for (int i = 0; i < prev_activations_overlap.length(); i++) {
-    if (prev_activations_overlap[i] != activations_overlap[i]) {
+  assert_eq(prev_error_signals_overlap.length(), error_signals_overlap.length());
+  for (int i = 0; i < prev_error_signals_overlap.length(); i++) {
+    if (prev_error_signals_overlap[i] != error_signals_overlap[i]) {
       return data_type_distconv_adapter<TensorDataType>::setup_error_signals_i(index);
     }
   }

--- a/src/layers/distconv_adapter.cpp
+++ b/src/layers/distconv_adapter.cpp
@@ -386,6 +386,12 @@ void distconv_adapter::setup_distributions(
   m_activations_dists.emplace_back(activations_dist);
   m_prev_error_signals_dists.emplace_back(prev_error_signals_dist);
   m_error_signals_dists.emplace_back(error_signals_dist);
+
+  std::string layer_name = layer().get_name();
+  constraints.update_name(get_prev_activations_dist(), layer_name + " prev_activations ");
+  constraints.update_name(get_activations_dist(), layer_name + " activations ");
+  constraints.update_name(get_prev_error_signals_dist(), layer_name + " prev_error_signals ");
+  constraints.update_name(get_error_signals_dist(), layer_name + " error_signals ");
 }
 
 void distconv_adapter::impose_adjacent_overlap_constraints(
@@ -470,6 +476,11 @@ void tensor_overlap_constraints::mark_invariant(const dc::Dist& d)
   m_invariants.insert(&d);
 }
 
+void tensor_overlap_constraints::update_name(const dc::Dist& d, std::string name)
+{
+  m_names[&d] = name;
+}
+
 void tensor_overlap_constraints::find_valid_overlap()
 {
   while (m_updated.size() > 0) {
@@ -483,7 +494,7 @@ void tensor_overlap_constraints::find_valid_overlap()
           // p must have equal dist as d but is different.
           if (m_invariants.find(p) != m_invariants.end()) {
             // p can't be changed, so we can't solve the constraint.
-            LBANN_ERROR("Incompatible overlap: ", *d, " <=> ", *p);
+            LBANN_ERROR("Incompatible overlap: ", m_names[d], *d, " <=> ", m_names[p], *p);
           }
           p->set_overlap(d->get_overlap());
           updated_new.insert(p);

--- a/src/layers/distconv_adapter.cpp
+++ b/src/layers/distconv_adapter.cpp
@@ -388,10 +388,13 @@ void distconv_adapter::setup_distributions(
   m_error_signals_dists.emplace_back(error_signals_dist);
 
   std::string layer_name = layer().get_name();
-  constraints.update_name(get_prev_activations_dist(), layer_name + " prev_activations ");
+  constraints.update_name(get_prev_activations_dist(),
+                          layer_name + " prev_activations ");
   constraints.update_name(get_activations_dist(), layer_name + " activations ");
-  constraints.update_name(get_prev_error_signals_dist(), layer_name + " prev_error_signals ");
-  constraints.update_name(get_error_signals_dist(), layer_name + " error_signals ");
+  constraints.update_name(get_prev_error_signals_dist(),
+                          layer_name + " prev_error_signals ");
+  constraints.update_name(get_error_signals_dist(),
+                          layer_name + " error_signals ");
 }
 
 void distconv_adapter::impose_adjacent_overlap_constraints(
@@ -476,7 +479,8 @@ void tensor_overlap_constraints::mark_invariant(const dc::Dist& d)
   m_invariants.insert(&d);
 }
 
-void tensor_overlap_constraints::update_name(const dc::Dist& d, std::string name)
+void tensor_overlap_constraints::update_name(const dc::Dist& d,
+                                             std::string name)
 {
   m_names[&d] = name;
 }
@@ -494,7 +498,12 @@ void tensor_overlap_constraints::find_valid_overlap()
           // p must have equal dist as d but is different.
           if (m_invariants.find(p) != m_invariants.end()) {
             // p can't be changed, so we can't solve the constraint.
-            LBANN_ERROR("Incompatible overlap: ", m_names[d], *d, " <=> ", m_names[p], *p);
+            LBANN_ERROR("Incompatible overlap: ",
+                        m_names[d],
+                        *d,
+                        " <=> ",
+                        m_names[p],
+                        *p);
           }
           p->set_overlap(d->get_overlap());
           updated_new.insert(p);


### PR DESCRIPTION
Added support for changing distconv overlaps in the identity layer. Also added a corresponding unit test.

To improve the debugging experience, the overlap mismatch error message now indicates the offending layers.