### PR TITLE
Use a pinned workspace in Slice layer

### DIFF
--- a/include/lbann/layers/transform/slice.hpp
+++ b/include/lbann/layers/transform/slice.hpp
@@ -121,7 +121,8 @@ private:
    *  Parameters for CUDA kernels are copied into this buffer and
    *  asynchronously transferred to GPU.
    */
-  std::vector<unsigned char> m_workspace;
+  std::shared_ptr<hydrogen::simple_buffer<unsigned char, El::Device::CPU>>
+    m_workspace;
   /** @brief CUDA event for workspace buffer.
    *
    *  Makes sure asynchronous GPU memory transfers are completed
@@ -156,6 +157,14 @@ slice_layer<TensorDataType, Layout, Device>::slice_layer(lbann_comm* comm)
   : data_type_layer<TensorDataType>(comm),
     m_set_slice_points_from_data_reader(false),
     m_var_category(slice_points_mode::NA)
+#ifdef LBANN_HAS_GPU
+    ,
+    m_workspace{
+      std::make_shared<hydrogen::simple_buffer<unsigned char, El::Device::CPU>>(
+        0UL,
+        hydrogen::SyncInfo<El::Device::CPU>{},
+        1U /*=pinned*/)}
+#endif                                    /* LBANN_HAS_GPU */
 {
   this->m_expected_num_child_layers = -1; // No limit on children
 }

--- a/src/layers/transform/slice.cu
+++ b/src/layers/transform/slice.cu
@@ -264,36 +264,36 @@ void fp_compute_impl(
 
   // Pack tensor data into a CPU buffer
   l.m_workspace_event.synchronize();
-  l.m_workspace.resize(sizeof(size_t) * input_offset_list.size() +
-                       sizeof(TensorDataType*) * output_buffer_list.size() +
-                       sizeof(dim4) * output_dims_list.size() +
-                       sizeof(dim4) * output_strides_list.size());
+  l.m_workspace->allocate(sizeof(size_t) * input_offset_list.size() +
+                          sizeof(TensorDataType*) * output_buffer_list.size() +
+                          sizeof(dim4) * output_dims_list.size() +
+                          sizeof(dim4) * output_strides_list.size());
   size_t pos = 0;
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               input_offset_list.data(),
               sizeof(size_t) * input_offset_list.size());
   pos += sizeof(size_t) * input_offset_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_buffer_list.data(),
               sizeof(TensorDataType*) * output_buffer_list.size());
   pos += sizeof(TensorDataType*) * output_buffer_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_dims_list.data(),
               sizeof(dim4) * output_dims_list.size());
   pos += sizeof(dim4) * output_dims_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_strides_list.data(),
               sizeof(dim4) * output_strides_list.size());
   pos += sizeof(dim4) * output_strides_list.size();
 
   // Copy tensor data to GPU
   hydrogen::simple_buffer<unsigned char, El::Device::GPU> device_workspace(
-    l.m_workspace.size(),
+    l.m_workspace->size(),
     sync_info);
   unsigned char* device_workspace_ptr = device_workspace.data();
-  hydrogen::gpu::Copy1DToDevice(l.m_workspace.data(),
+  hydrogen::gpu::Copy1DToDevice(l.m_workspace->data(),
                                 device_workspace_ptr,
-                                l.m_workspace.size(),
+                                l.m_workspace->size(),
                                 sync_info);
   l.m_workspace_event.record(sync_info.Stream());
   pos = 0;
@@ -426,37 +426,37 @@ void bp_compute_impl(
 
   // Pack tensor data into a CPU buffer
   l.m_workspace_event.synchronize();
-  l.m_workspace.resize(sizeof(TensorDataType*) *
-                         output_grad_buffer_list.size() +
-                       sizeof(dim4) * output_grad_dims_list.size() +
-                       sizeof(dim4) * output_grad_strides_list.size() +
-                       sizeof(size_t) * input_grad_offset_list.size());
+  l.m_workspace->allocate(sizeof(TensorDataType*) *
+                            output_grad_buffer_list.size() +
+                          sizeof(dim4) * output_grad_dims_list.size() +
+                          sizeof(dim4) * output_grad_strides_list.size() +
+                          sizeof(size_t) * input_grad_offset_list.size());
   size_t pos = 0;
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_grad_buffer_list.data(),
               sizeof(TensorDataType*) * output_grad_buffer_list.size());
   pos += sizeof(TensorDataType*) * output_grad_buffer_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_grad_dims_list.data(),
               sizeof(dim4) * output_grad_dims_list.size());
   pos += sizeof(dim4) * output_grad_dims_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               output_grad_strides_list.data(),
               sizeof(dim4) * output_grad_strides_list.size());
   pos += sizeof(dim4) * output_grad_strides_list.size();
-  std::memcpy(&l.m_workspace[pos],
+  std::memcpy(&l.m_workspace->data()[pos],
               input_grad_offset_list.data(),
               sizeof(size_t) * input_grad_offset_list.size());
   pos += sizeof(size_t) * input_grad_offset_list.size();
 
   // Copy tensor data to GPU
   hydrogen::simple_buffer<unsigned char, El::Device::GPU> device_workspace(
-    l.m_workspace.size(),
+    l.m_workspace->size(),
     sync_info);
   unsigned char* device_workspace_ptr = device_workspace.data();
-  hydrogen::gpu::Copy1DToDevice(l.m_workspace.data(),
+  hydrogen::gpu::Copy1DToDevice(l.m_workspace->data(),
                                 device_workspace_ptr,
-                                l.m_workspace.size(),
+                                l.m_workspace->size(),
                                 sync_info);
   l.m_workspace_event.record(sync_info.Stream());
   pos = 0;


### PR DESCRIPTION
@tbennun identified a costly memcpy that might be improved by using pinned memory. This attempts to implement this.