### PR TITLE
Update hdf5_c3fd_test_data_and_schemas.yaml

### DIFF
--- a/src/data_readers/unit_test/test_data/hdf5_c3fd_test_data_and_schemas.yaml
+++ b/src/data_readers/unit_test/test_data/hdf5_c3fd_test_data_and_schemas.yaml
@@ -28,7 +28,7 @@ const std::string hdf5_c3fd_data_sample=R"FOO(RUN_ID:
   000000001:
     NodeFeatures: [0.1, 0.2, 1.1, 1.2, 2.1, 2.2, 3.1, 3.2]
     EdgeFeatures: [0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 1]
-    COOList: [0, 0, 1, 2, 3, 2, 2, 0]
+    COOList: [0, 1, 0, 2, 1, 0, 1, 3, 2, 0, 2, 3, 3, 1, 3, 2]
 )FOO";
 
 const std::string hdf5_c3fd_data_schema = R"FOO(


### PR DESCRIPTION
Fixed COOlist data on hdf5 c3fd unit test.

The data creates a "square" graph with 8 directed edges:

```
0 ------- 1
|         |
|         |
|         |
2 ------- 3
```
