### PR TITLE
Make LBANN_ASSERT safer to use

### DIFF
--- a/include/lbann/utils/exception.hpp
+++ b/include/lbann/utils/exception.hpp
@@ -95,8 +95,11 @@
   } while (0)
 
 #define LBANN_ASSERT(cond)                                                     \
-  if (!(cond))                                                                 \
-  LBANN_ERROR("The assertion " #cond " failed.")
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      LBANN_ERROR("The assertion " #cond " failed.");                          \
+    }                                                                          \
+  } while (0)
 
 #ifdef LBANN_DEBUG
 #define LBANN_ASSERT_DEBUG(cond) LBANN_ASSERT(cond)


### PR DESCRIPTION
This wraps the body of the `LBANN_ASSERT` macro in the `do {} while (0)` idiom. This prevents the "dangling else" problem:
```
if (foo)
  LBANN_ASSSERT(whatever);
else
  function_call();
```
used to expand (`macroexpand-1`) to
```
if (foo)
  if (!(whatever)) LBANN_ERROR(<some message>);
else
  function_call();
```
But C++ grammar rules mean that the `else function_call()` is the `else` clause for the `if (!(whatever))` conditional. The new expansion (`macroexpand-1`) will be:
```
if (foo)
  do { if (!(whatever)) { LBANN_ERROR(<some message>); } } while(0);
else
  function_call();
```
so the `else function_call()` will associate with the correct `if`.