### PR TITLE
Enable async memcpy

### DIFF
--- a/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
+++ b/include/lbann/execution_algorithms/sgd_training_algorithm.hpp
@@ -36,6 +36,9 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/memory.hpp"
 #include "lbann/utils/timer_map.hpp"
+#ifdef LBANN_HAS_GPU
+#include "lbann/utils/gpu/helpers.hpp"
+#endif // LBANN_HAS_GPU
 
 #include <google/protobuf/message.h>
 
@@ -151,6 +154,10 @@ private:
    *              future.
    */
   bool m_suppress_timer = false;
+
+#ifdef LBANN_HAS_GPU
+  gpu_lib::event_wrapper m_data_prefetch_sync_event;
+#endif // LBANN_HAS_GPU
 };
 
 template <>

--- a/include/lbann/utils/tensor_impl.hpp
+++ b/include/lbann/utils/tensor_impl.hpp
@@ -39,16 +39,14 @@ template <typename TDT>
 void do_tensor_copy(const BaseDistMat& src, El::AbstractDistMatrix<TDT>& tgt)
 {
   bool copy_async = false;
-#if defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)
   auto src_dist_data = src.DistData();
   auto tgt_dist_data = tgt.DistData();
   // Asynchronously copy CPU data to GPU data if they are otherwise aligned
-  if ((src.dist_data.device == El::Device::CPU) &&
+  if ((src_dist_data.device == El::Device::CPU) &&
       (tgt_dist_data.device == El::Device::GPU)) {
     src_dist_data.device = El::Device::GPU;
     copy_async = (src_dist_data == tgt_dist_data);
   }
-#endif // defined(LBANN_HAS_GPU) && defined(ASYNC_INPUT_MEMORY_TRANSFER)
   if (copy_async) {
     El::CopyAsync(src, tgt);
   }

--- a/include/lbann/utils/tensor_impl.hpp
+++ b/include/lbann/utils/tensor_impl.hpp
@@ -39,6 +39,7 @@ template <typename TDT>
 void do_tensor_copy(const BaseDistMat& src, El::AbstractDistMatrix<TDT>& tgt)
 {
   bool copy_async = false;
+#if defined(LBANN_HAS_GPU)
   auto src_dist_data = src.DistData();
   auto tgt_dist_data = tgt.DistData();
   // Asynchronously copy CPU data to GPU data if they are otherwise aligned
@@ -47,6 +48,7 @@ void do_tensor_copy(const BaseDistMat& src, El::AbstractDistMatrix<TDT>& tgt)
     src_dist_data.device = El::Device::GPU;
     copy_async = (src_dist_data == tgt_dist_data);
   }
+#endif // defined(LBANN_HAS_GPU)
   if (copy_async) {
     El::CopyAsync(src, tgt);
   }

--- a/src/execution_algorithms/sgd_training_algorithm.cpp
+++ b/src/execution_algorithms/sgd_training_algorithm.cpp
@@ -206,10 +206,6 @@ bool SGDTrainingAlgorithm::train_mini_batch(SGDExecutionContext& c,
         model.forward_prop(execution_mode::training);
       }
 
-      // check if the data coordinator has finished the epoch and kickoff
-      // background I/O
-      finished = dc.epoch_complete(execution_mode::training);
-
       // Result is not needed until the end of the mini-batch.
       model.get_objective_function()->start_evaluation(
         execution_mode::training,
@@ -233,6 +229,10 @@ bool SGDTrainingAlgorithm::train_mini_batch(SGDExecutionContext& c,
       // Update step
       model.update_weights();
       model.update_layers();
+
+      // check if the data coordinator has finished the epoch and kickoff
+      // background I/O
+      finished = dc.epoch_complete(execution_mode::training);
 #if defined(LBANN_HAVE_OMP_TASKLOOP)
     }
   }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -47,12 +47,6 @@
 #include <utility>
 #include <vector>
 
-// Asynchronous memory transfers for input data
-// Note: This introduces a race condition. It is possible for the
-// input data to be modified by another layer before it is used by
-// this layer.
-// #define ASYNC_INPUT_MEMORY_TRANSFER
-
 namespace lbann {
 
 Layer::Layer() : m_frozen(false)


### PR DESCRIPTION
Re-enables asynchronous memcpy and adds a synchronization event to prevent a race condition. Also moves a data pre-fetching call to allow backwards kernels to be queued on the GPU first.