### PR TITLE
Skip in-place layers when followed by a viewing layer

### DIFF
--- a/ci_test/unit_tests/test_unit_inplace_views.py
+++ b/ci_test/unit_tests/test_unit_inplace_views.py
@@ -1,0 +1,32 @@
+import lbann
+import numpy as np
+import test_util
+import pytest
+
+
+@test_util.lbann_test(check_gradients=True)
+def test_inplace_view():
+    # Prepare reference output
+    np.random.seed(20230606)
+    # Note: The leaky ReLU is not differentiable at 0, so we make sure values
+    # are away from 0.
+    num_samples = 23
+    sample_size = 48
+    samples = np.random.choice([-1.0, 1.0], size=(num_samples, sample_size))
+    samples += np.random.uniform(-0.5, 0.5, size=samples.shape)
+    ref = np.where(samples > 0, samples, 2 * samples)
+
+    tester = test_util.ModelTester()
+
+    x_lbann = tester.inputs(samples)
+    reference = tester.make_reference(ref)
+
+    # LBANN implementation
+    x = lbann.Reshape(x_lbann, dims=[4, 2, 6])
+    y = lbann.LeakyRelu(x, negative_slope=2)
+    y = lbann.Reshape(y, dims=[48])
+
+
+    # Set test loss
+    tester.set_loss(lbann.MeanSquaredError(y, reference))
+    return tester

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -572,6 +572,22 @@ void Layer::setup_pointers()
       }
     }
 
+    // TODO:
+    // If any of the children is a viewing layer (Identity, Reshape, etc.),
+    // there is a bug (issue #2274) in which a layer deallocates memory too soon
+    // and deep-copying the tensors during backprop fails. THE FOLLOWING LINES
+    // SHOULD BE REMOVED AFTER NEW TENSORS ARE MERGED
+    if (can_run_inplace) {
+      for (int i = 0; i < get_num_children(); ++i) {
+        const auto& child = get_child_layer(i);
+        if (child.get_type() == "identity" || child.get_type() == "reshape" ||
+            child.get_type() == "identity_zero") {
+          can_run_inplace = false;
+          break;
+        }
+      }
+    }
+
     this->m_runs_inplace = can_run_inplace;
   }
 }


### PR DESCRIPTION
This fixes both @fiedorowicz1's issue and @aj-prime's issue.