### PR TITLE
Fix an issue with cuTT/hipTT not behaving correctly in inverse_permute

### DIFF
--- a/src/layers/transform/permute/cutt_permuteimpl.hpp
+++ b/src/layers/transform/permute/cutt_permuteimpl.hpp
@@ -317,6 +317,7 @@ void cuTT_PermuteImpl::do_mb_permute(
   CHECK_CUTT(cuttExecute(plan,
                          const_cast<DataT*>(in.LockedBuffer()), // UGH
                          out.Buffer()));
+  CHECK_CUTT(cuttDestroy(plan));
 }
 
 template <typename DataT>
@@ -338,6 +339,7 @@ void cuTT_PermuteImpl::do_sample_permute(
                            in_buf + sample * in_stride,
                            out_buf + sample * out_stride));
   }
+  CHECK_CUTT(cuttDestroy(plan));
 }
 
 inline void cuTT_PermuteImpl::swap(cuTT_PermuteImpl& other)


### PR DESCRIPTION
The original code was buggy. Removing the memoization is easier than fixing it, and there's no evidence that memoization is a performance benefit.