### PR TITLE
Fix get_distconv_environment

### DIFF
--- a/ci_test/common_python/tools.py
+++ b/ci_test/common_python/tools.py
@@ -1021,8 +1021,11 @@ def gpus_per_node(lbann):
 # Get the environment variables for Distconv.
 def get_distconv_environment(init_nvshmem=False):
     # TODO: Use the default halo exchange and shuffle method. See https://github.com/LLNL/lbann/issues/1659
-    return {"LBANN_DISTCONV_HALO_EXCHANGE": "AL",
+    environment = {"LBANN_DISTCONV_HALO_EXCHANGE": "AL",
             "LBANN_DISTCONV_TENSOR_SHUFFLER": "AL",
             "LBANN_KEEP_ERROR_SIGNALS": "1",
-            "LBANN_INIT_NVSHMEM": (1 if init_nvshmem else 0),
         }
+    if init_nvshmem:
+        environment["LBANN_INIT_NVSHMEM"] = 1
+
+    return environment

--- a/ci_test/common_python/tools.py
+++ b/ci_test/common_python/tools.py
@@ -1019,7 +1019,10 @@ def gpus_per_node(lbann):
 
 
 # Get the environment variables for Distconv.
-def get_distconv_environment():
+def get_distconv_environment(init_nvshmem=False):
     # TODO: Use the default halo exchange and shuffle method. See https://github.com/LLNL/lbann/issues/1659
     return {"LBANN_DISTCONV_HALO_EXCHANGE": "AL",
-            "LBANN_DISTCONV_TENSOR_SHUFFLER": "AL"}
+            "LBANN_DISTCONV_TENSOR_SHUFFLER": "AL",
+            "LBANN_KEEP_ERROR_SIGNALS": "1",
+            "LBANN_INIT_NVSHMEM": (1 if init_nvshmem else 0),
+        }

--- a/ci_test/unit_tests/test_unit_layer_gather_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_gather_distconv.py
@@ -196,5 +196,6 @@ def construct_data_reader(lbann):
 # ==============================================
 
 # Create test functions that can interact with PyTest
-for _test_func in tools.create_tests(setup_experiment, __file__):
+for _test_func in tools.create_tests(setup_experiment, __file__,
+                                     environment=tools.get_distconv_environment(init_nvshmem=True)):
     globals()[_test_func.__name__] = _test_func

--- a/ci_test/unit_tests/test_unit_layer_scatter_distconv.py
+++ b/ci_test/unit_tests/test_unit_layer_scatter_distconv.py
@@ -212,5 +212,5 @@ def construct_data_reader(lbann):
 
 # Create test functions that can interact with PyTest
 for _test_func in tools.create_tests(setup_experiment, __file__,
-                                    environment=tools.get_distconv_environment()):
+                                    environment=tools.get_distconv_environment(init_nvshmem=True)):
     globals()[_test_func.__name__] = _test_func

--- a/python/lbann/contrib/args.py
+++ b/python/lbann/contrib/args.py
@@ -74,8 +74,7 @@ def get_distconv_environment(parallel_io=False, num_io_partitions=1, init_nvshme
         num_io_partitions (int):
             The number of processes to read a single sample.
     """
-
-    return {
+    environment = {
         'DISTCONV_WS_CAPACITY_FACTOR': 0.8,
         'LBANN_DISTCONV_HALO_EXCHANGE': 'AL',
         'LBANN_DISTCONV_TENSOR_SHUFFLER': 'AL',
@@ -86,8 +85,11 @@ def get_distconv_environment(parallel_io=False, num_io_partitions=1, init_nvshme
         'LBANN_DISTCONV_COSMOFLOW_PARALLEL_IO': parallel_io,
         'LBANN_DISTCONV_NUM_IO_PARTITIONS': num_io_partitions,
         "LBANN_KEEP_ERROR_SIGNALS": "1",
-        "LBANN_INIT_NVSHMEM": (1 if init_nvshmem else 0),
     }
+    if init_nvshmem:
+        environment["LBANN_INIT_NVSHMEM"] = 1
+
+    return environment
 
 def add_optimizer_arguments(parser, default_optimizer='momentum',
                             default_learning_rate=0.01):

--- a/python/lbann/contrib/args.py
+++ b/python/lbann/contrib/args.py
@@ -65,7 +65,7 @@ def get_scheduler_kwargs(args):
     if args.setup_only: kwargs['setup_only'] = True
     return kwargs
 
-def get_distconv_environment(parallel_io=False, num_io_partitions=1):
+def get_distconv_environment(parallel_io=False, num_io_partitions=1, init_nvshmem=False):
     """Return recommended Distconv variables.
 
     Args:
@@ -85,6 +85,8 @@ def get_distconv_environment(parallel_io=False, num_io_partitions=1):
         'LBANN_DISTCONV_RANK_STRIDE': 1,
         'LBANN_DISTCONV_COSMOFLOW_PARALLEL_IO': parallel_io,
         'LBANN_DISTCONV_NUM_IO_PARTITIONS': num_io_partitions,
+        "LBANN_KEEP_ERROR_SIGNALS": "1",
+        "LBANN_INIT_NVSHMEM": (1 if init_nvshmem else 0),
     }
 
 def add_optimizer_arguments(parser, default_optimizer='momentum',


### PR DESCRIPTION
Updated the get_distconv_environment function to be able to initialize
NVSHMEM if requested and to set LBANN_KEEP_ERROR_SIGNALS to 1, 
since that is always required for distconv right now.

Updated two nvshmem unit tests to initialize NVSHMEM.