### PR TITLE
Stop passing output/error redirection to flux

### DIFF
--- a/python/lbann/launcher/flux.py
+++ b/python/lbann/launcher/flux.py
@@ -65,6 +65,10 @@ class FluxBatchScript(BatchScript):
         self.launcher = launcher
         self.launcher_args = launcher_args
 
+        # Slurm defines these in the ctor, so let's do that too.
+        self.add_header_line(f'#flux --output={self.out_log_file}')
+        self.add_header_line(f'#flux --error={self.err_log_file}')
+
     def add_parallel_command(self,
                              command,
                              work_dir=None,

--- a/python/lbann/launcher/flux.py
+++ b/python/lbann/launcher/flux.py
@@ -133,8 +133,6 @@ class FluxBatchScript(BatchScript):
         args.append(f'-o gpu-affinity=per-task')
         args.append(f'-o cpu-affinity=per-task')
         args.append(f'-o nosetpgrp')
-        args.append(f'--output={self.out_log_file}')
-        args.append(f'--error={self.err_log_file}')
 
         if time_limit is not None:
             args.append(f'--time={_time_string(time_limit)}')


### PR DESCRIPTION
The output is captured without explicitly passing `--output` and `--error` anyway. When running interactively, it's nice to have output displayed in the console.

After this change, users will have to redirect output if they run `batch.sh` manually, either via the usual redirection or pipes to `tee` or whatever they prefer. The usual `<job_dir>/{out,err}.log` files will only be created when launching via the Python Front-End.

This behavior is consistent with the behavior of interactive use of `batch.sh` with the other launchers. ~~To fully match the behavior in the case of batch jobs, we should add `#flux` directives to the scripts. This would have parity with slurm. I'll look into adding that.~~ I have added `#flux` directives to the batch script, so it should now have parity with at least slurm.

