### PR TITLE
Synthetic ImageNet support in ResNet/AlexNet

### DIFF
--- a/applications/vision/alexnet.py
+++ b/applications/vision/alexnet.py
@@ -22,6 +22,9 @@ parser.add_argument(
 parser.add_argument(
     '--num-classes', action='store', default=1000, type=int,
     help='number of ImageNet classes (default: 1000)', metavar='NUM')
+parser.add_argument(
+    '--synthetic', action='store_true', default=False,
+    help='Use synthetic data')
 lbann.contrib.args.add_optimizer_arguments(parser)
 args = parser.parse_args()
 
@@ -64,7 +67,9 @@ model = lbann.Model(args.num_epochs,
 opt = lbann.contrib.args.create_optimizer(args)
 
 # Setup data reader
-data_reader = data.imagenet.make_data_reader(num_classes=args.num_classes)
+data_reader = data.imagenet.make_data_reader(
+    num_classes=args.num_classes,
+    synthetic=args.synthetic)
 
 # Setup trainer
 trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size)

--- a/applications/vision/data/imagenet/__init__.py
+++ b/applications/vision/data/imagenet/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import os
 import os.path
 
@@ -5,11 +7,13 @@ import google.protobuf.text_format
 import lbann
 import lbann.contrib.launcher
 
-def make_data_reader(num_classes=1000, small_testing=False):
 
-    # Load Protobuf message from file
+def make_data_reader_imagenet(
+        num_classes: int = 1000,
+        small_testing: bool = False) -> Any:
+    """Load and set up the ImageNet data reader."""
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    if(small_testing):
+    if small_testing:
         protobuf_file = os.path.join(current_dir, 'data_reader_small.prototext')
     else:
         protobuf_file = os.path.join(current_dir, 'data_reader.prototext')
@@ -57,3 +61,25 @@ def make_data_reader(num_classes=1000, small_testing=False):
     message.reader[1].data_filename = test_label_file
 
     return message
+
+
+def make_data_reader_synthetic(num_classes: int = 1000) -> Any:
+    """Load and set up a synthetic data reader matching ImageNet."""
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    protobuf_file = os.path.join(current_dir, 'data_reader_synthetic.prototext')
+    message = lbann.lbann_pb2.LbannPB()
+    with open(protobuf_file, 'r') as f:
+        google.protobuf.text_format.Merge(f.read(), message)
+    message = message.data_reader
+
+    return message
+
+def make_data_reader(
+        num_classes: int = 1000,
+        small_testing: bool = False,
+        synthetic: bool = False) -> Any:
+    if synthetic:
+        return make_data_reader_synthetic(num_classes=num_classes)
+    else:
+        return make_data_reader_imagenet(
+            num_classes=num_classes, small_testing=small_testing)

--- a/applications/vision/data/imagenet/data_reader_synthetic.prototext
+++ b/applications/vision/data/imagenet/data_reader_synthetic.prototext
@@ -1,0 +1,24 @@
+data_reader {
+  reader {
+    name: "synthetic"
+    role: "train"
+    shuffle: true
+    num_samples: 1281167
+    num_labels: 1000
+    synth_dimensions: "3 224 224"
+    validation_percent: 0.0
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+  }
+
+  reader {
+    name: "synthetic"
+    role: "validate"
+    shuffle: true
+    num_samples: 50000
+    num_labels: 1000
+    synth_dimensions: "3 224 224"
+    absolute_sample_count: 0
+    percent_of_data_to_use: 1.0
+  }
+}

--- a/applications/vision/resnet.py
+++ b/applications/vision/resnet.py
@@ -50,6 +50,9 @@ parser.add_argument(
 parser.add_argument(
     '--random-seed', action='store', default=0, type=int,
     help='random seed for LBANN RNGs', metavar='NUM')
+parser.add_argument(
+    '--synthetic', action='store_true', default=False,
+    help='Use synthetic data')
 lbann.contrib.args.add_optimizer_arguments(parser, default_learning_rate=0.1)
 args = parser.parse_args()
 
@@ -145,14 +148,20 @@ model = lbann.Model(args.num_epochs,
 opt = lbann.contrib.args.create_optimizer(args)
 
 # Setup data reader
-data_reader = data.imagenet.make_data_reader(num_classes=args.num_classes)
+data_reader = data.imagenet.make_data_reader(
+    num_classes=args.num_classes,
+    synthetic=args.synthetic)
 
 # Setup trainer
 trainer = lbann.Trainer(mini_batch_size=args.mini_batch_size, random_seed=args.random_seed)
 
 # Run experiment
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
+if args.synthetic:
+    lbann_args = ""
+else:
+    lbann_args = " --use_data_store --preload_data_store --node_sizes_vary"
 lbann.contrib.launcher.run(trainer, model, data_reader, opt,
                            job_name=args.job_name,
-                           lbann_args=" --use_data_store --preload_data_store --node_sizes_vary",
+                           lbann_args=lbann_args,
                            **kwargs)


### PR DESCRIPTION
Adds a `--synthetic` flag to the ResNet and AlexNet applications to use LBANN's synthetic data reader rather than real ImageNet data.