### PR TITLE
Update NVSHMEM to work with the new DiHydrogen backend

### DIFF
--- a/include/lbann/layers/transform/distconv/distconv_gather.hpp
+++ b/include/lbann/layers/transform/distconv/distconv_gather.hpp
@@ -45,9 +45,9 @@ class Gather
 public:
   Gather(Backend& backend) : m_backend(backend)
   {
-    m_dist_scatter = util::make_unique<tensor::ScatterNVSHMEM<DataType>>(
+    m_dist_scatter = std::make_unique<tensor::ScatterNVSHMEM<DataType>>(
       m_backend.get_stream());
-    m_dist_gather = util::make_unique<tensor::GatherNVSHMEM<DataType>>(
+    m_dist_gather = std::make_unique<tensor::GatherNVSHMEM<DataType>>(
       m_backend.get_stream());
   };
 

--- a/include/lbann/layers/transform/distconv/distconv_scatter.hpp
+++ b/include/lbann/layers/transform/distconv/distconv_scatter.hpp
@@ -45,9 +45,9 @@ class Scatter
 public:
   Scatter(Backend& backend) : m_backend(backend)
   {
-    m_dist_scatter = util::make_unique<tensor::ScatterNVSHMEM<DataType>>(
+    m_dist_scatter = std::make_unique<tensor::ScatterNVSHMEM<DataType>>(
       m_backend.get_stream());
-    m_dist_gather = util::make_unique<tensor::GatherNVSHMEM<DataType>>(
+    m_dist_gather = std::make_unique<tensor::GatherNVSHMEM<DataType>>(
       m_backend.get_stream());
   }
 

--- a/src/layers/transform/distconv/distconv_gather.cpp
+++ b/src/layers/transform/distconv/distconv_gather.cpp
@@ -216,7 +216,7 @@ void Gather<Backend, DataType>::setup(
     tensor::Tensor<T, tensor::LocaleMPI, tensor::CUDAAllocator>&               \
       indices_grad);
 
-ETI(float, cudnn::BackendCUDNN)
-ETI(double, cudnn::BackendCUDNN)
+ETI(float, ::distconv::BackendDNNLib)
+ETI(double, ::distconv::BackendDNNLib)
 #undef ETI
 } // namespace distconv

--- a/src/layers/transform/distconv/distconv_scatter.cpp
+++ b/src/layers/transform/distconv/distconv_scatter.cpp
@@ -232,7 +232,7 @@ void Scatter<Backend, DataType>::setup(
     tensor::Tensor<T, tensor::LocaleMPI, tensor::CUDAAllocator>&               \
       indices_grad);
 
-ETI(float, cudnn::BackendCUDNN)
-ETI(double, cudnn::BackendCUDNN)
+ETI(float, ::distconv::BackendDNNLib)
+ETI(double, ::distconv::BackendDNNLib)
 #undef ETI
 } // namespace distconv


### PR DESCRIPTION
Update NVSHMEM to work with the new DiHydrogen backend.  Switch to using std::unique_ptr.