### PR TITLE
Reduce parallel clutter

### DIFF
--- a/include/lbann/utils/dnn_lib/miopen.hpp
+++ b/include/lbann/utils/dnn_lib/miopen.hpp
@@ -248,11 +248,14 @@ inline bwd_filter_conv_alg from_miopen(miopenConvBwdWeightsAlgorithm_t a)
 /** @brief Convert an LBANN pooling_mode to the MIOpen equivalent value. */
 inline miopenPoolingMode_t to_miopen(pooling_mode m)
 {
+  const int rank = lbann::get_rank_in_world();
   switch (m) {
   case pooling_mode::MAX:
     return miopenPoolingMax;
 #ifdef LBANN_DETERMINISTIC
-    LBANN_WARNING("Deterministic max pooling mode not supported in MIOpen");
+    if (rank == 0) {
+      LBANN_WARNING("Deterministic max pooling mode not supported in MIOpen");
+    }
     return miopenPoolingMax;
 #else
     return miopenPoolingMax;
@@ -262,7 +265,9 @@ inline miopenPoolingMode_t to_miopen(pooling_mode m)
   case pooling_mode::AVERAGE_COUNT_EXCLUDE_PADDING:
     return miopenPoolingAverage;
   case pooling_mode::MAX_DETERMINISTIC:
-    LBANN_WARNING("Deterministic max pooling mode not supported in MIOpen");
+    if (rank == 0) {
+      LBANN_WARNING("Deterministic max pooling mode not supported in MIOpen");
+    }
     return miopenPoolingMax;
   default:
     LBANN_ERROR("Invalid pooling mode requested");

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -1063,7 +1063,7 @@ void print_parameters(const lbann_comm& comm,
                    << static_cast<unsigned int>(data_seq_random_seeds[i])
                    << " ";
     }
-    else {
+    else if (rank_in_trainer == max_rng_seeds) {
       root_rng << "... ";
       rng << "... ";
       data_seq_rng << "... ";

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -161,9 +161,11 @@ trainer& construct_trainer(lbann_comm* comm,
 
   // Check to see if the model wants to reduce the I/O parallelism
   bool const serialized_io = pb_trainer->serialize_io();
-  if (serialized_io) {
-    std::cout << "Trainer " << pb_trainer->name()
-              << " serialized the I/O threads" << std::endl;
+  if (comm->am_trainer_master()) {
+    if (serialized_io) {
+      std::cout << "Trainer " << pb_trainer->name()
+                << " serialized the I/O threads" << std::endl;
+    }
   }
 
   // Initalize a per-trainer I/O thread pool


### PR DESCRIPTION
Reduce the number of ranks reporting boilerplate ROCm warnings and random numbers.