### PR TITLE
Fix an error in buffer views

### DIFF
--- a/include/lbann/layers/transform/stop_gradient.hpp
+++ b/include/lbann/layers/transform/stop_gradient.hpp
@@ -78,7 +78,7 @@ protected:
   }
   void fp_setup_outputs(El::Int mini_batch_size) override
   {
-    El::LockedView(this->get_activations(), this->get_prev_activations());
+    El::View(this->get_activations(), this->get_prev_activations());
   }
   void fp_compute() override {}
 };


### PR DESCRIPTION
The `LockedView` is probably actually correct... in a world where the rest of the code is `const`-correct. But here we are.