### PR TITLE
Use Caliper's default-generated output name

### DIFF
--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -269,7 +269,7 @@ void construct_std_options()
   arg_parser.add_option(LBANN_OPTION_CALIPER_CONFIG,
                         {"--caliper_config"},
                         "[STD] Caliper configuration string",
-                        "spot(output=lbann.cali)");
+                        "spot");
 #endif
 }
 


### PR DESCRIPTION
We were using `lbann.cali` as the Caliper output filename (when not overridden). However, this means multiple runs will cause Caliper to overwrite its prior output. Using the filename it generates by default (which is a timestamp) will avoid this.