### PR TITLE
Fix DistConv Memory Optimization Bug

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -14,6 +14,11 @@ Python front-end:
 
 Performance optimizations:
  - Support in-place computations for capable layers as a memory optimization
+ - Allow distconv-enabled convolution and batchnorm layers to reuse their
+   input activations as error signals as a memory optimization if the parent
+   layer does not need its activations in the backward pass. This optimization
+   can be disabled by setting the environment variable
+   DISTCONV_DISABLE_MEM_OPT=1.
 
 Model portability & usability:
 

--- a/include/lbann/layers/regularizers/batch_normalization_impl.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization_impl.hpp
@@ -200,7 +200,9 @@ batch_normalization_distconv_adapter<TensorDataType, T_layout, Dev>::
   assert_eq(index, 0);
   auto& parent_layer = this->layer().get_parent_layer();
   if (parent_layer.get_backprop_requirements() & ACTIVATIONS
-      || parent_layer.get_type() == "identity") {
+      || parent_layer.get_type() == "identity"
+      || this->get_prev_activations_dist() != this->get_error_signals_dist()
+      || std::getenv("DISTCONV_DISABLE_MEM_OPT")) {
     return data_type_distconv_adapter<TensorDataType>::setup_error_signals_i(0);
   }
   const auto& prev_activations = this->get_prev_activations(0);

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -1329,7 +1329,10 @@ base_convolution_adapter<TensorDataType, Device>::
   assert_eq(index, 0);
   auto& parent_layer = this->layer().get_parent_layer();
   if (parent_layer.get_backprop_requirements() & ACTIVATIONS
-      || parent_layer.get_type() == "identity") {
+      || parent_layer.get_type() == "identity"
+      || this->get_prev_activations_dist() != this->get_error_signals_dist()
+      || std::getenv("DISTCONV_DISABLE_MEM_OPT")
+      ) {
     return data_type_distconv_adapter<TensorDataType>::setup_error_signals_i(0);
   }
   const auto& prev_activations = this->get_prev_activations(0);

--- a/src/layers/learning/convolution.cpp
+++ b/src/layers/learning/convolution.cpp
@@ -325,6 +325,14 @@ void convolution_distconv_adapter<TensorDataType, T_layout, Dev>::
   error_signals_dist.set_overlap(overlap);
   constraints.mark_updated(error_signals_dist);
   constraints.mark_invariant(error_signals_dist);
+  // For the memory optimization that reuses prev_activations as error_signals,
+  // set the overlap of the activations to be the same as prev_error_signals.
+  // This ensures that a child layer can take advantage of this optimization.
+  // Note that the overlap is not marked as invariant so that the optimization
+  // can be disabled if the overlap needs to be changed.
+  auto& activations_dist = this->get_activations_dist();
+  activations_dist.set_overlap(overlap);
+  constraints.mark_updated(activations_dist);
 }
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>


### PR DESCRIPTION
Fixes a bug where input and error signal distributions don't match in the distconv memory optimization to reuse inputs as error signals for convolution/batchnorm. Also adds an environment variable to disable the optimization.

Lastly, sets the activations of the convolution layer to have the same overlap as the previous error signals by default. This ensures that child layers can take advantage of this optimization.