### PR TITLE
Fix debugging check in cross-entropy

### DIFF
--- a/src/layers/loss/cross_entropy.cpp
+++ b/src/layers/loss/cross_entropy.cpp
@@ -63,8 +63,8 @@ void local_fp_cpu(const El::AbstractMatrix<TensorDataType>& local_prediction,
       if (xhat > zero) {
         const auto& x = local_prediction(row, col);
 #ifdef LBANN_DEBUG
-        if (x <= zero) {
-          LBANN_ERROR("non-positive prediction");
+        if (x < zero) {
+          LBANN_ERROR("negative prediction");
         }
 #endif // LBANN_DEBUG
         sum += -xhat * std::log(x);


### PR DESCRIPTION
0 is a valid output from a softmax, so it should not be an error.

CI is running.