### PR TITLE
Move some annotations for Caliper around

### DIFF
--- a/include/lbann/optimizers/data_type_optimizer_impl.hpp
+++ b/include/lbann/optimizers/data_type_optimizer_impl.hpp
@@ -27,6 +27,7 @@
 #ifndef LBANN_OPTIMIZERS_DATA_TYPE_OPTIMIZER_IMPL_HPP_INCLUDED
 #define LBANN_OPTIMIZERS_DATA_TYPE_OPTIMIZER_IMPL_HPP_INCLUDED
 
+#include "lbann/utils/profiling.hpp"
 #include "lbann/utils/serialize.hpp"
 #include "lbann/utils/timer.hpp"
 #include "lbann/weights/data_type_weights.hpp"
@@ -172,6 +173,9 @@ void data_type_optimizer<TensorDataType>::set_learning_rate(
 template <typename TensorDataType>
 void data_type_optimizer<TensorDataType>::step()
 {
+  LBANN_CALIPER_MARK_SCOPE(
+    (this->get_type() + " " + m_weights->get_name()).c_str());
+
   if (m_weights == nullptr) {
     LBANN_ERROR("attempted to perform optimization step without weights");
   }

--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -67,6 +67,13 @@
               << std::endl;                                                    \
   } while (0)
 
+#define LBANN_WARNING_WORLD_ROOT(...)                                          \
+  do {                                                                         \
+    if (lbann::get_rank_in_world() == 0) {                                     \
+      LBANN_WARNING(__VA_ARGS__);                                              \
+    }                                                                          \
+  } while (0)
+
 // Macro to print a message to standard cout stream.
 #define LBANN_MSG(...)                                                         \
   do {                                                                         \

--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -96,6 +96,7 @@ namespace lbann {
 #define LBANN_OPTION_NUM_SUBGRIDS_BLOCK_ORDER                                  \
   "Divide each trainer into equally-sized sub-grids with blocked ordering"
 #ifdef LBANN_HAS_CALIPER
+#define LBANN_OPTION_USE_CALIPER "use caliper"
 #define LBANN_OPTION_CALIPER_CONFIG "caliper_config"
 #endif
 

--- a/include/lbann/utils/profiling.hpp
+++ b/include/lbann/utils/profiling.hpp
@@ -44,11 +44,18 @@
 #define LBANN_CALIPER_MARK_END(x) \
   CALI_MARK_END(x)
 
+#define LBANN_CALIPER_LOOP_BEGIN(label, desc) CALI_CXX_MARK_LOOP_BEGIN(label, desc)
+#define LBANN_CALIPER_LOOP_END(label) CALI_CXX_MARK_LOOP_END(label)
+#define LBANN_CALIPER_LOOP_ITER(label, id) CALI_CXX_MARK_LOOP_ITERATION(label, id)
+
 #else
 #define LBANN_CALIPER_MARK_SCOPE(x) ((void)0)
 #define LBANN_CALIPER_MARK_FUNCTION ((void)0)
 #define LBANN_CALIPER_MARK_BEGIN(x) ((void)0)
 #define LBANN_CALIPER_MARK_END(x) ((void)0)
+#define LBANN_CALIPER_LOOP_BEGIN(...) ((void)0)
+#define LBANN_CALIPER_LOOP_END(...) ((void)0)
+#define LBANN_CALIPER_LOOP_ITER(...) ((void)0)
 #endif
 
 namespace lbann {
@@ -84,6 +91,11 @@ private:
 
 // Using a macro so it's easy to remove if needed.
 #define BASIC_PROF_REGION(NAME) ProfRegion _(NAME)
+
+#ifdef LBANN_HAS_CALIPER
+void initialize_caliper();
+void finalize_caliper();
+#endif
 
 } // namespace lbann
 #endif // LBANN_UTILS_PROFILING_HPP

--- a/include/lbann/utils/profiling.hpp
+++ b/include/lbann/utils/profiling.hpp
@@ -28,7 +28,9 @@
 #ifndef LBANN_UTILS_PROFILING_HPP
 #define LBANN_UTILS_PROFILING_HPP
 
-#ifdef LBANN_HAS_CALIPER
+#include <lbann_config.hpp>
+
+#if defined(LBANN_HAS_CALIPER)
 #include <caliper/cali.h>
 #include <caliper/cali_macros.h>
 
@@ -59,6 +61,12 @@
 #endif
 
 namespace lbann {
+
+#if defined(LBANN_HAS_CALIPER)
+void initialize_caliper();
+void finalize_caliper();
+bool is_caliper_initialized() noexcept;
+#endif
 
 // Colors to use for profiling.
 constexpr int num_prof_colors = 20;
@@ -91,11 +99,6 @@ private:
 
 // Using a macro so it's easy to remove if needed.
 #define BASIC_PROF_REGION(NAME) ProfRegion _(NAME)
-
-#ifdef LBANN_HAS_CALIPER
-void initialize_caliper();
-void finalize_caliper();
-#endif
 
 } // namespace lbann
 #endif // LBANN_UTILS_PROFILING_HPP

--- a/python/lbann/contrib/args.py
+++ b/python/lbann/contrib/args.py
@@ -191,12 +191,11 @@ def add_profiling_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '--profile-init', action='store_true', default=False,
         help='enable profiling initialization')
-    if lbann.has_feature('CALIPER'):
-        parser.add_argument('--caliper', action='store_true', default=False,
-                            help='enable Caliper')
-        parser.add_argument(
-            '--caliper-config', action='store', default=None, type=str,
-            help='Configuration string for Caliper')
+    parser.add_argument('--caliper', action='store_true', default=False,
+                        help='enable Caliper')
+    parser.add_argument(
+        '--caliper-config', action='store', default=None, type=str,
+        help='Configuration string for Caliper')
 
 
 def create_profile_callback(args: argparse.Namespace) -> Any:
@@ -253,4 +252,6 @@ def get_profile_args(args: argparse.Namespace) -> list[str]:
             return ['--caliper', '--caliper_config', f'"{caliper_config}"']
         if caliper:
             return ['--caliper']
+    elif caliper_config or caliper:
+        raise RuntimeError('Requested Caliper but LBANN does not have Caliper support.')
     return []

--- a/python/lbann/contrib/args.py
+++ b/python/lbann/contrib/args.py
@@ -191,11 +191,12 @@ def add_profiling_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '--profile-init', action='store_true', default=False,
         help='enable profiling initialization')
-    parser.add_argument('--caliper', action='store_true', default=False,
-                        help='enable Caliper')
-    parser.add_argument(
-        '--caliper-config', action='store', default=None, type=str,
-        help='Configuration string for Caliper')
+    if lbann.has_feature('CALIPER'):
+        parser.add_argument('--caliper', action='store_true', default=False,
+                            help='enable Caliper')
+        parser.add_argument(
+            '--caliper-config', action='store', default=None, type=str,
+            help='Configuration string for Caliper')
 
 
 def create_profile_callback(args: argparse.Namespace) -> Any:
@@ -247,7 +248,7 @@ def get_profile_args(args: argparse.Namespace) -> list[str]:
         raise ValueError('passed arguments have not been processed by '
                          '`add_profiling_arguments`')
 
-    if lbann.has_feature("CALIPER"):
+    if lbann.has_feature('CALIPER'):
         if caliper_config:
             return ['--caliper', '--caliper_config', f'"{caliper_config}"']
         if caliper:

--- a/python/lbann/contrib/args.py
+++ b/python/lbann/contrib/args.py
@@ -8,7 +8,6 @@ import lbann
 import lbann.core.optimizer
 
 
-
 def add_scheduler_arguments(parser):
     """Add command-line arguments for common scheduler settings.
 
@@ -170,8 +169,13 @@ def add_profiling_arguments(parser: argparse.ArgumentParser) -> None:
     """Add command-line arguments for common profiler settings within
     LBANN.
 
-    Adds the following options: `--profile`, `--profile-init`, and
-    `--caliper-config`.
+    Adds the following options: `--profile`, `--profile-init`,
+    `--caliper` and `--caliper-config`.
+
+    `--caliper-config` implies `--caliper`. `--caliper` without a
+    `--caliper-config` will use the default configuration in LBANN.
+    These options will only have an effect if LBANN has been built
+    with Caliper support.
 
     The caller is responsible for using them.
 
@@ -187,6 +191,8 @@ def add_profiling_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         '--profile-init', action='store_true', default=False,
         help='enable profiling initialization')
+    parser.add_argument('--caliper', action='store_true', default=False,
+                        help='enable Caliper')
     parser.add_argument(
         '--caliper-config', action='store', default=None, type=str,
         help='Configuration string for Caliper')
@@ -235,11 +241,15 @@ def get_profile_args(args: argparse.Namespace) -> list[str]:
 
     """
     try:
+        caliper = args.caliper
         caliper_config = args.caliper_config
     except AttributeError:
         raise ValueError('passed arguments have not been processed by '
                          '`add_profiling_arguments`')
 
-    if caliper_config:
-        return ['--caliper_config', f'"{caliper_config}"']
+    if lbann.has_feature("CALIPER"):
+        if caliper_config:
+            return ['--caliper', '--caliper_config', f'"{caliper_config}"']
+        if caliper:
+            return ['--caliper']
     return []

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -243,6 +243,10 @@ auto lbann::initialize(int& argc, char**& argv) -> world_comm_ptr
   hwloc_topology_destroy(topo);
 #endif
 
+#ifdef LBANN_HAS_CALIPER
+  initialize_caliper();
+#endif
+
 #ifdef LBANN_HAS_SHMEM
   // Initialize SHMEM
   if (arg_parser.get<bool>(LBANN_OPTION_INIT_SHMEM)) {
@@ -288,6 +292,10 @@ void lbann::finalize(lbann_comm* comm)
 #ifdef LBANN_HAS_SHMEM
   shmem_finalize();
 #endif // LBANN_HAS_SHMEM
+#ifdef LBANN_HAS_CALIPER
+  finalize_caliper();
+#endif
+
   if (comm != nullptr) {
     delete comm;
   }

--- a/src/base.cpp
+++ b/src/base.cpp
@@ -58,6 +58,9 @@
 #ifdef LBANN_HAS_DISTCONV
 #include "lbann/utils/distconv.hpp"
 #endif
+#ifdef LBANN_HAS_CALIPER
+#include "lbann/utils/profiling.hpp"
+#endif
 
 #include <cereal/types/polymorphic.hpp>
 
@@ -127,6 +130,10 @@ auto lbann::initialize_lbann(El::mpi::Comm&& c) -> std::unique_ptr<lbann_comm>
   hwloc_topology_destroy(topo);
 #endif
 
+#ifdef LBANN_HAS_CALIPER
+  initialize_caliper();
+#endif
+
 #ifdef LBANN_HAS_SHMEM
   // Initialize SHMEM
   if (arg_parser.get<bool>(LBANN_OPTION_INIT_SHMEM)) {
@@ -183,6 +190,10 @@ void lbann::finalize_lbann(lbann_comm* comm)
 #ifdef LBANN_HAS_SHMEM
   shmem_finalize();
 #endif // LBANN_HAS_SHMEM
+#ifdef LBANN_HAS_CALIPER
+  finalize_caliper();
+#endif
+
   if (comm != nullptr) {
     delete comm;
   }

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -80,11 +80,6 @@ void profiler::write_specific_proto(lbann_data::Callback& proto) const
   msg->set_skip_init(m_skip_init);
 }
 
-// Note: we don't add "counting" annotations with caliper. Caliper
-// prefers to have its own loop annotation, tracking the iteration
-// count separately. This is not supported in our profiling API. So we
-// annotate directly in the SGD algorithm.
-
 void profiler::on_epoch_begin(model* m)
 {
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
@@ -92,92 +87,72 @@ void profiler::on_epoch_begin(model* m)
   if (m_skip_init && c.get_epoch() == 1) {
     prof_start();
   }
-#ifndef LBANN_HAS_CALIPER
   prof_region_begin(("epoch " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
-#endif
 }
 
 void profiler::on_epoch_end(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("epoch " + std::to_string(c.get_epoch())).c_str(), m_sync);
-#endif
 }
 
 void profiler::on_validation_begin(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_begin(("val " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
-#endif
 }
 
 void profiler::on_validation_end(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("val " + std::to_string(c.get_epoch())).c_str(), m_sync);
-#endif
 }
 
 void profiler::on_test_begin(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_begin(("test " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
-#endif
 }
 
 void profiler::on_test_end(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("test " + std::to_string(c.get_epoch())).c_str(), m_sync);
-#endif
 }
 
 void profiler::on_batch_begin(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_begin(("batch " + std::to_string(c.get_step())).c_str(),
                     prof_colors[1],
                     m_sync);
-#endif
 }
 
 void profiler::on_batch_end(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_end(("batch " + std::to_string(c.get_step())).c_str(), m_sync);
-#endif
 }
 
 void profiler::on_batch_evaluate_begin(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_begin(("batch eval " + std::to_string(c.get_step())).c_str(),
                     prof_colors[1],
                     m_sync);
-#endif
 }
 
 void profiler::on_batch_evaluate_end(model* m)
 {
-#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_end(("batch eval " + std::to_string(c.get_step())).c_str(),
                   m_sync);
-#endif
 }
 
 void profiler::on_forward_prop_begin(model* m)

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -80,6 +80,11 @@ void profiler::write_specific_proto(lbann_data::Callback& proto) const
   msg->set_skip_init(m_skip_init);
 }
 
+// Note: we don't add "counting" annotations with caliper. Caliper
+// prefers to have its own loop annotation, tracking the iteration
+// count separately. This is not supported in our profiling API. So we
+// annotate directly in the SGD algorithm.
+
 void profiler::on_epoch_begin(model* m)
 {
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
@@ -87,72 +92,92 @@ void profiler::on_epoch_begin(model* m)
   if (m_skip_init && c.get_epoch() == 1) {
     prof_start();
   }
+#ifndef LBANN_HAS_CALIPER
   prof_region_begin(("epoch " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
+#endif
 }
 
 void profiler::on_epoch_end(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("epoch " + std::to_string(c.get_epoch())).c_str(), m_sync);
+#endif
 }
 
 void profiler::on_validation_begin(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_begin(("val " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
+#endif
 }
 
 void profiler::on_validation_end(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("val " + std::to_string(c.get_epoch())).c_str(), m_sync);
+#endif
 }
 
 void profiler::on_test_begin(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_begin(("test " + std::to_string(c.get_epoch())).c_str(),
                     prof_colors[0],
                     m_sync);
+#endif
 }
 
 void profiler::on_test_end(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = static_cast<SGDExecutionContext&>(m->get_execution_context());
   prof_region_end(("test " + std::to_string(c.get_epoch())).c_str(), m_sync);
+#endif
 }
 
 void profiler::on_batch_begin(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_begin(("batch " + std::to_string(c.get_step())).c_str(),
                     prof_colors[1],
                     m_sync);
+#endif
 }
 
 void profiler::on_batch_end(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_end(("batch " + std::to_string(c.get_step())).c_str(), m_sync);
+#endif
 }
 
 void profiler::on_batch_evaluate_begin(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_begin(("batch eval " + std::to_string(c.get_step())).c_str(),
                     prof_colors[1],
                     m_sync);
+#endif
 }
 
 void profiler::on_batch_evaluate_end(model* m)
 {
+#ifndef LBANN_HAS_CALIPER
   const auto& c = m->get_execution_context();
   prof_region_end(("batch eval " + std::to_string(c.get_step())).c_str(),
                   m_sync);
+#endif
 }
 
 void profiler::on_forward_prop_begin(model* m)

--- a/src/callbacks/profiler.cpp
+++ b/src/callbacks/profiler.cpp
@@ -51,6 +51,16 @@ namespace callback {
 profiler::profiler(bool sync, bool skip_init)
   : callback_base(), m_sync(sync), m_skip_init(skip_init)
 {
+#ifdef LBANN_HAS_CALIPER
+  if (is_caliper_initialized()) {
+    LBANN_WARNING_WORLD_ROOT(
+      "LBANN is detected to be running with Caliper. This profiler callback is "
+      "likely superfluous and may result in undefined behavior, possibly "
+      "including duplicate regions. It is NOT recommended to run this callback "
+      "and Caliper simultaneously.");
+  }
+#endif
+
 #ifdef LBANN_NVPROF
   nvtxNameCudaStreamA(hydrogen::cuda::GetDefaultStream(), "Hydrogen");
 #endif

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -87,6 +87,7 @@ data_type_layer<InputTensorDataType, OutputTensorDataType>::operator=(
 template <typename InputTensorDataType, typename OutputTensorDataType>
 void data_type_layer<InputTensorDataType, OutputTensorDataType>::forward_prop()
 {
+  LBANN_CALIPER_MARK_SCOPE(("fp " + this->get_name()).c_str());
   const auto fp_start = get_time();
 
   // Setup weights proxies

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -704,6 +704,8 @@ void Layer::remove_as_gradient_source()
 
 void Layer::back_prop()
 {
+  LBANN_CALIPER_MARK_SCOPE(("bp " + this->get_name()).c_str());
+
   allocate_new_gradients_();
   back_prop_impl_();
   propagate_error_signals_to_parents_();

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1576,6 +1576,7 @@ void model::clear_gradients()
 
 void model::forward_prop(execution_mode mode)
 {
+  LBANN_CALIPER_MARK_FUNCTION;
   do_model_forward_prop_begin_cbs(mode);
 
   for (El::Int i = 0; i < get_num_layers(); ++i) {
@@ -1603,7 +1604,7 @@ void model::forward_prop(execution_mode mode)
 
 void model::backward_prop(bool compute_weight_grads_only)
 {
-
+  LBANN_CALIPER_MARK_FUNCTION;
   do_model_backward_prop_begin_cbs();
 
   for (El::Int i = get_num_layers() - 1; i >= 0; --i) {
@@ -1655,6 +1656,7 @@ void model::backward_prop(bool compute_weight_grads_only)
 
 void model::update_weights()
 {
+  LBANN_CALIPER_MARK_FUNCTION;
   do_model_optimize_begin_cbs();
 
   // Apply optimization step to weights

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -33,6 +33,9 @@
 #include "lbann/proto/init_image_data_readers.hpp"
 #include "lbann/utils/argument_parser.hpp"
 #include "lbann/utils/file_utils.hpp"
+#if defined(LBANN_HAS_CALIPER)
+#include "lbann/utils/profiling.hpp"
+#endif
 
 #include "lbann/data_readers/data_reader_HDF5.hpp"
 #include "lbann/utils/options.hpp"
@@ -1024,6 +1027,11 @@ void print_parameters(const lbann_comm& comm,
 #else
   bool const enable_determinism = false;
 #endif // LBANN_DETERMINISTIC
+#if defined(LBANN_HAS_CALIPER)
+  bool const enable_caliper = is_caliper_initialized();
+#else
+  bool const enable_caliper = false;
+#endif
 
   std::cout << "\nRunning with these parameters:\n"
             << " General:\n"
@@ -1037,6 +1045,8 @@ void print_parameters(const lbann_comm& comm,
             << "  num_parallel_readers:       " << t.num_parallel_readers()
             << '\n'
             << "  serialize_io:               " << t.serialize_io() << '\n'
+            << "  caliper:                    "
+            << (enable_caliper ? "enabled" : "disabled") << '\n'
             << "  cuda:                       "
             << (disable_cuda ? "disabled" : "enabled") << '\n'
             << "  cudnn:                      "

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -263,6 +263,9 @@ void construct_std_options()
                         "sub-grids with blocked ordering",
                         0);
 #ifdef LBANN_HAS_CALIPER
+  arg_parser.add_flag(LBANN_OPTION_USE_CALIPER,
+                      {"--caliper"},
+                      "[STD] Enable caliper.");
   arg_parser.add_option(LBANN_OPTION_CALIPER_CONFIG,
                         {"--caliper_config"},
                         "[STD] Caliper configuration string",

--- a/src/utils/profiling.cpp
+++ b/src/utils/profiling.cpp
@@ -137,7 +137,6 @@ void do_adiak_init()
   if (tsize >= 4) {
     // pickup path version <compiler-version-hash|date>/mpispec/bin/exec
     std::string const path_version = tokens[tsize - 4];
-    std::cout << "Compiler path version: " << path_version << "\n";
     auto const s = split(path_version, "-");
     if (s.size() >= 2) {
       std::string const path_version_short = s[0] + "-" + s[1];
@@ -214,8 +213,8 @@ void initialize_caliper()
   }
   do_adiak_init();
 
-  auto& arg_parser = global_argument_parser();
-  auto config =
+  auto const& arg_parser = global_argument_parser();
+  auto const config =
     arg_parser.get<std::string>(LBANN_OPTION_CALIPER_CONFIG).c_str();
   cali_mgr.add(config);
   if (cali_mgr.error()) {

--- a/src/utils/profiling.cpp
+++ b/src/utils/profiling.cpp
@@ -30,8 +30,8 @@
 #include "lbann/base.hpp"
 #include "lbann/utils/exception.hpp"
 // For get_current_comm, which is here for some reason.
-#include "lbann/utils/serialize.hpp"
 #include "lbann/utils/options.hpp"
+#include "lbann/utils/serialize.hpp"
 
 #if defined(LBANN_SCOREP)
 #include <scorep/SCOREP_User.h>
@@ -51,8 +51,8 @@
 
 #ifdef LBANN_HAS_CALIPER
 #include <adiak.hpp>
-#include <caliper/cali.h>
 #include <caliper/cali-manager.h>
+#include <caliper/cali.h>
 
 #include "adiak_config.hpp"
 #include <algorithm>
@@ -80,7 +80,7 @@ namespace {
 
 cali::ConfigManager cali_mgr;
 bool caliper_initialized = false;
-MPI_Comm adiak_comm;  // Dedicated Adiak communicator.
+MPI_Comm adiak_comm; // Dedicated Adiak communicator.
 
 std::vector<std::string> split(std::string const str,
                                std::string const regex_str)
@@ -94,10 +94,9 @@ std::vector<std::string> split(std::string const str,
 
 std::string as_lowercase(std::string str)
 {
-  std::transform(cbegin(str),
-                 cend(str),
-                 begin(str),
-                 [](unsigned char c) { return ::tolower(c); });
+  std::transform(cbegin(str), cend(str), begin(str), [](unsigned char c) {
+    return ::tolower(c);
+  });
   return str;
 }
 
@@ -200,14 +199,15 @@ void do_adiak_init()
   adiak::value("omp_max_threads", omp_get_max_threads());
 #endif
 }
-void do_adiak_finalize() {
+void do_adiak_finalize()
+{
   adiak::fini();
   MPI_Comm_free(&adiak_comm);
 }
 
-}  // namespace
+} // namespace
 
-void prof_start()
+void initialize_caliper()
 {
   if (caliper_initialized) {
     LBANN_ERROR("Cannot reinitialize Caliper");
@@ -215,33 +215,38 @@ void prof_start()
   do_adiak_init();
 
   auto& arg_parser = global_argument_parser();
-  auto config = arg_parser.get<std::string>(LBANN_OPTION_CALIPER_CONFIG).c_str();
+  auto config =
+    arg_parser.get<std::string>(LBANN_OPTION_CALIPER_CONFIG).c_str();
   cali_mgr.add(config);
   if (cali_mgr.error()) {
     LBANN_ERROR("Caliper config parse error: ", cali_mgr.error_msg());
   }
   cali_mgr.start();
-
-  profiling_started = true;
   caliper_initialized = true;
 }
-void prof_stop()
+
+void finalize_caliper()
 {
   if (caliper_initialized) {
     cali_mgr.stop();
     cali_mgr.flush();
     do_adiak_finalize();
   }
-  profiling_started = false;
 }
+
+void prof_start() { profiling_started = true; }
+void prof_stop() { profiling_started = false; }
+
 void prof_region_begin(const char* s, int, bool)
 {
-  if (!profiling_started) return;
+  if (!profiling_started)
+    return;
   cali_begin_region(s);
 }
 void prof_region_end(const char* s, bool)
 {
-  if (!profiling_started) return;
+  if (!profiling_started)
+    return;
   cali_end_region(s);
 }
 #elif defined(LBANN_SCOREP)


### PR DESCRIPTION
This is the start of using loop annotations in Caliper.

This approach is a bit clunky, but keeps us in Caliper "macro-land" -- on another branch I'm playing with using the Caliper C++ API directly, which requires less restructuring (which I might still do since I think it's a bit cleaner anyway) but more book-keeping. Either approach could be done by tomorrow, it's just a matter of which approach we prefer.