### PR TITLE
Memoize cuTT/hipTT plans again

### DIFF
--- a/src/layers/transform/permute/cutt_permuteimpl.hpp
+++ b/src/layers/transform/permute/cutt_permuteimpl.hpp
@@ -149,8 +149,12 @@ public:
   ///@}
 
 private:
+  using BatchSizeT = El::Int;
   using Plan = cuttHandle;
-  using PlanMap = std::unordered_map<El::Int, Plan>;
+  using PlanMap = std::unordered_map<BatchSizeT, Plan>;
+  // The key here corresponds to the minibatch size. This is chosen to
+  // be robust to variable batch sizes beyond the simple last-batch
+  // "remainder", however unlikely any other case may be.
 
 private:
   template <typename DataT>
@@ -198,8 +202,8 @@ private:
   // Plan memoization -- lazily constructed.
   mutable PlanMap m_fwd_plans;
   mutable PlanMap m_inv_plans;
-  mutable Plan m_sample_fwd_plan = 0;
-  mutable Plan m_sample_inv_plan = 0;
+  mutable Plan m_sample_fwd_plan = 0U;
+  mutable Plan m_sample_inv_plan = 0U;
 }; // class cuTT_PermuteImpl
 
 inline cuTT_PermuteImpl::cuTT_PermuteImpl(ColMajorPerm perm)
@@ -373,7 +377,7 @@ void cuTT_PermuteImpl::do_sample_permute(
   El::Matrix<DataT, El::Device::GPU> const& in,
   El::Matrix<DataT, El::Device::GPU>& out) const
 {
-  if (sample_plan == 0UL)
+  if (sample_plan == 0U)
     sample_plan = get_sample_plan(perm, in_dims, out_dims, in, out);
 
   DataT* const in_buf = const_cast<DataT*>(in.LockedBuffer());

--- a/src/layers/transform/permute/cutt_permuteimpl.hpp
+++ b/src/layers/transform/permute/cutt_permuteimpl.hpp
@@ -363,6 +363,8 @@ void cuTT_PermuteImpl::do_mb_permute(
   El::Matrix<DataT, El::Device::GPU> const& in,
   El::Matrix<DataT, El::Device::GPU>& out) const
 {
+  auto multisync =
+    El::MakeMultiSync(El::SyncInfoFromMatrix(out), El::SyncInfoFromMatrix(in));
   auto const plan = get_mb_plan(plan_map, perm, in_dims, out_dims, in, out);
   LBANN_CHECK_CUTT(
     cuttExecute(plan, const_cast<DataT*>(in.LockedBuffer()), out.Buffer()));
@@ -377,6 +379,8 @@ void cuTT_PermuteImpl::do_sample_permute(
   El::Matrix<DataT, El::Device::GPU> const& in,
   El::Matrix<DataT, El::Device::GPU>& out) const
 {
+  auto multisync =
+    El::MakeMultiSync(El::SyncInfoFromMatrix(out), El::SyncInfoFromMatrix(in));
   if (sample_plan == 0U)
     sample_plan = get_sample_plan(perm, in_dims, out_dims, in, out);
 

--- a/src/layers/transform/permute/cutt_permuteimpl.hpp
+++ b/src/layers/transform/permute/cutt_permuteimpl.hpp
@@ -41,7 +41,17 @@
 #include <utility>
 #include <vector>
 
-static char const* cutt_err_string(cuttResult err) noexcept
+#define LBANN_CHECK_CUTT(cmd)                                                  \
+  do {                                                                         \
+    cuttResult _check_cutt_err_result = (cmd);                                 \
+    if (CUTT_SUCCESS != _check_cutt_err_result) {                              \
+      LBANN_ERROR("cuTT operation \"" #cmd "\" FAILED (",                      \
+                  cutt_err_string(_check_cutt_err_result),                     \
+                  ")");                                                        \
+    }                                                                          \
+  } while (0)
+
+static inline char const* cutt_err_string(cuttResult err) noexcept
 {
   switch (err) {
   case CUTT_SUCCESS:
@@ -60,16 +70,6 @@ static char const* cutt_err_string(cuttResult err) noexcept
     return "<Unknown error value>";
   }
 }
-
-#define CHECK_CUTT(cmd)                                                        \
-  do {                                                                         \
-    cuttResult _check_cutt_err_result = (cmd);                                 \
-    if (CUTT_SUCCESS != _check_cutt_err_result) {                              \
-      LBANN_ERROR("cuTT operation \"" #cmd "\" FAILED (",                      \
-                  cutt_err_string(_check_cutt_err_result),                     \
-                  ")");                                                        \
-    }                                                                          \
-  } while (0)
 
 namespace {
 
@@ -100,7 +100,7 @@ public:
   ///@{
 
   cuTT_PermuteImpl(ColMajorPerm perm);
-  ~cuTT_PermuteImpl() noexcept = default;
+  ~cuTT_PermuteImpl() noexcept;
   ///@}
   /** @name Read-only Accessors (for testing) */
   ///@{
@@ -149,8 +149,13 @@ public:
   ///@}
 
 private:
+  using Plan = cuttHandle;
+  using PlanMap = std::unordered_map<El::Int, Plan>;
+
+private:
   template <typename DataT>
-  cuttHandle get_mb_plan(ColMajorPerm const& perm,
+  cuttHandle get_mb_plan(PlanMap& plan_map,
+                         ColMajorPerm const& perm,
                          DimsType const& in_dims,
                          DimsType const& out_dims,
                          El::Matrix<DataT, El::Device::GPU> const& in,
@@ -165,14 +170,20 @@ private:
                   El::Matrix<DataT, El::Device::GPU> const& out) const;
 
   template <typename DataT>
-  void do_mb_permute(ColMajorPerm const& perm,
+  bool is_mb_permutable(El::Matrix<DataT, El::Device::GPU> const& in,
+                        El::Matrix<DataT, El::Device::GPU> const& out) const;
+
+  template <typename DataT>
+  void do_mb_permute(PlanMap& plan_map,
+                     ColMajorPerm const& perm,
                      DimsType const& in_dims,
                      DimsType const& out_dims,
                      El::Matrix<DataT, El::Device::GPU> const& in,
                      El::Matrix<DataT, El::Device::GPU>& out) const;
 
   template <typename DataT>
-  void do_sample_permute(ColMajorPerm const& perm,
+  void do_sample_permute(Plan& plan,
+                         ColMajorPerm const& perm,
                          DimsType const& in_dims,
                          DimsType const& out_dims,
                          El::Matrix<DataT, El::Device::GPU> const& in,
@@ -183,6 +194,12 @@ private:
   ColMajorPerm m_inv_perm;
   DimsType m_input_dims;
   DimsType m_output_dims;
+
+  // Plan memoization -- lazily constructed.
+  mutable PlanMap m_fwd_plans;
+  mutable PlanMap m_inv_plans;
+  mutable Plan m_sample_fwd_plan = 0;
+  mutable Plan m_sample_inv_plan = 0;
 }; // class cuTT_PermuteImpl
 
 inline cuTT_PermuteImpl::cuTT_PermuteImpl(ColMajorPerm perm)
@@ -190,6 +207,26 @@ inline cuTT_PermuteImpl::cuTT_PermuteImpl(ColMajorPerm perm)
 {
   LBANN_ASSERT_DEBUG(is_valid(m_perm));
   LBANN_ASSERT_DEBUG(is_valid(m_inv_perm));
+}
+
+inline cuTT_PermuteImpl::~cuTT_PermuteImpl() noexcept
+{
+  try {
+    for (auto& [_, plan] : m_fwd_plans)
+      if (plan)
+        LBANN_CHECK_CUTT(cuttDestroy(plan));
+    for (auto& [_, plan] : m_inv_plans)
+      if (plan)
+        LBANN_CHECK_CUTT(cuttDestroy(plan));
+    if (m_sample_fwd_plan)
+      LBANN_CHECK_CUTT(cuttDestroy(m_sample_fwd_plan));
+    if (m_sample_inv_plan)
+      LBANN_CHECK_CUTT(cuttDestroy(m_sample_inv_plan));
+  }
+  catch (lbann::exception const& e) {
+    std::cerr << e.what();
+    std::terminate();
+  }
 }
 
 inline auto cuTT_PermuteImpl::perm() const noexcept -> ColMajorPerm const&
@@ -215,6 +252,7 @@ inline void cuTT_PermuteImpl::set_dims(DimsType input_dims)
 
 template <typename DataT>
 cuttHandle cuTT_PermuteImpl::get_mb_plan(
+  PlanMap& plan_map,
   ColMajorPerm const& perm,
   DimsType const& in_dims,
   DimsType const& out_dims,
@@ -225,17 +263,21 @@ cuttHandle cuTT_PermuteImpl::get_mb_plan(
   LBANN_ASSERT_DEBUG(perm.size() == in_dims.size() &&
                      perm.size() == out_dims.size());
 
-  std::vector<int> permutation(perm.get()), dimensions(in_dims.get());
-  permutation.push_back(static_cast<int>(perm.size()));
-  dimensions.push_back(in.Width());
-  cuttHandle plan;
-  CHECK_CUTT(cuttPlan(&plan,
-                      dimensions.size(),
-                      dimensions.data(),
-                      permutation.data(),
-                      sizeof(DataT),
-                      out.GetSyncInfo().Stream()));
-  return plan;
+  auto const key = in.Width();
+  if (plan_map.count(key) == 0UL) {
+    std::vector<int> permutation(perm.get()), dimensions(in_dims.get());
+    permutation.push_back(static_cast<int>(perm.size()));
+    dimensions.push_back(in.Width());
+    cuttHandle plan = 0U;
+    LBANN_CHECK_CUTT(cuttPlan(&plan,
+                              dimensions.size(),
+                              dimensions.data(),
+                              permutation.data(),
+                              sizeof(DataT),
+                              out.GetSyncInfo().Stream()));
+    plan_map.emplace(key, plan);
+  }
+  return plan_map[key];
 }
 
 template <typename DataT>
@@ -247,14 +289,23 @@ cuttHandle cuTT_PermuteImpl::get_sample_plan(
   El::Matrix<DataT, El::Device::GPU> const& out) const
 {
   std::vector<int> permutation(perm.get()), dimensions(in_dims.get());
-  cuttHandle sample_plan = 0U;
-  CHECK_CUTT(cuttPlan(&sample_plan,
-                      dimensions.size(),
-                      dimensions.data(),
-                      permutation.data(),
-                      sizeof(DataT),
-                      out.GetSyncInfo().Stream()));
-  return sample_plan;
+  Plan plan = 0UL;
+  LBANN_CHECK_CUTT(cuttPlan(&plan,
+                            dimensions.size(),
+                            dimensions.data(),
+                            permutation.data(),
+                            sizeof(DataT),
+                            out.GetSyncInfo().Stream()));
+  return plan;
+}
+
+template <typename DataT>
+bool cuTT_PermuteImpl::is_mb_permutable(
+  El::Matrix<DataT, El::Device::GPU> const& in,
+  El::Matrix<DataT, El::Device::GPU> const& out) const
+{
+  return in.LDim() == in.Height() && out.LDim() == out.Height() &&
+         in.Width() > 1;
 }
 
 template <typename DataT>
@@ -264,20 +315,15 @@ void cuTT_PermuteImpl::permute(El::Matrix<DataT, El::Device::GPU> const& in,
   if (in.Width() == El::Int{0})
     return;
 
-  auto const& in_dims = m_input_dims;
-  auto const& out_dims = m_output_dims;
-  auto const& perm = m_perm;
-
-  auto multisync =
-    El::MakeMultiSync(El::SyncInfoFromMatrix(out), El::SyncInfoFromMatrix(in));
-
-  if (in.LDim() == in.Height() && out.LDim() == out.Height() &&
-      in.Width() > 1) {
-    do_mb_permute(perm, in_dims, out_dims, in, out);
-  }
-  else {
-    do_sample_permute(perm, in_dims, out_dims, in, out);
-  }
+  if (is_mb_permutable(in, out))
+    do_mb_permute(m_fwd_plans, m_perm, m_input_dims, m_output_dims, in, out);
+  else
+    do_sample_permute(m_sample_fwd_plan,
+                      m_inv_perm,
+                      m_input_dims,
+                      m_output_dims,
+                      in,
+                      out);
 }
 
 template <typename DataT>
@@ -288,58 +334,59 @@ void cuTT_PermuteImpl::inverse_permute(
   if (in.Width() == El::Int{0})
     return;
 
-  // Aliases to help this read better.
-  auto const& in_dims = m_output_dims;
-  auto const& out_dims = m_input_dims;
-  auto const& perm = m_inv_perm;
-
-  auto multisync =
-    El::MakeMultiSync(El::SyncInfoFromMatrix(out), El::SyncInfoFromMatrix(in));
-
-  if (in.LDim() == in.Height() && out.LDim() == out.Height() &&
-      in.Width() > 1) {
-    do_mb_permute(perm, in_dims, out_dims, in, out);
-  }
-  else {
-    do_sample_permute(perm, in_dims, out_dims, in, out);
-  }
+  if (is_mb_permutable(in, out))
+    do_mb_permute(m_inv_plans,
+                  m_inv_perm,
+                  m_output_dims,
+                  m_input_dims,
+                  in,
+                  out);
+  else
+    do_sample_permute(m_sample_inv_plan,
+                      m_inv_perm,
+                      m_output_dims,
+                      m_input_dims,
+                      in,
+                      out);
 }
 
 template <typename DataT>
 void cuTT_PermuteImpl::do_mb_permute(
+  PlanMap& plan_map,
   ColMajorPerm const& perm,
   DimsType const& in_dims,
   DimsType const& out_dims,
   El::Matrix<DataT, El::Device::GPU> const& in,
   El::Matrix<DataT, El::Device::GPU>& out) const
 {
-  auto const plan = get_mb_plan(perm, in_dims, out_dims, in, out);
-  CHECK_CUTT(cuttExecute(plan,
-                         const_cast<DataT*>(in.LockedBuffer()), // UGH
-                         out.Buffer()));
-  CHECK_CUTT(cuttDestroy(plan));
+  auto const plan = get_mb_plan(plan_map, perm, in_dims, out_dims, in, out);
+  LBANN_CHECK_CUTT(
+    cuttExecute(plan, const_cast<DataT*>(in.LockedBuffer()), out.Buffer()));
 }
 
 template <typename DataT>
 void cuTT_PermuteImpl::do_sample_permute(
+  Plan& sample_plan,
   ColMajorPerm const& perm,
   DimsType const& in_dims,
   DimsType const& out_dims,
   El::Matrix<DataT, El::Device::GPU> const& in,
   El::Matrix<DataT, El::Device::GPU>& out) const
 {
-  auto const plan = get_sample_plan(perm, in_dims, out_dims, in, out);
-  DataT* const in_buf = const_cast<DataT*>(in.LockedBuffer()); // UGH
+  if (sample_plan == 0UL)
+    sample_plan = get_sample_plan(perm, in_dims, out_dims, in, out);
+
+  DataT* const in_buf = const_cast<DataT*>(in.LockedBuffer());
   DataT* const out_buf = out.Buffer();
+
   auto const batch_size = in.Width();
   auto const in_stride = in.LDim();
   auto const out_stride = out.LDim();
   for (El::Int sample = 0; sample < batch_size; ++sample) {
-    CHECK_CUTT(cuttExecute(plan,
-                           in_buf + sample * in_stride,
-                           out_buf + sample * out_stride));
+    LBANN_CHECK_CUTT(cuttExecute(sample_plan,
+                                 in_buf + sample * in_stride,
+                                 out_buf + sample * out_stride));
   }
-  CHECK_CUTT(cuttDestroy(plan));
 }
 
 inline void cuTT_PermuteImpl::swap(cuTT_PermuteImpl& other)
@@ -351,4 +398,5 @@ inline void cuTT_PermuteImpl::swap(cuTT_PermuteImpl& other)
 }
 
 } // namespace
+#undef LBANN_CHECK_CUTT
 #endif // LBANN_SRC_LAYERS_TRANSFORM_CUTT_PERMUTEIMPL_HPP_INCLUDED


### PR DESCRIPTION
#2272 was hastily implemented as "working correctly" was more important than "working well" at the time. Profiling discovered some (not surprising) issues with constructing plans each iteration (again, not surprising). This restores the memoization but takes care to consider the forward and inverse actions separately. It does NOT optimize further to the case in which a permutation is its own inverse; in this case, at least two plans will still be constructed and stored.