### PR TITLE
Stop error signal backpropagation

### DIFF
--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -202,11 +202,12 @@ enum class matrix_format
 /// Backpropagation requirements from a layer or operator
 enum BackpropRequirements
 {
-  NO_REQUIREMENTS = 0,
-  ERROR_SIGNALS = 1,    // Error signals from child layers
-  PREV_ACTIVATIONS = 2, // Input activations from forward pass
-  ACTIVATIONS = 4,      // Output activations from forward pass
-  WEIGHTS = 8,          // Weights
+  PROPAGATE_NOTHING = 0, // Stop gradient computation to parents (including
+                         // error signals)
+  ERROR_SIGNALS = 1,     // Error signals from child layers
+  PREV_ACTIVATIONS = 2,  // Input activations from forward pass
+  ACTIVATIONS = 4,       // Output activations from forward pass
+  WEIGHTS = 8,           // Weights
 };
 
 /// @todo This should move to hydrogen

--- a/include/lbann/layers/transform/constant.hpp
+++ b/include/lbann/layers/transform/constant.hpp
@@ -59,7 +59,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return NO_REQUIREMENTS; }
+  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
 
   description get_description() const override
   {

--- a/include/lbann/layers/transform/dummy.hpp
+++ b/include/lbann/layers/transform/dummy.hpp
@@ -74,7 +74,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return NO_REQUIREMENTS; }
+  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
 
 #ifdef LBANN_HAS_ONNX
   void fill_onnx_node(onnx::GraphProto& graph) const override {}

--- a/include/lbann/layers/transform/dummy.hpp
+++ b/include/lbann/layers/transform/dummy.hpp
@@ -74,7 +74,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
+  int get_backprop_requirements() const override { return ERROR_SIGNALS; }
 
 #ifdef LBANN_HAS_ONNX
   void fill_onnx_node(onnx::GraphProto& graph) const override {}

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -120,7 +120,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return NO_REQUIREMENTS; }
+  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
 
 #ifdef LBANN_HAS_ONNX
   void fill_onnx_node(onnx::GraphProto& graph) const override;

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -120,7 +120,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
+  int get_backprop_requirements() const override { return ERROR_SIGNALS; }
 
 #ifdef LBANN_HAS_ONNX
   void fill_onnx_node(onnx::GraphProto& graph) const override;

--- a/include/lbann/layers/transform/stop_gradient.hpp
+++ b/include/lbann/layers/transform/stop_gradient.hpp
@@ -62,7 +62,7 @@ public:
   data_layout get_data_layout() const override { return T_layout; }
   El::Device get_device_allocation() const override { return Dev; }
   bool can_run_inplace() const override { return false; }
-  int get_backprop_requirements() const override { return NO_REQUIREMENTS; }
+  int get_backprop_requirements() const override { return PROPAGATE_NOTHING; }
 
 protected:
   /** Add layer specific data to prototext */

--- a/include/lbann/utils/options.hpp
+++ b/include/lbann/utils/options.hpp
@@ -66,6 +66,7 @@ namespace lbann {
 #define LBANN_OPTION_INIT_SHMEM "Initialize SHMEM when initializing LBANN"
 #define LBANN_OPTION_INIT_NVSHMEM "Initialize NVSHMEM when initializing LBANN"
 #define LBANN_OPTION_NO_INPLACE "no_inplace"
+#define LBANN_OPTION_NO_BACKPROP_DISABLE "no_backprop_disable"
 
 // Input options
 #define LBANN_OPTION_CKPT_DIR "ckpt_dir"

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -827,7 +827,6 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
       temp_grad = output_mat_builder->MakeEmpty(grid, 0);
     }
 
-
     count = 1;
     for (auto& subgrid_tensor : m_subgrid_tensors_split) {
       subgrid_tensor = input_mat_builder->MakeEmpty(*grids[count], 0);
@@ -1240,6 +1239,11 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::
 {
   for (int i = 0; i < get_num_parents(); ++i) {
     auto& parent = const_cast<Layer&>(get_parent_layer(i));
+
+    // If this parent layer does not require any error signals,
+    // skip it.
+    if (parent.get_backprop_requirements() == PROPAGATE_NOTHING)
+      continue;
 
     // If my error signals persist, my parent can always view them,
     // assuming the distdata is right. Otherwise, my views and my data

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1642,9 +1642,16 @@ void model::backward_prop(bool compute_weight_grads_only)
     }
 
     // Add parents to disabled layers if this layer is disabled
-    if (!enable_layer) {
-      for (auto& parent : l.get_parent_layers()) {
-        disabled_layers.insert(parent);
+    if (envvar_disable_layers) {
+      // Start propagating disabled layers up
+      if (l.get_backprop_requirements() == PROPAGATE_NOTHING)
+        enable_layer = false;
+
+      // Either start or continue propagating disabled layers
+      if (!enable_layer) {
+        for (auto& parent : l.get_parent_layers()) {
+          disabled_layers.insert(parent);
+        }
       }
     }
 

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -32,6 +32,7 @@
 #include "lbann/objective_functions/objective_function.hpp"
 #include <lbann/base.hpp>
 #include <lbann/layers/io/input_layer.hpp>
+#include <lbann/layers/layer.hpp>
 #include <lbann/models/model.hpp>
 #include <lbann/proto/factories.hpp>
 #include <lbann/utils/lbann_library.hpp>
@@ -58,10 +59,11 @@ auto mock_datareader_metadata()
 }
 
 template <typename T>
-auto make_model(lbann::lbann_comm& comm)
+auto make_model(lbann::lbann_comm& comm,
+                const std::string& model_contents = model_prototext)
 {
   lbann_data::LbannPB my_proto;
-  if (!pb::TextFormat::ParseFromString(model_prototext, &my_proto))
+  if (!pb::TextFormat::ParseFromString(model_contents, &my_proto))
     throw "Parsing protobuf failed.";
   // Construct a trainer so that the model can register the input layer
   lbann::construct_trainer(&comm, my_proto.mutable_trainer(), my_proto);
@@ -162,4 +164,135 @@ TEST_CASE("Serializing models", "[mpi][model][serialize]")
     }
   }
 #endif // LBANN_HAS_CEREAL_XML_ARCHIVES
+}
+
+// Prototext graphs
+const std::string backprop_test_model = R"""(
+model {
+  layer {
+    name: "inp"
+    children: "layer1"
+    weights: "dummy_inputs"
+    weights_layer {
+      dims: 3
+    }
+  }
+  layer {
+    name: "layer1"
+    parents: "inp"
+    children: "stopgrad"
+    relu {
+    }
+  }
+  layer {
+    name: "stopgrad"
+    parents: "layer1"
+    children: "layer2"
+    stop_gradient {
+    }
+  }
+  layer {
+    name: "layer2"
+    parents: "stopgrad"
+    relu {
+    }
+  }
+  weights {
+    name: "dummy_inputs"
+    initializer {
+      value_initializer {
+        values: -1.2
+        values: 3.4
+        values: -5.67
+      }
+    }
+  }
+}
+)""";
+
+class backprop_test_layer final : public lbann::data_type_layer<float>
+{
+public:
+  backprop_test_layer(lbann::lbann_comm* comm)
+    : lbann::data_type_layer<float>(comm),
+      m_fprop_computed(false),
+      m_bprop_computed(false)
+  {}
+  backprop_test_layer* copy() const final
+  {
+    return new backprop_test_layer(*this);
+  }
+
+  std::string get_type() const final { return "backprop_test_layer"; }
+  lbann::data_layout get_data_layout() const final
+  {
+    return lbann::data_layout::DATA_PARALLEL;
+  }
+  El::Device get_device_allocation() const final { return El::Device::CPU; }
+  void write_specific_proto(lbann_data::Layer& proto) const final {}
+  bool fprop_computed() const { return m_fprop_computed; }
+  bool bprop_computed() const { return m_bprop_computed; }
+
+private:
+  friend class cereal::access;
+  backprop_test_layer() : backprop_test_layer(nullptr) {}
+
+  void setup_dims(lbann::DataReaderMetaData& dr_metadata) final
+  {
+    lbann::data_type_layer<float>::setup_dims(dr_metadata);
+    this->set_output_dims(this->get_input_dims());
+  }
+  void fp_setup_outputs(El::Int mini_batch_size) override
+  {
+    El::LockedView(this->get_activations(), this->get_prev_activations());
+  }
+  void bp_setup_gradient_wrt_inputs(El::Int mini_batch_size) override
+  {
+    El::LockedView(this->get_error_signals(), this->get_prev_error_signals());
+  }
+
+  void fp_compute() final { m_fprop_computed = true; }
+
+  void bp_compute() final { m_bprop_computed = true; }
+
+  bool m_fprop_computed, m_bprop_computed;
+};
+
+TEST_CASE("Gradient backpropagation stop", "[mpi][model][backprop]")
+{
+  using DataType = float;
+
+  auto& comm = unit_test::utilities::current_world_comm();
+
+  auto& g = comm.get_trainer_grid();
+  lbann::utils::grid_manager mgr(g);
+  std::unique_ptr<lbann::model> model =
+    make_model<DataType>(comm, backprop_test_model);
+
+  std::shared_ptr<backprop_test_layer> before_stopgrad =
+    std::make_shared<backprop_test_layer>(&comm);
+  std::shared_ptr<backprop_test_layer> after_stopgrad =
+    std::make_shared<backprop_test_layer>(&comm);
+
+  model->insert_layer(before_stopgrad, "layer1");
+  model->insert_layer(after_stopgrad, "layer2");
+
+  // Reset the model after adding the new layers
+  auto metadata = lbann::DataReaderMetaData();
+  model->setup(1UL, metadata, {&g}, true);
+
+  REQUIRE(!before_stopgrad->fprop_computed());
+  REQUIRE(!before_stopgrad->bprop_computed());
+  REQUIRE(!after_stopgrad->fprop_computed());
+  REQUIRE(!after_stopgrad->bprop_computed());
+
+  // Run forward
+  REQUIRE_NOTHROW(model->forward_prop(lbann::execution_mode::training));
+  REQUIRE(before_stopgrad->fprop_computed());
+  REQUIRE(after_stopgrad->fprop_computed());
+
+  // Run backprop
+  REQUIRE_NOTHROW(model->backward_prop(false));
+  REQUIRE(!before_stopgrad->bprop_computed());
+  REQUIRE(after_stopgrad->bprop_computed());
 }

--- a/src/utils/options.cpp
+++ b/src/utils/options.cpp
@@ -24,9 +24,9 @@
 // permissions and limitations under the license.
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "lbann_config.hpp"
 #include "lbann/utils/options.hpp"
 #include "lbann/utils/argument_parser.hpp"
+#include "lbann_config.hpp"
 
 namespace lbann {
 
@@ -135,6 +135,10 @@ void construct_std_options()
                       {"--no_inplace"},
                       utils::ENV("LBANN_NO_INPLACE"),
                       "[STD] Disable in-place layer memory optimization");
+  arg_parser.add_flag(LBANN_OPTION_NO_BACKPROP_DISABLE,
+                      {"--no_backprop_disable"},
+                      utils::ENV("LBANN_NO_BACKPROP_DISABLE"),
+                      "[STD] Always compute all layers in backpropagation");
 
   // Input options
   arg_parser.add_option(
@@ -400,10 +404,11 @@ void construct_datareader_options()
                         {"--data_filename_validate"},
                         "[DATAREADER] Sets the filename for validation data",
                         "");
-  arg_parser.add_option(LBANN_OPTION_DATA_READER_FRACTION,
-                        {"--data_reader_fraction"},
-                        "[DATAREADER] Sets the fraction of total samples to use",
-                        (float)-1);
+  arg_parser.add_option(
+    LBANN_OPTION_DATA_READER_FRACTION,
+    {"--data_reader_fraction"},
+    "[DATAREADER] Sets the fraction of total samples to use",
+    (float)-1);
   arg_parser.add_option(
     LBANN_OPTION_LABEL_FILENAME_TEST,
     {"--label_filename_test"},


### PR DESCRIPTION
Stops error signal backpropagation if layer is tagged with `PROPAGATE_NOTHING` backpropagation requirements. Disabling computations can be disabled via the `LBANN_NO_BACKPROP_DISABLE`.