### PR TITLE
Always enable the check for distconv

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -1022,6 +1022,11 @@ private:
   mutable bool m_distconv_enabled = false;
   mutable bool m_distconv_enabled_set = false;
   std::unique_ptr<distconv_adapter> m_dc;
+#else
+public:
+  /** @brief Indicate whether distconv is enabled. */
+  bool distconv_enabled() const { return false; }
+
 #endif // LBANN_HAS_DISTCONV
 };
 


### PR DESCRIPTION
This will just return `false` when DistConv support is not enabled.