### PR TITLE
Initial layer parallelism

### DIFF
--- a/applications/vision/lenet.py
+++ b/applications/vision/lenet.py
@@ -20,8 +20,8 @@ args = parser.parse_args()
 # ----------------------------------
 
 # Input data
-images = lbann.Input(data_field='samples')
-labels = lbann.Input(data_field='labels')
+images = lbann.Input(data_field='samples', grid_tag=0)
+labels = lbann.Input(data_field='labels', grid_tag=0)
 
 # LeNet
 x = lbann.Convolution(images,
@@ -31,13 +31,13 @@ x = lbann.Convolution(images,
                       kernel_size = 5,
                       stride = 1,
                       dilation = 1,
-                      has_bias = True)
-x = lbann.Relu(x)
+                      has_bias = True, grid_tag=1)
+x = lbann.Relu(x, grid_tag=1)
 x = lbann.Pooling(x,
                   num_dims = 2,
                   pool_dims_i = 2,
                   pool_strides_i = 2,
-                  pool_mode = "max")
+                  pool_mode = "max", grid_tag=1)
 x = lbann.Convolution(x,
                       num_dims = 2,
                       out_channels = 16,
@@ -45,23 +45,24 @@ x = lbann.Convolution(x,
                       kernel_size = 5,
                       stride = 1,
                       dilation = 1,
-                      has_bias = True)
-x = lbann.Relu(x)
+                      has_bias = True, grid_tag=1)
+x = lbann.Relu(x, grid_tag=1)
 x = lbann.Pooling(x,
                   num_dims = 2,
                   pool_dims_i = 2,
                   pool_strides_i = 2,
-                  pool_mode = "max")
-x = lbann.FullyConnected(x, num_neurons = 120, has_bias = True)
-x = lbann.Relu(x)
-x = lbann.FullyConnected(x, num_neurons = 84, has_bias = True)
-x = lbann.Relu(x)
-x = lbann.FullyConnected(x, num_neurons = 10, has_bias = True)
-probs = lbann.Softmax(x)
+                  pool_mode = "max", grid_tag=1)
+
+x = lbann.FullyConnected(x, num_neurons = 120, has_bias = True, grid_tag=2)
+x = lbann.Relu(x, grid_tag=2)
+x = lbann.FullyConnected(x, num_neurons = 84, has_bias = True, grid_tag=2)
+x = lbann.Relu(x, grid_tag=2)
+x = lbann.FullyConnected(x, num_neurons = 10, has_bias = True, grid_tag=2)
+probs = lbann.Softmax(x, grid_tag=2)
 
 # Loss function and accuracy
-loss = lbann.CrossEntropy(probs, labels)
-acc = lbann.CategoricalAccuracy(probs, labels)
+loss = lbann.CrossEntropy(probs, labels, grid_tag=2)
+acc = lbann.CategoricalAccuracy(probs, labels, grid_tag=2)
 
 # ----------------------------------
 # Setup experiment
@@ -95,4 +96,5 @@ trainer = lbann.Trainer(mini_batch_size=mini_batch_size)
 kwargs = lbann.contrib.args.get_scheduler_kwargs(args)
 lbann.contrib.launcher.run(trainer, model, data_reader, opt,
                            job_name=args.job_name,
+                           lbann_args=['--num-subgrids', '2'],
                            **kwargs)

--- a/applications/vision/lenet_lp.py
+++ b/applications/vision/lenet_lp.py
@@ -1,3 +1,7 @@
+"""
+Trains Lenet using 2 "grids" in a layer-parallel configuration.
+"""
+
 import argparse
 import lbann
 import data.mnist

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -121,6 +121,9 @@ public:
     return TypeName<OutputTensorDataType>();
   };
 
+  /** @brief Determine if we're participating in the compute on this process */
+  bool is_participating() const final;
+
   /** Forward propagation step.
    *  Apply a mathematical operation to input tensors to obtain output
    *  tensors.

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -122,7 +122,7 @@ public:
   };
 
   /** @brief Determine if we're participating in the compute on this process */
-  bool is_participating() const final;
+  bool is_participating() const override;
 
   /** Forward propagation step.
    *  Apply a mathematical operation to input tensors to obtain output

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -248,6 +248,12 @@ protected:
    */
   void setup_matrices(const std::vector<El::Grid*>& grids) override;
 
+  /** @brief Setup distributed matrices with "subgraph parallelism" logic */
+  virtual void do_setup_matrices_subgraph(std::vector<El::Grid*> const& grids);
+
+  /** @brief Setup all distributed matrices with given grid */
+  virtual void do_setup_matrices_simple(El::Grid const& grid);
+
   /** Setup layer data.
    *  Called by the 'setup' function. Memory is allocated for
    *  distributed matrices.

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -681,9 +681,10 @@ public:
   void grid_tag(int tag);
   ///@}
 
-  /** @brief Identifying tag for process grid */
+  /// @todo Unify Layer-Parallel and Subgraph-Parallel implementations
+  /** @brief Identifying tag for process grid (subgraph parallelism) */
   int get_grid_tag() const noexcept;
-  /** @brief Set process grid */
+  /** @brief Set process grid (subgraph parallelism) */
   void set_grid_tag(int tag);
 
   /** @name Hint layer access functions */

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -666,6 +666,14 @@ public:
   /** Get reference to LBANN communicator. */
   lbann_comm* get_comm() const;
 
+  /** @name Layer parallelism interface */
+  ///@{
+  /** @brief Get the "layer parallelism" grid tag. */
+  int grid_tag() const noexcept;
+  /** @brief Set the "layer parallelism" grid tag. */
+  void grid_tag(int tag);
+  ///@}
+
   /** @brief Identifying tag for process grid */
   int get_grid_tag() const noexcept;
   /** @brief Set process grid */
@@ -884,6 +892,32 @@ protected:
    * on layer traits and neighboring layers.
    */
   bool m_runs_inplace = false;
+
+  /** @name Layer parallelism */
+  ///@{
+
+  /** @brief The tag used to choose the grid.
+   *
+   *  During model setup, this will be checked. If it has not been set
+   *  (i.e., it is "-1"), then it will be chosen to match its parents
+   *  (which must all be on the same grid -- "transitional" layers
+   *  must be explicitly marked).
+   *
+   *  Temporary: While the legacy "subgraph parallelism"
+   *  infrastructure coexists, setup will also check that both this
+   *  and the subgraph-related "m_grid_tag" are not both set. If using
+   *  "subgraph", every layer will leave this as "-1" and the grid
+   *  setup will proceed according to the legacy subgraph setup.
+   *
+   *  After setup, this is guaranteed to be >= 0, except when the
+   *  legacy "subgraph" codepath is being used. The actual @c Grid
+   *  object can be retrieved through the activation matrices. These
+   *  are guaranteed to be assigned the "layer parallelism" grid, if
+   *  any.
+   */
+  int m_lp_grid_tag = -1;
+
+  ///@}
 
   // -------------------------------------------------------
   // Objects for sub-grid parallelism

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -911,7 +911,7 @@ protected:
    *  must be explicitly marked).
    *
    *  Temporary: While the legacy "subgraph parallelism"
-   *  infrastructure coexists, setup will also check that both this
+   *  infrastructure coexists, setup will also check that this
    *  and the subgraph-related "m_grid_tag" are not both set. If using
    *  "subgraph", every layer will leave this as "-1" and the grid
    *  setup will proceed according to the legacy subgraph setup.

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -375,6 +375,13 @@ public:
    */
   virtual El::Device get_device_allocation() const = 0;
 
+  /** @brief Get whether this layer participates on this process.
+   *
+   *  @note This is technically possible to implement here, but easier
+   *        in data_type_layer.
+   */
+  virtual bool is_participating() const = 0;
+
   /** @brief Get expected number of parent layers.
    *  A negative value indicates no limit.
    */

--- a/include/lbann/layers/transform/cross_grid_sum_slice.hpp
+++ b/include/lbann/layers/transform/cross_grid_sum_slice.hpp
@@ -164,7 +164,7 @@ protected:
       this->setup_reference_counter(output);
     }
   }
-
+  bool is_participating() const final { return true; }
   void bp_setup_gradient_wrt_inputs() override
   {
     auto children = this->get_child_layers();

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -116,7 +116,6 @@ protected:
 
   void fp_setup_outputs() override
   {
-
     const auto& input = this->get_prev_activations();
     auto mini_batch_size =
       this->infer_mini_batch_size_from_parents_or_default_to_current();
@@ -129,6 +128,8 @@ protected:
                                                           El::VC,
                                                           El::ELEMENT,
                                                           Dev> const*>(&input);
+      LBANN_ASSERT(ptr_input);
+
       int tag = 0;
       auto childs = this->get_child_layers();
       if (this->get_communication_flag() == COLL_OPT) {

--- a/include/lbann/optimizers/data_type_optimizer.hpp
+++ b/include/lbann/optimizers/data_type_optimizer.hpp
@@ -97,14 +97,6 @@ public:
   /** @name Gradient update management */
   ///@{
 
-  /** @brief Get the full objective function gradient w.r.t. the weights,
-   *  synchronized across all ranks in the trainer.
-   *
-   *  A collective operation (allreduce or allgather) may be launched and/or
-   *  synchronized if needed.
-   */
-  std::unique_ptr<AbsDistMatrixType> get_gradient();
-
   /** @brief Get the raw objective function gradient w.r.t. the weights,
    *  synchronized across all ranks in the trainer. This may be a local sharded
    *  version and not contain the gradients of all weights, but it will

--- a/include/lbann/optimizers/data_type_optimizer_impl.hpp
+++ b/include/lbann/optimizers/data_type_optimizer_impl.hpp
@@ -94,32 +94,6 @@ auto data_type_optimizer<TensorDataType>::get_weights() const
 }
 
 template <typename TensorDataType>
-auto data_type_optimizer<TensorDataType>::get_gradient()
-  -> std::unique_ptr<AbsDistMatrixType>
-{
-  auto matrix_dist = std::get<2>(this->get_matrix_info());
-
-  // Create a new matrix with the correct value distribution (usually STAR_STAR)
-  // and copy the values from there.
-  std::unique_ptr<AbsDistMatrixType> result;
-  result.reset(AbsDistMatrixType::Instantiate(*matrix_dist.grid,
-                                              matrix_dist.root,
-                                              matrix_dist.colDist,
-                                              matrix_dist.rowDist,
-                                              El::ELEMENT,
-                                              matrix_dist.device));
-
-  // If the gradient is not sharded, return a view
-  if (!this->is_sharded()) {
-    El::LockedView(*result, *m_gradient);
-  }
-  else {
-    El::Copy(*m_gradient, *result);
-  }
-  return result;
-}
-
-template <typename TensorDataType>
 auto data_type_optimizer<TensorDataType>::get_gradient_sharded()
   -> AbsDistMatrixType&
 {

--- a/include/lbann/optimizers/optimizer_impl.hpp
+++ b/include/lbann/optimizers/optimizer_impl.hpp
@@ -100,6 +100,10 @@ public:
 
   void start_sync(lbann_comm& comm) override
   {
+    if (!global_gradient_->Participating()) {
+      return;
+    }
+
     // Complete outstanding synchronization of the same data type
     static GradientHelperImpl<TensorDataType>* lastsync = nullptr;
     if (lastsync != nullptr) {
@@ -148,6 +152,10 @@ public:
 
   void complete_sync(lbann_comm& comm) override
   {
+    if (!global_gradient_->Participating()) {
+      return;
+    }
+
     switch (this->get_status()) {
     case optimizer_gradient_status::sync_started:
       comm.wait(sync_req_);
@@ -286,6 +294,10 @@ void optimizer::accumulate_all_gradient_contributions(
 {
   using AbsDistMatType = El::AbstractDistMatrix<TensorDataType>;
   static const TensorDataType one = TensorDataType(1.f);
+
+  if (!gradient.Participating()) {
+    return;
+  }
 
   // There are a few cases to note here:
   //   1. One update of the same type.

--- a/include/lbann/utils/summary_impl.hpp
+++ b/include/lbann/utils/summary_impl.hpp
@@ -27,8 +27,8 @@
 #ifndef LBANN_SUMMARY_IMPL_HPP_INCLUDED
 #define LBANN_SUMMARY_IMPL_HPP_INCLUDED
 
-#include "lbann/utils/summary.hpp"
 #include "lbann/utils/profiling.hpp"
+#include "lbann/utils/summary.hpp"
 
 namespace lbann {
 

--- a/include/lbann/utils/summary_impl.hpp
+++ b/include/lbann/utils/summary_impl.hpp
@@ -48,7 +48,7 @@ lbann_summary::reduce_mean(const std::string tag,
   El::DistData mat_format(mat);
   if (mat_format.colDist == El::STAR && mat_format.rowDist == El::STAR) {
     // Compute local sum on master process if matrix is Star,Star
-    if (m_comm->am_trainer_master()) {
+    if (mat.RedundantRank() == 0) {
       sum = local_sum(mat.LockedMatrix());
     }
   }
@@ -105,7 +105,7 @@ lbann_summary::reduce_stdev(const std::string tag,
   El::DistData mat_format(mat);
   if (mat_format.colDist == El::STAR && mat_format.rowDist == El::STAR) {
     // Compute local sums on master process if matrix is Star,Star
-    if (m_comm->am_trainer_master()) {
+    if (mat.RedundantRank() == 0) {
       local_sum_sqsum(mat.LockedMatrix(), sum, sqsum);
     }
   }
@@ -129,7 +129,7 @@ template <typename TensorDataType>
 inline void
 lbann_summary::reduce_scalar(const std::string tag, TensorDataType s, int step)
 {
-  if (m_comm->am_trainer_master()) {
+  if (mat.RedundantRank() == 0) {
     m_pending_scalars.emplace_back(tag, step, s);
   }
 }
@@ -166,7 +166,7 @@ inline void lbann_summary::reduce_histogram(
   El::DistData mat_format(mat);
   if (mat_format.colDist == El::STAR && mat_format.rowDist == El::STAR) {
     // Compute local sums on master process if matrix is Star,Star
-    if (m_comm->am_trainer_master()) {
+    if (mat.RedundantRank() == 0) {
       local_sum_sqsum(mat.LockedMatrix(), sum, sqsum);
     }
   }

--- a/include/lbann/utils/tensor_impl.hpp
+++ b/include/lbann/utils/tensor_impl.hpp
@@ -153,9 +153,13 @@ void view_or_copy_tensor(const BaseDistMat& src,
 
   if (src.DistData() == tgt.DistData()) {
     if (locked_view) {
-      El::LockedView(tgt, dynamic_cast<const El::AbstractDistMatrix<TDT>&>(src));
-    } else {
-      El::View(tgt, dynamic_cast<El::AbstractDistMatrix<TDT>&>(const_cast<BaseDistMat&>(src)));
+      El::LockedView(tgt,
+                     dynamic_cast<const El::AbstractDistMatrix<TDT>&>(src));
+    }
+    else {
+      El::View(tgt,
+               dynamic_cast<El::AbstractDistMatrix<TDT>&>(
+                 const_cast<BaseDistMat&>(src)));
     }
   }
   else {

--- a/include/lbann/utils/tensor_impl.hpp
+++ b/include/lbann/utils/tensor_impl.hpp
@@ -53,12 +53,7 @@ void do_tensor_copy(const BaseDistMat& src, El::AbstractDistMatrix<TDT>& tgt)
     El::CopyAsync(src, tgt);
   }
   else {
-    if (src.DistData().grid == tgt.DistData().grid) {
-      El::Copy(src, tgt);
-    }
-    else {
-      utils::details::do_tensor_copy_between_grids(src, tgt);
-    }
+    El::Copy(src, tgt);
   }
 }
 

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -37,6 +37,7 @@ class Layer(abc.ABC):
                  data_layout=None,
                  datatype=None,
                  hint_layer=None,
+                 grid_tag=None,
                  parallel_strategy={}):
         Layer.global_count += 1
         self.parents = []
@@ -47,6 +48,7 @@ class Layer(abc.ABC):
         self.data_layout = data_layout
         self.datatype = datatype
         self.hint_layer = hint_layer
+        self.grid_tag = { 'value': grid_tag } if grid_tag else {}
         self.parallel_strategy = parallel_strategy if parallel_strategy else {}
 
         # Initialize parents, children, and weights
@@ -71,6 +73,11 @@ class Layer(abc.ABC):
             proto.datatype = self.datatype
         if self.hint_layer:
             proto.hint_layer = self.hint_layer.name
+        if self.grid_tag:
+            lbann.core.util.set_protobuf_message(
+                proto.grid_tag ,
+                **self.grid_tag)
+            proto.grid_tag.SetInParent()
         if self.parallel_strategy:
             lbann.core.util.set_protobuf_message(proto.parallel_strategy,
                                                  **self.parallel_strategy)
@@ -108,17 +115,16 @@ class Layer(abc.ABC):
 if layers_pb2:
     classes = lbann.core.util.generate_classes_from_protobuf_message(
         layers_pb2.Layer,
-        skip_fields=set([
+        skip_fields = set([
             'name', 'parents', 'children', 'data_layout', 'device_allocation',
-            'datatype', 'weights', 'freeze', 'hint_layer', 'parallel_strategy',
-            'top', 'bottom', 'type', 'motif_layer'
-        ]),
-        base_class=Layer,
-        base_kwargs=set([
-            'parents', 'children', 'weights', 'name', 'device', 'data_layout',
-            'datatype', 'hint_layer', 'parallel_strategy'
-        ]),
-        base_has_export_proto=True)
+            'datatype', 'weights', 'freeze', 'hint_layer', 'grid_tag',
+            'parallel_strategy', 'top', 'bottom', 'type', 'motif_layer']),
+        base_class = Layer,
+        base_kwargs = set([
+            'parents', 'children', 'weights',
+            'name', 'device', 'data_layout', 'datatype', 'hint_layer', 'grid_tag',
+            'parallel_strategy']),
+        base_has_export_proto = True)
     for c in classes:
         globals()[c.__name__] = c
 

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -48,7 +48,7 @@ class Layer(abc.ABC):
         self.data_layout = data_layout
         self.datatype = datatype
         self.hint_layer = hint_layer
-        self.grid_tag = { 'value': grid_tag } if grid_tag else {}
+        self.grid_tag = { 'value': grid_tag } if grid_tag is not None else {}
         self.parallel_strategy = parallel_strategy if parallel_strategy else {}
 
         # Initialize parents, children, and weights

--- a/python/lbann/core/layer.py
+++ b/python/lbann/core/layer.py
@@ -38,7 +38,7 @@ class Layer(abc.ABC):
                  datatype=None,
                  hint_layer=None,
                  grid_tag=None,
-                 parallel_strategy={}):
+                 parallel_strategy=None):
         Layer.global_count += 1
         self.parents = []
         self.children = []

--- a/src/callbacks/check_dataset.cpp
+++ b/src/callbacks/check_dataset.cpp
@@ -65,15 +65,12 @@ void check_dataset::add_to_set(model* m,
     return;
   }
 
-  // FIXME (trb 10/03/2023): This is not the "right" fix (which is
-  // probably to reconsider this callback entirely, but this is the
-  // drop-in replacement for the line that was here
-  // (l->get_sample_indices_per_mb(), which just returns 'nullptr'
-  // (which is never checked, of course, so the loop below would
-  // segfault almost instantly))).
+  // FIXME (trb 10/03/2023): It is probably best to reconsider this
+  // callback entirely.
   auto const mode = m->get_execution_context().get_execution_mode();
   El::Matrix<El::Int> const* const indices =
     get_trainer().get_data_coordinator().get_sample_indices_per_mb(mode);
+  LBANN_ASSERT((bool) indices);
 
   for (El::Int j = 0; j < indices->Width(); j++) {
     for (El::Int i = 0; i < indices->Height(); i++) {

--- a/src/callbacks/check_nan.cpp
+++ b/src/callbacks/check_nan.cpp
@@ -168,8 +168,8 @@ struct DumpWeightsFunctor : DefaultErrorReporter
     El::Write(dtw.get_values().LockedMatrix(), prefix + "Weights", El::ASCII);
     auto* opt = dtw.get_optimizer();
     if (opt != nullptr) {
-      auto grad = opt->get_gradient();
-      El::Write(grad->LockedMatrix(), prefix + "Gradient", El::ASCII);
+      auto& grad = opt->get_gradient_sharded();
+      El::Write(grad.LockedMatrix(), prefix + "Gradient", El::ASCII);
     }
   }
 }; // struct DumpWeightsFunctor
@@ -323,8 +323,8 @@ void check_nan::on_backward_prop_end(model* m)
     auto* opt = dtw.get_optimizer();
     if (opt != nullptr) {
       El::Int row, col;
-      auto grad = opt->get_gradient();
-      proxy_type mat_proxy(*grad);
+      auto& grad = opt->get_gradient_sharded();
+      proxy_type mat_proxy(grad);
       if (has_nan(mat_proxy.GetLocked(), row, col)) {
         dump_network(m);
         LBANN_ERROR("rank ",

--- a/src/callbacks/dump_error_signals.cpp
+++ b/src/callbacks/dump_error_signals.cpp
@@ -56,6 +56,8 @@ void dump_error_signals::on_backward_prop_end(model* m, Layer* l)
 
   // Write each activation matrix to file
   for (int i = 0; i < l->get_num_parents(); ++i) {
+    if (!l->is_participating())
+      continue;
 
     // File name
     std::stringstream file;

--- a/src/callbacks/dump_gradients.cpp
+++ b/src/callbacks/dump_gradients.cpp
@@ -70,8 +70,10 @@ void dump_gradients::on_backward_prop_end(model* m)
          std::to_string(c.get_epoch()) + "-step" +
          std::to_string(c.get_step()) + "-" + w->get_name() + "-Gradient");
       auto* dt_opt = dynamic_cast<data_type_optimizer<DataType>*>(opt);
-      auto grad = dt_opt->get_gradient();
-      El::Write(*grad, file, El::ASCII);
+      auto& grad = dt_opt->get_gradient_sharded();
+      if (grad.Participating()) {
+        El::Write(grad, file, El::ASCII);
+      }
     }
   }
 }

--- a/src/callbacks/summary.cpp
+++ b/src/callbacks/summary.cpp
@@ -172,8 +172,8 @@ void summary::save_histograms(model* m)
     optimizer* opt = w->get_optimizer();
     if (opt != nullptr) {
       auto* dt_opt = dynamic_cast<OptimizerType*>(opt);
-      auto grad = dt_opt->get_gradient();
-      AbsDistMatReadProxy<El::Device::CPU> gradients(*grad);
+      auto& grad = dt_opt->get_gradient_sharded();
+      AbsDistMatReadProxy<El::Device::CPU> gradients(grad);
       m_summarizer->reduce_histogram(prefix + "weights_gradient",
                                      gradients.GetLocked(),
                                      c.get_step());

--- a/src/execution_algorithms/kfac/kfac_block_channelwise_fc.cpp
+++ b/src/execution_algorithms/kfac/kfac_block_channelwise_fc.cpp
@@ -414,7 +414,7 @@ void kfac_block_channelwise_fc<Device>::compute_preconditioned_gradients(
       // BVE FIXME unused variable
       // auto* b_dto =
       // dynamic_cast<data_type_optimizer<DataType>*>(b_optimizer); const auto&
-      // b_grads_orig = b_dto->get_gradient().LockedMatrix();
+      // b_grads_orig = b_dto->get_gradient_sharded().LockedMatrix();
 
       auto& grad_buffer_biases =
         b_optimizer->get_gradient_buffer(dst_scale, gradient_scale, false);

--- a/src/execution_algorithms/kfac/kfac_block_fc_conv.cpp
+++ b/src/execution_algorithms/kfac/kfac_block_fc_conv.cpp
@@ -463,7 +463,7 @@ void kfac_block_fc_conv<Device>::compute_preconditioned_gradients(
       // BVE FIXME unused variable
       // auto* b_dto =
       // dynamic_cast<data_type_optimizer<DataType>*>(b_optimizer); const auto&
-      // b_grads_orig = b_dto->get_gradient().LockedMatrix();
+      // b_grads_orig = b_dto->get_gradient_sharded().LockedMatrix();
 
       auto& grad_buffer_biases =
         b_optimizer->get_gradient_buffer(dst_scale, gradient_scale, false);

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -167,9 +167,6 @@ modify_reference_counter(PointerRangeReferenceCounter& refcnt,
 template <typename InputTensorDataType, typename OutputTensorDataType>
 void data_type_layer<InputTensorDataType, OutputTensorDataType>::forward_prop()
 {
-  if (!this->is_participating())
-    return;
-
   // This bit is preprocessed out since the LBANN_CALIPER macro
   // won't help us out here.
 #ifdef LBANN_HAS_CALIPER
@@ -223,6 +220,7 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::forward_prop()
 #endif // LBANN_HAS_DISTCONV
 
   // Apply layer's compute function
+  if (this->is_participating())
   {
     LBANN_CALIPER_MARK_SCOPE(("fp_compute:" + this->get_name()).c_str());
     const auto fp_compute_start = get_time();

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -87,6 +87,8 @@ data_type_layer<InputTensorDataType, OutputTensorDataType>::operator=(
 template <typename InT, typename OutT>
 bool data_type_layer<InT, OutT>::is_participating() const
 {
+  if (this->subgraph_parallelism_execution())
+    return true;
   if (this->get_num_children() > 0)
     return this->get_activations().Participating();
   if (this->get_num_parents() > 0)

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -84,6 +84,19 @@ data_type_layer<InputTensorDataType, OutputTensorDataType>::operator=(
   return *this;
 }
 
+template <typename InT, typename OutT>
+bool data_type_layer<InT, OutT>::is_participating() const
+{
+  if (this->get_num_children() > 0)
+    return this->get_activations().Participating();
+  if (this->get_num_parents() > 0)
+    return this->get_prev_activations().Participating();
+
+  LBANN_ERROR("Layer \"", this->get_name(), "\" has no children "
+              "and no parents; cannot determine grid.");
+  return false;
+}
+
 template <typename InputTensorDataType, typename OutputTensorDataType>
 El::Int
 data_type_layer<InputTensorDataType,
@@ -154,6 +167,9 @@ modify_reference_counter(PointerRangeReferenceCounter& refcnt,
 template <typename InputTensorDataType, typename OutputTensorDataType>
 void data_type_layer<InputTensorDataType, OutputTensorDataType>::forward_prop()
 {
+  if (!this->is_participating())
+    return;
+
   // This bit is preprocessed out since the LBANN_CALIPER macro
   // won't help us out here.
 #ifdef LBANN_HAS_CALIPER

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -777,67 +777,22 @@ auto MakeMatBuilder(data_layout const layout, El::Device const device)
 
 } // namespace
 
-template <typename InputTensorDataType, typename OutputTensorDataType>
-void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
-  const std::vector<El::Grid*>& grids)
+template <typename InT, typename OutT>
+void data_type_layer<InT, OutT>::do_setup_matrices_subgraph(
+  std::vector<El::Grid*> const& grids)
 {
-
-  LBANN_CALIPER_MARK_FUNCTION;
-  using InputMatrixBuilderType = details::MatrixBuilder<InputTensorDataType>;
-  using OutputMatrixBuilderType = details::MatrixBuilder<OutputTensorDataType>;
-
-  // DEBUG
-  {
-    char* keep_error_signals = getenv("LBANN_KEEP_ERROR_SIGNALS");
-    if (!keep_error_signals || (std::stoi(keep_error_signals) == 0))
-      m_persistent_error_signals = false;
-    else
-      m_persistent_error_signals = true;
-  }
-
-  // If no CUB, force persistent error signals:
-#if defined(HYDROGEN_HAVE_GPU) && !defined(HYDROGEN_HAVE_CUB)
-  if (this->get_device_allocation() == El::Device::GPU)
-    m_persistent_error_signals = true;
-#endif
+  // Only to be called in subgraph_parallelism land.
+  LBANN_ASSERT(this->get_model()->is_subgraph_parallelism_enabled());
 
   // Figure out how to make new matrices
-  std::unique_ptr<InputMatrixBuilderType> input_mat_builder =
-    MakeMatBuilder<InputTensorDataType>(this->get_data_layout(),
-                                        this->get_device_allocation());
-  std::unique_ptr<OutputMatrixBuilderType> output_mat_builder =
-    MakeMatBuilder<OutputTensorDataType>(this->get_data_layout(),
-                                         this->get_device_allocation());
+  auto input_mat_builder =
+    MakeMatBuilder<InT>(this->get_data_layout(), this->get_device_allocation());
+  auto output_mat_builder = MakeMatBuilder<OutT>(this->get_data_layout(),
+                                                 this->get_device_allocation());
 
-  // Destroy previously setup matrices
-  m_inputs.clear();
-  m_outputs.clear();
-  m_gradient_wrt_outputs.clear();
-  m_gradient_wrt_inputs.clear();
-  m_temp_grad.clear();
-  m_subgrid_tensors_split.clear();
-
-  // Construct matrices
-  m_inputs.resize(get_num_parents());
-  m_outputs.resize(get_num_children());
-  m_gradient_wrt_outputs.resize(get_num_children());
-  m_gradient_wrt_inputs.resize(get_num_parents());
-  m_temp_grad.resize(1);
-  m_subgrid_tensors_split.resize(1);
-
-  int tag = this->get_grid_tag();
-  const El::Grid& grid = *grids[tag];
-
-  // If any of the parents reside on different subgrids, do not run in-place
-  if (this->m_runs_inplace) {
-    for (int i = 0; i < get_num_parents(); ++i) {
-      const auto& parent = get_parent_layer(i);
-      if (parent.get_grid_tag() != tag) {
-        this->m_runs_inplace = false;
-        break;
-      }
-    }
-  }
+  int const tag = this->get_grid_tag();
+  LBANN_ASSERT(0 <= tag && tag < static_cast<int>(grids.size()));
+  auto const& grid = *grids[tag];
 
   if (grid.InGrid())
     this->set_run_layer_in_subgraph();
@@ -846,7 +801,6 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
   auto parents = get_parent_layers();
 
   if ((this->get_type() == "split" || this->get_type() == "slice") &&
-      this->get_model()->is_subgraph_parallelism_enabled() &&
       this->subgraph_parallelism_execution()) {
 
     // split layer
@@ -895,8 +849,7 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
     // create interprocess subgrid communicator
   }
   else if ((get_type() == "cross_grid_sum" ||
-            get_type() == "cross_grid_sum_slice") &&
-           this->get_model()->is_subgraph_parallelism_enabled()) {
+            get_type() == "cross_grid_sum_slice")) {
     m_subgrid_tensors_split.clear();
     m_subgrid_tensors_split.resize(childs[0]->get_num_spliting_groups());
 
@@ -933,7 +886,6 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
     }
   }
   else if ((get_type() == "sum" || this->get_type() == "concatenate") &&
-           this->get_model()->is_subgraph_parallelism_enabled() &&
            this->subgraph_parallelism_execution()) {
     // sum layer
 
@@ -973,29 +925,104 @@ void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
     }
   }
   else {
+    this->do_setup_matrices_simple(grid);
+  }
+}
 
-    for (auto& input : m_inputs) {
-      input = input_mat_builder->MakeEmpty(grid, 0);
+template <typename InT, typename OutT>
+void data_type_layer<InT, OutT>::do_setup_matrices_simple(El::Grid const& grid)
+{
+  // Figure out how to make new matrices
+  auto input_mat_builder =
+    MakeMatBuilder<InT>(this->get_data_layout(), this->get_device_allocation());
+  auto output_mat_builder = MakeMatBuilder<OutT>(this->get_data_layout(),
+                                                 this->get_device_allocation());
+
+  for (auto& input : m_inputs) {
+    input = input_mat_builder->MakeEmpty(grid, 0);
+  }
+
+  for (auto& output : m_outputs) {
+    output = output_mat_builder->MakeEmpty(grid, 0);
+  }
+
+  for (auto& grad_wrt_output : m_gradient_wrt_outputs) {
+    grad_wrt_output = output_mat_builder->MakeEmpty(grid, 0);
+  }
+
+  for (auto& grad_wrt_input : m_gradient_wrt_inputs) {
+    grad_wrt_input = input_mat_builder->MakeEmpty(grid, 0);
+  }
+
+  // FIXME (trb 09/29/2023): We should probably skip these if we're
+  // not doing subgraph stuff.
+  for (auto& temp_grad : m_temp_grad) {
+    temp_grad = output_mat_builder->MakeEmpty(grid, 0);
+  }
+  for (auto& subgrid_tensor : m_subgrid_tensors_split) {
+    subgrid_tensor = output_mat_builder->MakeEmpty(grid, 0);
+  }
+}
+
+template <typename InputTensorDataType, typename OutputTensorDataType>
+void data_type_layer<InputTensorDataType, OutputTensorDataType>::setup_matrices(
+  const std::vector<El::Grid*>& grids)
+{
+
+  LBANN_CALIPER_MARK_FUNCTION;
+
+  // DEBUG
+  {
+    char* keep_error_signals = getenv("LBANN_KEEP_ERROR_SIGNALS");
+    if (!keep_error_signals || (std::stoi(keep_error_signals) == 0))
+      m_persistent_error_signals = false;
+    else
+      m_persistent_error_signals = true;
+  }
+
+  // If no CUB, force persistent error signals:
+#if defined(HYDROGEN_HAVE_GPU) && !defined(HYDROGEN_HAVE_CUB)
+  if (this->get_device_allocation() == El::Device::GPU)
+    m_persistent_error_signals = true;
+#endif
+
+  // Destroy previously setup matrices
+  m_inputs.clear();
+  m_outputs.clear();
+  m_gradient_wrt_outputs.clear();
+  m_gradient_wrt_inputs.clear();
+  m_temp_grad.clear();
+  m_subgrid_tensors_split.clear();
+
+  // Construct matrices
+  m_inputs.resize(get_num_parents());
+  m_outputs.resize(get_num_children());
+  m_gradient_wrt_outputs.resize(get_num_children());
+  m_gradient_wrt_inputs.resize(get_num_parents());
+  m_temp_grad.resize(1);
+  m_subgrid_tensors_split.resize(1);
+
+  if (this->get_model()->is_subgraph_parallelism_enabled()) {
+    // If any of the parents reside on different subgrids, do not run in-place
+    int const tag = this->get_grid_tag();
+    if (this->m_runs_inplace) {
+      for (int i = 0; i < get_num_parents(); ++i) {
+        const auto& parent = get_parent_layer(i);
+        if (parent.get_grid_tag() != tag) {
+          this->m_runs_inplace = false;
+          break;
+        }
+      }
     }
 
-    for (auto& output : m_outputs) {
-      output = output_mat_builder->MakeEmpty(grid, 0);
-    }
-
-    for (auto& grad_wrt_output : m_gradient_wrt_outputs) {
-      grad_wrt_output = output_mat_builder->MakeEmpty(grid, 0);
-    }
-
-    for (auto& grad_wrt_input : m_gradient_wrt_inputs) {
-      grad_wrt_input = input_mat_builder->MakeEmpty(grid, 0);
-    }
-
-    for (auto& temp_grad : m_temp_grad) {
-      temp_grad = output_mat_builder->MakeEmpty(grid, 0);
-    }
-    for (auto& subgrid_tensor : m_subgrid_tensors_split) {
-      subgrid_tensor = output_mat_builder->MakeEmpty(grid, 0);
-    }
+    this->do_setup_matrices_subgraph(grids);
+  }
+  else {
+    // Use the "layer parallel" tag. If no layer-parallelism
+    int const tag = std::max(this->grid_tag(), 0);
+    LBANN_ASSERT(tag < static_cast<int>(grids.size()));
+    LBANN_ASSERT(grids[tag]);
+    this->do_setup_matrices_simple(*grids[tag]);
   }
 
 #ifdef LBANN_HAS_GPU

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -322,6 +322,7 @@ void data_type_layer<InputTensorDataType,
 #endif // LBANN_HAS_DISTCONV
 
   // Backprop the compute function.
+  if (this->is_participating())
   {
     LBANN_CALIPER_MARK_SCOPE(("bp_compute" + this->get_name()).c_str());
     const auto bp_compute_start = get_time();

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -251,9 +251,27 @@ lbann_comm* Layer::get_comm() const
   return m_model->get_comm();
 }
 
+// Layer parallelism
+int Layer::grid_tag() const noexcept { return m_lp_grid_tag; }
+
+// Layer parallelism
+void Layer::grid_tag(int tag)
+{
+  LBANN_ASSERT(tag >= 0);         // This tag is valid
+  LBANN_ASSERT(m_grid_tag == -1); // The subgraph tag is not set
+  m_lp_grid_tag = tag;
+}
+
+// Subgraph parallelism
 int Layer::get_grid_tag() const noexcept { return m_grid_tag; }
 
-void Layer::set_grid_tag(int tag) { m_grid_tag = tag; }
+// Subgraph parallelism
+void Layer::set_grid_tag(int tag)
+{
+  LBANN_ASSERT(tag == -1 ||
+               m_lp_grid_tag == -1); // the layer parallel tag is not set
+  m_grid_tag = tag;
+}
 
 bool Layer::update()
 {

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -772,6 +772,9 @@ void Layer::remove_as_gradient_source()
 
 void Layer::back_prop()
 {
+  if (!this->is_participating())
+    return;
+
   // This bit is preprocessed out since the LBANN_CALIPER macro
   // won't help us out here.
 #ifdef LBANN_HAS_CALIPER

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -215,6 +215,7 @@ description Layer::get_description() const
 
   // Sub-grid
   desc.add("Process grid", get_grid_tag());
+  desc.add("LP grid", grid_tag());
 
   // Freeze state
   if (is_frozen()) {
@@ -779,10 +780,8 @@ void Layer::back_prop()
   LBANN_CALIPER_MARK_SCOPE(scope_name.c_str());
 #endif
 
-  if (this->is_participating()) {
-    allocate_new_gradients_();
-    back_prop_impl_();
-  }
+  allocate_new_gradients_();
+  back_prop_impl_();
   propagate_error_signals_to_parents_();
   clear_prev_error_signals_();
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -215,7 +215,7 @@ description Layer::get_description() const
 
   // Sub-grid
   desc.add("Process grid", get_grid_tag());
-  desc.add("LP grid", grid_tag());
+  desc.add("Layer-Parallel grid", grid_tag());
 
   // Freeze state
   if (is_frozen()) {

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -772,9 +772,6 @@ void Layer::remove_as_gradient_source()
 
 void Layer::back_prop()
 {
-  if (!this->is_participating())
-    return;
-
   // This bit is preprocessed out since the LBANN_CALIPER macro
   // won't help us out here.
 #ifdef LBANN_HAS_CALIPER
@@ -782,8 +779,10 @@ void Layer::back_prop()
   LBANN_CALIPER_MARK_SCOPE(scope_name.c_str());
 #endif
 
-  allocate_new_gradients_();
-  back_prop_impl_();
+  if (this->is_participating()) {
+    allocate_new_gradients_();
+    back_prop_impl_();
+  }
   propagate_error_signals_to_parents_();
   clear_prev_error_signals_();
 

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -681,8 +681,6 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_dnn(
     (local_input.Height() > 0 && local_input.Width() > 0 &&
      local_gradient_wrt_output.Height() > 0 &&
      local_gradient_wrt_output.Width() > 0);
-  if (!has_local_data)
-    return;
 
   // Compute bias gradient
   if (m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero() &&
@@ -987,8 +985,6 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_im2col(
     this->get_local_prev_error_signals();
   const bool has_local_data =
     (!local_input.IsEmpty() && !local_gradient_wrt_output.IsEmpty());
-  if (!has_local_data)
-    return;
 
   // Get convolution parameters
   const El::Int local_width = local_input.Width();

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -678,6 +678,8 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_dnn(
     (local_input.Height() > 0 && local_input.Width() > 0 &&
      local_gradient_wrt_output.Height() > 0 &&
      local_gradient_wrt_output.Width() > 0);
+  if (!has_local_data)
+    return;
 
   // Compute bias gradient
   if (m_bias_scaling_factor != El::TypeTraits<ScalingType>::Zero() &&
@@ -978,6 +980,8 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_im2col(
     this->get_local_prev_error_signals();
   const bool has_local_data =
     (!local_input.IsEmpty() && !local_gradient_wrt_output.IsEmpty());
+  if (!has_local_data)
+    return;
 
   // Get convolution parameters
   const El::Int local_width = local_input.Width();

--- a/src/layers/learning/base_convolution.cpp
+++ b/src/layers/learning/base_convolution.cpp
@@ -439,11 +439,12 @@ void base_convolution_layer<TensorDataType, Device>::setup_gpu()
                         kernel_dims);
 
   // Set convolution descriptor
-  m_convolution_dnn_desc.set(m_pads,
-                             m_strides,
-                             m_dilations,
-                             dnn_lib::get_convolution_data_type<TensorDataType>(),
-                             dnn_lib::DNN_CROSS_CORRELATION);
+  m_convolution_dnn_desc.set(
+    m_pads,
+    m_strides,
+    m_dilations,
+    dnn_lib::get_convolution_data_type<TensorDataType>(),
+    dnn_lib::DNN_CROSS_CORRELATION);
   m_convolution_dnn_desc.set_math_mode(m_convolution_math_type);
   m_convolution_dnn_desc.set_group_count(m_groups);
 
@@ -611,32 +612,34 @@ void base_convolution_layer<TensorDataType, Device>::
 
   // Perform transposed convolution on the GPU
   // Determine transposed convolution algorithm and math mode.
-  dnn_lib::bwd_data_conv_alg_config transposed_convolution_dnn_algorithm_config =
-    get_backward_data_algo_dnn(input.Width(),
-                               m_kernel_dnn_desc,
-                               kernel.LockedBuffer(),
-                               input_desc,
-                               input.LockedBuffer(),
-                               m_convolution_dnn_desc,
-                               output_desc,
-                               output.Buffer(),
-                               workspace_size,
-                               workspace.Buffer());
+  dnn_lib::bwd_data_conv_alg_config
+    transposed_convolution_dnn_algorithm_config =
+      get_backward_data_algo_dnn(input.Width(),
+                                 m_kernel_dnn_desc,
+                                 kernel.LockedBuffer(),
+                                 input_desc,
+                                 input.LockedBuffer(),
+                                 m_convolution_dnn_desc,
+                                 output_desc,
+                                 output.Buffer(),
+                                 workspace_size,
+                                 workspace.Buffer());
 
   // Perform transposed convolution
   m_convolution_dnn_desc.set_math_mode(
     transposed_convolution_dnn_algorithm_config.second);
-  dnn_lib::convolution_backward_data(one,
-                                     m_kernel_dnn_desc,
-                                     kernel.LockedMatrix(),
-                                     input_desc,
-                                     input,
-                                     m_convolution_dnn_desc,
-                                     transposed_convolution_dnn_algorithm_config.first,
-                                     workspace,
-                                     zero,
-                                     output_desc,
-                                     output);
+  dnn_lib::convolution_backward_data(
+    one,
+    m_kernel_dnn_desc,
+    kernel.LockedMatrix(),
+    input_desc,
+    input,
+    m_convolution_dnn_desc,
+    transposed_convolution_dnn_algorithm_config.first,
+    workspace,
+    zero,
+    output_desc,
+    output);
 
 #endif // LBANN_HAS_DNN_LIB
 }
@@ -743,29 +746,31 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_dnn(
                                                        multisync);
         workspace.Resize(workspace_size / sizeof(TensorDataType), 1);
         workspace_size = workspace.Height() * sizeof(TensorDataType);
-        dnn_lib::bwd_filter_conv_alg_config kernel_gradient_dnn_algorithm_config =
-          get_backward_filter_algo_dnn(local_input.Width(),
-                                       gradient_wrt_output_desc,
-                                       local_gradient_wrt_output.LockedBuffer(),
-                                       input_desc,
-                                       local_input.LockedBuffer(),
-                                       m_convolution_dnn_desc,
-                                       m_kernel_dnn_desc,
-                                       workspace_size,
-                                       workspace.Buffer());
+        dnn_lib::bwd_filter_conv_alg_config
+          kernel_gradient_dnn_algorithm_config = get_backward_filter_algo_dnn(
+            local_input.Width(),
+            gradient_wrt_output_desc,
+            local_gradient_wrt_output.LockedBuffer(),
+            input_desc,
+            local_input.LockedBuffer(),
+            m_convolution_dnn_desc,
+            m_kernel_dnn_desc,
+            workspace_size,
+            workspace.Buffer());
         m_convolution_dnn_desc.set_math_mode(
           kernel_gradient_dnn_algorithm_config.second);
-        dnn_lib::convolution_backward_filter(gradient_scale,
-                                             gradient_wrt_output_desc,
-                                             local_gradient_wrt_output,
-                                             input_desc,
-                                             local_input,
-                                             m_convolution_dnn_desc,
-                                             kernel_gradient_dnn_algorithm_config.first,
-                                             workspace,
-                                             dst_scale,
-                                             m_kernel_dnn_desc,
-                                             kernel_gradient.Matrix());
+        dnn_lib::convolution_backward_filter(
+          gradient_scale,
+          gradient_wrt_output_desc,
+          local_gradient_wrt_output,
+          input_desc,
+          local_input,
+          m_convolution_dnn_desc,
+          kernel_gradient_dnn_algorithm_config.first,
+          workspace,
+          dst_scale,
+          m_kernel_dnn_desc,
+          kernel_gradient.Matrix());
       }
       else {
         size_t workspace_size =
@@ -776,29 +781,31 @@ void base_convolution_layer<TensorDataType, Device>::compute_gradients_dnn(
                                                        multisync);
         workspace.Resize(workspace_size / sizeof(TensorDataType), 1);
         workspace_size = workspace.Height() * sizeof(TensorDataType);
-        dnn_lib::bwd_filter_conv_alg_config kernel_gradient_dnn_algorithm_config =
-          get_backward_filter_algo_dnn(local_input.Width(),
-                                       input_desc,
-                                       local_input.LockedBuffer(),
-                                       gradient_wrt_output_desc,
-                                       local_gradient_wrt_output.LockedBuffer(),
-                                       m_convolution_dnn_desc,
-                                       m_kernel_dnn_desc,
-                                       workspace_size,
-                                       workspace.Buffer());
+        dnn_lib::bwd_filter_conv_alg_config
+          kernel_gradient_dnn_algorithm_config = get_backward_filter_algo_dnn(
+            local_input.Width(),
+            input_desc,
+            local_input.LockedBuffer(),
+            gradient_wrt_output_desc,
+            local_gradient_wrt_output.LockedBuffer(),
+            m_convolution_dnn_desc,
+            m_kernel_dnn_desc,
+            workspace_size,
+            workspace.Buffer());
         m_convolution_dnn_desc.set_math_mode(
           kernel_gradient_dnn_algorithm_config.second);
-        dnn_lib::convolution_backward_filter(gradient_scale,
-                                             input_desc,
-                                             local_input,
-                                             gradient_wrt_output_desc,
-                                             local_gradient_wrt_output,
-                                             m_convolution_dnn_desc,
-                                             kernel_gradient_dnn_algorithm_config.first,
-                                             workspace,
-                                             dst_scale,
-                                             m_kernel_dnn_desc,
-                                             kernel_gradient.Matrix());
+        dnn_lib::convolution_backward_filter(
+          gradient_scale,
+          input_desc,
+          local_input,
+          gradient_wrt_output_desc,
+          local_gradient_wrt_output,
+          m_convolution_dnn_desc,
+          kernel_gradient_dnn_algorithm_config.first,
+          workspace,
+          dst_scale,
+          m_kernel_dnn_desc,
+          kernel_gradient.Matrix());
       }
     }
     else {

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -515,11 +515,16 @@ void fp_compute_impl(fully_connected_layer<TensorDataType,
 {
 
   // Matrices
+  const auto& linearity = l.weights_values(0);
   const auto& local_input = l.get_local_prev_activations();
   auto& local_output = l.get_local_activations();
 
+  if (!linearity.Participating()) {
+    return;
+  }
+
   // Apply linearity
-  const auto& local_linearity = l.weights_values(0).LockedMatrix();
+  const auto& local_linearity = linearity.LockedMatrix();
   El::Gemm(l.m_transpose ? El::TRANSPOSE : El::NORMAL,
            El::NORMAL,
            El::TypeTraits<TensorDataType>::One(),
@@ -555,10 +560,14 @@ void bp_compute_impl(fully_connected_layer<TensorDataType,
 {
 
   // Matrices
-  const auto& local_linearity = l.weights_values(0).LockedMatrix();
+  const auto& linearity = l.weights_values(0);
+  const auto& local_linearity = linearity.LockedMatrix();
   const auto& local_input = l.get_local_prev_activations();
   const auto& local_gradient_wrt_output = l.get_local_prev_error_signals();
   auto& local_gradient_wrt_input = l.get_local_error_signals();
+  if (!linearity.Participating()) {
+    return;
+  }
 
   // Compute gradient w.r.t. bias if needed
   if (l.m_bias_scaling_factor != El::TypeTraits<TensorDataType>::Zero()) {

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -823,12 +823,18 @@ void fully_connected_layer<T, L, D>::write_specific_proto(
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 void fully_connected_layer<TensorDataType, T_layout, Dev>::fp_compute()
 {
+  if (!this->weights_values(0).Participating())
+    return;
+
   fp_compute_impl<TensorDataType>(*this);
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 void fully_connected_layer<TensorDataType, T_layout, Dev>::bp_compute()
 {
+  if (!this->weights_values(0).Participating())
+    return;
+
   bp_compute_impl<TensorDataType>(*this);
 }
 

--- a/src/layers/learning/fully_connected.cpp
+++ b/src/layers/learning/fully_connected.cpp
@@ -823,18 +823,12 @@ void fully_connected_layer<T, L, D>::write_specific_proto(
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 void fully_connected_layer<TensorDataType, T_layout, Dev>::fp_compute()
 {
-  if (!this->weights_values(0).Participating())
-    return;
-
   fp_compute_impl<TensorDataType>(*this);
 }
 
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 void fully_connected_layer<TensorDataType, T_layout, Dev>::bp_compute()
 {
-  if (!this->weights_values(0).Participating())
-    return;
-
   bp_compute_impl<TensorDataType>(*this);
 }
 

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1016,7 +1016,18 @@ void model::setup_layer_grid_tags(const std::vector<El::Grid*>& fngrids)
   // the same, set to parent value. If any is different, set to 0.
   // (Note that if we're doing "layer parallelism", they should all be
   // -1 and this definition will recover that.)
-  for (auto& layer : this->get_layers()) {
+  bool doing_subgraph_stuff = false;
+  auto const layers = this->get_layers();
+  for (auto& layer : layers) {
+    if (layer->get_grid_tag() > 0) {
+      doing_subgraph_stuff = true;
+      break;
+    }
+  }
+  if (!doing_subgraph_stuff)
+    return;
+
+  for (auto& layer : layers) {
     int tag = layer->get_grid_tag();
     if (tag < 0) {
       tag = 0; // now it's at least valid if there are no parents

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1567,7 +1567,7 @@ void model::forward_prop(execution_mode mode)
     auto& l = get_layer(i);
 
     if (this->is_subgraph_parallelism_enabled()) {
-      if (l.get_run_layer_in_subgraph() || l.get_name() == "layer1") {
+      if (l.get_run_layer_in_subgraph()) {
         do_layer_forward_prop_begin_cbs(mode, &l);
         l.forward_prop();
         do_layer_forward_prop_end_cbs(mode, &l);

--- a/src/proto/layers.proto
+++ b/src/proto/layers.proto
@@ -116,6 +116,9 @@ message Layer {
   /** @brief Configuration for advanced parallelization strategies */
   ParallelStrategy parallel_strategy = 12;
 
+  /** @brief Tag for layer-parallelism grid */
+  google.protobuf.Int64Value grid_tag = 13;
+
   // ===========================================
   // Deprecated options
   // ===========================================


### PR DESCRIPTION
This is currently distinct from "subgraph parallelism", but the notion is a bit simpler.

The implementation crux of this functionality is that every `Layer` in the model manages its own data completely internally (weights, prev_activations, activations). At layer boundaries, when a layer and its parent are on different grids, a deep copy will be done explicitly to move the data from `parent_layer.grid` to `this->grid`.

See the blurb I put on Confluence for some other discussion and assumptions.