### PR TITLE
Reduce reliance on `data_*`: remove unused data reader arguments and methods from API (3/3)

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -4,6 +4,7 @@ C++ API:
 Support for new training algorithms:
 
 Support for new network structures:
+  - Added GPT-3 transformers and training recipes
 
 Support for new layers:
   - Select operator (set tensor value based on predicate)
@@ -30,7 +31,9 @@ Internal features:
 
 I/O & data readers:
  - Renamed percent_of_data_to_use more accurately to fraction_of_data_to_use.
- - DataReaderMetaData was removed from the model and layer API
+ - DataReaderMetaData, training_dr_linearized_data_size, and num_parallel_readers
+   were removed from the model and layer API, and instead reside in the data
+   ingestion pipeline.
 
 Build system:
  - Updated build script to use CachedCMakeProject mode, which should
@@ -41,6 +44,8 @@ Bug fixes:
 
 Retired features:
  - Support for autoencoder strategy in the summarize images callback was removed
+ - Removed deprecated Layer protobuf fields: weight_data, 
+   num_neurons_from_data_reader
 
 ============================== Release Notes: v0.103 ==============================
 C++ API:

--- a/docs/layers.rst
+++ b/docs/layers.rst
@@ -175,19 +175,7 @@ Common Layer Arguments
 
 Deprecated:
 
-  :num_neurons_from_data_reader: (``bool``)
-
   :freeze: (``bool``)
-
-Deprecated and unused:
-
-  :WeightsData weights_data: (``repeated``)
-
-  :top: (``string``)
-
-  :bottom: (``string``)
-
-  :type: (``string``)
 
 
 .. _layers-list:

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -518,8 +518,6 @@ public:
   /** @brief Set the model that manages this layer. */
   inline void set_model(model* m) { m_model = m; }
 
-  virtual El::Matrix<El::Int>* get_sample_indices_per_mb() { return nullptr; };
-
   /** @brief Write layer to proto file */
   void write_proto(lbann_data::Layer& proto);
 

--- a/include/lbann/proto/factories.hpp
+++ b/include/lbann/proto/factories.hpp
@@ -70,7 +70,6 @@ construct_trainer(lbann_comm* comm, const lbann_data::Trainer& proto_trainer);
 
 /** Construct a model specified with a prototext. */
 std::unique_ptr<model> construct_model(lbann_comm* comm,
-                                       int training_dr_linearized_data_size,
                                        const lbann_data::Optimizer& proto_opt,
                                        const lbann_data::Trainer& proto_trainer,
                                        const lbann_data::Model& proto_model);
@@ -78,15 +77,12 @@ std::unique_ptr<model> construct_model(lbann_comm* comm,
 /** Construct a layer graph specified with a prototext. */
 std::vector<OwningLayerPtr>
 construct_layer_graph(lbann_comm* comm,
-                      int training_dr_linearized_data_size,
                       const lbann_data::Trainer& proto_trainer,
                       const lbann_data::Model& proto_model);
 
 /** Construct a layer specified with prototext. */
 template <typename TensorDataType, data_layout layout, El::Device Dev>
 std::unique_ptr<Layer> construct_layer(lbann_comm* comm,
-                                       int training_dr_linearized_data_size,
-                                       int num_parallel_readers,
                                        const lbann_data::Layer& proto_layer);
 
 /** Construct an operator specified with prototext. */

--- a/include/lbann/utils/lbann_library.hpp
+++ b/include/lbann/utils/lbann_library.hpp
@@ -87,8 +87,7 @@ std::unique_ptr<model> build_model_from_prototext(
   lbann_data::LbannPB& pb,
   lbann_comm* comm,
   thread_pool& io_thread_pool,
-  std::vector<std::shared_ptr<callback_base>>& shared_callbacks,
-  int training_dr_linearized_data_size);
+  std::vector<std::shared_ptr<callback_base>>& shared_callbacks);
 
 void print_lbann_configuration(lbann_comm* comm,
                                int io_threads_per_process,

--- a/model_zoo/lbann.cpp
+++ b/model_zoo/lbann.cpp
@@ -184,12 +184,6 @@ int main(int argc, char* argv[])
 
     thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
-    int training_dr_linearized_data_size = -1;
-    auto* dr =
-      trainer.get_data_coordinator().get_data_reader(execution_mode::training);
-    if (dr != nullptr) {
-      training_dr_linearized_data_size = dr->get_linearized_data_size();
-    }
     lbann_data::Model* pb_model = pb.mutable_model();
 
     auto model =
@@ -199,8 +193,7 @@ int main(int argc, char* argv[])
                                  pb,
                                  comm.get(),
                                  io_thread_pool,
-                                 trainer.get_callbacks_with_ownership(),
-                                 training_dr_linearized_data_size);
+                                 trainer.get_callbacks_with_ownership());
 
     if (!arg_parser.get<bool>(LBANN_OPTION_EXIT_AFTER_SETUP)) {
 

--- a/model_zoo/lbann_aecycgan.cpp
+++ b/model_zoo/lbann_aecycgan.cpp
@@ -108,13 +108,6 @@ int main(int argc, char* argv[])
 
     thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
-    int training_dr_linearized_data_size = -1;
-    auto* dr =
-      trainer.get_data_coordinator().get_data_reader(execution_mode::training);
-    if (dr != nullptr) {
-      training_dr_linearized_data_size = dr->get_linearized_data_size();
-    }
-
     auto model_1 =
       build_model_from_prototext(argc,
                                  argv,
@@ -122,10 +115,9 @@ int main(int argc, char* argv[])
                                  *(pbs[0]),
                                  comm.get(),
                                  io_thread_pool,
-                                 trainer.get_callbacks_with_ownership(),
-                                 training_dr_linearized_data_size); // ae
-    std::unique_ptr<model> model_2,                                 // cycgan
-      model_3;                                                      // ae+cycgan
+                                 trainer.get_callbacks_with_ownership()); // ae
+    std::unique_ptr<model> model_2, // cycgan
+      model_3;                      // ae+cycgan
 
     if (pbs.size() > 1) {
       model_2 =
@@ -135,8 +127,7 @@ int main(int argc, char* argv[])
                                    *(pbs[1]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     if (pbs.size() > 2) {
@@ -147,8 +138,7 @@ int main(int argc, char* argv[])
                                    *(pbs[2]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     const lbann_data::Model pb_model_1 = pbs[0]->model();

--- a/model_zoo/lbann_cycgan.cpp
+++ b/model_zoo/lbann_cycgan.cpp
@@ -125,22 +125,14 @@ int main(int argc, char* argv[])
 
     thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
-    int training_dr_linearized_data_size = -1;
-    auto* dr =
-      trainer.get_data_coordinator().get_data_reader(execution_mode::training);
-    if (dr != nullptr) {
-      training_dr_linearized_data_size = dr->get_linearized_data_size();
-    }
-
-    auto model_1 =
-      build_model_from_prototext(argc,
-                                 argv,
-                                 pb_trainer,
-                                 *(pbs[0]),
-                                 comm.get(),
-                                 io_thread_pool,
-                                 trainer.get_callbacks_with_ownership(),
-                                 training_dr_linearized_data_size); // D1 solver
+    auto model_1 = build_model_from_prototext(
+      argc,
+      argv,
+      pb_trainer,
+      *(pbs[0]),
+      comm.get(),
+      io_thread_pool,
+      trainer.get_callbacks_with_ownership()); // D1 solver
     // hack, overide model name to make reporting easy, what can break?"
     std::unique_ptr<model> model_2, // G1 solver
       model_3,                      // G2 solver
@@ -157,8 +149,7 @@ int main(int argc, char* argv[])
                                    *(pbs[1]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     if (pbs.size() > 2) {
@@ -169,8 +160,7 @@ int main(int argc, char* argv[])
                                    *(pbs[2]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     if (pbs.size() > 3) {
@@ -181,8 +171,7 @@ int main(int argc, char* argv[])
                                    *(pbs[3]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     if (pbs.size() > 4) {
@@ -193,8 +182,7 @@ int main(int argc, char* argv[])
                                    *(pbs[4]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     const lbann_data::Model pb_model = pbs[0]->model();

--- a/model_zoo/lbann_gan.cpp
+++ b/model_zoo/lbann_gan.cpp
@@ -108,13 +108,6 @@ int main(int argc, char* argv[])
 
     thread_pool& io_thread_pool = trainer.get_io_thread_pool();
 
-    int training_dr_linearized_data_size = -1;
-    auto* dr =
-      trainer.get_data_coordinator().get_data_reader(execution_mode::training);
-    if (dr != nullptr) {
-      training_dr_linearized_data_size = dr->get_linearized_data_size();
-    }
-
     auto model_1 = build_model_from_prototext(
       argc,
       argv,
@@ -122,9 +115,8 @@ int main(int argc, char* argv[])
       *(pbs[0]),
       comm.get(),
       io_thread_pool,
-      trainer.get_callbacks_with_ownership(),
-      training_dr_linearized_data_size);      // discriminator model
-    std::unique_ptr<model> model_2 = nullptr; // adversarial model
+      trainer.get_callbacks_with_ownership()); // discriminator model
+    std::unique_ptr<model> model_2 = nullptr;  // adversarial model
     if (pbs.size() > 1) {
       model_2 =
         build_model_from_prototext(argc,
@@ -133,8 +125,7 @@ int main(int argc, char* argv[])
                                    *(pbs[1]),
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size);
+                                   trainer.get_callbacks_with_ownership());
     }
 
     const lbann_data::Model pb_model = pbs[0]->model();

--- a/model_zoo/lbann_inf.cpp
+++ b/model_zoo/lbann_inf.cpp
@@ -81,13 +81,9 @@ int main(int argc, char* argv[])
     auto& trainer = construct_trainer(comm.get(), pb_trainer, *(pbs[0]));
 
     thread_pool& io_thread_pool = trainer.get_io_thread_pool();
-    int training_dr_linearized_data_size = -1;
     auto* dr =
       trainer.get_data_coordinator().get_data_reader(execution_mode::testing);
-    if (dr != nullptr) {
-      training_dr_linearized_data_size = dr->get_linearized_data_size();
-    }
-    else {
+    if (dr == nullptr) {
       LBANN_ERROR("No testing data reader defined");
     }
 
@@ -100,8 +96,7 @@ int main(int argc, char* argv[])
                                    *pb_model,
                                    comm.get(),
                                    io_thread_pool,
-                                   trainer.get_callbacks_with_ownership(),
-                                   training_dr_linearized_data_size));
+                                   trainer.get_callbacks_with_ownership()));
     }
 
     /// Interleave the inference between the models so that they can use a

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.prototext
@@ -284,7 +284,6 @@ model {
     parents: "relu9"
     name: "decode1"
     data_layout: "model_parallel"
-    num_neurons_from_data_reader: true
     fully_connected {
       has_bias: true
     }

--- a/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.py
+++ b/model_zoo/models/autoencoder_candle_pilot1/model_autoencoder_chem_ecfp.py
@@ -149,7 +149,6 @@ decode1 = lbann.FullyConnected(relu9,
                                name="decode1",
                                data_layout="model_parallel",
                                hint_layer=data,
-                               #num_neurons_from_data_reader=True,
                                has_bias=True)
 
 relu10 = lbann.Relu(decode1, name="relu10", data_layout="model_parallel")

--- a/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
+++ b/model_zoo/models/candle/pilot1/ae_nodeselect_gdc.prototext
@@ -102,7 +102,6 @@ model {
     name: "decode1"
     data_layout: "model_parallel"
     weights: "w1"
-    num_neurons_from_data_reader: true
     fully_connected {
       has_bias: true
       transpose: true

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -4,6 +4,7 @@ from lbann import layers_pb2
 from lbann.util import make_iterable
 import lbann.core.util
 
+
 class Layer(abc.ABC):
     """Neural network tensor operation.
 
@@ -71,9 +72,8 @@ class Layer(abc.ABC):
         if self.hint_layer:
             proto.hint_layer = self.hint_layer.name
         if self.parallel_strategy:
-            lbann.core.util.set_protobuf_message(
-                proto.parallel_strategy,
-                **self.parallel_strategy)
+            lbann.core.util.set_protobuf_message(proto.parallel_strategy,
+                                                 **self.parallel_strategy)
             proto.parallel_strategy.SetInParent()
         return proto
 
@@ -101,23 +101,27 @@ class Layer(abc.ABC):
         """
         self.add_parent(parent)
 
+
 # Generate Layer sub-classes from lbann.proto
 # Note: The list of skip fields must be updated if any new fields are
 # added to the Layer message in lbann.proto
 if layers_pb2:
     classes = lbann.core.util.generate_classes_from_protobuf_message(
         layers_pb2.Layer,
-        skip_fields = set([
-            'name', 'parents', 'children', 'data_layout', 'device_allocation', 'datatype',
-            'weights', 'num_neurons_from_data_reader', 'freeze', 'hint_layer',
-            'parallel_strategy', 'weights_data', 'top', 'bottom', 'type', 'motif_layer']),
-        base_class = Layer,
-        base_kwargs = set([
-            'parents', 'children', 'weights',
-            'name', 'device', 'data_layout', 'datatype', 'hint_layer', 'parallel_strategy']),
-        base_has_export_proto = True)
+        skip_fields=set([
+            'name', 'parents', 'children', 'data_layout', 'device_allocation',
+            'datatype', 'weights', 'hint_layer', 'parallel_strategy', 'top',
+            'bottom', 'type', 'motif_layer'
+        ]),
+        base_class=Layer,
+        base_kwargs=set([
+            'parents', 'children', 'weights', 'name', 'device', 'data_layout',
+            'datatype', 'hint_layer', 'parallel_strategy'
+        ]),
+        base_has_export_proto=True)
     for c in classes:
         globals()[c.__name__] = c
+
 
 def traverse_layer_graph(layers):
     """Topologically ordered traversal of layer graph.
@@ -152,8 +156,7 @@ def traverse_layer_graph(layers):
     stack = roots
     while stack:
         l = stack.pop()
-        if (l not in visited
-            and all([(p in visited) for p in l.parents])):
+        if (l not in visited and all([(p in visited) for p in l.parents])):
             visited.add(l)
             stack.extend(l.children)
             yield l

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -110,8 +110,8 @@ if layers_pb2:
         layers_pb2.Layer,
         skip_fields=set([
             'name', 'parents', 'children', 'data_layout', 'device_allocation',
-            'datatype', 'weights', 'hint_layer', 'parallel_strategy', 'top',
-            'bottom', 'type', 'motif_layer'
+            'datatype', 'weights', 'freeze', 'hint_layer', 'parallel_strategy',
+            'top', 'bottom', 'type', 'motif_layer'
         ]),
         base_class=Layer,
         base_kwargs=set([

--- a/scripts/viz.py
+++ b/scripts/viz.py
@@ -55,8 +55,7 @@ graph.attr('node', shape='rect')
 layer_types = (set(layers_pb2.Layer.DESCRIPTOR.fields_by_name.keys())
                - set(['name', 'parents', 'children', 'datatype',
                       'data_layout', 'device_allocation', 'weights',
-                      'num_neurons_from_data_reader', 'freeze',
-                      'hint_layer', 'weights_data',
+                      'hint_layer',
                       'top', 'bottom', 'type', 'motif_layer']))
 for l in model.layer:
 

--- a/scripts/viz.py
+++ b/scripts/viz.py
@@ -10,31 +10,42 @@ from lbann import lbann_pb2, layers_pb2
 # Parse command-line arguments
 parser = argparse.ArgumentParser(
     description='Visualize an LBANN model\'s layer graph and save to file.')
-parser.add_argument(
-    'input', action='store', type=str,
-    help='model prototext file')
-parser.add_argument(
-    'output', action='store', nargs='?',
-    default='graph.pdf', type=str,
-    help='output file (default: graph.pdf)')
-parser.add_argument(
-    '--file-format', action='store', default='pdf', type=str,
-    help='output file format (default: pdf)', metavar='FORMAT')
-parser.add_argument(
-    '--label-format',
-    action='store', default='type-only', type=str,
-    choices=('type-only', 'name-only', 'type-and-name', 'full'),
-    help='displayed layer info (default: type-only)')
-parser.add_argument(
-    '--graphviz-engine', action='store', default='dot', type=str,
-    help='Graphviz visualization scheme (default: dot)', metavar='ENGINE')
+parser.add_argument('input',
+                    action='store',
+                    type=str,
+                    help='model prototext file')
+parser.add_argument('output',
+                    action='store',
+                    nargs='?',
+                    default='graph.pdf',
+                    type=str,
+                    help='output file (default: graph.pdf)')
+parser.add_argument('--file-format',
+                    action='store',
+                    default='pdf',
+                    type=str,
+                    help='output file format (default: pdf)',
+                    metavar='FORMAT')
+parser.add_argument('--label-format',
+                    action='store',
+                    default='type-only',
+                    type=str,
+                    choices=('type-only', 'name-only', 'type-and-name',
+                             'full'),
+                    help='displayed layer info (default: type-only)')
+parser.add_argument('--graphviz-engine',
+                    action='store',
+                    default='dot',
+                    type=str,
+                    help='Graphviz visualization scheme (default: dot)',
+                    metavar='ENGINE')
 args = parser.parse_args()
 
 # Strip extension from filename
 filename = args.output
 file_format = args.file_format
 if filename.endswith('.' + file_format):
-    filename = filename[:-len(file_format)-1]
+    filename = filename[:-len(file_format) - 1]
 
 # Convert label format to lowercase with no spaces
 label_format = re.sub(r' |-|_', '', args.label_format.lower())
@@ -52,18 +63,18 @@ graph = graphviz.Digraph(filename=filename,
 graph.attr('node', shape='rect')
 
 # Construct nodes in layer graph
-layer_types = (set(layers_pb2.Layer.DESCRIPTOR.fields_by_name.keys())
-               - set(['name', 'parents', 'children', 'datatype',
-                      'data_layout', 'device_allocation', 'weights',
-                      'hint_layer',
-                      'top', 'bottom', 'type', 'motif_layer']))
+layer_types = (set(layers_pb2.Layer.DESCRIPTOR.fields_by_name.keys()) - set([
+    'name', 'parents', 'children', 'datatype', 'data_layout',
+    'device_allocation', 'weights', 'freeze', 'hint_layer', 'top', 'bottom',
+    'type', 'motif_layer'
+]))
 for l in model.layer:
 
     # Determine layer type
     type = ''
     for _type in layer_types:
         if l.HasField(_type):
-            type = getattr(l,_type).DESCRIPTOR.name
+            type = getattr(l, _type).DESCRIPTOR.name
             break
 
     # Construct node label

--- a/src/callbacks/check_dataset.cpp
+++ b/src/callbacks/check_dataset.cpp
@@ -28,6 +28,7 @@
 #include "lbann/comm_impl.hpp"
 #include "lbann/data_coordinator/data_coordinator.hpp"
 #include "lbann/execution_algorithms/execution_context.hpp"
+#include "lbann/execution_algorithms/sgd_execution_context.hpp"
 #include "lbann/layers/io/input_layer.hpp"
 #include "lbann/models/model.hpp"
 #include "lbann/trainers/trainer.hpp"
@@ -64,7 +65,12 @@ void check_dataset::add_to_set(model* m,
     return;
   }
 
-  El::Matrix<El::Int>* indices = l->get_sample_indices_per_mb();
+  const auto& c =
+    static_cast<const SGDExecutionContext&>(m->get_execution_context());
+  // Print minibatch sample indices of the data coordinator
+  data_coordinator& dc = get_trainer().get_data_coordinator();
+  El::Matrix<El::Int>* indices =
+    dc.get_sample_indices_per_mb(c.get_execution_mode());
 
   std::set<long>::iterator it;
 

--- a/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
+++ b/src/execution_algorithms/unit_test/inference_algorithm_test.cpp
@@ -72,7 +72,6 @@ auto make_model(lbann::lbann_comm& comm, int class_n)
     lbann::construct_trainer(&comm, my_proto.mutable_trainer(), my_proto);
   unit_test::utilities::mock_data_reader(trainer, {1, 1, class_n}, class_n);
   auto my_model = lbann::proto::construct_model(&comm,
-                                                -1,
                                                 my_proto.optimizer(),
                                                 my_proto.trainer(),
                                                 my_proto.model());

--- a/src/layers/activations/unit_test/inplace_test.cpp
+++ b/src/layers/activations/unit_test/inplace_test.cpp
@@ -82,7 +82,6 @@ std::unique_ptr<lbann::model> setup_model(const std::string& model_contents)
   // Construct a trainer so that the model can register the input layer
   lbann::construct_trainer(&world_comm, pb.mutable_trainer(), pb);
   auto my_model = lbann::proto::construct_model(&world_comm,
-                                                -1,
                                                 pb.optimizer(),
                                                 pb.trainer(),
                                                 pb.model());

--- a/src/models/unit_test/model_test.cpp
+++ b/src/models/unit_test/model_test.cpp
@@ -60,7 +60,6 @@ auto make_model(lbann::lbann_comm& comm,
     lbann::construct_trainer(&comm, my_proto.mutable_trainer(), my_proto);
   unit_test::utilities::mock_data_reader(trainer, {1, 28, 28}, 10);
   auto my_model = lbann::proto::construct_model(&comm,
-                                                -1,
                                                 my_proto.optimizer(),
                                                 my_proto.trainer(),
                                                 my_proto.model());

--- a/src/models/unit_test/modify_test.cpp
+++ b/src/models/unit_test/modify_test.cpp
@@ -57,7 +57,6 @@ auto make_model(lbann::lbann_comm& comm)
     lbann::construct_trainer(&comm, my_proto.mutable_trainer(), my_proto);
   unit_test::utilities::mock_data_reader(trainer, {1, 28, 28}, 10);
   auto my_model = lbann::proto::construct_model(&comm,
-                                                -1,
                                                 my_proto.optimizer(),
                                                 my_proto.trainer(),
                                                 my_proto.model());

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -241,14 +241,6 @@ construct_layer_legacy(lbann_comm* comm,
   // arguments.
   if (proto_layer.has_reshape()) {
     const auto& params = proto_layer.reshape();
-    if (proto_layer.num_neurons_from_data_reader()) {
-      if (training_dr_linearized_data_size == -1) {
-        LBANN_ERROR("Training data reader does not exist!");
-      }
-      return std::make_unique<reshape_layer<TensorDataType, Layout, Device>>(
-        comm,
-        std::vector<int>{training_dr_linearized_data_size});
-    }
     return std::make_unique<reshape_layer<TensorDataType, Layout, Device>>(
       comm,
       protobuf::to_vector<int>(params.dims()));

--- a/src/proto/factories/layer_factory.cpp
+++ b/src/proto/factories/layer_factory.cpp
@@ -229,16 +229,10 @@ factory_type const& get_layer_factory() noexcept
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 std::unique_ptr<Layer>
-construct_layer_legacy(lbann_comm* comm,
-                       int training_dr_linearized_data_size,
-                       int num_parallel_readers,
-                       const lbann_data::Layer& proto_layer)
+construct_layer_legacy(lbann_comm* comm, const lbann_data::Layer& proto_layer)
 {
 
   // Transform layers
-  // Currently this cannot be suitably removed from this function
-  // because it relies on LBANN_OPTION_NUM_PARALLEL_READERS and "data_readers"
-  // arguments.
   if (proto_layer.has_reshape()) {
     const auto& params = proto_layer.reshape();
     return std::make_unique<reshape_layer<TensorDataType, Layout, Device>>(
@@ -253,8 +247,6 @@ construct_layer_legacy(lbann_comm* comm,
 
 template <typename TensorDataType, data_layout Layout, El::Device Device>
 std::unique_ptr<Layer> construct_layer(lbann_comm* comm,
-                                       int training_dr_linearized_data_size,
-                                       int num_parallel_readers,
                                        const lbann_data::Layer& proto_layer)
 {
 
@@ -265,14 +257,8 @@ std::unique_ptr<Layer> construct_layer(lbann_comm* comm,
     factory.create_object(msg.GetDescriptor()->name(), comm, proto_layer);
   if (!l) {
     if constexpr (std::is_same_v<TensorDataType, DataType>)
-      l = construct_layer_legacy<DataType, Layout, Device>(
-        comm,
-        training_dr_linearized_data_size,
-        num_parallel_readers,
-        proto_layer);
+      l = construct_layer_legacy<DataType, Layout, Device>(comm, proto_layer);
     else {
-      (void)training_dr_linearized_data_size;
-      (void)num_parallel_readers;
       LBANN_ERROR("Currently, layers of type \"",
                   msg.GetDescriptor()->name(),
                   "\" are not constructible with any type other than the "
@@ -294,14 +280,10 @@ std::unique_ptr<Layer> construct_layer(lbann_comm* comm,
   template std::unique_ptr<Layer>                                              \
   construct_layer<T, data_layout::DATA_PARALLEL, Device>(                      \
     lbann_comm * comm,                                                         \
-    int training_dr_linearized_data_size,                                      \
-    int num_parallel_readers,                                                  \
     const lbann_data::Layer& proto_layer);                                     \
   template std::unique_ptr<Layer>                                              \
   construct_layer<T, data_layout::MODEL_PARALLEL, Device>(                     \
     lbann_comm * comm,                                                         \
-    int training_dr_linearized_data_size,                                      \
-    int num_parallel_readers,                                                  \
     const lbann_data::Layer& proto_layer)
 
 #include "lbann/macros/instantiate_device.hpp"

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -101,7 +101,6 @@ void setup_hints(
 
 std::vector<OwningLayerPtr>
 construct_layer_graph(lbann_comm* comm,
-                      int training_dr_linearized_data_size,
                       const lbann_data::Trainer& proto_trainer,
                       const lbann_data::Model& proto_model)
 {
@@ -140,7 +139,6 @@ construct_layer_graph(lbann_comm* comm,
       (layout_str.empty() ? data_layout::DATA_PARALLEL
                           : data_layout_from_string(layout_str));
 
-    const auto& num_parallel_readers = proto_trainer.num_parallel_readers();
     El::Device device = El::Device::CPU;
 #ifdef LBANN_HAS_GPU
     // Input layers must be on CPU
@@ -161,11 +159,8 @@ construct_layer_graph(lbann_comm* comm,
   do {                                                                         \
     if (proto_datatype == TypeToProtoDataType<TensorDataType>::value &&        \
         layout == T_layout && device == T_device) {                            \
-      l = construct_layer<TensorDataType, T_layout, T_device>(                 \
-        comm,                                                                  \
-        training_dr_linearized_data_size,                                      \
-        num_parallel_readers,                                                  \
-        proto_layer);                                                          \
+      l = construct_layer<TensorDataType, T_layout, T_device>(comm,            \
+                                                              proto_layer);    \
     }                                                                          \
   } while (0)
 

--- a/src/proto/factories/model_factory.cpp
+++ b/src/proto/factories/model_factory.cpp
@@ -237,17 +237,13 @@ void assign_weights_to_objective_function(
 } // namespace
 
 std::unique_ptr<model> construct_model(lbann_comm* comm,
-                                       int training_dr_linearized_data_size,
                                        const lbann_data::Optimizer& proto_opt,
                                        const lbann_data::Trainer& proto_trainer,
                                        const lbann_data::Model& proto_model)
 {
 
   // Construct layer graph
-  auto layer_list = construct_layer_graph(comm,
-                                          training_dr_linearized_data_size,
-                                          proto_trainer,
-                                          proto_model);
+  auto layer_list = construct_layer_graph(comm, proto_trainer, proto_model);
 
   // Construct objective function
   const auto& proto_obj = proto_model.objective_function();

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -117,13 +117,8 @@ message Layer {
   // ===========================================
   // Deprecated options
   // ===========================================
-
-  /// Deprecated
-  bool num_neurons_from_data_reader = 400;
   /// Deprecated
   bool freeze = 401;
-  /// Deprecated and unused
-  repeated WeightsData weights_data = 402;
 
   // ===========================================
   // Concrete layer types

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -387,8 +387,7 @@ std::unique_ptr<model> build_model_from_prototext(
   lbann_data::LbannPB& pb,
   lbann_comm* comm,
   thread_pool& io_thread_pool,
-  std::vector<std::shared_ptr<callback_base>>& shared_callbacks,
-  int training_dr_linearized_data_size)
+  std::vector<std::shared_ptr<callback_base>>& shared_callbacks)
 {
 
   bool master = comm->am_world_master();
@@ -410,11 +409,7 @@ std::unique_ptr<model> build_model_from_prototext(
 
   // Initalize model
   std::unique_ptr<model> ret_model =
-    proto::construct_model(comm,
-                           training_dr_linearized_data_size,
-                           pb.optimizer(),
-                           pb.trainer(),
-                           pb.model());
+    proto::construct_model(comm, pb.optimizer(), pb.trainer(), pb.model());
 
   // Add the trainer's callbacks to the model
   for (auto&& c : shared_callbacks) {


### PR DESCRIPTION
* `Layer::get_sample_indices_per_mb` (unused)
* `construct_layer(..., training_dr_linearized_data_size, ...)` (The argument's existence was based on a deprecated feature)
* `construct_layer(..., num_parallel_readers, ...)` (unused)