### PR TITLE
Add env var support for subbing in a new RCCL

### DIFF
--- a/python/lbann/contrib/lc/launcher.py
+++ b/python/lbann/contrib/lc/launcher.py
@@ -96,6 +96,9 @@ def make_batch_script(
         prepend_environment_path('LD_LIBRARY_PATH', os.getenv('CRAY_LD_LIBRARY_PATH'))
         if os.getenv('ROCM_PATH') is not None:
             prepend_environment_path('LD_LIBRARY_PATH', os.path.join(os.getenv('ROCM_PATH'), 'llvm', 'lib'))
+        different_ofi_plugin = os.getenv('LBANN_USE_THIS_OFI_PLUGIN')
+        if different_ofi_plugin is not None:
+            prepend_environment_path('LD_LIBRARY_PATH', different_ofi_plugin)
 
     # Optimizations for Sierra-like systems
     if system in ('sierra', 'lassen', 'rzansel'):

--- a/python/lbann/launcher/flux.py
+++ b/python/lbann/launcher/flux.py
@@ -137,7 +137,9 @@ class FluxBatchScript(BatchScript):
         args.append(f'-o gpu-affinity=per-task')
         args.append(f'-o cpu-affinity=per-task')
         args.append(f'-o nosetpgrp')
-
+        use_this_rccl=os.getenv('LBANN_USE_THIS_RCCL')
+        if use_this_rccl is not None:
+            args.append(f'--env=LD_PRELOAD=' + use_this_rccl)
         if time_limit is not None:
             args.append(f'--time={_time_string(time_limit)}')
         if job_name:


### PR DESCRIPTION
The main function of these is to leave a record of their use in your `batch.sh`.