### PR TITLE
Add a simple extension-based switch to read protobuf in binary

### DIFF
--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -734,21 +734,10 @@ void read_prototext_file(const std::string& fn,
                          lbann_data::LbannPB& pb,
                          const bool /*master*/)
 {
-  int fd = open(fn.c_str(), O_RDONLY);
-  if (fd == -1) {
-    LBANN_ERROR("failed to open ", fn, " for reading");
-  }
-  using FIS = google::protobuf::io::FileInputStream;
-  auto input = std::unique_ptr<FIS, std::function<void(FIS*)>>(
-    new google::protobuf::io::FileInputStream(fd),
-    [](FIS* x) {
-      x->Close();
-      delete x;
-    });
-  bool success = google::protobuf::TextFormat::Parse(input.get(), &pb);
-  if (!success) {
-    LBANN_ERROR("failed to read or parse prototext file: ", fn);
-  }
+  if (fn.rfind("protobin") != std::string::npos)
+    lbann::protobuf::load(fn, pb);
+  else
+    lbann::protobuf::text::load(fn, pb);
 }
 
 void read_prototext_string(const std::string& contents,

--- a/src/utils/protobuf.cpp
+++ b/src/utils/protobuf.cpp
@@ -135,7 +135,7 @@ void lbann::protobuf::fill(std::string const& pbuf_str,
 void lbann::protobuf::load(std::string const& pbuf_file,
                            google::protobuf::Message& msg)
 {
-  std::ifstream ifs(pbuf_file);
+  std::ifstream ifs(pbuf_file, std::ios::binary | std::ios::in);
   LBANN_ASSERT((bool)ifs);
   fill(ifs, msg);
 }


### PR DESCRIPTION
This is a quick hack. Pass a file to any of the prototext flags (`--prototext`, `--model`, etc) that contains the string "protobin" and it will be read as a binary file. Any other file will be read as "prototext".
