### PR TITLE
Transformer optimizations

### DIFF
--- a/applications/nlp/utils/paths.py
+++ b/applications/nlp/utils/paths.py
@@ -35,7 +35,7 @@ def wmt_dir(system=system()):
     if system in ('lassen', 'sierra'):
         path = '/p/gpfs1/brainusr/datasets/wmt16_en_de'
     elif system in ('pascal', 'catalyst', 'quartz', 'surface'):
-        path = '/p/lscratchh/brainusr/datasets/wmt16_en_de'
+        path = '/p/vast1/lbann/datasets/wmt16_en_de'
 
     # Default path if cached dataset isn't available
     if not path or not os.access(path, os.R_OK):

--- a/ci_test/unit_tests/test_unit_module_mha.py
+++ b/ci_test/unit_tests/test_unit_module_mha.py
@@ -1,133 +1,64 @@
-import os
-import os.path
-import sys
+import lbann
 import numpy as np
 import pytest
+import test_util
 
-# Bamboo utilities
-current_file = os.path.realpath(__file__)
-current_dir = os.path.dirname(current_file)
-sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
-import tools
-
-# ==============================================
-# Objects for Python data reader
-# ==============================================
-# Note: The Python data reader imports this file as a module and calls
-# the functions below to ingest data.
-
-# Data
-np.random.seed(20230510)
-_num_samples = 2
-
-_sequence_length = 32
-embed_dim = 64
-num_heads = 8
-
-_samples = np.random.normal(size=(_num_samples, 3, _sequence_length,
-                                  embed_dim)).astype(np.float32)
-
-# ------------------------------------------
-# PyTorch implementation
-# ------------------------------------------
 try:
     import torch
 except (ModuleNotFoundError, ImportError):
     pytest.skip('PyTorch is required for this test', allow_module_level=True)
 
-torch.manual_seed(20230510)
-mha_module = torch.nn.MultiheadAttention(embed_dim=embed_dim,
-                                         num_heads=num_heads,
-                                         batch_first=True,
-                                         bias=True)
-
-# Weights are packed in the PyTorch module by default, unpack to q/k/v
-q_w, k_w, v_w = mha_module.in_proj_weight.detach().split(embed_dim)
-q_b, k_b, v_b = mha_module.in_proj_bias.detach().split(embed_dim)
-
-# Compute reference values
-with torch.no_grad():
-    q, k, v = torch.from_numpy(_samples).unbind(dim=1)
-    acts_pt, _ = mha_module(q, k, v)
-    acts_np = acts_pt.detach().cpu().numpy()
-
-# Store samples along with reference values
-_samples_with_validation = np.concatenate(
-    (_samples, acts_np.reshape(_num_samples, 1, _sequence_length, embed_dim)),
-    axis=1)
+num_samples = 2
+sequence_length = 32
+embed_dim = 64
+num_heads = 8
 
 
-# Sample access functions
-def get_sample(index):
-    return _samples_with_validation[index].flatten()
+def make_mha_module(self_attention):
+    np.random.seed(20230510)
+    torch.manual_seed(20230510)
+    samples = np.random.normal(size=(num_samples, 3, sequence_length,
+                                     embed_dim)).astype(np.float32)
+
+    # PyTorch implementation
+    mha_module = torch.nn.MultiheadAttention(embed_dim=embed_dim,
+                                             num_heads=num_heads,
+                                             batch_first=True,
+                                             bias=True).eval()
+    # Compute reference values
+    with torch.no_grad():
+        # Randomize bias for testing
+        mha_module.in_proj_bias[:] = torch.randn(embed_dim * 3)
+
+        q, k, v = torch.from_numpy(samples).unbind(dim=1)
+        if self_attention:
+            acts_pt, _ = mha_module(q, q, q)
+        else:
+            acts_pt, _ = mha_module(q, k, v)
+        acts_np = acts_pt.detach().cpu().numpy()
+
+    return mha_module, (q, k, v), acts_np
 
 
-def num_samples():
-    return _num_samples
+@test_util.lbann_test(check_gradients=True)
+def test_multihead_attention():
+    mha_module, samples, activations = make_mha_module(self_attention=False)
 
+    # Weights are packed in the PyTorch module by default, unpack to q/k/v
+    q_w, k_w, v_w = mha_module.in_proj_weight.detach().split(embed_dim)
+    q_b, k_b, v_b = mha_module.in_proj_bias.detach().split(embed_dim)
 
-def sample_dims():
-    return (4 * _sequence_length, embed_dim)
-
-
-# ==============================================
-# Setup LBANN experiment
-# ==============================================
-
-err_tol = abs(8 * np.mean(_samples_with_validation[:, -1]) *
-              np.finfo(np.float32).eps)
-
-
-def setup_experiment(lbann, weekly):
-    """Construct LBANN experiment.
-
-    Args:
-        lbann (module): Module for LBANN Python frontend
-
-    """
-    mini_batch_size = num_samples()
-    trainer = lbann.Trainer(mini_batch_size)
-    model = construct_model(lbann)
-    data_reader = construct_data_reader(lbann)
-    optimizer = lbann.NoOptimizer()
-    return trainer, model, data_reader, optimizer, None  # Don't request any specific number of nodes
-
-
-def construct_model(lbann):
-    """Construct LBANN model.
-
-    Args:
-        lbann (module): Module for LBANN Python frontend
-
-    """
-
-    # ------------------------------------------
     # LBANN implementation
-    # ------------------------------------------
-
-    # Objects for LBANN model
-    metrics = []
-    callbacks = []
-
-    # Input data
-    x = lbann.Slice(
-        lbann.Input(data_field='samples'),
-        slice_points=[
-            0, _sequence_length, _sequence_length * 2, _sequence_length * 3,
-            _sequence_length * 4
-        ],
-    )
-
-    q = lbann.Identity(x)
-    k = lbann.Identity(x)
-    v = lbann.Identity(x)
-    verification = lbann.Identity(x)
+    tester = test_util.ModelTester()
+    q, k, v = tester.inputs_like(*samples)
+    tester.make_reference(activations)
 
     # Test module
     from lbann.modules.transformer import MultiheadAttention
     mha = MultiheadAttention(
         embed_dim=embed_dim,
         num_heads=num_heads,
+        self_attention=False,
     )
 
     mha.query_weights = [
@@ -148,6 +79,7 @@ def construct_model(lbann):
         lbann.Weights(initializer=lbann.ValueInitializer(
             values=np.nditer(v_b.contiguous()))),
     ]
+
     mha.output_weights = [
         lbann.Weights(initializer=lbann.ValueInitializer(
             values=np.nditer(mha_module.out_proj.weight.detach().cpu().
@@ -156,62 +88,49 @@ def construct_model(lbann):
             mha_module.out_proj.bias.detach().cpu().contiguous().numpy()))),
     ]
 
-    # TODO: Test mask and self-attention
     acts = mha(q, k, v)
 
     # Compute MSE loss w.r.t. verification tensor
-    l2_loss = lbann.MeanSquaredError(acts, verification)
-    metrics.append(lbann.Metric(l2_loss, name='acts'))
-
-    callbacks.append(
-        lbann.CallbackCheckMetric(metric=metrics[-1].name,
-                                  lower_bound=0,
-                                  upper_bound=err_tol,
-                                  error_on_failure=True,
-                                  execution_modes='test'))
-
-    # ------------------------------------------
-    # Construct model
-    # ------------------------------------------
-
-    num_epochs = 0
-    return lbann.Model(num_epochs,
-                       layers=lbann.traverse_layer_graph(x),
-                       metrics=metrics,
-                       callbacks=callbacks)
+    tester.set_loss_function(lbann.MeanSquaredError, acts)
+    return tester
 
 
-def construct_data_reader(lbann):
-    """Construct Protobuf message for Python data reader.
+@test_util.lbann_test(check_gradients=True)
+def test_self_attention():
+    mha_module, samples, activations = make_mha_module(self_attention=True)
 
-    The Python data reader will import the current Python file to
-    access the sample access functions.
+    # LBANN implementation
+    tester = test_util.ModelTester()
+    q = tester.inputs(samples[0])
+    tester.make_reference(activations)
 
-    Args:
-        lbann (module): Module for LBANN Python frontend
+    # Test module
+    from lbann.modules.transformer import MultiheadAttention
+    mha = MultiheadAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+        self_attention=True,
+    )
 
-    """
+    mha.qkv_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(mha_module.in_proj_weight.detach().cpu().transpose(0, 1).contiguous().numpy())
+        )),
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(mha_module.in_proj_bias.detach().cpu().numpy()))),
+    ]
 
-    # Note: The training data reader should be removed when
-    # https://github.com/LLNL/lbann/issues/1098 is resolved.
-    message = lbann.reader_pb2.DataReader()
-    message.reader.extend([
-        tools.create_python_data_reader(lbann, current_file, 'get_sample',
-                                        'num_samples', 'sample_dims', 'train')
-    ])
-    message.reader.extend([
-        tools.create_python_data_reader(lbann, current_file, 'get_sample',
-                                        'num_samples', 'sample_dims', 'test')
-    ])
-    return message
+    mha.output_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(mha_module.out_proj.weight.detach().cpu().
+                             transpose(0, 1).contiguous().numpy()))),
+        lbann.Weights(initializer=lbann.ValueInitializer(values=np.nditer(
+            mha_module.out_proj.bias.detach().cpu().contiguous().numpy()))),
+    ]
 
+    acts = mha(q, q, q)
 
-# ==============================================
-# Setup PyTest
-# ==============================================
-
-# Create test functions that can interact with PyTest
-# Note: Create test name by removing ".py" from file name
-_test_name = os.path.splitext(os.path.basename(current_file))[0]
-for _test_func in tools.create_tests(setup_experiment, _test_name):
-    globals()[_test_func.__name__] = _test_func
+    # Compute MSE loss w.r.t. verification tensor
+    tester.set_loss_function(lbann.MeanSquaredError, acts)
+    tester.extra_callbacks.append(lbann.CallbackPrintModelDescription())
+    return tester

--- a/ci_test/unit_tests/test_unit_module_mha.py
+++ b/ci_test/unit_tests/test_unit_module_mha.py
@@ -1,0 +1,217 @@
+import os
+import os.path
+import sys
+import numpy as np
+import pytest
+
+# Bamboo utilities
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+sys.path.insert(0, os.path.join(os.path.dirname(current_dir), 'common_python'))
+import tools
+
+# ==============================================
+# Objects for Python data reader
+# ==============================================
+# Note: The Python data reader imports this file as a module and calls
+# the functions below to ingest data.
+
+# Data
+np.random.seed(20230510)
+_num_samples = 2
+
+_sequence_length = 32
+embed_dim = 64
+num_heads = 8
+
+_samples = np.random.normal(size=(_num_samples, 3, _sequence_length,
+                                  embed_dim)).astype(np.float32)
+
+# ------------------------------------------
+# PyTorch implementation
+# ------------------------------------------
+try:
+    import torch
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch is required for this test', allow_module_level=True)
+
+torch.manual_seed(20230510)
+mha_module = torch.nn.MultiheadAttention(embed_dim=embed_dim,
+                                         num_heads=num_heads,
+                                         batch_first=True,
+                                         bias=True)
+
+# Weights are packed in the PyTorch module by default, unpack to q/k/v
+q_w, k_w, v_w = mha_module.in_proj_weight.detach().split(embed_dim)
+q_b, k_b, v_b = mha_module.in_proj_bias.detach().split(embed_dim)
+
+# Compute reference values
+with torch.no_grad():
+    q, k, v = torch.from_numpy(_samples).unbind(dim=1)
+    acts_pt, _ = mha_module(q, k, v)
+    acts_np = acts_pt.detach().cpu().numpy()
+
+# Store samples along with reference values
+_samples_with_validation = np.concatenate(
+    (_samples, acts_np.reshape(_num_samples, 1, _sequence_length, embed_dim)),
+    axis=1)
+
+
+# Sample access functions
+def get_sample(index):
+    return _samples_with_validation[index].flatten()
+
+
+def num_samples():
+    return _num_samples
+
+
+def sample_dims():
+    return (4 * _sequence_length, embed_dim)
+
+
+# ==============================================
+# Setup LBANN experiment
+# ==============================================
+
+err_tol = abs(8 * np.mean(_samples_with_validation[:, -1]) *
+              np.finfo(np.float32).eps)
+
+
+def setup_experiment(lbann, weekly):
+    """Construct LBANN experiment.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+    mini_batch_size = num_samples()
+    trainer = lbann.Trainer(mini_batch_size)
+    model = construct_model(lbann)
+    data_reader = construct_data_reader(lbann)
+    optimizer = lbann.NoOptimizer()
+    return trainer, model, data_reader, optimizer, None  # Don't request any specific number of nodes
+
+
+def construct_model(lbann):
+    """Construct LBANN model.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # ------------------------------------------
+    # LBANN implementation
+    # ------------------------------------------
+
+    # Objects for LBANN model
+    metrics = []
+    callbacks = []
+
+    # Input data
+    x = lbann.Slice(
+        lbann.Input(data_field='samples'),
+        slice_points=[
+            0, _sequence_length, _sequence_length * 2, _sequence_length * 3,
+            _sequence_length * 4
+        ],
+    )
+
+    q = lbann.Identity(x)
+    k = lbann.Identity(x)
+    v = lbann.Identity(x)
+    verification = lbann.Identity(x)
+
+    # Test module
+    from lbann.modules.transformer import MultiheadAttention
+    mha = MultiheadAttention(
+        embed_dim=embed_dim,
+        num_heads=num_heads,
+    )
+
+    mha.query_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(q_w.transpose(0, 1).contiguous()))),
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(q_b.contiguous()))),
+    ]
+    mha.key_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(k_w.transpose(0, 1).contiguous()))),
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(k_b.contiguous()))),
+    ]
+    mha.value_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(v_w.transpose(0, 1).contiguous()))),
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(v_b.contiguous()))),
+    ]
+    mha.output_weights = [
+        lbann.Weights(initializer=lbann.ValueInitializer(
+            values=np.nditer(mha_module.out_proj.weight.detach().cpu().
+                             transpose(0, 1).contiguous().numpy()))),
+        lbann.Weights(initializer=lbann.ValueInitializer(values=np.nditer(
+            mha_module.out_proj.bias.detach().cpu().contiguous().numpy()))),
+    ]
+
+    # TODO: Test mask and self-attention
+    acts = mha(q, k, v)
+
+    # Compute MSE loss w.r.t. verification tensor
+    l2_loss = lbann.MeanSquaredError(acts, verification)
+    metrics.append(lbann.Metric(l2_loss, name='acts'))
+
+    callbacks.append(
+        lbann.CallbackCheckMetric(metric=metrics[-1].name,
+                                  lower_bound=0,
+                                  upper_bound=err_tol,
+                                  error_on_failure=True,
+                                  execution_modes='test'))
+
+    # ------------------------------------------
+    # Construct model
+    # ------------------------------------------
+
+    num_epochs = 0
+    return lbann.Model(num_epochs,
+                       layers=lbann.traverse_layer_graph(x),
+                       metrics=metrics,
+                       callbacks=callbacks)
+
+
+def construct_data_reader(lbann):
+    """Construct Protobuf message for Python data reader.
+
+    The Python data reader will import the current Python file to
+    access the sample access functions.
+
+    Args:
+        lbann (module): Module for LBANN Python frontend
+
+    """
+
+    # Note: The training data reader should be removed when
+    # https://github.com/LLNL/lbann/issues/1098 is resolved.
+    message = lbann.reader_pb2.DataReader()
+    message.reader.extend([
+        tools.create_python_data_reader(lbann, current_file, 'get_sample',
+                                        'num_samples', 'sample_dims', 'train')
+    ])
+    message.reader.extend([
+        tools.create_python_data_reader(lbann, current_file, 'get_sample',
+                                        'num_samples', 'sample_dims', 'test')
+    ])
+    return message
+
+
+# ==============================================
+# Setup PyTest
+# ==============================================
+
+# Create test functions that can interact with PyTest
+# Note: Create test name by removing ".py" from file name
+_test_name = os.path.splitext(os.path.basename(current_file))[0]
+for _test_func in tools.create_tests(setup_experiment, _test_name):
+    globals()[_test_func.__name__] = _test_func

--- a/docs/layers/miscellaneous_layers.rst
+++ b/docs/layers/miscellaneous_layers.rst
@@ -97,7 +97,7 @@ ChannelwiseSoftmax
 The :python:`ChannelwiseSoftmax` layer applies the Softmax function
 across channel dimensions.
 
-The input tensor is sliced along the first tensor dimension (by default, the
+The input tensor is sliced along the chosen tensor dimension (by default, the
 "channel" dimension for image data in CHW format) and the softmax
 function is computed for each slice.
 

--- a/docs/layers/miscellaneous_layers.rst
+++ b/docs/layers/miscellaneous_layers.rst
@@ -97,11 +97,17 @@ ChannelwiseSoftmax
 The :python:`ChannelwiseSoftmax` layer applies the Softmax function
 across channel dimensions.
 
-The input tensor is sliced along the first tensor dimension (the
+The input tensor is sliced along the first tensor dimension (by default, the
 "channel" dimension for image data in CHW format) and the softmax
 function is computed for each slice.
 
-Arguments: None
+Arguments:
+
+   :dim: (``int64``) The tensor dimension to use (defaults to first).
+
+   :single_dim_mode: (``bool``) If true, only performs softmax on the chosen
+                     dimension. Otherwise all dimensions but ``dim`` will be
+                     used.
 
 :ref:`Back to Top<miscellaneous-layers>`
 

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -66,7 +66,7 @@ public:
   std::string get_type() const override { return "weighted sum"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-  bool can_run_inplace() const override { return false; }
+  bool can_run_inplace() const override { return true; }
   int get_backprop_requirements() const override { return ERROR_SIGNALS; }
 
   description get_description() const override

--- a/include/lbann/layers/transform/weighted_sum.hpp
+++ b/include/lbann/layers/transform/weighted_sum.hpp
@@ -66,7 +66,7 @@ public:
   std::string get_type() const override { return "weighted sum"; }
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
-  bool can_run_inplace() const override { return true; }
+  bool can_run_inplace() const override { return false; }
   int get_backprop_requirements() const override { return ERROR_SIGNALS; }
 
   description get_description() const override

--- a/python/lbann/models/transformer.py
+++ b/python/lbann/models/transformer.py
@@ -397,6 +397,8 @@ class Transformer(lbann.modules.Module):
             for i in range(num_decoder_layers)
         ]
         self.separate_heads = self.decoder[0].attention1.separate_heads
+        assert all(dec.attention1.separate_heads == self.separate_heads
+                   for dec in self.decoder)
 
     def _positional_encoding(self, sequence_length):
         """Positional encodings corresponding to a sequence length.

--- a/src/layers/misc/misc_builders.cpp
+++ b/src/layers/misc/misc_builders.cpp
@@ -206,17 +206,24 @@ std::unique_ptr<lbann::Layer> lbann::build_channelwise_mean_layer_from_pbuf(
 }
 
 template <typename T, lbann::data_layout L, El::Device D>
-std::unique_ptr<lbann::Layer>
-lbann::build_channelwise_softmax_layer_from_pbuf(lbann_comm* comm,
-                                                 lbann_data::Layer const&)
+std::unique_ptr<lbann::Layer> lbann::build_channelwise_softmax_layer_from_pbuf(
+  lbann_comm* comm,
+  lbann_data::Layer const& proto_layer)
 {
+  auto const& layer = proto_layer.channelwise_softmax();
   if constexpr (L == data_layout::DATA_PARALLEL) {
     if constexpr (std::is_same_v<T, float>)
       return std::make_unique<
-        channelwise_softmax_layer<float, data_layout::DATA_PARALLEL, D>>(comm);
+        channelwise_softmax_layer<float, data_layout::DATA_PARALLEL, D>>(
+        comm,
+        layer.dim(),
+        layer.single_dim_mode());
     else if constexpr (std::is_same_v<T, double>)
       return std::make_unique<
-        channelwise_softmax_layer<double, data_layout::DATA_PARALLEL, D>>(comm);
+        channelwise_softmax_layer<double, data_layout::DATA_PARALLEL, D>>(
+        comm,
+        layer.dim(),
+        layer.single_dim_mode());
   }
   (void)comm;
   LBANN_ERROR("Attempted to construct channelwise_softmax_layer ",

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -1418,11 +1418,18 @@ message Layer {
 
   /** @brief Softmax across channel dimension
    *
-   *  The input tensor is sliced along the first tensor dimension (the
-   *  "channel" dimension for image data in CHW format) and the
+   *  The input tensor is sliced along the chosen tensor dimension (by default,
+   *  the "channel" dimension for image data in CHW format) and the
    *  softmax function is computed for each slice.
    */
-  message ChannelwiseSoftmax {}
+  message ChannelwiseSoftmax {
+    /** @brief The tensor dimension to use (defaults to first) */
+    int64 dim = 1;
+
+    /** @brief If true, only performs softmax on the chosen dimension. Otherwise
+               all dimensions _but_ ``dim`` will be used. */
+    bool single_dim_mode = 2;
+  }
 
   /** @brief Embedding layer with distributed weights
    *
@@ -1573,8 +1580,8 @@ message WeightsData {
 enum Imcomm {
   DEFAULT = 0;  // add Layer to Imcomm callback if all_learning_layers = true in
                 // the CallbackImComm
-  EXCLUDE = 1;  //*do not* add Layer to Imcomm callback if all_learning_layers =
-                //true in the CallbackImComm
+  EXCLUDE = 1;  // *do not* add Layer to Imcomm callback if all_learning_layers
+                // = true in the CallbackImComm
   INCLUDE =
       2;  // add Layer to Imcomm callback regardless of whether
           // all_learning_layers in the CallbackImComm is set to true or false


### PR DESCRIPTION
This PR includes two major modifications to transformers:
* Batching heads in multi-head attention into single operations instead of on a per-head basis
* Stacking the weights and biases for queries/keys/values in self-attention

The PR also includes fixes for the weighted sum operator (w.r.t. in-place layers) and path fixes for the transformer test