### PR TITLE
Update Python front-end LC system parameters

### DIFF
--- a/python/lbann/contrib/lc/systems.py
+++ b/python/lbann/contrib/lc/systems.py
@@ -16,15 +16,13 @@ class SystemParams:
 # Supported LC systems
 _system_params = {
     'catalyst': SystemParams(24, 0, 'slurm'),
-    'corona':   SystemParams(24, 4, 'flux'),
+    'corona':   SystemParams(48, 8, 'flux'),
+    'lassen':   SystemParams(44, 4, 'lsf'),
     'pascal':   SystemParams(36, 2, 'slurm'),
     'quartz':   SystemParams(36, 0, 'slurm'),
-    'surface':  SystemParams(16, 2, 'slurm'),
-    'lassen':   SystemParams(44, 4, 'lsf'),
-    'ray':      SystemParams(40, 4, 'lsf'),
-    'sierra':   SystemParams(44, 4, 'lsf'),
     'rzansel':  SystemParams(44, 4, 'lsf'),
-    'rzhasgpu': SystemParams(16, 2, 'slurm'),
+    'rzvernal': SystemParams(64, 8, 'flux'),
+    'sierra':   SystemParams(44, 4, 'lsf'),
     'tioga':    SystemParams(64, 8, 'flux'),
 }
 


### PR DESCRIPTION
This removes decommissioned systems (ray, surface, rzhasgpu), adds in RZVernal, and updates Corona. The parameters are now consistent with the values listed at https://hpc.llnl.gov/hardware/compute-platforms. (I still disagree with Lassen and friends - it should be 40 - but "I read on the internet..." 🤷‍♂️)