### PR TITLE
PyTorch Frontend

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -9,6 +9,8 @@ Support for new layers:
   - Select operator (set tensor value based on predicate)
 
 Python front-end:
+ - Support for PyTorch Module conversion to LBANN graphs (requires PyTorch 2.0
+   or newer, compiled with PyTorch Dynamo)
 
 Performance optimizations:
  - Support in-place computations for capable layers as a memory optimization

--- a/ci_test/common_python/test_util.py
+++ b/ci_test/common_python/test_util.py
@@ -33,7 +33,7 @@ import numpy as np
 import os
 import re
 import tools
-import single_tensor_data_reader
+import lbann.contrib.single_tensor_data_reader as single_tensor_data_reader
 
 
 def lbann_test(check_gradients=False, train=False, **decorator_kwargs):

--- a/ci_test/pytorch_tests/test_cosmoflow.py
+++ b/ci_test/pytorch_tests/test_cosmoflow.py
@@ -1,0 +1,41 @@
+"""
+Tests a reference implementation of CosmoFlow with the LBANN PyTorch frontend.
+"""
+import pytest
+
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError('PyTorch < 2.0')
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch 2.0 is required for this test',
+                allow_module_level=True)
+
+import lbann
+import lbann.torch
+
+# Import the reference CosmoFlow module
+import os
+import sys
+
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+path_to_cosmoflow = os.path.join(current_dir, '..', '..', 'applications',
+                                 'physics', 'cosmology', 'cosmoflow', 'ref')
+sys.path.insert(0, path_to_cosmoflow)
+from model import CosmoFlow
+
+
+def test_cosmoflow():
+    mod = CosmoFlow().cuda()
+    x = torch.randn(1, 4, 128, 128, 128).cuda()
+    reference = mod(x)
+
+    g = lbann.torch.compile(mod, x=x)
+    outputs = lbann.evaluate(g, x.detach().cpu().numpy())
+
+    # Using loose tolerance values due to running a full network on 128^3 inputs
+    assert torch.allclose(reference.cpu(),
+                          torch.tensor(outputs),
+                          rtol=1e-2,
+                          atol=1e-2)

--- a/ci_test/pytorch_tests/test_cosmoflow.py
+++ b/ci_test/pytorch_tests/test_cosmoflow.py
@@ -34,7 +34,7 @@ def test_cosmoflow():
     reference = mod(x)
 
     g = lbann.torch.compile(mod, x=x)
-    outputs = lbann.evaluate(g, x.detach().cpu().numpy())
+    outputs = lbann.evaluate(g, x.detach().cpu().numpy(), binary_protobuf=True)
 
     # Using loose tolerance values due to running a full network on 128^3 inputs
     assert torch.allclose(reference.cpu(),

--- a/ci_test/pytorch_tests/test_cosmoflow.py
+++ b/ci_test/pytorch_tests/test_cosmoflow.py
@@ -27,6 +27,8 @@ from model import CosmoFlow
 
 
 def test_cosmoflow():
+    torch.manual_seed(20230621)
+
     mod = CosmoFlow().cuda()
     x = torch.randn(1, 4, 128, 128, 128).cuda()
     reference = mod(x)

--- a/ci_test/pytorch_tests/test_lenet.py
+++ b/ci_test/pytorch_tests/test_lenet.py
@@ -125,3 +125,4 @@ def test_lenet_train():
 
 if __name__ == '__main__':
     test_lenet_eval()
+    test_lenet_train()

--- a/ci_test/pytorch_tests/test_lenet.py
+++ b/ci_test/pytorch_tests/test_lenet.py
@@ -69,6 +69,7 @@ class LeNet5(nn.Module):
 
 
 def test_lenet_eval():
+    torch.manual_seed(20230621)
     B = 8
     mod = LeNet5()
 
@@ -83,6 +84,7 @@ def test_lenet_eval():
 
 
 def test_lenet_train():
+    torch.manual_seed(20230621)
     B = 8
     mod = LeNet5()
 

--- a/ci_test/pytorch_tests/test_lenet.py
+++ b/ci_test/pytorch_tests/test_lenet.py
@@ -78,7 +78,7 @@ def test_lenet_eval():
     reference = mod(inputs)
 
     g = lbann.torch.compile(mod, x=torch.rand(B, 1, 28, 28))
-    outputs = lbann.evaluate(g, inputs)
+    outputs = lbann.evaluate(g, inputs.numpy())
 
     assert torch.allclose(reference, torch.tensor(outputs))
 
@@ -121,3 +121,7 @@ def test_lenet_train():
                                data_reader,
                                opt,
                                job_name='lenet_pytorch_test')
+
+
+if __name__ == '__main__':
+    test_lenet_eval()

--- a/ci_test/pytorch_tests/test_lenet.py
+++ b/ci_test/pytorch_tests/test_lenet.py
@@ -1,0 +1,121 @@
+"""
+Testing correctenss of the LBANN PyTorch frontend with LeNet-5 for evaluation
+and training.
+"""
+import pytest
+
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError('PyTorch < 2.0')
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch 2.0 is required for this test',
+                allow_module_level=True)
+
+from torch import nn
+import torch.nn.functional as F
+
+import lbann
+import lbann.torch
+import lbann.contrib.launcher
+
+# Import MNIST dataset from applications
+import sys
+import os
+
+current_file = os.path.realpath(__file__)
+current_dir = os.path.dirname(current_file)
+path_to_datasets = os.path.join(current_dir, '..', '..', 'applications',
+                                'vision')
+sys.path.insert(0, path_to_datasets)
+import data.mnist
+
+
+def convsize(insize, pad, stride, dilation, kernel):
+    return ((insize + 2 * pad - dilation * (kernel - 1) - 1) // stride) + 1
+
+
+class LeNet5(nn.Module):
+    """
+    LeNet-5, as presented in Y. LeCun et al., "Gradient-Based Learning Applied
+    to Document Recognition", Proc. IEEE 1998.
+    """
+
+    def __init__(self, size=28, classes=10):
+        super().__init__()
+
+        self.conv1 = nn.Conv2d(1, 6, 5, 1, 2)
+        size = convsize(size, 2, 1, 1, 5)
+        self.pool1 = nn.AvgPool2d(2, 2)
+        size //= 2
+        self.conv2 = nn.Conv2d(6, 16, 5, 1, 0)
+        size = convsize(size, 0, 1, 1, 5)
+        self.pool2 = nn.AvgPool2d(2, 2)
+        size //= 2
+        self.dense1 = nn.Linear(size * size * 16, 120)
+        self.dense2 = nn.Linear(120, 84)
+        self.dense3 = nn.Linear(84, classes)
+
+    def forward(self, x):
+        x = F.tanh(self.conv1(x))
+        x = self.pool1(x)
+        x = F.tanh(self.conv2(x))
+        x = self.pool2(x)
+        x = x.flatten(1, -1)
+        x = F.tanh(self.dense1(x))
+        x = F.tanh(self.dense2(x))
+        x = self.dense3(x)
+        return F.softmax(x, dim=-1)
+
+
+def test_lenet_eval():
+    B = 8
+    mod = LeNet5()
+
+    # Evaluate on random inputs
+    inputs = torch.rand(B, 1, 28, 28)
+    reference = mod(inputs)
+
+    g = lbann.torch.compile(mod, x=torch.rand(B, 1, 28, 28))
+    outputs = lbann.evaluate(g, inputs)
+
+    assert torch.allclose(reference, torch.tensor(outputs))
+
+
+def test_lenet_train():
+    B = 8
+    mod = LeNet5()
+
+    # Get initial graph
+    graph = lbann.torch.compile(mod, x=torch.rand(B, 1, 28, 28))
+    images = graph[0]
+    probs = graph[-1]
+
+    # Create loss function and accuracy
+    labels = lbann.Input(data_field='labels')
+    loss = lbann.CrossEntropy(probs, labels)
+    acc = lbann.CategoricalAccuracy(probs, labels)
+
+    # Setup model
+    num_epochs = 5
+    model = lbann.Model(num_epochs,
+                        layers=lbann.traverse_layer_graph([images, labels]),
+                        objective_function=loss,
+                        metrics=[lbann.Metric(acc, name='accuracy', unit='%')],
+                        callbacks=[lbann.CallbackPrint()])
+
+    # Setup optimizer
+    opt = lbann.SGD(learn_rate=0.01, momentum=0.9)
+
+    # Setup data reader
+    data_reader = data.mnist.make_data_reader()
+
+    # Setup trainer
+    trainer = lbann.Trainer(mini_batch_size=64)
+
+    # Run experiment
+    lbann.contrib.launcher.run(trainer,
+                               model,
+                               data_reader,
+                               opt,
+                               job_name='lenet_pytorch_test')

--- a/ci_test/pytorch_tests/test_lowering.py
+++ b/ci_test/pytorch_tests/test_lowering.py
@@ -1,0 +1,56 @@
+"""
+Tests lowering functionality of the LBANN PyTorch frontend
+"""
+from typing import Any
+import pytest
+
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError('PyTorch < 2.0')
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch 2.0 is required for this test',
+                allow_module_level=True)
+
+from torch import nn
+import lbann.torch
+import numpy as np
+
+
+def test_swish():
+    """
+    An activation function that LBANN does not have an equivalent of.
+    """
+
+    class testmodule(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.mod = nn.Hardswish()
+
+        def forward(self, input):
+            return self.mod(input)
+
+    mod = testmodule()
+    inp = torch.randn(1, 20)
+    ref = mod(inp)
+
+    print('Input:')
+    print(inp)
+    print('Reference:')
+    print(ref)
+
+    # Expect a warning
+    with pytest.warns(UserWarning,
+                      match='Could not find replacement for module'):
+        g = lbann.torch.compile(mod, input=inp)
+
+    out = lbann.evaluate(
+        g,
+        inp.detach().numpy(),
+        extra_callbacks=[lbann.CallbackPrintModelDescription()])
+    
+    print('Output:')
+    print(out)
+
+    assert torch.allclose(ref, torch.tensor(out))

--- a/ci_test/pytorch_tests/test_lowering.py
+++ b/ci_test/pytorch_tests/test_lowering.py
@@ -35,11 +35,6 @@ def test_swish():
     inp = torch.randn(1, 20)
     ref = mod(inp)
 
-    print('Input:')
-    print(inp)
-    print('Reference:')
-    print(ref)
-
     # Expect a warning
     with pytest.warns(UserWarning,
                       match='Could not find replacement for module'):
@@ -49,8 +44,5 @@ def test_swish():
         g,
         inp.detach().numpy(),
         extra_callbacks=[lbann.CallbackPrintModelDescription()])
-    
-    print('Output:')
-    print(out)
 
     assert torch.allclose(ref, torch.tensor(out))

--- a/ci_test/pytorch_tests/test_lowering.py
+++ b/ci_test/pytorch_tests/test_lowering.py
@@ -21,6 +21,7 @@ def test_swish():
     """
     An activation function that LBANN does not have an equivalent of.
     """
+    torch.manual_seed(20230620)
 
     class testmodule(nn.Module):
 

--- a/ci_test/pytorch_tests/test_resnet.py
+++ b/ci_test/pytorch_tests/test_resnet.py
@@ -1,0 +1,68 @@
+"""
+Tests a reference implementation of CosmoFlow with the LBANN PyTorch frontend.
+"""
+import pytest
+import math
+
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError('PyTorch < 2.0')
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch 2.0 is required for this test',
+                allow_module_level=True)
+
+try:
+    import timm
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('Torch Image Models (timm) is required for this test',
+                allow_module_level=True)
+
+import lbann
+import lbann.torch
+from torch import nn
+
+
+def test_batchnorm():
+    torch.manual_seed(20230622)
+
+    class module(nn.Module):
+
+        def __init__(self):
+            super().__init__()
+            self.bn = nn.BatchNorm2d(3, eps=1e-5, momentum=0.1)
+
+        def forward(self, x):
+            return self.bn(x)
+
+    mod = module()
+    n = 8
+    x = torch.randn(n, 3, 2, 1)
+    reference = mod(x)
+
+    g = lbann.torch.compile(mod, x=x)
+    # training=True is required to evaluate batch normalization
+    outputs = lbann.evaluate(g, x.detach().numpy(), training=True)
+
+    # Loose tolerance to account for differences in implementations
+    assert torch.allclose(reference,
+                          torch.tensor(outputs),
+                          atol=1e-1,
+                          rtol=1e-1)
+
+
+def test_resnet_34():
+    torch.manual_seed(20230622)
+
+    # Test both architecture and loading pretrained weights
+    mod = timm.create_model('resnet34', pretrained=True)
+
+    x = torch.randn(32, 3, 32, 32)
+    reference = mod(x)
+
+    g = lbann.torch.compile(mod, x=x)
+    outputs = lbann.evaluate(g, x.detach().numpy(), training=True)
+
+    # Using loose tolerance to account for full model differences in operator
+    # implementations and determinism
+    assert torch.allclose(reference, torch.tensor(outputs), atol=1e1, rtol=1.0)

--- a/ci_test/pytorch_tests/test_resnet.py
+++ b/ci_test/pytorch_tests/test_resnet.py
@@ -1,5 +1,5 @@
 """
-Tests a reference implementation of CosmoFlow with the LBANN PyTorch frontend.
+Tests a reference implementation of ResNet with the LBANN PyTorch frontend.
 """
 import pytest
 import math
@@ -44,11 +44,7 @@ def test_batchnorm():
     # training=True is required to evaluate batch normalization
     outputs = lbann.evaluate(g, x.detach().numpy(), training=True)
 
-    # Loose tolerance to account for differences in implementations
-    assert torch.allclose(reference,
-                          torch.tensor(outputs),
-                          atol=1e-1,
-                          rtol=1e-1)
+    assert torch.allclose(reference, torch.tensor(outputs))
 
 
 def test_resnet_34():
@@ -63,6 +59,9 @@ def test_resnet_34():
     g = lbann.torch.compile(mod, x=x)
     outputs = lbann.evaluate(g, x.detach().numpy(), training=True)
 
-    # Using loose tolerance to account for full model differences in operator
-    # implementations and determinism
-    assert torch.allclose(reference, torch.tensor(outputs), atol=1e1, rtol=1.0)
+    # Using loose tolerance to account for full model differences, operator
+    # implementations, and determinism
+    assert torch.allclose(reference,
+                          torch.tensor(outputs),
+                          atol=1e-2,
+                          rtol=1e-2)

--- a/ci_test/pytorch_tests/test_simple.py
+++ b/ci_test/pytorch_tests/test_simple.py
@@ -58,8 +58,7 @@ def test_simple_module():
     # Compile and run graph with numpy
     inp = np.random.rand(20, 20).astype(np.float32)
     ref = inp * inp + 5
-    out = lbann.evaluate(
-        g, inp, extra_callbacks=[lbann.CallbackPrintModelDescription()])
+    out = lbann.evaluate(g, inp)
 
     # Test correctness
     assert np.allclose(out, ref)
@@ -85,10 +84,7 @@ def test_module_with_parameters():
 
     # Compile and run LBANN graph
     g = lbann.torch.compile(mod, x=inp)
-    out = lbann.evaluate(
-        g,
-        inp.numpy(),
-        extra_callbacks=[lbann.CallbackPrintModelDescription()])
+    out = lbann.evaluate(g, inp.numpy())
 
     # Test correctness
     assert torch.allclose(ref, torch.tensor(out))
@@ -113,8 +109,7 @@ def test_module_with_parameters_custom():
     # Compile and run graph with numpy
     inp = np.random.rand(1, 20).astype(np.float32)
     ref = inp * mod.p.detach().numpy()
-    out = lbann.evaluate(
-        g, inp, extra_callbacks=[lbann.CallbackPrintModelDescription()])
+    out = lbann.evaluate(g, inp)
 
     # Test correctness
     assert np.allclose(out, ref)

--- a/ci_test/pytorch_tests/test_simple.py
+++ b/ci_test/pytorch_tests/test_simple.py
@@ -26,6 +26,7 @@ def test_simple_function():
         return a + b
 
     # Obtain graph
+    torch.manual_seed(20230620)
     a = torch.randn(1, 20)
     graph = fn(a)
 
@@ -56,6 +57,7 @@ def test_simple_module():
     g = lbann.torch.compile(a, x=torch.randn(20, 20))
 
     # Compile and run graph with numpy
+    np.random.seed(20230620)
     inp = np.random.rand(20, 20).astype(np.float32)
     ref = inp * inp + 5
     out = lbann.evaluate(g, inp)
@@ -78,6 +80,7 @@ def test_module_with_parameters():
     mod = parameterized()
 
     # Run PyTorch version
+    torch.manual_seed(20230620)
     with torch.no_grad():
         inp = torch.randn(2, 1, 3, 3)
         ref = mod(inp)
@@ -87,7 +90,7 @@ def test_module_with_parameters():
     out = lbann.evaluate(g, inp.numpy())
 
     # Test correctness
-    assert torch.allclose(ref, torch.tensor(out))
+    assert torch.allclose(ref, torch.tensor(out), atol=1e-6)
 
 
 def test_module_with_parameters_custom():
@@ -107,6 +110,7 @@ def test_module_with_parameters_custom():
     g = lbann.torch.compile(mod, x=torch.randn(20))
 
     # Compile and run graph with numpy
+    np.random.seed(20230620)
     inp = np.random.rand(1, 20).astype(np.float32)
     ref = inp * mod.p.detach().numpy()
     out = lbann.evaluate(g, inp)

--- a/ci_test/pytorch_tests/test_simple.py
+++ b/ci_test/pytorch_tests/test_simple.py
@@ -1,0 +1,127 @@
+"""
+Tests simple compiled functions and nn.Modules with the LBANN PyTorch frontend
+"""
+from typing import Any
+import pytest
+
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError('PyTorch < 2.0')
+except (ModuleNotFoundError, ImportError):
+    pytest.skip('PyTorch 2.0 is required for this test',
+                allow_module_level=True)
+
+from torch import nn
+import lbann.torch
+import numpy as np
+
+
+def test_simple_function():
+
+    @lbann.torch.lazy_compile
+    def fn(x):
+        a = torch.cos(x)
+        b = torch.sin(x) + 2
+        return a + b
+
+    # Obtain graph
+    a = torch.randn(1, 20)
+    graph = fn(a)
+
+    # Test correctness
+    reference = torch.cos(a) + torch.sin(a) + 2
+    output = lbann.evaluate(graph, a.numpy())
+    assert torch.allclose(reference, torch.tensor(output))
+
+
+def test_simple_module():
+
+    class mymod(nn.Module):
+
+        def __init__(self, func=lambda a, b: a + b):
+            super().__init__()
+            self.func = func
+
+        def forward(self, x):
+            return self.func(x, x)
+
+    # Challenging setup where a lambda function does not reside in the same
+    # line and modified at runtime.
+    a = mymod()
+    a.func = lambda x,y:\
+        x*y+5
+
+    # Create graph
+    g = lbann.torch.compile(a, x=torch.randn(20, 20))
+
+    # Compile and run graph with numpy
+    inp = np.random.rand(20, 20).astype(np.float32)
+    ref = inp * inp + 5
+    out = lbann.evaluate(
+        g, inp, extra_callbacks=[lbann.CallbackPrintModelDescription()])
+
+    # Test correctness
+    assert np.allclose(out, ref)
+
+
+def test_module_with_parameters():
+
+    class parameterized(nn.Module):
+
+        def __init__(self, func=lambda a, b: a + b):
+            super().__init__()
+            self.conv = nn.Conv2d(1, 2, kernel_size=3)
+
+        def forward(self, x):
+            return self.conv(x)
+
+    mod = parameterized()
+
+    # Run PyTorch version
+    with torch.no_grad():
+        inp = torch.randn(2, 1, 3, 3)
+        ref = mod(inp)
+
+    # Compile and run LBANN graph
+    g = lbann.torch.compile(mod, x=inp)
+    out = lbann.evaluate(
+        g,
+        inp.numpy(),
+        extra_callbacks=[lbann.CallbackPrintModelDescription()])
+
+    # Test correctness
+    assert torch.allclose(ref, torch.tensor(out))
+
+
+def test_module_with_parameters_custom():
+
+    class parameterized(nn.Module):
+
+        def __init__(self, func=lambda a, b: a + b):
+            super().__init__()
+            self.p = nn.Parameter(torch.randn(1, 20))
+
+        def forward(self, x):
+            return x * self.p
+
+    mod = parameterized()
+
+    # Create graph
+    g = lbann.torch.compile(mod, x=torch.randn(20))
+
+    # Compile and run graph with numpy
+    inp = np.random.rand(1, 20).astype(np.float32)
+    ref = inp * mod.p.detach().numpy()
+    out = lbann.evaluate(
+        g, inp, extra_callbacks=[lbann.CallbackPrintModelDescription()])
+
+    # Test correctness
+    assert np.allclose(out, ref)
+
+
+if __name__ == '__main__':
+    test_simple_function()
+    test_simple_module()
+    test_module_with_parameters()
+    test_module_with_parameters_custom()

--- a/ci_test/pytorch_tests/test_simple.py
+++ b/ci_test/pytorch_tests/test_simple.py
@@ -67,6 +67,7 @@ def test_simple_module():
 
 
 def test_module_with_parameters():
+    torch.manual_seed(20230620)
 
     class parameterized(nn.Module):
 
@@ -80,7 +81,6 @@ def test_module_with_parameters():
     mod = parameterized()
 
     # Run PyTorch version
-    torch.manual_seed(20230620)
     with torch.no_grad():
         inp = torch.randn(2, 1, 3, 3)
         ref = mod(inp)
@@ -90,10 +90,12 @@ def test_module_with_parameters():
     out = lbann.evaluate(g, inp.numpy())
 
     # Test correctness
-    assert torch.allclose(ref, torch.tensor(out), atol=1e-6)
+    as_torch = torch.tensor(out).reshape(ref.shape)
+    assert torch.allclose(ref, as_torch, atol=1e-6)
 
 
 def test_module_with_parameters_custom():
+    torch.manual_seed(20230620)
 
     class parameterized(nn.Module):
 

--- a/ci_test/unit_tests/test_unit_evaluate.py
+++ b/ci_test/unit_tests/test_unit_evaluate.py
@@ -1,0 +1,44 @@
+""" Tests the LBANN evaluator. """
+import lbann
+import numpy as np
+
+
+def test_evaluate_simple():
+    a = lbann.Input(data_field='samples')
+    b = lbann.AddConstant(a, constant=1)
+
+    inputarr = np.random.rand(2, 3)
+    outputarr = lbann.evaluate(b, inputarr)
+    assert np.allclose(outputarr, inputarr + 1)
+
+
+def test_evaluate_model():
+    a = lbann.Input(data_field='samples')
+    b = lbann.AddConstant(a, constant=2)
+    model = lbann.Model(20, [a, b],
+                        callbacks=[lbann.CallbackPrintModelDescription()])
+
+    inputarr = np.random.rand(2, 3)
+    outputarr = lbann.evaluate(model, inputarr)
+
+    # Test outputs
+    assert np.allclose(outputarr, inputarr + 2)
+
+    # Test properties
+    assert (len(model.callbacks) == 1 and isinstance(
+        model.callbacks[0], lbann.CallbackPrintModelDescription))
+    assert model.epochs == 20
+
+
+def test_evaluate_multioutput():
+    a = lbann.Input(data_field='samples')
+    lbann.AddConstant(a, constant=1, name='one')
+    lbann.AddConstant(a, constant=2, name='two')
+    lbann.AddConstant(a, constant=3, name='three')
+
+    inputarr = np.random.rand(2, 3)
+    out1, out3 = lbann.evaluate(a, inputarr, ['one', 'three'])
+
+    # Test outputs
+    assert np.allclose(out1, inputarr + 1)
+    assert np.allclose(out3, inputarr + 3)

--- a/ci_test/unit_tests/test_unit_evaluate.py
+++ b/ci_test/unit_tests/test_unit_evaluate.py
@@ -50,3 +50,18 @@ def test_evaluate_multioutput():
     reshaped = inputarr.reshape(2, 12)
     assert np.allclose(out1, reshaped + 1)
     assert np.allclose(out3, reshaped + 3)
+
+
+def test_evaluate_multidim():
+    if not lbann.has_feature('CNPY'):
+        pytest.skip('LBANN needs to be compiled with cnpy for this test')
+
+    a = lbann.Input(data_field='samples')
+    b = lbann.Reshape(a, dims=[3, 4])
+
+    inputarr = np.random.rand(2, 3, 4)
+    outputarr = lbann.evaluate(b, inputarr)
+
+    # Test outputs
+    assert outputarr.shape == inputarr.shape
+    assert np.allclose(outputarr, inputarr)

--- a/python/lbann/__init__.py
+++ b/python/lbann/__init__.py
@@ -88,3 +88,4 @@ from lbann.core.training_algorithm import *
 from lbann.core.weights import *
 from lbann.launcher import run
 from lbann.lbann_features import *
+from lbann.core.evaluate import evaluate

--- a/python/lbann/contrib/single_tensor_data_reader.py
+++ b/python/lbann/contrib/single_tensor_data_reader.py
@@ -25,7 +25,8 @@
 #
 ################################################################################
 """
-Simple data reader that opens one file with one tensor. Used for unit testing.
+Simple data reader that opens one file with one tensor. Used for testing and
+evaluation.
 """
 import numpy as np
 

--- a/python/lbann/core/evaluate.py
+++ b/python/lbann/core/evaluate.py
@@ -34,6 +34,7 @@ import numpy as np
 import numpy.typing as npt
 import os
 from typing import Dict, List, Optional, Tuple, Union
+import warnings
 
 
 def evaluate(
@@ -115,8 +116,15 @@ def evaluate(
 
 def _setup_data_reader(inputs: npt.NDArray, workdir: str):
     # Save inputs
-    input = inputs.reshape(inputs.shape[0], -1)
-    np.save(os.path.join(workdir, 'data.npy'), input)
+    if len(inputs.shape) == 1:  # Minibatch dimension must exist
+        inputs = inputs.reshape(1, inputs.shape[0])
+    elif len(inputs.shape) > 2:
+        warnings.warn(
+            f'{len(inputs.shape)}-dimensional tensor given, all dimensions '
+            'beyond the second one will be flattened')
+        inputs = inputs.reshape(inputs.shape[0], -1)
+
+    np.save(os.path.join(workdir, 'data.npy'), inputs)
 
     # Construct protobuf message for data reader
     file_name = os.path.realpath(single_tensor_data_reader.__file__)

--- a/python/lbann/core/evaluate.py
+++ b/python/lbann/core/evaluate.py
@@ -146,7 +146,7 @@ def _setup_data_reader(inputs: npt.NDArray, workdir: str, training: bool):
     reader.name = 'python'
     reader.role = 'test'
     reader.shuffle = False
-    reader.percent_of_data_to_use = 1.0
+    reader.fraction_of_data_to_use = 1.0
     reader.python.module = module_name
     reader.python.module_dir = dir_name
     reader.python.sample_function = 'get_sample'

--- a/python/lbann/core/evaluate.py
+++ b/python/lbann/core/evaluate.py
@@ -1,0 +1,154 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+""" Python interface to evaluate a single set of inputs. """
+
+import copy
+import lbann
+from lbann.launcher import make_timestamped_work_dir
+from lbann.contrib import single_tensor_data_reader
+import numpy as np
+import numpy.typing as npt
+import os
+from typing import Dict, List, Optional, Tuple, Union
+
+
+def evaluate(
+    model: Union[lbann.Model, List[lbann.Layer]],
+    inputs: npt.NDArray,
+    outputs: Optional[List[str]] = None,
+    **kwargs,
+) -> Union[npt.NDArray, Tuple[npt.NDArray]]:
+    """
+    Runs a given LBANN model once on the given inputs and returns its forward
+    propagation outputs. All tensors are numpy arrays.
+
+    :param model: The LBANN model or layer graph to evaluate.
+    :param inputs: A tensor with the inputs to the model. It will be mapped
+                   to the ``lbann.Input`` with the ``samples`` data field.
+    :param outputs: An optional list of layer names to output as the return
+                    value. If not given, returns all layers without children.
+    :param kwargs: Additional keyword arguments to pass onto ``lbann.run``
+    :return: Output tensor or tensors of the LBANN model.
+    """
+
+    ########################
+    # Canonicalize arguments
+
+    # Set model to always be an lbann.Model
+    if isinstance(model, (list, tuple, set, lbann.Layer)):
+        if isinstance(model, lbann.Layer):
+            model = [model]
+        model = lbann.Model(0, model)
+
+    # Obtain outputs if not given
+    if not outputs:
+        outputs = [l.name for l in model.layers if not l.children]
+    #####################
+    if 'job_name' not in kwargs:
+        kwargs['job_name'] = 'lbann_evaluate'
+
+    workdir = make_timestamped_work_dir(**kwargs)
+
+    # Reset fields for evaluation
+    old_epochs = model.epochs
+    old_callbacks = model.callbacks
+    old_metrics = model.metrics
+
+    try:
+        model.epochs = 0
+        model.callbacks = [
+            lbann.CallbackDumpOutputs(batch_interval=1,
+                                      execution_modes='test',
+                                      directory=workdir,
+                                      layers=' '.join(outputs))
+        ]
+        model.metrics = []
+
+        data_reader = _setup_data_reader(inputs, workdir)
+        trainer = lbann.Trainer(inputs.shape[0])
+
+        ########################
+        # Run model
+        lbann.run(trainer, model, data_reader, lbann.NoOptimizer(), workdir,
+                  **kwargs)
+
+        #######################
+        # Collect outputs
+        output_tensors = _collect_outputs(outputs, workdir, inputs.dtype)
+
+    finally:
+        # Set fields back to original state
+        model.epochs = old_epochs
+        model.callbacks = old_callbacks
+        model.metrics = old_metrics
+
+    # Unpack tuple if single-element
+    if len(output_tensors) == 1:
+        output_tensors = output_tensors[0]
+
+    return output_tensors
+
+
+def _setup_data_reader(inputs: npt.NDArray, workdir: str):
+    # Save inputs
+    input = inputs.reshape(inputs.shape[0], -1)
+    np.save(os.path.join(workdir, 'data.npy'), input)
+
+    # Construct protobuf message for data reader
+    file_name = os.path.realpath(single_tensor_data_reader.__file__)
+    dir_name = os.path.dirname(file_name)
+    module_name = os.path.splitext(os.path.basename(file_name))[0]
+    reader = lbann.reader_pb2.Reader()
+    reader.name = 'python'
+    reader.role = 'test'
+    reader.shuffle = False
+    reader.percent_of_data_to_use = 1.0
+    reader.python.module = module_name
+    reader.python.module_dir = dir_name
+    reader.python.sample_function = 'get_sample'
+    reader.python.num_samples_function = 'num_samples'
+    reader.python.sample_dims_function = 'sample_dims'
+    train_reader = copy.deepcopy(reader)
+    train_reader.role = 'train'
+
+    data_reader = lbann.reader_pb2.DataReader()
+    data_reader.reader.extend([train_reader, reader])
+
+    return data_reader
+
+
+def _collect_outputs(output_names: List[str], workdir: str,
+                     dtype: np.dtype) -> Tuple[npt.NDArray]:
+    output_dir = os.path.join(workdir, 'trainer0', 'model0')
+    file_prefix = 'sgd.testing.epoch.0.step.0'
+
+    outputs = []
+    for name in output_names:
+        fname = os.path.join(output_dir, f'{file_prefix}_{name}_output0.csv')
+        outputs.append(np.loadtxt(fname, dtype, delimiter=','))
+
+    return tuple(outputs)

--- a/python/lbann/core/model.py
+++ b/python/lbann/core/model.py
@@ -80,3 +80,7 @@ class Model:
         model.callback.extend([c.export_proto() for c in self.callbacks])
 
         return model
+
+    def __call__(self, *args, **kwargs):
+        from lbann.core.evaluate import evaluate  # Avoid circular imports
+        return evaluate(self, *args, **kwargs)

--- a/python/lbann/core/operators.py
+++ b/python/lbann/core/operators.py
@@ -449,6 +449,17 @@ class Max(Operator):
         params = OpProto.MaxOperator()
         return params
 
+class MaxConstant(Operator):
+    """Perform entrywise max of input tensor against a constant."""
+    def __init__(self, constant: float = 0.0, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.constant = constant
+
+    def do_export_proto(self):
+        params = OpProto.MaxConstantOperator()
+        params.constant = self.constant
+        return params
+
 class Min(Operator):
     """Apply the Min operator entrywise."""
     def __init__(self, *args, **kwargs):
@@ -456,6 +467,17 @@ class Min(Operator):
 
     def do_export_proto(self):
         params = OpProto.MinOperator()
+        return params
+
+class MinConstant(Operator):
+    """Perform entrywise min of input tensor against a constant."""
+    def __init__(self, constant: float = 0.0, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.constant = constant
+
+    def do_export_proto(self):
+        params = OpProto.MinConstantOperator()
+        params.constant = self.constant
         return params
 
 class Mod(Operator):

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -10,22 +10,23 @@ import lbann.launcher.lsf
 import lbann.launcher.pjm
 from lbann.util import make_iterable, nvprof_command
 
-def make_timestamped_work_dir(work_dir=None,
-                              experiment_dir=None,
-                              job_name='lbann',
-                              **kwargs,
+
+def make_timestamped_work_dir(
+    work_dir=None,
+    experiment_dir=None,
+    job_name='lbann',
+    **kwargs,
 ):
     # Create work directory if not provided
     if not work_dir:
-       work_dir = experiment_dir
+        work_dir = experiment_dir
     if not work_dir:
         if 'LBANN_EXPERIMENT_DIR' in os.environ:
             work_dir = os.environ['LBANN_EXPERIMENT_DIR']
         else:
             work_dir = os.path.join(os.getcwd())
         timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-        work_dir = os.path.join(work_dir,
-                                '{}_{}'.format(timestamp, job_name))
+        work_dir = os.path.join(work_dir, '{}_{}'.format(timestamp, job_name))
         # Differentiate the work directory with a few key parameters
         if 'nodes' in kwargs:
             work_dir = ('{}_n{}'.format(work_dir, kwargs['nodes']))
@@ -35,40 +36,46 @@ def make_timestamped_work_dir(work_dir=None,
         i = 1
         while os.path.lexists(work_dir):
             i += 1
-            work_dir = os.path.join(
-                os.path.dirname(work_dir),
-                '{}_{}_{}'.format(timestamp, job_name, i))
+            work_dir = os.path.join(os.path.dirname(work_dir),
+                                    '{}_{}_{}'.format(timestamp, job_name, i))
     work_dir = os.path.realpath(work_dir)
     os.makedirs(work_dir, exist_ok=True)
 
     return work_dir
 
+
 # ==============================================
 # Run experiments
 # ==============================================
 
-def run(trainer, model, data_reader, optimizer,
-        work_dir=None,
-        proto_file_name='experiment.prototext',
-        nodes=1,
-        procs_per_node=1,
-        time_limit=None,
-        scheduler=None,
-        job_name='lbann',
-        partition=None,
-        account=None,
-        reservation=None,
-        launcher_args=[],
-        lbann_exe=lbann.lbann_exe(),
-        lbann_args=[],
-        procs_per_trainer=None,
-        environment={},
-        overwrite_script=False,
-        setup_only=False,
-        batch_job=False,
-        nvprof=False,
-        nvprof_output_name=None,
-        experiment_dir=None,
+
+def run(
+    trainer,
+    model,
+    data_reader,
+    optimizer,
+    work_dir=None,
+    proto_file_name=None,
+    nodes=1,
+    procs_per_node=1,
+    time_limit=None,
+    scheduler=None,
+    job_name='lbann',
+    partition=None,
+    account=None,
+    reservation=None,
+    launcher_args=[],
+    lbann_exe=lbann.lbann_exe(),
+    lbann_args=[],
+    procs_per_trainer=None,
+    environment={},
+    overwrite_script=False,
+    setup_only=False,
+    batch_job=False,
+    nvprof=False,
+    nvprof_output_name=None,
+    binary_protobuf=False,
+    experiment_dir=None,
 ):
     """Run LBANN.
 
@@ -118,6 +125,8 @@ def run(trainer, model, data_reader, optimizer,
         nvprof_output_name (str, optional): nvprof output filename.
             Filename should be unique to each process by using %q{ENV}
             (see https://docs.nvidia.com/cuda/profiler-users-guide/).
+        binary_protobuf (bool, optional): If true, saves experiment description
+            as a binary file. Otherwise, saves as prototext.
         experiment_dir (str, optional, deprecated): See `work_dir`.
 
     Returns:
@@ -147,16 +156,22 @@ def run(trainer, model, data_reader, optimizer,
     lbann_command = [lbann_exe]
     if nvprof:
         lbann_command = nvprof_command(
-            work_dir=work_dir,
-            output_name=nvprof_output_name)+lbann_command
+            work_dir=work_dir, output_name=nvprof_output_name) + lbann_command
     lbann_command.extend(make_iterable(lbann_args))
-    prototext_file = os.path.join(script.work_dir, proto_file_name)
-    lbann.proto.save_prototext(prototext_file,
+
+    # Set default file name and extension
+    if proto_file_name is None:
+        proto_file_name = ('experiment.protobin'
+                           if binary_protobuf else 'experiment.prototext')
+    proto_file = os.path.join(script.work_dir, proto_file_name)
+
+    lbann.proto.save_prototext(proto_file,
+                               binary=binary_protobuf,
                                trainer=trainer,
                                model=model,
                                data_reader=data_reader,
                                optimizer=optimizer)
-    lbann_command.append('--prototext={}'.format(prototext_file))
+    lbann_command.append('--prototext={}'.format(proto_file))
     if procs_per_trainer is not None:
         lbann_command.append(f'--procs_per_trainer={procs_per_trainer}')
 
@@ -176,6 +191,7 @@ def run(trainer, model, data_reader, optimizer,
     else:
         status = script.run(overwrite=overwrite_script)
     return status
+
 
 def make_batch_script(script_file=None,
                       work_dir=None,
@@ -268,7 +284,7 @@ def make_batch_script(script_file=None,
     if not script_file:
         script_file = os.path.join(work_dir, 'batch.sh')
     script = None
-    if scheduler.lower() in ('openmpi',):
+    if scheduler.lower() in ('openmpi', ):
         script = lbann.launcher.openmpi.OpenMPIBatchScript(
             script_file=script_file,
             work_dir=work_dir,
@@ -320,8 +336,7 @@ def make_batch_script(script_file=None,
             partition=partition,
             launcher_args=launcher_args)
     else:
-        raise RuntimeError('unsupported job scheduler ({})'
-                           .format(scheduler))
+        raise RuntimeError('unsupported job scheduler ({})'.format(scheduler))
 
     # Set batch script preamble commands
     for cmd in preamble_cmds:

--- a/python/lbann/launcher/__init__.py
+++ b/python/lbann/launcher/__init__.py
@@ -27,9 +27,9 @@ def make_timestamped_work_dir(work_dir=None,
         work_dir = os.path.join(work_dir,
                                 '{}_{}'.format(timestamp, job_name))
         # Differentiate the work directory with a few key parameters
-        if kwargs['nodes']:
+        if 'nodes' in kwargs:
             work_dir = ('{}_n{}'.format(work_dir, kwargs['nodes']))
-        if kwargs['procs_per_node']:
+        if 'procs_per_node' in kwargs:
             work_dir = ('{}_ppn{}'.format(work_dir, kwargs['procs_per_node']))
 
         i = 1

--- a/python/lbann/proto.py
+++ b/python/lbann/proto.py
@@ -4,11 +4,13 @@ import google.protobuf.text_format
 import google.protobuf.message
 from lbann import lbann_pb2, NoOptimizer
 
-def save_prototext(filename, **kwargs):
+
+def save_prototext(filename, binary=False, **kwargs):
     """Save a prototext file.
 
     LbannPB fields (e.g. `model`, `data_reader`, `optimizer`) are
-    accepted via `kwargs`.
+    accepted via `kwargs`. The `binary` field saves the experiment file as
+    a protobuf binary message, rather than as a text format.
 
     """
 
@@ -41,5 +43,9 @@ def save_prototext(filename, **kwargs):
 
     # Write to file
     with open(filename, 'wb') as f:
-        f.write(google.protobuf.text_format.MessageToString(
-            message, use_index_order=True).encode())
+        if binary:
+            f.write(message.SerializeToString())
+        else:
+            f.write(
+                google.protobuf.text_format.MessageToString(
+                    message, use_index_order=True).encode())

--- a/python/lbann/proto/__init__.py
+++ b/python/lbann/proto/__init__.py
@@ -1,0 +1,1 @@
+from .serialize import *

--- a/python/lbann/proto/bin2text.py
+++ b/python/lbann/proto/bin2text.py
@@ -1,0 +1,52 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Entry point for protobin-to-prototext converter.
+"""
+
+import argparse
+
+from lbann.proto.serialize import bin2text
+
+
+def main():
+    argparser = argparse.ArgumentParser(
+        description="Convert LBANN protobin files to prototext")
+    argparser.add_argument('infile', type=str, help="Input .protobin file")
+    argparser.add_argument(
+        '--outfile',
+        '-o',
+        type=str,
+        default='experiment.prototext',
+        help='Output file, defaults to experiment.prototext')
+    args = argparser.parse_args()
+
+    bin2text(args.infile, args.outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/lbann/proto/serialize.py
+++ b/python/lbann/proto/serialize.py
@@ -49,3 +49,34 @@ def save_prototext(filename, binary=False, **kwargs):
             f.write(
                 google.protobuf.text_format.MessageToString(
                     message, use_index_order=True).encode())
+
+
+def text2bin(infile: str, outfile: str):
+    """
+    Converts a .prototext file to a .protobin file.
+    """
+    # Read file
+    with open(infile, 'rb') as f:
+        message = google.protobuf.text_format.Parse(f.read(),
+                                                    lbann_pb2.LbannPB())
+
+    # Write file
+    with open(outfile, 'wb') as f:
+        f.write(message.SerializeToString())
+
+
+def bin2text(infile: str, outfile: str):
+    """
+    Converts a .prototext file to a .protobin file.
+    """
+    message = lbann_pb2.LbannPB()
+
+    # Read file
+    with open(infile, 'rb') as f:
+        message.ParseFromString(f.read())
+
+    # Write file
+    with open(outfile, 'wb') as f:
+        f.write(
+            google.protobuf.text_format.MessageToString(
+                message, use_index_order=True).encode())

--- a/python/lbann/proto/text2bin.py
+++ b/python/lbann/proto/text2bin.py
@@ -1,0 +1,51 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Entry point for prototext-to-protobin converter.
+"""
+
+import argparse
+
+from lbann.proto.serialize import text2bin
+
+
+def main():
+    argparser = argparse.ArgumentParser(
+        description="Convert LBANN prototext files to protobin")
+    argparser.add_argument('infile', type=str, help="Input .prototext file")
+    argparser.add_argument('--outfile',
+                           '-o',
+                           type=str,
+                           default='experiment.protobin',
+                           help='Output file, defaults to experiment.protobin')
+    args = argparser.parse_args()
+
+    text2bin(args.infile, args.outfile)
+
+
+if __name__ == '__main__':
+    main()

--- a/python/lbann/torch/__init__.py
+++ b/python/lbann/torch/__init__.py
@@ -1,0 +1,32 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+LBANN's PyTorch frontend. Contains APIs to ingest existing PyTorch modules
+and functions and convert them to LBANN graphs, including network parameters.
+"""
+
+from .compiler import compile, lazy_compile

--- a/python/lbann/torch/compiler.py
+++ b/python/lbann/torch/compiler.py
@@ -1,0 +1,189 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Provides an API for LBANN graph compilation with PyTorch 2.x.
+"""
+
+# Version check
+try:
+    import torch
+    if int(torch.__version__.split('.')[0]) < 2:
+        raise ImportError(
+            'PyTorch 2.0 or newer is required for the LBANN torch frontend. '
+            f'Found version {torch.__version__}')
+except (ModuleNotFoundError, ImportError):
+    raise ImportError(
+        'PyTorch (version 2.0 or newer) is required for the LBANN torch '
+        'frontend.')
+# End of version check
+
+import functools
+import inspect
+import lbann
+from lbann.torch import converters, opaque, lowering
+from lbann.torch.helpers import LBANNGraph
+from torch import nn, _dynamo as dynamo
+from torch._dynamo.exc import BackendCompilerFailed
+from typing import Any, Callable, List, Optional, Union
+
+
+def compile(module_or_function: Union[nn.Module, Callable[..., Any]],
+            *sample_args,
+            trace: bool = False,
+            **sample_kwargs) -> List[lbann.Layer]:
+    """
+    Compiles the given PyTorch module or function into an LBANN graph.
+    Internally uses PyTorch Dynamo to parse the module/function's contents
+    and the module and function converters in ``lbann.torch.replacements``.
+    A ``trace`` mode is also available to work with dynamic modules that
+    Dynamo currently cannot compile into one graph.
+
+    :param module_or_function: ``torch.nn.Module`` or function to compile.
+    :param sample_args: Positional arguments to pass in for compilation (used
+                        only if tracing is enabled).
+    :param trace: If False (default), compiles the function statically (e.g.,
+                  supporting conditions). Otherwise, traces through the function
+                  in order to construct the LBANN graph.
+    :param sample_kwargs: Named arguments to pass in for compilation. Note that
+                          this is necessary to compile ahead-of-time (without
+                          tracing).
+    :return: An LBANN graph given as a list of Layers.
+    """
+    if not trace and sample_args:
+        raise ValueError('All arguments must be named in ahead-of-time '
+                         'compilation')
+
+    if trace:
+        return _trace(module_or_function, sample_args, sample_kwargs)
+
+    cmod = lazy_compile(module_or_function)
+    return cmod(*tuple(sample_kwargs.values()))
+
+
+def _trace(f, example_args, example_kwargs) -> List[lbann.Layer]:
+    """
+    Traces through a function or Module to obtain an LBANN graph.
+
+    :param f: Function or module to trace.
+    :param example_args: Positional arguments to pass in for tracing.
+    :param example_kwargs: Keyword arguments to pass in for tracing.
+    :return: An LBANN graph given as a list of Layers.
+    """
+    converters.load_replacements()
+
+    huggingface = False
+    if isinstance(f, nn.Module):
+        # Workaround to automatically call Huggingface's tracer
+        for m in f.modules():
+            if m.__module__.startswith('transformers'):
+                huggingface = True
+                break
+
+    if huggingface:
+        from transformers.utils import fx
+        input_names = [k for k, v in example_kwargs.items() if v is not None]
+        input_vals = [example_kwargs[k] for k in input_names]
+        g = fx.symbolic_trace(f, input_names=input_names)
+        try:
+            lowering.dynamo_callback(input_names, g, input_vals)
+        except LBANNGraph as ex:
+            return ex.graph
+    else:
+        # Otherwise, call traced function with the standard tracer
+        from torch.fx.experimental import proxy_tensor
+        fxf = proxy_tensor.make_fx(f, tracing_mode='real')
+        g = fxf(*example_args, *tuple(example_kwargs.values()))
+        try:
+            lowering.dynamo_callback([], g, example_args)
+        except LBANNGraph as ex:
+            return ex.graph
+
+    raise RuntimeError(
+        'Could not extract an LBANN graph while tracing the given PyTorch '
+        'module or function')
+
+
+def _get_argnames(f) -> List[str]:
+    """
+    Returns the argument names of a Python function.
+    """
+    try:
+        return list(inspect.signature(f).parameters.keys())
+    except AttributeError:
+        return inspect.getargspec(f).args
+
+
+def _get_module_argnames(f: Union[nn.Module, Callable[..., Any]]) -> List[str]:
+    """
+    Returns the argument names of a Python function or ``nn.Module``.
+    """
+    if isinstance(f, nn.Module):
+        return _get_argnames(f.forward)
+    return _get_argnames(f)
+
+
+def lazy_compile(module_or_function: Union[nn.Module, Callable[..., Any]]):
+    """
+    Compile a Python function with PyTorch to an LBANN graph lazily. This means
+    that whenever the decorated function is called, an LBANN graph will be
+    returned instead of calling the function.
+
+    :param module_or_function: ``torch.nn.Module`` or function to mark for
+                               compilation.
+    :param argnames: A list of strings representing the argument names. If not
+                     given, tries to automatically obtain them from the
+                     function's signature.
+    """
+    converters.load_replacements()
+
+    argnames = _get_module_argnames(module_or_function)
+
+    f = module_or_function
+    if isinstance(f, nn.Module):
+        f = opaque.wrap_modules(f)
+        print('Replaced opaque operators on the module tree:',
+              opaque.count_replaced_submodules(f))
+
+    f = dynamo.optimize(functools.partial(lowering.dynamo_callback, argnames),
+                        nopython=True)(f)
+
+    @functools.wraps(f)
+    def _wrapped(*args, **kwargs):
+        try:
+            f(*args, **kwargs)
+        except BackendCompilerFailed as ex:
+            if isinstance(ex.inner_exception, LBANNGraph):
+                return ex.inner_exception.graph
+            raise
+        except LBANNGraph as ex:
+            return ex.graph
+
+        raise RuntimeError(
+            'Could not extract an LBANN graph from PyTorch module '
+            'or function')
+
+    return _wrapped

--- a/python/lbann/torch/compiler.py
+++ b/python/lbann/torch/compiler.py
@@ -164,7 +164,7 @@ def lazy_compile(module_or_function: Union[nn.Module, Callable[..., Any]]):
 
     f = module_or_function
     if isinstance(f, nn.Module):
-        f = opaque.wrap_modules(f)
+        f = opaque.wrap_opaque_modules(f)
         print('Replaced opaque operators on the module tree:',
               opaque.count_replaced_submodules(f))
 

--- a/python/lbann/torch/converters.py
+++ b/python/lbann/torch/converters.py
@@ -1,0 +1,135 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Conversion utilities from PyTorch ``nn.Module``s and built-in functions
+to LBANN Layers and Weights.
+"""
+import lbann
+import torch
+from torch import nn
+from typing import Any, Callable, Dict, Sequence, Tuple, Type, Union
+
+# Mapping of PyTorch modules to LBANN Layer generator functions. The functions
+# in the dictionary values accept the module and any parameters it was called
+# with.
+modules: Dict[Type[nn.Module], Callable[..., lbann.Layer]] = {}
+
+# Mapping of PyTorch built-in functions to LBANN Layer generator functions.
+# Dictionary keys store functions by their name, and the functions
+# in the dictionary values accept the same parameters as the function would.
+functions: Dict[str, Callable[..., Any]] = {}
+
+# Mapping of PyTorch module types to LBANN parameter generator functions.
+# The functions in the dictionary values accept the module object and the
+# matching LBANN layer, and set its weights after performing the necessary
+# transformations (e.g., transposition).
+module_parameters: Dict[Type[nn.Module], Callable[[nn.Module, lbann.Layer],
+                                                  None]] = {}
+
+# Mapping of PyTorch module types to shape inference functions. Shape inference
+# functions accept the ``nn.Module`` objects along with any given parameters
+# and return a tuple of the resulting tensor's dtype, shape, and device.
+# Used for "skipping" certain layers that cannot be parsed by PyTorch Dynamo
+# directly (such as GNNs).
+opaque_shape_inference: Dict[Type[nn.Module],
+                             Tuple[str, Callable[...,
+                                                 Tuple[torch.dtype, Tuple[int],
+                                                       torch.device]]]] = {}
+
+
+def load_replacements():
+    """
+    Populates the replacement dictionaries
+    """
+    # Import modules to populate the above dictionaries
+    from lbann.torch.replacements import functions, modules
+
+
+def register_function(layername: str):
+    """
+    
+    Syntax::
+    
+        @register_function("")
+        def replacement():
+            return lbann.MatchingClass(...)
+
+    """
+
+    def func(f):
+        functions[layername] = f
+        return f
+
+    return func
+
+
+def register_module(modclass: Union[Type[nn.Module],
+                                    Sequence[Type[nn.Module]]]):
+    """
+    
+    Syntax::
+    
+        @register_module(ClassName)
+        def replacement(mod: ClassName):
+            return lbann.MatchingClass(...)
+
+    """
+
+    def func(f):
+        if isinstance(modclass, (list, tuple)):
+            for cls in modclass:
+                modules[cls] = f
+        else:
+            modules[modclass] = f
+
+        return f
+
+    return func
+
+
+def register_opaque_shape_inference(
+        modclass: Union[Type[nn.Module], Sequence[Type[nn.Module]]]):
+    """
+
+    Syntax::
+
+        @register_opaque_shape_inference(GCNConv)
+        def infer(mod: GCNConv, *args, **kwargs):
+            return dtype, shape, device
+
+    """
+
+    def func(f):
+        if isinstance(modclass, (list, tuple)):
+            for cls in modclass:
+                opaque_shape_inference[cls] = (cls.__name__, f)
+        else:
+            opaque_shape_inference[modclass] = (modclass.__name__, f)
+
+        return f
+
+    return func

--- a/python/lbann/torch/converters.py
+++ b/python/lbann/torch/converters.py
@@ -123,6 +123,40 @@ def register_module(modclass: Union[Type[nn.Module],
     return func
 
 
+def register_module_weight_converter(
+        modclass: Union[Type[nn.Module], Sequence[Type[nn.Module]]]):
+    """
+    Registers a PyTorch nn.Module (by class type) with a weight conversion
+    procedure that takes the PyTorch module and the resulting LBANN layer.
+    Internally, the function modifies the parameters (for example, transposition)
+    and fills in the ``Weights`` objects of the layers with a
+    ``ValueInitializer``.
+
+    Syntax::
+
+        @register_module_weight_converter(ClassName)
+        def replacement(mod: ClassName, layer: lbann.MatchingClass):
+            layer.weights = lbann.Weights(
+                initializer=lbann.ValueInitializer(
+                    values=mod.weights.detach().cpu().numpy().flat))
+
+
+    :param modclass: A module type or a sequence thereof whose weights will be
+                     set.
+    """
+
+    def func(f):
+        if isinstance(modclass, (list, tuple)):
+            for cls in modclass:
+                module_parameters[cls] = f
+        else:
+            module_parameters[modclass] = f
+
+        return f
+
+    return func
+
+
 def register_opaque_shape_inference(
         modclass: Union[Type[nn.Module], Sequence[Type[nn.Module]]]):
     """

--- a/python/lbann/torch/helpers.py
+++ b/python/lbann/torch/helpers.py
@@ -1,0 +1,47 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Helper utilities and classes for the LBANN PyTorch frontend.
+"""
+import lbann
+from typing import List
+
+
+class LBANNGraph(Exception):
+    """
+    An exception type used as a workaround to extract the resulting LBANN graph
+    from within PyTorch Dynamo's mechanisms.
+    """
+
+    def __init__(self, graph: List[lbann.Layer]):
+        self.graph = graph
+
+    def __repr__(self) -> str:
+        return f'LBANNGraph(graph={repr(self.graph)})'
+
+    def __str__(self) -> str:
+        return str(self.graph)

--- a/python/lbann/torch/lowering.py
+++ b/python/lbann/torch/lowering.py
@@ -159,6 +159,16 @@ def replace_fx(gm: fx.GraphModule,
                     submodule, *repl(node.args),
                     **{k: repl(v)
                        for k, v in node.kwargs.items()})
+
+                # Convert weights
+                if with_weights:
+                    if type(submodule) not in converters.module_parameters:
+                        warnings.warn('No converter found for weights of '
+                                      f'module type "{type(submodule)}"!')
+                    else:
+                        converters.module_parameters[type(submodule)](
+                            submodule, replaced[node])
+
                 replaced[node].name = node.name
                 replaced[node].shape = node.meta['val'].shape
                 rep.add(node.stack_trace)
@@ -247,7 +257,7 @@ def replace_fx(gm: fx.GraphModule,
                         dims=attr.shape,
                         weights=lbann.Weights(
                             initializer=lbann.ValueInitializer(
-                                values=attr.detach().numpy().flat)))
+                                values=attr.detach().cpu().numpy().flat)))
                 else:
                     lbann_node = lbann.WeightsLayer(dims=attr.shape)
                 make_input = False

--- a/python/lbann/torch/lowering.py
+++ b/python/lbann/torch/lowering.py
@@ -1,0 +1,399 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Functionality for using PyTorch Dynamo to selectively lower PyTorch graphs
+and maintain neural network semantics necessary for LBANN.
+"""
+
+import lbann
+from lbann.torch import converters, helpers, opaque
+
+import torch
+from torch import fx
+import torch._inductor.compile_fx as inductor
+from torch.fx.passes.fake_tensor_prop import FakeTensorProp
+from torch._subclasses.fake_tensor import FakeTensorMode
+from typing import Any, Dict, List, Optional
+import warnings
+
+
+def dynamo_callback(input_names: List[str], graph_module: fx.GraphModule,
+                    example_inputs: List[torch.Tensor]) -> helpers.LBANNGraph:
+    """
+    Entry point into the LBANN frontend from the PyTorch Dynamo interface.
+    Converts the Dynamo-parsed ``torch.fx`` ``GraphModule`` to an LBANN
+    list of Layers (constituting a graph). Note that this function never returns
+    but instead raises the resulting graph as an exception, in order to work
+    around the PyTorch framework expecting certain (callable) return values.
+
+    :param input_names: Names of the parameters to use as inputs.
+    :param graph_module: Dynamo-compiled FX graph module.
+    :param example_inputs: Example input tensors fed at compile time (used for
+                           shape and type inference).
+    :return: An LBANNGraph object containing the LBANN layers.
+    """
+
+    # Verbose printout
+    # graph_module.graph.print_tabular()
+
+    # Call internal function that parses the graph
+    _, inputs, _ = replace_fx(graph_module, example_inputs)
+
+    # Reconstruct LBANN graph and exit with original graph
+    if not input_names:
+        layer_graph = list(lbann.traverse_layer_graph(inputs))
+    else:
+        layer_graph = list(
+            lbann.traverse_layer_graph(inputs[-len(input_names):]))
+
+    raise helpers.LBANNGraph(layer_graph)
+
+
+def replace_fx(gm: fx.GraphModule,
+               example_inputs: List[torch.Tensor],
+               replaced: Optional[Dict[fx.Node, lbann.Layer]] = None,
+               subgraph: bool = False):
+    """
+    Converts a PyTorch FX ``GraphModule`` to an LBANN graph in a 4-pass manner.
+    First pass ensures all tensors have propagated types and shapes (using both
+    PyTorch Dynamo and Opaque modules registered in LBANN). The second pass then
+    selectively lowers every graph node that has no replacement (see 
+    ``partial_lowering``), followed by re-propagating types/shapes. Lastly, a
+    fourth pass converts every remaining function and module to the matching
+    LBANN subgraphs using the converters in ``replacements``.
+
+    :param gm: The graph module to convert.
+    :param example_inputs: Example input tensors fed at compile time (used for
+                           shape and type inference).
+    :param replaced: Internal field used for recursive parsing. Maintains
+                     a dictionary of already-performed replacements.
+    :param subgraph: Internal field used for recursive parsing. Set to True if
+                     a subgraph is being replaced.
+    """
+
+    # Tensor metadata (type, shape, etc.) propagation
+    fake_mode = FakeTensorMode(allow_non_fake_inputs=True)
+    FakeTensorProp(gm, fake_mode).propagate(*example_inputs)
+
+    # Partially lower graph when a module or function is unsupported
+    if not subgraph:
+        gm = partial_lowering(gm)
+        gm.graph.eliminate_dead_code()
+
+    # Re-propagate tensor metadata after lowering
+    FakeTensorProp(gm, fake_mode).propagate(*example_inputs)
+
+    replaced = replaced or {}
+    inputs = []
+    outputs = []
+    rep = set()
+
+    # Helper function that replaces sequences and objects (for handling
+    # arguments)
+    def repl(args):
+        if not isinstance(args, (tuple, list)):
+            return replaced.get(args, args)
+
+        result = []
+        for arg in args:
+            if isinstance(arg, (tuple, list)):
+                result.append(repl(arg))
+            else:
+                try:
+                    result.append(replaced.get(arg, arg))
+                except:
+                    result.append(arg)
+        return result
+
+    # Traverse FX graph
+    for node in gm.graph.nodes:
+        # Replace once
+        if node in replaced:
+            continue
+
+        if node.op == "call_module":
+            submodule = _fetch_attr(gm, node.target)
+
+            # Extract original module if opaque
+            if isinstance(submodule, opaque.Opaque):
+                submodule = submodule.origmod
+
+            if isinstance(submodule, fx.GraphModule):
+                raise NotImplementedError('Need to inline nested graph module')
+            elif type(submodule) in converters.modules:
+                # If module is replaceable, replace it
+                node.stack_trace = f'{type(submodule).__name__}_{len(replaced)}'
+                replaced[node] = converters.modules[type(submodule)](
+                    submodule, *repl(node.args),
+                    **{k: repl(v)
+                       for k, v in node.kwargs.items()})
+                replaced[node].name = node.name
+                replaced[node].shape = node.meta['val'].shape
+                rep.add(node.stack_trace)
+            else:
+                raise NameError(
+                    'Could not find high-level replacement for '
+                    f'module type "{type(submodule)}" ({funcname}). Lowering')
+
+        elif node.op == "call_function":
+            funcname = str(node.target)
+            if funcname not in converters.functions:
+                # Try by qualified (module and function) name
+                funcname = node.target.__module__ + '.' + node.target.__name__
+
+            if funcname in converters.functions:
+                node.stack_trace = f'{funcname}_{len(replaced)}'
+                replaced[node] = converters.functions[funcname](*repl(
+                    node.args), **{k: repl(v)
+                                   for k, v in node.kwargs.items()})
+                replaced[node].name = node.name
+                replaced[node].shape = node.meta['val'].shape
+                rep.add(node.stack_trace)
+            else:  # Already in lowered subgraph, all low-level replacements must be supported
+                raise NameError(
+                    f'Function "{str(node.target)}" ({funcname}) is unsupported.'
+                )
+
+        # Special case for torch.unbind
+        elif node.op == 'call_method' and str(node.target) == 'unbind':
+            # Get slice points
+            shp = node.args[0].meta['val'].shape
+            s = shp[node.args[1]]
+            replaced[node] = lbann.Slice(replaced[node.args[0]],
+                                         axis=node.args[1],
+                                         slice_points=list(range(s)))
+            # Loop over children in-order to produce the slices
+            for user in node.users.keys():
+                replaced[user] = lbann.Identity(replaced[node])
+                replaced[user].shape = user.meta['val'].shape
+        # Special case for torch.split
+        elif node.op == 'call_method' and str(node.target) == 'split':
+            # Get slice points
+            shp = node.args[0].meta['val'].shape
+            dim = node.kwargs['dim']
+            slice_size_or_slices = node.args[1]
+            if isinstance(slice_size_or_slices, list):
+                ind = 0
+                slice_points = [0]
+                for s in slice_size_or_slices:
+                    ind += s
+                    slice_points.append(s)
+            else:  # Single number: slice size (last one cut off)
+                num_even_slices = shp[dim] // slice_size_or_slices
+                ind = 0
+                slice_points = [0]
+                for _ in range(num_even_slices):
+                    ind += slice_size_or_slices
+                    slice_points.append(ind)
+                # Add final slice
+                if num_even_slices != len(node.users):
+                    slice_points.append(shp[dim])
+
+            replaced[node] = lbann.Slice(replaced[node.args[0]],
+                                         axis=dim,
+                                         slice_points=slice_points)
+            # Loop over children in-order to produce the slices
+            for user in node.users.keys():
+                replaced[user] = lbann.Identity(replaced[node])
+                replaced[user].shape = user.meta['val'].shape
+
+        elif node.op == "placeholder" and not subgraph:
+            replaced[node] = lbann.Input(data_field='samples')
+            inputs.append(replaced[node])
+            replaced[node].shape = node.meta['val'].shape
+        elif node.op == "get_attr" and not subgraph:
+            replaced[node] = lbann.Input(data_field='samples')
+            inputs.append(replaced[node])
+            replaced[node].shape = node.meta['val'].shape
+        elif node.op == "output":
+            outputs = repl(node.args)
+
+    return replaced, inputs, outputs
+
+
+# Adapted from PyTorch source - recursively fetches attributes from target name.
+def _fetch_attr(x: Any, target: str):
+    target_atoms = target.split('.')
+    attr_itr = x
+    for i, atom in enumerate(target_atoms):
+        if not hasattr(attr_itr, atom):
+            raise RuntimeError('Node referenced nonexistent target '
+                               f'{".".join(target_atoms[:i])}')
+        attr_itr = getattr(attr_itr, atom)
+    return attr_itr
+
+
+def lower_single_node(gm: fx.GraphModule, node: fx.Node) -> fx.GraphModule:
+    """
+    Selectively lowers a single ``torch.fx`` graph node into a graph module
+    of its own. This is used for functions that have no replacements (for
+    example, an esoteric activation function). Uses PyTorch Inductor to perform
+    the lowering and returns another graph module.
+
+    :param gm: Original graph module.
+    :param node: Node to lower.
+    :return: A new FX graph module containing the lowered graph.
+    """
+
+    # Make graph with one node
+    subgraph = fx.Graph()
+    value_remap = {}
+
+    # Inputs
+    args = []
+    input_nodes = []
+    for input in node.all_input_nodes:
+        value_remap[input] = subgraph.placeholder(input.name)
+        input_nodes.append(input)
+        args.append(input.meta['val'])
+
+    # Computation
+    output = subgraph.node_copy(node, lambda n: value_remap[n])
+
+    # Output
+    subgraph.output(output)
+
+    # Make and lower the graph module
+    subgm = fx.GraphModule(gm, subgraph)
+
+    # Get graph from internal function without modifying PyTorch
+    class GetLoweredGraph(Exception):
+
+        def __init__(self, graph, inputs) -> None:
+            self.graph = graph
+            self.inputs = inputs
+
+    def lower_only(lowered: fx.GraphModule,
+                   example_params_and_inputs: List[torch.Tensor],
+                   num_fixed=0,
+                   is_backward=False,
+                   is_inference=False,
+                   **kwargs):
+        if is_backward:
+            return
+        if num_fixed > 0:
+            raise ValueError(
+                'Cannot convert parameterized module. Please register a '
+                'module replacement.')
+        raise GetLoweredGraph(lowered, example_params_and_inputs)
+
+    def lower():
+        try:
+            inductor.compile_fx(
+                subgm,
+                args,
+                inner_compile=lower_only,
+            )
+        except GetLoweredGraph as ex:
+            return ex.graph, ex.inputs
+
+        # If no internal exception was raised, ``lower_only`` was not called
+        # properly
+        raise ValueError('Could not obtain lowered graph')
+
+    # End of PyTorch inductor lowering plumbing
+
+    lowered_graph, _ = lower()
+
+    return lowered_graph
+
+
+def partial_lowering(gm: fx.GraphModule) -> fx.GraphModule:
+    """
+    A pass on a PyTorch FX graph module that finds unsupported operations (i.e.,
+    no registered converter) and selectively lowers them using
+    ``lower_single_node``.
+
+    :param gm: The input graph module.
+    :return: A graph module where unsupported operations are expanded to new
+             subgraphs.
+    """
+
+    new_graph = fx.Graph()
+    env = {}
+    tracer = fx.proxy.GraphAppendingTracer(new_graph)
+    skip_nodes = set()
+
+    # Traverse graph in-order
+    for node in gm.graph.nodes:
+        # Decide whether this node should be lowered
+        decompose = False
+        if node not in skip_nodes:
+            if node.op == 'call_module':
+                submodule = _fetch_attr(gm, node.target)
+
+                # Extract original module if opaque
+                if isinstance(submodule, opaque.Opaque):
+                    submodule = submodule.origmod
+
+                if isinstance(submodule, fx.GraphModule) or type(
+                        submodule) not in converters.modules:
+                    decompose = True
+                    warnings.warn(
+                        'Could not find replacement for '
+                        f'module type "{type(submodule)}". Lowering.')
+            elif node.op == 'call_function':
+                funcname = str(node.target)
+                if funcname not in converters.functions:
+                    # Try by qualified (module and function) name
+                    funcname = node.target.__module__ + '.' + node.target.__name__
+                if funcname not in converters.functions:
+                    decompose = True
+                    warnings.warn(
+                        'Could not find replacement for '
+                        f'function "{str(node.target)}" ({funcname}). Lowering.'
+                    )
+            elif node.op == 'call_method':
+                decompose = True
+
+        if node.op == 'call_method' and str(
+                node.target) in ('unbind', 'split'):
+            # Special case for unbind + getitem
+            assert len(node.users) == len(node.meta['val'])
+            for user in node.users.keys():
+                assert (user.op == 'call_function'
+                        and str(user.target) == '<built-in function getitem>')
+                skip_nodes.add(user)
+            decompose = False
+        # End of lowering decision
+
+        if decompose:
+            # Lower and reconstruct graph
+            lowered = lower_single_node(gm, node)
+            proxy_args = [
+                fx.Proxy(env[x.name], tracer) if isinstance(x, fx.Node) else x
+                for x in node.args if isinstance(x, fx.Node)
+            ]
+            output_proxy = lowered(*proxy_args)
+            new_node = output_proxy[0].node
+            env[node.name] = new_node
+        else:
+            # Copy node as-is
+            new_node = new_graph.node_copy(node, lambda x: env[x.name])
+            env[node.name] = new_node
+
+    return fx.GraphModule(gm, new_graph)

--- a/python/lbann/torch/opaque.py
+++ b/python/lbann/torch/opaque.py
@@ -1,0 +1,105 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Opaque PyTorch module functionality.
+"""
+
+import torch
+import torch._dynamo as dynamo
+import torch.nn
+from typing import Any, Callable
+
+
+@dynamo.allow_in_graph
+class Opaque(torch.nn.Module):
+    """
+    An opaque PyTorch module that prohibits Dynamo from inlining the contents
+    of the original module, which might not be compilable.
+    """
+
+    def __init__(self, name: str, origmod: torch.nn.Module,
+                 shape_inference: Callable[..., Any]) -> None:
+        super().__init__()
+        self.name = name
+        self.origmod = origmod  # The wrapped module
+        self.shape_infer = shape_inference
+        self.unique_key = id(self)
+
+    def forward(self, *args, **kwargs):
+        # Create an output tensor with some constant value but the right shape
+        # and type, so that PyTorch can create a coherent graph
+        dtype, shape, device = self.shape_infer(self.origmod, *args, **kwargs)
+        result = torch.full(shape, self.unique_key, dtype=dtype, device=device)
+        return result
+
+
+def wrap_opaque_modules(mod: torch.nn.Module) -> torch.nn.Module:
+    """
+    Traverses a PyTorch module tree and wraps any module with custom shape
+    inference with an ``Opaque`` class.
+
+    :param mod: The module to traverse.
+    :return: A new module where every relevant submodule (or the module itself)
+             is replaced with an ``Opaque`` module.
+    """
+    # Avoid cyclical imports
+    from lbann.torch.converters import opaque_shape_inference
+
+    # Module itself should be opaque
+    if type(mod) in opaque_shape_inference:
+        newname, shape_infer = opaque_shape_inference[type(mod)]
+        return Opaque(newname, mod, shape_infer)
+
+    # Any submodule should be opaque
+    for name, m in mod.named_children():
+        if isinstance(m, Opaque):
+            continue
+        if type(m) in opaque_shape_inference:
+            newname, shape_infer = opaque_shape_inference[type(m)]
+            setattr(mod, name, Opaque(newname, m, shape_infer))
+        elif m is not mod:
+            wrap_opaque_modules(m)
+
+    return mod
+
+
+def count_replaced_submodules(mod: torch.nn.Module) -> int:
+    """
+    Helper function that counts how many modules or submodules were replaced.
+    """
+    if isinstance(mod, Opaque):
+        return 1
+
+    result = 0
+    for _, m in mod.named_children():
+        if isinstance(m, Opaque):
+            result += 1
+            continue
+        if m is not mod:
+            result += count_replaced_submodules(m)
+
+    return result

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -292,6 +292,16 @@ def full(size, fill_value, **kwargs):
     return lbann.Constant(value=fill_value, num_neurons=size)
 
 
+@register_function('torch.ones')
+def ones(size, **kwargs):
+    return full(size, 1, **kwargs)
+
+
+@register_function('torch.zeros')
+def zeros(size, **kwargs):
+    return full(size, 0, **kwargs)
+
+
 @register_function('torch.addmm')
 def addmm(input, mat1, mat2, *, beta=1, alpha=1):
     rhs = lbann.Scale(lbann.MatMul(mat1, mat2), constant=alpha)

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -130,6 +130,11 @@ def _impl(x, **kwargs):
     return lbann.Cos(x)
 
 
+@register_function('torch.nn.functional.tanh')
+def _impl(x, **kwargs):
+    return lbann.Tanh(x)
+
+
 @register_function('torch.flatten')
 def flatten_impl(x, start_dim=1, end_dim=-1):
     if start_dim == 0 or end_dim == 0:

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -64,6 +64,8 @@ def add(x, y, **kwargs):
         return lbann.AddConstant(x, constant=y)
     if isinstance(x, (int, float)):
         return lbann.AddConstant(y, constant=x)
+    if x == y:
+        return lbann.Scale(x, constant=2)
 
     return lbann.Add(x, y)
 
@@ -76,6 +78,12 @@ def sub(x, y, **kwargs):
         return lbann.SubtractConstant(x, constant=y)
     if isinstance(x, (int, float)):
         return lbann.ConstantSubtract(y, constant=x)
+    if x == y:
+        shp = x.shape
+        cst = lbann.Constant(value=0,
+                             num_neurons=functools.reduce(
+                                 lambda a, b: a * b, shp[1:], 1))
+        return lbann.Reshape(cst, dims=shp[1:])
 
     return lbann.Subtract(x, y)
 
@@ -88,6 +96,8 @@ def mul(x, y, **kwargs):
         return lbann.Scale(x, constant=y)
     if isinstance(x, (int, float)):
         return lbann.Scale(y, constant=x)
+    if x == y:
+        return lbann.Square(x)
 
     return lbann.Multiply(x, y)
 
@@ -100,6 +110,12 @@ def div(x, y, **kwargs):
         return lbann.Scale(x, constant=1 / y)
     if isinstance(x, (int, float)):
         return lbann.Scale(lbann.Reciprocal(y), constant=x)
+    if x == y:
+        shp = x.shape
+        cst = lbann.Constant(value=1,
+                             num_neurons=functools.reduce(
+                                 lambda a, b: a * b, shp[1:], 1))
+        return lbann.Reshape(cst, dims=shp[1:])
 
     return lbann.Divide(x, y)
 

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -42,6 +42,9 @@ def _full(shape, value, **kwargs):
 
 @register_function('aten.view.default')
 def reshape(x, new_shape, **kwargs):
+    if x.shape[0] != new_shape[0]:
+        raise NotImplementedError(
+            'Views that reshape the minibatch dimension are unsupported')
     return lbann.Reshape(x, dims=new_shape[1:])
 
 

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -191,12 +191,12 @@ def clone(x, **kwargs):
 
 @register_function('aten.clamp_min.default')
 def clamp_min(x, clampval):
-    return lbann.Clamp(x, min=clampval)
+    return lbann.MaxConstant(x, constant=clampval)
 
 
 @register_function('aten.clamp_max.default')
 def clamp_max(x, clampval):
-    return lbann.Clamp(x, max=clampval)
+    return lbann.MinConstant(x, constant=clampval)
 
 
 @register_function('aten.tanh.default')

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -57,7 +57,6 @@ def unsqueeze(x, dim):
 
 
 @register_function('<built-in function add>')  # operator.add
-# TODO: Ensure this works properly!
 @register_function('<built-in function iadd>')  # operator.iadd
 @register_function('aten.add.Tensor')
 def add(x, y, **kwargs):

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -47,6 +47,12 @@ def reshape(x, new_shape, **kwargs):
 
 @register_function('aten.slice.Tensor')
 def _slice(x, dim, start, end):
+    if start == 0 and end > x.shape[dim]:
+        return x
+
+    # Clamp to end of tensor
+    end = min(end, x.shape[dim])
+
     return lbann.Slice(x, axis=dim, slice_points=[start, end])
 
 

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -1,0 +1,268 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Specific function converters for the LBANN PyTorch frontend.
+"""
+
+import functools
+import lbann
+from lbann.torch.converters import register_function
+import torch.nn as nn
+import warnings
+
+
+@register_function('aten.full.default')
+def _full(shape, value, **kwargs):
+    return lbann.Constant(num_neurons=shape[-1], value=value)
+
+
+@register_function('aten.view.default')
+def reshape(x, new_shape, **kwargs):
+    return lbann.Reshape(x, dims=new_shape[1:])
+
+
+@register_function('aten.slice.Tensor')
+def _slice(x, dim, start, end):
+    return lbann.Slice(x, axis=dim, slice_points=[start, end])
+
+
+@register_function('aten.unsqueeze.default')
+def unsqueeze(x, dim):
+    new_shape = list(x.shape[0:dim]) + [1] + list(x.shape[dim:])
+    return lbann.Reshape(x, dims=new_shape[1:])
+
+
+@register_function('<built-in function add>')  # operator.add
+# TODO: Ensure this works properly!
+@register_function('<built-in function iadd>')  # operator.iadd
+@register_function('aten.add.Tensor')
+def add(x, y, **kwargs):
+    if isinstance(y, (int, float)):
+        return lbann.AddConstant(x, constant=y)
+    if isinstance(x, (int, float)):
+        return lbann.AddConstant(y, constant=x)
+
+    return lbann.Add(x, y)
+
+
+@register_function('<built-in function sub>')  # operator.sub
+@register_function('<built-in function isub>')  # operator.isub
+@register_function('aten.sub.Tensor')
+def sub(x, y, **kwargs):
+    if isinstance(y, (int, float)):
+        return lbann.SubtractConstant(x, constant=y)
+    if isinstance(x, (int, float)):
+        return lbann.ConstantSubtract(y, constant=x)
+
+    return lbann.Subtract(x, y)
+
+
+@register_function('<built-in function mul>')  # operator.mul
+@register_function('<built-in function imul>')  # operator.imul
+@register_function('aten.mul.Tensor')
+def mul(x, y, **kwargs):
+    if isinstance(y, (int, float)):
+        return lbann.Scale(x, constant=y)
+    if isinstance(x, (int, float)):
+        return lbann.Scale(y, constant=x)
+
+    return lbann.Multiply(x, y)
+
+
+@register_function('<built-in function truediv>')  # operator.truediv
+@register_function('<built-in function itruediv>')  # operator.itruediv
+@register_function('aten.div.Tensor')
+def div(x, y, **kwargs):
+    if isinstance(y, (int, float)):
+        return lbann.Scale(x, constant=1 / y)
+    if isinstance(x, (int, float)):
+        return lbann.Scale(lbann.Reciprocal(y), constant=x)
+
+    return lbann.Divide(x, y)
+
+
+@register_function('torch.flatten')
+def flatten_impl(x, start_dim=1, end_dim=-1):
+    if start_dim == 0 or end_dim == 0:
+        raise ValueError('Cannot flatten batch dimension in LBANN')
+
+    shp = x.shape
+    n = len(shp)
+    start_dim = start_dim if start_dim > 0 else n + start_dim
+    end_dim = end_dim if end_dim >= 0 else n + end_dim + 1
+
+    new_shape = list(shp[:start_dim]) + [
+        functools.reduce(lambda a, b: a * b, shp[start_dim:end_dim], 1)
+    ] + list(shp[end_dim:])
+
+    return lbann.Reshape(x, dims=new_shape[1:])
+
+
+@register_function('torch.nn.functional.batch_norm')
+def batchnorm_impl(x,
+                   running_mean,
+                   running_var,
+                   w,
+                   b=None,
+                   training=False,
+                   momentum=0.1,
+                   eps=1e-5):
+    return lbann.BatchNormalization(x, decay=1 - momentum, epsilon=eps)
+
+
+@register_function('torch.nn.functional.softmax')
+def softmax_impl(x, dim=None, **kwargs):
+    return lbann.Softmax(x)
+
+
+@register_function('prims.convert_element_type.default')
+def conv(x, dtype, **kwargs):
+    warnings.warn(f'Casting to {dtype} will not be converted')
+    return x
+
+
+@register_function('aten.permute.default')
+def permute(x, dims, **kwargs):
+    if dims[0] != 0:
+        raise NotImplementedError('Batch dimension cannot be permuted when '
+                                  'converting to LBANN')
+    new_dims = [d - 1 for d in dims[1:]]
+    return lbann.TensorPermute(x, axes=new_dims)
+
+
+@register_function('aten.clone.default')
+def clone(x, **kwargs):
+    return lbann.Identity(x)
+
+
+@register_function('aten.clamp_min.default')
+def clamp_min(x, clampval):
+    return lbann.Clamp(x, min=clampval)
+
+
+@register_function('aten.clamp_max.default')
+def clamp_max(x, clampval):
+    return lbann.Clamp(x, max=clampval)
+
+
+@register_function('aten.tanh.default')
+def tanh(x):
+    return lbann.Tanh(x)
+
+
+@register_function('aten.mean.dim')
+def mean(x, dims, keepdim=False, **kwargs):
+    return lbann.ChannelwiseMean(x)
+
+
+@register_function('torch._C._nn.linear')
+def linear(x, weight, bias=None, **kwargs):
+    return lbann.FullyConnected(
+        x,
+        num_neurons=weight.shape[0],
+        has_bias=(True if (bias is not None and bias.shape) else False))
+
+
+@register_function('torch.nn.functional.relu')
+def relu(x):
+    return lbann.Relu(x)
+
+
+@register_function('torch.nn.functional.max_pool2d')
+def mp2d(x, kernel_size, strides=None, padding=0, **kwargs):
+    assert len(x.shape) == 4  # Batch, channels
+    return lbann.Pooling(x,
+                         pool_mode='max',
+                         num_dims=2,
+                         has_vectors=True,
+                         pool_dims=kernel_size,
+                         pool_pads=padding or [0, 0],
+                         pool_strides=strides or [1, 1])
+
+
+@register_function('torch.cat')
+def cat(args, dim=1):
+    return lbann.Concatenation(*args, axis=dim)
+
+
+@register_function('torch.tile')
+def tile(x, dims):
+    ndims = len(x.shape) - 1  # Remove batch dimension
+    if len(dims) > ndims:
+        dims = dims[1:]
+
+    if len(dims) < ndims:  # Pad with ones
+        dims = [1] * (ndims - len(dims)) + dims
+
+    new_shape = [s * d for s, d in zip(x.shape[1:], dims)]
+    return lbann.Tessellate(x, dims=new_shape)
+
+
+@register_function('aten.expand.default')
+def expand(x, dims):
+    if tuple(dims) == tuple(x.shape):
+        return x
+    raise NotImplementedError('Expand not implemented for differing shapes')
+
+
+@register_function('aten.bmm.default')
+def bmm(x, y, **kwargs):
+    return lbann.MatMul(x, y)
+
+
+@register_function('aten.erf.default')
+def erf(x):
+    return lbann.Erf(x)
+
+
+@register_function('aten.exp.default')
+def exp(x):
+    return lbann.Exp(x)
+
+
+@register_function('aten.select.int')
+def select_int(x, dim: int, index: int):
+    return lbann.Slice(x, axis=dim, slice_points=[index, index])
+
+
+@register_function('aten.amax.default')
+def amax(x, dims, keepdim=False):
+    # Dimension-wise max
+    if len(dims) == 1 and x.shape[dims[0]] == 1 and keepdim:
+        return x
+    raise NotImplementedError('Dimension-wise max not implemented')
+
+
+@register_function('torch.full')
+def full(size, fill_value, **kwargs):
+    return lbann.Constant(value=fill_value, num_neurons=size)
+
+
+@register_function('torch.addmm')
+def addmm(input, mat1, mat2, *, beta=1, alpha=1):
+    rhs = lbann.Scale(lbann.MatMul(mat1, mat2), constant=alpha)
+    return lbann.Add(lbann.Scale(input, constant=beta), rhs)

--- a/python/lbann/torch/replacements/functions.py
+++ b/python/lbann/torch/replacements/functions.py
@@ -105,6 +105,16 @@ def div(x, y, **kwargs):
     return lbann.Divide(x, y)
 
 
+@register_function('torch.sin')
+def _impl(x, **kwargs):
+    return lbann.Sin(x)
+
+
+@register_function('torch.cos')
+def _impl(x, **kwargs):
+    return lbann.Cos(x)
+
+
 @register_function('torch.flatten')
 def flatten_impl(x, start_dim=1, end_dim=-1):
     if start_dim == 0 or end_dim == 0:

--- a/python/lbann/torch/replacements/modules.py
+++ b/python/lbann/torch/replacements/modules.py
@@ -238,6 +238,10 @@ def _impl(mod: nn.AdaptiveAvgPool3d, x):
     return aap_nd(x, 3)
 
 
+@register_module(nn.Tanh)
+def _impl(mod: nn.Tanh, x):
+    return lbann.Tanh(x)
+
 #################################################################
 # Weight conversion
 
@@ -308,6 +312,11 @@ def batch_norm_weights(mod: nn.BatchNorm2d, layer: lbann.BatchNormalization):
         weights.extend([0, 1])
 
     layer.weights = [_as_weights(w) for w in weights]
+
+
+@register_module_weight_converter(nn.Embedding)
+def embedding_impl(mod: nn.Embedding, layer: lbann.Embedding):
+    layer.weights = [_as_weights(mod.weight)]
 
 
 #################################################################

--- a/python/lbann/torch/replacements/modules.py
+++ b/python/lbann/torch/replacements/modules.py
@@ -1,0 +1,233 @@
+################################################################################
+# Copyright (c) 2014-2023, Lawrence Livermore National Security, LLC.
+# Produced at the Lawrence Livermore National Laboratory.
+# Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+# the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+#
+# LLNL-CODE-697807.
+# All rights reserved.
+#
+# This file is part of LBANN: Livermore Big Artificial Neural Network
+# Toolkit. For details, see http://software.llnl.gov/LBANN or
+# https://github.com/LLNL/LBANN.
+#
+# Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+# may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied. See the License for the specific language governing
+# permissions and limitations under the license.
+#
+################################################################################
+"""
+Specific PyTorch Module converters for the LBANN PyTorch frontend.
+"""
+import functools
+import lbann
+from lbann.torch.converters import register_module, register_opaque_shape_inference
+import torch.nn as nn
+
+
+def convnd_layer(c, dims: int, args, kwargs):
+    return lbann.Convolution(*args,
+                             **kwargs,
+                             num_dims=dims,
+                             out_channels=c.out_channels,
+                             kernel_size=c.kernel_size,
+                             padding=c.padding,
+                             stride=c.stride,
+                             dilation=c.dilation,
+                             has_bias=c.bias is not None,
+                             groups=c.groups)
+
+
+def deconvnd_layer(c: nn.ConvTranspose2d, dims: int, args, kwargs):
+    return lbann.Deconvolution(*args,
+                               **kwargs,
+                               num_dims=dims,
+                               out_channels=c.out_channels,
+                               kernel_size=c.kernel_size,
+                               padding=c.padding,
+                               output_padding=c.output_padding,
+                               stride=c.stride,
+                               dilation=c.dilation,
+                               has_bias=c.bias is not None,
+                               groups=c.groups)
+
+
+@register_module(nn.Conv2d)
+def conv2d(c: nn.Conv2d, *args, **kwargs):
+    return convnd_layer(c, 2, args, kwargs)
+
+
+@register_module(nn.Conv3d)
+def conv3d(c: nn.Conv3d, *args, **kwargs):
+    return convnd_layer(c, 3, args, kwargs)
+
+
+@register_module(nn.ConvTranspose1d)
+def deconv1d(c: nn.ConvTranspose1d, *args, **kwargs):
+    return deconvnd_layer(c, 1, args, kwargs)
+
+
+@register_module(nn.ConvTranspose2d)
+def deconv2d(c: nn.ConvTranspose2d, *args, **kwargs):
+    return deconvnd_layer(c, 2, args, kwargs)
+
+
+@register_module(nn.ConvTranspose3d)
+def deconv3d(c: nn.ConvTranspose3d, *args, **kwargs):
+    return deconvnd_layer(c, 3, args, kwargs)
+
+
+@register_module(nn.LeakyReLU)
+def leaky_relu_impl(origmod: nn.LeakyReLU, *args, **kwargs):
+    return lbann.LeakyRelu(*args,
+                           **kwargs,
+                           negative_slope=origmod.negative_slope)
+
+
+@register_module(nn.AvgPool3d)
+def avgpool3d_impl(origmod: nn.AvgPool3d, *args, **kwargs):
+    return lbann.Pooling(*args,
+                         **kwargs,
+                         pool_mode='average',
+                         num_dims=3,
+                         has_vectors=False,
+                         pool_dims_i=origmod.kernel_size,
+                         pool_pads_i=origmod.padding,
+                         pool_strides_i=origmod.stride)
+
+
+@register_module(nn.Dropout)
+def dropout_impl(mod: nn.Dropout, *args, **kwargs):
+    return lbann.Dropout(*args, **kwargs, keep_prob=(1 - mod.p))
+
+
+@register_module(nn.Linear)
+def linear_impl(origmod: nn.Linear, *args, **kwargs):
+    return lbann.FullyConnected(*args,
+                                **kwargs,
+                                num_neurons=origmod.out_features,
+                                has_bias=origmod.bias is not None,
+                                transpose=False)
+
+
+@register_module(nn.Flatten)
+def flatten_impl(mod: nn.Flatten, x, **kwargs):
+    if mod.start_dim == 0 or mod.end_dim == 0:
+        raise ValueError('Cannot flatten batch dimension in LBANN')
+
+    shp = x.shape
+    n = len(shp)
+    start_dim = mod.start_dim if mod.start_dim > 0 else n + mod.start_dim
+    end_dim = mod.end_dim if mod.end_dim >= 0 else n + mod.end_dim + 1
+
+    new_shape = list(shp[:start_dim]) + [
+        functools.reduce(lambda a, b: a * b, shp[start_dim:end_dim], 1)
+    ] + list(shp[end_dim:])
+
+    return lbann.Reshape(x, dims=new_shape[1:])
+
+
+@register_module(nn.ReLU)
+def relu_impl(mod: nn.ReLU, *args, **kwargs):
+    return lbann.Relu(*args, **kwargs)
+
+
+@register_module(nn.Identity)
+def identity_impl(mod: nn.Identity, x, *args, **kwargs):
+    return x  #return lbann.Identity(x)
+
+
+@register_module(nn.Embedding)
+def embedding_impl(mod: nn.Embedding, x, *args, **kwargs):
+    return lbann.Embedding(x,
+                           num_embeddings=mod.num_embeddings,
+                           embedding_dim=mod.embedding_dim,
+                           padding_idx=mod.padding_idx)
+
+
+@register_module(nn.LayerNorm)
+def ln_impl(mod: nn.LayerNorm, x, *args, **kwargs):
+    return lbann.LayerNorm(x, epsilon=mod.eps)
+
+
+@register_module([nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d])
+def bn_impl(mod: nn.BatchNorm2d, x, *args, **kwargs):
+    return lbann.BatchNormalization(x, decay=1 - mod.momentum, epsilon=mod.eps)
+
+
+def make_vector(val, dims):
+    if isinstance(val, int):
+        return [val] * dims
+    return val
+
+
+def pool_nd_impl(mod: nn.MaxPool2d, x, dims: int):
+    assert len(x.shape) == dims + 2  # Batch, channels
+    return lbann.Pooling(x,
+                         pool_mode='max',
+                         num_dims=dims,
+                         has_vectors=True,
+                         pool_dims=make_vector(mod.kernel_size, dims),
+                         pool_pads=make_vector(mod.padding, dims),
+                         pool_strides=make_vector(mod.stride, dims))
+
+
+@register_module(nn.MaxPool1d)
+def _impl(mod: nn.MaxPool1d, x):
+    return pool_nd_impl(mod, x, 1)
+
+
+@register_module(nn.MaxPool2d)
+def _impl(mod: nn.MaxPool2d, x):
+    return pool_nd_impl(mod, x, 2)
+
+
+@register_module(nn.MaxPool3d)
+def _impl(mod: nn.MaxPool3d, x):
+    return pool_nd_impl(mod, x, 3)
+
+
+def aap_nd(x, dims: int):
+    assert len(x.shape) == dims + 2  # Batch, channels
+    return lbann.ChannelwiseMean(x)
+
+
+@register_module(nn.AdaptiveAvgPool1d)
+def _impl(mod: nn.AdaptiveAvgPool1d, x):
+    return aap_nd(x, 1)
+
+
+@register_module(nn.AdaptiveAvgPool2d)
+def _impl(mod: nn.AdaptiveAvgPool2d, x):
+    return aap_nd(x, 2)
+
+
+@register_module(nn.AdaptiveAvgPool3d)
+def _impl(mod: nn.AdaptiveAvgPool3d, x):
+    return aap_nd(x, 3)
+
+
+# PyTorch Geometric
+try:
+    from torch_geometric.nn import GCNConv
+
+    @register_opaque_shape_inference(GCNConv)
+    def infer(mod: GCNConv, x, edge_index, edge_weight=None):
+        new_shape = (x.shape[0], mod.out_channels)
+        return x.dtype, new_shape, x.device
+
+    @register_module(GCNConv)
+    def _impl(mod: GCNConv, x, edge_index, edge_weight=None):
+        raise NotImplementedError
+
+except (ImportError, ModuleNotFoundError):
+    # No PyTorch Geometric installation found, skip
+    pass

--- a/python/lbann/torch/replacements/modules.py
+++ b/python/lbann/torch/replacements/modules.py
@@ -131,6 +131,14 @@ def dropout_impl(mod: nn.Dropout, *args, **kwargs):
 
 @register_module(nn.Linear)
 def linear_impl(origmod: nn.Linear, *args, **kwargs):
+    # Batched matrix multiplication corresponds to channelwise fully-connected
+    if len(args[0].shape) > 2:
+        return lbann.ChannelwiseFullyConnected(
+            *args,
+            **kwargs,
+            output_channel_dims=origmod.out_features,
+            bias=origmod.bias is not None,
+            transpose=True)
     return lbann.FullyConnected(*args,
                                 **kwargs,
                                 num_neurons=origmod.out_features,
@@ -241,6 +249,7 @@ def _impl(mod: nn.AdaptiveAvgPool3d, x):
 @register_module(nn.Tanh)
 def _impl(mod: nn.Tanh, x):
     return lbann.Tanh(x)
+
 
 #################################################################
 # Weight conversion

--- a/python/lbann/torch/replacements/modules.py
+++ b/python/lbann/torch/replacements/modules.py
@@ -180,7 +180,10 @@ def ln_impl(mod: nn.LayerNorm, x, *args, **kwargs):
 
 @register_module([nn.BatchNorm1d, nn.BatchNorm2d, nn.BatchNorm3d])
 def bn_impl(mod: nn.BatchNorm2d, x, *args, **kwargs):
-    return lbann.BatchNormalization(x, decay=1 - mod.momentum, epsilon=mod.eps)
+    return lbann.BatchNormalization(x,
+                                    decay=1 - mod.momentum,
+                                    epsilon=mod.eps,
+                                    no_bessel_correction=True)
 
 
 def make_vector(val, dims):

--- a/python/lbann/torch/replacements/modules.py
+++ b/python/lbann/torch/replacements/modules.py
@@ -252,7 +252,7 @@ def weights_and_biases(mod: nn.Module,
 
     :param mod: The module to convert parameters from.
     :param layer: The layer to convert weights to.
-    :param transpose: If True, transposes the last two dimensions of the weights
+    :param transpose: If True, transposes the last two dimensions of the weight
                       tensor.
     """
     # Obtain weights
@@ -270,8 +270,10 @@ def weights_and_biases(mod: nn.Module,
                 values=mod.bias.detach().cpu().numpy().flat))
         ]
     else:
-        layer.weights = lbann.Weights(initializer=lbann.ValueInitializer(
-            values=weights_numpy.flat))
+        layer.weights = [
+            lbann.Weights(initializer=lbann.ValueInitializer(
+                values=weights_numpy.flat))
+        ]
 
 
 #################################################################

--- a/src/layers/regularizers/batch_normalization.cpp
+++ b/src/layers/regularizers/batch_normalization.cpp
@@ -54,6 +54,8 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute()
   const auto& num_channels = output_dims[0];
   const auto& channel_size = this->get_output_size() / num_channels;
 
+  const int correction = this->m_bessel_correction ? 1 : 0;
+
   // Compute statistics
   if (is_training) {
     using ValuesGetter = weights_details::SafeWeightsAccessor<TensorDataType>;
@@ -123,7 +125,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute()
         const auto& mean = local_mean(channel, 0) / num_per_sum_dt;
         const auto& sqmean = local_var(channel, 0) / num_per_sum_dt;
         auto var = num_per_sum_dt * (sqmean - mean * mean) /
-                   (num_per_sum_dt - El::TypeTraits<TensorDataType>::One());
+                   (num_per_sum_dt - correction);
         var = std::max(var, this->m_epsilon);
         local_mean(channel, 0) = mean;
         local_var(channel, 0) = var;
@@ -202,6 +204,8 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute()
   const auto& output_dims = this->get_output_dims();
   const auto& num_channels = output_dims[0];
   const auto& channel_size = this->get_output_size() / num_channels;
+
+  const int correction = this->m_bessel_correction ? 1 : 0;
 
   // Compute local gradients
   LBANN_OMP_PARALLEL_FOR
@@ -306,7 +310,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute()
       const TensorDataType inv_stdev =
         static_cast<TensorDataType>(1 / El::Sqrt(var + this->m_epsilon));
       const auto& dmean_term = dmean / num_per_sum;
-      const auto& dvar_term = dvar * 2 / (num_per_sum - 1);
+      const auto& dvar_term = dvar * 2 / (num_per_sum - correction);
 
       // Compute error signal for current channel
       const auto& row_start = channel * channel_size;

--- a/src/layers/regularizers/batch_normalization.cu
+++ b/src/layers/regularizers/batch_normalization.cu
@@ -120,6 +120,7 @@ template <typename TensorDataType>
 __global__ void
 fp_statistics_kernel(int num_sums,
                      int num_per_sum,
+                     int correction,
                      TensorDataType epsilon,
                      TensorDataType decay,
                      TensorDataType* __restrict__ global_mean,
@@ -136,8 +137,8 @@ fp_statistics_kernel(int num_sums,
     // Compute mean and variance
     const auto& mean = global_mean[i] / num_per_sum_dt;
     const auto& sqmean = global_var[i] / num_per_sum_dt;
-    auto var =
-      num_per_sum_dt * (sqmean - mean * mean) / TensorDataType(num_per_sum - 1);
+    auto var = num_per_sum_dt * (sqmean - mean * mean) /
+               TensorDataType(num_per_sum - correction);
     var = var > epsilon ? var : epsilon;
     global_mean[i] = mean;
     global_var[i] = var;
@@ -310,6 +311,7 @@ __global__ void bp_input_grad_kernel(
   int num_channels,
   int channel_size,
   int num_per_sum,
+  int correction,
   const TensorDataType* __restrict__ global_input,
   int input_ldim,
   const TensorDataType* __restrict__ global_gradient_wrt_output,
@@ -341,7 +343,7 @@ __global__ void bp_input_grad_kernel(
     const auto& dvar = global_dvar[k];
     const auto& dmean_term = dmean / TensorDataType(num_per_sum);
     const auto& dvar_term =
-      dvar * TensorDataType(2) / TensorDataType(num_per_sum - 1);
+      dvar * TensorDataType(2) / TensorDataType(num_per_sum - correction);
     for (auto j = gidy; j < mini_batch_size; j += nthreadsy) {
       for (auto i = gidx; i < channel_size; i += nthreadsx) {
         const auto& x = global_input[i + k * channel_size + j * input_ldim];
@@ -511,6 +513,8 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute()
   const auto& num_channels = output_dims[0];
   const auto& channel_size = this->get_output_size() / num_channels;
 
+  const int correction = this->m_bessel_correction ? 1 : 0;
+
   // Compute statistics
   if (is_training) {
     using ValuesGetter = weights_details::SafeWeightsAccessor<TensorDataType>;
@@ -599,6 +603,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::fp_compute()
                                   multisync,
                                   num_channels,
                                   num_per_sum,
+                                  correction,
                                   this->m_epsilon,
                                   this->m_decay,
                                   local_mean.Buffer(),
@@ -688,6 +693,8 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute()
   const auto& output_dims = this->get_output_dims();
   const auto& num_channels = output_dims[0];
   const auto& channel_size = this->get_output_size() / num_channels;
+
+  const int correction = this->m_bessel_correction ? 1 : 0;
 
   // Compute local gradients
   // Compute gradients w.r.t. batch norm parameters
@@ -802,6 +809,7 @@ void batch_normalization_layer<TensorDataType, T_layout, Dev>::bp_compute()
                                 num_channels,
                                 channel_size,
                                 num_per_sum,
+                                correction,
                                 local_input.LockedBuffer(),
                                 local_input.LDim(),
                                 local_gradient_wrt_output.LockedBuffer(),

--- a/src/layers/regularizers/batch_normalization_builder.cpp
+++ b/src/layers/regularizers/batch_normalization_builder.cpp
@@ -69,18 +69,21 @@ std::unique_ptr<lbann::Layer> lbann::build_batch_normalization_layer_from_pbuf(
     // Set defaults if not given.
     auto const decay = params.decay() == 0.0 ? 0.9 : params.decay();
     auto const epsilon = params.epsilon() == 0.0 ? 1e-5 : params.epsilon();
+    auto const bessel = params.no_bessel_correction() ? false : true;
     if constexpr (std::is_same_v<T, float>)
       return std::make_unique<
         batch_normalization_layer<float, data_layout::DATA_PARALLEL, D>>(
         decay,
         epsilon,
-        statistics_group_size);
+        statistics_group_size,
+        bessel);
     else
       return std::make_unique<
         batch_normalization_layer<double, data_layout::DATA_PARALLEL, D>>(
         decay,
         epsilon,
-        statistics_group_size);
+        statistics_group_size,
+        bessel);
   }
   else {
     LBANN_ERROR("batch normalization layer is only supported for \"float\" and "

--- a/src/layers/regularizers/cereal_registration/batch_normalization.cpp
+++ b/src/layers/regularizers/cereal_registration/batch_normalization.cpp
@@ -38,7 +38,8 @@ void batch_normalization_layer<TensorDataType, Layout, Device>::serialize(
                         ::cereal::base_class<DataTypeLayer>(this)),
      CEREAL_NVP(m_decay),
      CEREAL_NVP(m_epsilon),
-     CEREAL_NVP(m_statistics_group_size));
+     CEREAL_NVP(m_statistics_group_size),
+     CEREAL_NVP(m_bessel_correction));
 }
 
 } // namespace lbann

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -459,9 +459,20 @@ message Layer {
      */
     int64 statistics_group_size = 6;
 
+    /** @brief Disable Bessel's correction to the batch normalization
+     * denominator.
+     *
+     *  Default: false
+     *
+     *  Bessel's correction makes the layer more statistically robust;
+     *  disabling it, however, makes the layer compatible with PyTorch's
+     *  implementation.
+     */
+    bool no_bessel_correction = 7;
+
     /// Deprecated and unused
     double scale_init = 2;
-    /// Deprecated and unsued
+    /// Deprecated and unused
     double bias_init = 3;
     /// Deprecated
     string stats_aggregation = 5;


### PR DESCRIPTION
PyTorch (2.0 and above) frontend for LBANN. Contains APIs to ingest existing PyTorch modules and functions, and convert them to LBANN graphs, including network parameters.

- [x] `lbann.evaluate` API as a testing and ease-of-use infrastructure
- [x] Add ability to save/load `.protobin` files (especially useful for large models with pretrained parameters)
    - [x] protobin<->prototext converter in `python -m lbann.proto.text2bin` and `bin2text`
- [x] `lbann.torch` module with `compile`/`lazy_compile` API based on PyTorch Dynamo/Inductor
    - [x] Module PyTorch->LBANN replacements
    - [x] Functional PyTorch->LBANN replacements
    - [x] Weight/Parameter conversion procedures
- [x] Tests: 
    - [x] Simple functions and `nn.Module`s
    - [x] Lowering test
    - [x] LeNet-5
    - [x] CosmoFlow
    - [x] ResNet from TIMM
    - [x] ~BERT from HuggingFace Transformers~ HuggingFace unsupported until minibatch dimension can be modified
- [x] Add option to disable Bessel's correction in Batch Normalization to better match PyTorch (only activated by default in the PyTorch frontend)