### PR TITLE
Some mild clean up

### DIFF
--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -286,9 +286,6 @@ protected:
   weights& master_weights(size_t idx) { return get_weights(idx); }
   weights const& master_weights(size_t idx) const { return get_weights(idx); }
 
-  void setup_inter_subgrid_comm_based_on_childs(const El::Grid& grid);
-  void setup_inter_subgrid_comm_based_on_parents(const El::Grid& grid);
-
 private:
   /** @brief Attempt to take ownership of the previous error signal.
    *

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -1324,59 +1324,6 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::
   }
 }
 
-template <typename InputTensorDataType, typename OutputTensorDataType>
-void data_type_layer<InputTensorDataType, OutputTensorDataType>::
-  setup_inter_subgrid_comm_based_on_childs(const El::Grid& grid)
-{
-  // Now we are creating sub-communicators in model.cpp as this method will lead
-  // to several instances of sub-communicators on same rank sets. BUG: NCCL
-  // allocates some memory for each communicator, which lead to Out-of-memory
-  // (OOM) when we have large number of communicators
-  const auto& childs = get_child_layers();
-
-  int indexSubgrid = -1;
-  for (int child = 0; child < this->get_num_children(); ++child) {
-    if (childs[child]->get_mygrid()->InGrid())
-
-    {
-      indexSubgrid = child;
-    }
-  }
-  const int posInSubGrid = childs[indexSubgrid]->get_mygrid()->VCRank();
-  const int posInGrid = grid.ViewingRank();
-  auto& interSubgridComm = this->get_subgrid_comm();
-  El::mpi::Split(this->get_comm()->get_trainer_comm(),
-                 posInSubGrid,
-                 posInGrid,
-                 interSubgridComm);
-}
-
-template <typename InputTensorDataType, typename OutputTensorDataType>
-void data_type_layer<InputTensorDataType, OutputTensorDataType>::
-  setup_inter_subgrid_comm_based_on_parents(const El::Grid& grid)
-{
-  // Now we are creating sub-communicators in model.cpp as this method will lead
-  // to several instances of sub-communicators on same rank sets. BUG: NCCL
-  // allocates some memory for each communicator, which lead to Out-of-memory
-  // (OOM) when we have large number of communicators
-
-  const auto& parents = get_parent_layers();
-
-  int indexSubgrid = -1;
-  for (int parent = 0; parent < this->get_num_parents(); ++parent) {
-    if (parents[parent]->get_mygrid()->InGrid()) {
-      indexSubgrid = parent;
-    }
-  }
-  const int posInSubGrid = parents[indexSubgrid]->get_mygrid()->VCRank();
-  const int posInGrid = grid.ViewingRank();
-  auto& interSubgridComm = this->get_subgrid_comm();
-  El::mpi::Split(this->get_comm()->get_trainer_comm(),
-                 posInSubGrid,
-                 posInGrid,
-                 interSubgridComm);
-}
-
 #ifdef LBANN_HAS_DISTCONV
 template <typename InputTensorDataType, typename OutputTensorDataType>
 void data_type_layer<InputTensorDataType, OutputTensorDataType>::


### PR DESCRIPTION
This was just in my stash, where it's doing nobody any good.

- Removes unneeded functions (zero references)
- Clean up some loops (range-based for)
- Only print distconv enabled/disabled list if any layer is distconv-enabled. Also, only do distconv setup if any layer is distconv-enabled. (All the functions called after the short-circuit only have meaningful side effects on layer that are distconv-enabled, so we can save ourselves a few no-op loops over all the layers if none is distconv-enabled...)
- Resolve warnings about variable shadowing (also, yeah yeah I know my IDE can tell me which variables are actually members, but I shouldn't need an IDE to read/write code. Mark data members with `m_` prefix or `_` suffix)