### PR TITLE
Add datatype to weights description

### DIFF
--- a/include/lbann/weights/data_type_weights.hpp
+++ b/include/lbann/weights/data_type_weights.hpp
@@ -30,6 +30,7 @@
 #include "lbann/optimizers/data_type_optimizer.hpp"
 #include "lbann/weights/initializer.hpp"
 #include "lbann/weights/weights.hpp"
+#include "lbann/utils/typename.hpp"
 
 namespace cereal {
 class access;
@@ -84,6 +85,10 @@ public:
   data_type_weights(const data_type_weights& other);
   data_type_weights& operator=(const data_type_weights& other);
   virtual ~data_type_weights() = default;
+
+  std::string get_datatype_name() const override {
+    return TypeName<TensorDataType>();
+  }
 
   bool has_optimizer() const override { return m_optimizer != nullptr; }
 

--- a/include/lbann/weights/weights.hpp
+++ b/include/lbann/weights/weights.hpp
@@ -125,6 +125,9 @@ public:
   /** Human-readable description. */
   description get_description() const;
 
+  /** Get a string representing the weights's datatype. */
+  virtual std::string get_datatype_name() const = 0;
+
   virtual bool has_optimizer() const = 0;
 
   // -----------------------------------------------

--- a/src/weights/weights.cpp
+++ b/src/weights/weights.cpp
@@ -108,6 +108,9 @@ description weights::get_description() const
   }
   desc.add("Dimensions", ss.str());
 
+  // Datatype.
+  desc.add("Data type", get_datatype_name());
+
   // Freeze state
   if (is_frozen()) {
     desc.add("Frozen");


### PR DESCRIPTION
This is a minor convenience to help sanity-check types.