### PR TITLE
Double data type optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,12 @@ option(LBANN_DEBUG_PRINT_SUBTARGETS
   "Turn on debugging output of internal target properties." OFF)
 mark_as_advanced(LBANN_DEBUG_PRINT_SUBTARGETS)
 
+option(LBANN_WITH_DOUBLE
+  "Build with support for double precision layers, optimizers, and weights." OFF)
+if (LBANN_WITH_DOUBLE)
+  set(LBANN_HAS_DOUBLE TRUE)
+endif (LBANN_WITH_DOUBLE)
+
 option(LBANN_EXPLICIT_LIBDL
   "Explicitly find and link to libdl" OFF)
 mark_as_advanced(LBANN_EXPLICIT_LIBDL)
@@ -264,6 +270,10 @@ endif ()
 include(SetupOpenMP)
 include(SetupMPI)
 include(SetupProtobuf)
+
+if (LBANN_DATATYPE STREQUAL "double")
+  set(LBANN_HAS_DOUBLE TRUE)
+endif ()
 
 # Setup FFTW
 if (LBANN_WITH_FFT)
@@ -1066,6 +1076,7 @@ append_str_tf(_str
   LBANN_HAS_DETERMINISTIC
   LBANN_HAS_DIHYDROGEN
   LBANN_HAS_DISTCONV
+  LBANN_HAS_DOUBLE
   LBANN_HAS_DOXYGEN
   LBANN_HAS_FFTW
   LBANN_HAS_HIPTT

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -70,6 +70,8 @@
 
 #cmakedefine LBANN_DETERMINISTIC
 
+#cmakedefine LBANN_HAS_DOUBLE
+
 #cmakedefine LBANN_HAS_CUDA
 #cmakedefine LBANN_HAS_CUDNN
 #cmakedefine LBANN_HAS_CUTENSOR

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -186,7 +186,11 @@ using Mat =
 
 // Datatype for model evaluation
 // Examples: timing, metrics, objective functions
+#ifdef LBANN_HAS_DOUBLE
 using EvalType = double;
+#else
+using EvalType = float;
+#endif // LBANN_HAS_DOUBLE
 
 /// Distributed matrix format
 enum class matrix_format

--- a/include/lbann/base.hpp
+++ b/include/lbann/base.hpp
@@ -186,11 +186,7 @@ using Mat =
 
 // Datatype for model evaluation
 // Examples: timing, metrics, objective functions
-#ifdef LBANN_HAS_DOUBLE
 using EvalType = double;
-#else
-using EvalType = float;
-#endif // LBANN_HAS_DOUBLE
 
 /// Distributed matrix format
 enum class matrix_format

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -61,8 +61,10 @@ using supported_layer_data_type = h2::meta::TL<
 #ifdef LBANN_HAS_HALF
   cpu_fp16,
 #endif
-  float,
-  double>;
+#ifdef LBANN_HAS_DOUBLE
+  double,
+#endif // LBANN_HAS_DOUBLE
+  float>;
 
 template <typename InputTensorDataType,
           typename OutputTensorDataType = InputTensorDataType>

--- a/include/lbann/layers/data_type_layer.hpp
+++ b/include/lbann/layers/data_type_layer.hpp
@@ -54,7 +54,7 @@ template <typename U>
 class entrywise_layer_tensor_manager;
 } // namespace dnn_lib
 
-using supported_layer_data_type = h2::meta::TL<
+using supported_layer_data_type = h2::meta::tlist::Unique<h2::meta::TL<
 #ifdef LBANN_HAS_GPU_FP16
   fp16,
 #endif
@@ -64,7 +64,8 @@ using supported_layer_data_type = h2::meta::TL<
 #ifdef LBANN_HAS_DOUBLE
   double,
 #endif // LBANN_HAS_DOUBLE
-  float>;
+  EvalType,
+  float>>;
 
 template <typename InputTensorDataType,
           typename OutputTensorDataType = InputTensorDataType>
@@ -466,10 +467,12 @@ protected:
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 #undef PROTO
 #undef LBANN_INSTANTIATE_CPU_HALF
 #undef LBANN_INSTANTIATE_GPU_HALF
+#undef LBANN_INSTANTIATE_DOUBLE
 
 #endif // LBANN_DATA_TYPE_LAYER_INSTANTIATE
 

--- a/include/lbann/layers/misc/dft_abs.hpp
+++ b/include/lbann/layers/misc/dft_abs.hpp
@@ -123,11 +123,9 @@ void dft_abs_layer<T, D>::write_specific_proto(lbann_data::Layer& proto) const
 #ifdef LBANN_HAS_FFTW_FLOAT
 extern template class dft_abs_layer<float, El::Device::CPU>;
 #endif // LBANN_HAS_FFTW_FLOAT
-#ifdef LBANN_HAS_FFTW_DOUBLE
-#ifdef LBANN_HAS_DOUBLE
+#if defined(LBANN_HAS_DOUBLE) && defined(LBANN_HAS_FFTW_DOUBLE)
 extern template class dft_abs_layer<double, El::Device::CPU>;
-#endif // LBANN_HAS_DOUBLE
-#endif // LBANN_HAS_FFTW_DOUBLE
+#endif // defined(LBANN_HAS_DOUBLE) && defined (LBANN_HAS_FFTW_DOUBLE)
 
 #ifdef LBANN_HAS_GPU
 // cuFFT always supports both types.

--- a/include/lbann/layers/misc/dft_abs.hpp
+++ b/include/lbann/layers/misc/dft_abs.hpp
@@ -124,13 +124,17 @@ void dft_abs_layer<T, D>::write_specific_proto(lbann_data::Layer& proto) const
 extern template class dft_abs_layer<float, El::Device::CPU>;
 #endif // LBANN_HAS_FFTW_FLOAT
 #ifdef LBANN_HAS_FFTW_DOUBLE
+#ifdef LBANN_HAS_DOUBLE
 extern template class dft_abs_layer<double, El::Device::CPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_FFTW_DOUBLE
 
 #ifdef LBANN_HAS_GPU
 // cuFFT always supports both types.
 extern template class dft_abs_layer<float, El::Device::GPU>;
+#ifdef LBANN_HAS_DOUBLE
 extern template class dft_abs_layer<double, El::Device::GPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 
 #endif // LBANN_DFT_ABS_LAYER_INSTANTIATE

--- a/include/lbann/layers/transform/evaluation.hpp
+++ b/include/lbann/layers/transform/evaluation.hpp
@@ -178,10 +178,12 @@ void evaluation_layer<T, L, D>::fill_onnx_node(onnx::GraphProto& graph) const
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 #undef PROTO
 #undef LBANN_INSTANTIATE_CPU_HALF
 #undef LBANN_INSTANTIATE_GPU_HALF
+#undef LBANN_INSTANTIATE_DOUBLE
 
 #define PROTO_DEVICE(T, Device)                                                \
   extern template class evaluation_layer<T,                                    \

--- a/include/lbann/macros/instantiate.hpp
+++ b/include/lbann/macros/instantiate.hpp
@@ -25,7 +25,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 PROTO(float);
+#ifdef LBANN_HAS_DOUBLE
 PROTO(double);
+#endif // LBANN_HAS_DOUBLE
 
 #ifdef LBANN_HAS_HALF
 #ifdef LBANN_INSTANTIATE_CPU_HALF

--- a/include/lbann/macros/instantiate.hpp
+++ b/include/lbann/macros/instantiate.hpp
@@ -25,9 +25,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 PROTO(float);
-#ifdef LBANN_HAS_DOUBLE
+#if defined(LBANN_HAS_DOUBLE) || defined(LBANN_INSTANTIATE_DOUBLE)
 PROTO(double);
-#endif // LBANN_HAS_DOUBLE
+#endif // defined(LBANN_HAS_DOUBLE) || defined (LBANN_INSTANTIATE_DOUBLE)
 
 #ifdef LBANN_HAS_HALF
 #ifdef LBANN_INSTANTIATE_CPU_HALF

--- a/include/lbann/utils/timer.hpp
+++ b/include/lbann/utils/timer.hpp
@@ -33,8 +33,17 @@
 
 namespace lbann {
 
+// Datatype for model evaluation
+// Examples: timing, metrics, objective functions
+#ifdef LBANN_HAS_DOUBLE
+using EvalType = double;
+#else
+using EvalType = float;
+#endif // LBANN_HAS_DOUBLE
+
 /** @brief Return time in fractional seconds since an epoch. */
-inline double get_time()
+// inline double get_time()
+inline EvalType get_time()
 {
   using namespace std::chrono;
   return duration_cast<duration<double>>(steady_clock::now().time_since_epoch())
@@ -86,7 +95,8 @@ public:
    *
    *  @post running() returns @c false, as if reset() were called.
    */
-  double stop() noexcept
+  //  double stop() noexcept
+  EvalType stop() noexcept
   {
     auto elapsed_time = this->check();
     this->reset();
@@ -94,7 +104,8 @@ public:
   }
 
   /** @brief Get the current elapsed time (seconds) without stopping. */
-  double check() const noexcept
+  EvalType check() const noexcept
+  //  double check() const noexcept
   {
     using seconds_type = std::chrono::duration<double>;
     return running() ? seconds_type(ClockType::now() - m_start).count() : 0.;

--- a/include/lbann/utils/timer.hpp
+++ b/include/lbann/utils/timer.hpp
@@ -33,17 +33,8 @@
 
 namespace lbann {
 
-// Datatype for model evaluation
-// Examples: timing, metrics, objective functions
-#ifdef LBANN_HAS_DOUBLE
-using EvalType = double;
-#else
-using EvalType = float;
-#endif // LBANN_HAS_DOUBLE
-
 /** @brief Return time in fractional seconds since an epoch. */
-// inline double get_time()
-inline EvalType get_time()
+inline double get_time()
 {
   using namespace std::chrono;
   return duration_cast<duration<double>>(steady_clock::now().time_since_epoch())
@@ -95,8 +86,7 @@ public:
    *
    *  @post running() returns @c false, as if reset() were called.
    */
-  //  double stop() noexcept
-  EvalType stop() noexcept
+  double stop() noexcept
   {
     auto elapsed_time = this->check();
     this->reset();
@@ -104,8 +94,7 @@ public:
   }
 
   /** @brief Get the current elapsed time (seconds) without stopping. */
-  EvalType check() const noexcept
-  //  double check() const noexcept
+  double check() const noexcept
   {
     using seconds_type = std::chrono::duration<double>;
     return running() ? seconds_type(ClockType::now() - m_start).count() : 0.;

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -953,6 +953,7 @@ int get_rank_in_world()
                                          Al::request& req,                     \
                                          El::mpi::Op op) const
 
+#define LBANN_INSTANTIATE_DOUBLE
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
 #include "lbann/macros/instantiate.hpp"

--- a/src/layers/activations/unit_test/identity_test.cpp
+++ b/src/layers/activations/unit_test/identity_test.cpp
@@ -53,8 +53,11 @@ using LayerTypesAllDevices = h2::meta::tlist::Append<
 #endif // LBANN_HAS_GPU
   LayerTypesAllLayouts<T, El::Device::CPU>>;
 
-using AllLayerTypes = h2::meta::tlist::Append<LayerTypesAllDevices<float>,
-                                              LayerTypesAllDevices<double>>;
+using AllLayerTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<float>>;
 
 using unit_test::utilities::IsValidPtr;
 TEMPLATE_LIST_TEST_CASE("Serializing Identity layer",

--- a/src/layers/data_type_distconv_adapter.cpp
+++ b/src/layers/data_type_distconv_adapter.cpp
@@ -1203,6 +1203,7 @@ El::Int data_type_distconv_adapter<InputTensorDataType, OutputTensorDataType>::
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 } // namespace lbann

--- a/src/layers/data_type_layer.cpp
+++ b/src/layers/data_type_layer.cpp
@@ -1510,6 +1510,7 @@ data_type_layer<InputTensorDataType,
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 } // namespace lbann

--- a/src/layers/image/image_layer_builders.cpp
+++ b/src/layers/image/image_layer_builders.cpp
@@ -64,11 +64,13 @@ lbann::build_composite_image_transformation_layer_from_pbuf(
         composite_image_transformation_layer<float,
                                              data_layout::DATA_PARALLEL,
                                              El::Device::CPU>>(comm);
+#ifdef LBANN_HAS_DOUBLE
     else if constexpr (std::is_same_v<T, double>)
       return std::make_unique<
         composite_image_transformation_layer<double,
                                              data_layout::DATA_PARALLEL,
                                              El::Device::CPU>>(comm);
+#endif // LBANN_HAS_DOUBLE
     else {
       (void)comm;
       LBANN_ERROR("composite_image_transformation_layer is only supported for "
@@ -94,10 +96,12 @@ lbann::build_rotation_layer_from_pbuf(lbann_comm* comm,
       return std::make_unique<
         rotation_layer<float, data_layout::DATA_PARALLEL, El::Device::CPU>>(
         comm);
+#ifdef LBANN_HAS_DOUBLE
     else if constexpr (std::is_same_v<T, double>)
       return std::make_unique<
         rotation_layer<double, data_layout::DATA_PARALLEL, El::Device::CPU>>(
         comm);
+#endif // LBANN_HAS_DOUBLE
     else {
       (void)comm;
       LBANN_ERROR(
@@ -119,10 +123,12 @@ lbann::build_cutout_layer_from_pbuf(lbann_comm* comm, lbann_data::Layer const&)
     if constexpr (std::is_same_v<T, float>)
       return std::make_unique<
         cutout_layer<float, data_layout::DATA_PARALLEL, El::Device::CPU>>(comm);
+#ifdef LBANN_HAS_DOUBLE
     else if constexpr (std::is_same_v<T, double>)
       return std::make_unique<
         cutout_layer<double, data_layout::DATA_PARALLEL, El::Device::CPU>>(
         comm);
+#endif // LBANN_HAS_DOUBLE
     else {
       (void)comm;
       LBANN_ERROR(

--- a/src/layers/learning/unit_test/convolution_test.cpp
+++ b/src/layers/learning/unit_test/convolution_test.cpp
@@ -54,8 +54,11 @@ using LayerTypesAllDevices =
 #endif // LBANN_HAS_GPU
                >;
 
-using AllLayerTypes = h2::meta::tlist::Append<LayerTypesAllDevices<float>,
-                                              LayerTypesAllDevices<double>>;
+using AllLayerTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<float>>;
 
 using unit_test::utilities::IsValidPtr;
 TEMPLATE_LIST_TEST_CASE("Serializing convolution layer",

--- a/src/layers/misc/cereal_registration/dft_abs.cpp
+++ b/src/layers/misc/cereal_registration/dft_abs.cpp
@@ -55,11 +55,15 @@ void dft_abs_layer<TensorDataType, Device>::serialize(ArchiveT& ar)
 PROTO_DEVICE(float, El::Device::CPU)
 #endif // LBANN_HAS_FFTW_FLOAT
 #ifdef LBANN_HAS_FFTW_DOUBLE
+#ifdef LBANN_HAS_DOUBLE
 PROTO_DEVICE(double, El::Device::CPU)
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_FFTW_DOUBLE
 #ifdef LBANN_HAS_GPU
 PROTO_DEVICE(float, El::Device::GPU)
+#ifdef LBANN_HAS_DOUBLE
 PROTO_DEVICE(double, El::Device::GPU)
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 #endif // LBANN_HAS_FFTW
 

--- a/src/layers/misc/cereal_registration/dft_abs.cpp
+++ b/src/layers/misc/cereal_registration/dft_abs.cpp
@@ -54,11 +54,9 @@ void dft_abs_layer<TensorDataType, Device>::serialize(ArchiveT& ar)
 #ifdef LBANN_HAS_FFTW_FLOAT
 PROTO_DEVICE(float, El::Device::CPU)
 #endif // LBANN_HAS_FFTW_FLOAT
-#ifdef LBANN_HAS_FFTW_DOUBLE
-#ifdef LBANN_HAS_DOUBLE
+#if defined(LBANN_HAS_DOUBLE) && defined(LBANN_HAS_FFTW_DOUBLE)
 PROTO_DEVICE(double, El::Device::CPU)
-#endif // LBANN_HAS_DOUBLE
-#endif // LBANN_HAS_FFTW_DOUBLE
+#endif // defined(LBANN_HAS_DOUBLE) && defined (LBANN_HAS_FFTW_DOUBLE)
 #ifdef LBANN_HAS_GPU
 PROTO_DEVICE(float, El::Device::GPU)
 #ifdef LBANN_HAS_DOUBLE

--- a/src/layers/misc/dft_abs.cpp
+++ b/src/layers/misc/dft_abs.cpp
@@ -312,11 +312,9 @@ dft_abs_layer<T, D>::dft_abs_layer(dft_abs_layer const& other)
 #ifdef LBANN_HAS_FFTW_FLOAT
 template class dft_abs_layer<float, El::Device::CPU>;
 #endif // LBANN_HAS_FFTW_FLOAT
-#ifdef LBANN_HAS_FFTW_DOUBLE
-#ifdef LBANN_HAS_DOUBLE
+#if defined(LBANN_HAS_DOUBLE) && defined(LBANN_HAS_FFTW_DOUBLE)
 template class dft_abs_layer<double, El::Device::CPU>;
-#endif // LBANN_HAS_DOUBLE
-#endif // LBANN_HAS_FFTW_DOUBLE
+#endif // defined(LBANN_HAS_DOUBLE) && defined (LBANN_HAS_FFTW_DOUBLE)
 
 #ifdef LBANN_HAS_GPU
 template class dft_abs_layer<float, El::Device::GPU>;

--- a/src/layers/misc/dft_abs.cpp
+++ b/src/layers/misc/dft_abs.cpp
@@ -139,18 +139,20 @@ static void MyRealPart(El::Matrix<El::Complex<T>, El::Device::CPU> const& in,
 // Have to instantiate this in device-compiled code.
 void Abs(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
          El::Matrix<float, El::Device::GPU>& out);
-void Abs(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
-         El::Matrix<double, El::Device::GPU>& out);
 void ApplyAbsGradientUpdate(
   El::Matrix<float, El::Device::GPU> const& grad_wrt_output,
   El::Matrix<El::Complex<float>, El::Device::GPU>& input_output);
+void MyRealPart(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
+                El::Matrix<float, El::Device::GPU>& out);
+#ifdef LBANN_HAS_DOUBLE
+void Abs(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
+         El::Matrix<double, El::Device::GPU>& out);
 void ApplyAbsGradientUpdate(
   El::Matrix<double, El::Device::GPU> const& grad_wrt_output,
   El::Matrix<El::Complex<double>, El::Device::GPU>& input_output);
-void MyRealPart(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
-                El::Matrix<float, El::Device::GPU>& out);
 void MyRealPart(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
                 El::Matrix<double, El::Device::GPU>& out);
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 
 } // namespace internal
@@ -311,12 +313,16 @@ dft_abs_layer<T, D>::dft_abs_layer(dft_abs_layer const& other)
 template class dft_abs_layer<float, El::Device::CPU>;
 #endif // LBANN_HAS_FFTW_FLOAT
 #ifdef LBANN_HAS_FFTW_DOUBLE
+#ifdef LBANN_HAS_DOUBLE
 template class dft_abs_layer<double, El::Device::CPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_FFTW_DOUBLE
 
 #ifdef LBANN_HAS_GPU
 template class dft_abs_layer<float, El::Device::GPU>;
+#ifdef LBANN_HAS_DOUBLE
 template class dft_abs_layer<double, El::Device::GPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 
 } // namespace lbann

--- a/src/layers/misc/dft_abs.cu
+++ b/src/layers/misc/dft_abs.cu
@@ -35,6 +35,7 @@ void Abs(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
     return thrust::abs(x);
   });
 }
+#ifdef LBANN_HAS_DOUBLE
 void Abs(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
          El::Matrix<double, El::Device::GPU>& out)
 {
@@ -42,6 +43,7 @@ void Abs(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
     return thrust::abs(x);
   });
 }
+#endif // LBANN_HAS_DOUBLE
 void MyRealPart(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
                 El::Matrix<float, El::Device::GPU>& out)
 {
@@ -49,6 +51,7 @@ void MyRealPart(El::Matrix<El::Complex<float>, El::Device::GPU> const& in,
     return x.real();
   });
 }
+#ifdef LBANN_HAS_DOUBLE
 void MyRealPart(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
                 El::Matrix<double, El::Device::GPU>& out)
 {
@@ -56,6 +59,7 @@ void MyRealPart(El::Matrix<El::Complex<double>, El::Device::GPU> const& in,
     return x.real();
   });
 }
+#endif // LBANN_HAS_DOUBLE
 void ApplyAbsGradientUpdate(
   El::Matrix<float, El::Device::GPU> const& grad_wrt_output,
   El::Matrix<El::Complex<float>, El::Device::GPU>& input_output)
@@ -69,6 +73,7 @@ void ApplyAbsGradientUpdate(
                           : thrust::conj(x * (dy / thrust::abs(x))));
               });
 }
+#ifdef LBANN_HAS_DOUBLE
 void ApplyAbsGradientUpdate(
   El::Matrix<double, El::Device::GPU> const& grad_wrt_output,
   El::Matrix<El::Complex<double>, El::Device::GPU>& input_output)
@@ -82,5 +87,6 @@ void ApplyAbsGradientUpdate(
                           : thrust::conj(x * (dy / thrust::abs(x))));
               });
 }
+#endif // LBANN_HAS_DOUBLE
 } // namespace internal
 } // namespace lbann

--- a/src/layers/misc/dist_embedding.cpp
+++ b/src/layers/misc/dist_embedding.cpp
@@ -419,17 +419,21 @@ build_dist_embedding_layer_from_pbuf(lbann_comm* comm,
 template class dist_embedding_layer<float,
                                     data_layout::DATA_PARALLEL,
                                     El::Device::CPU>;
+#ifdef LBANN_HAS_DOUBLE
 template class dist_embedding_layer<double,
                                     data_layout::DATA_PARALLEL,
                                     El::Device::CPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_SHMEM
 #if defined(LBANN_HAS_GPU) && defined(LBANN_HAS_NVSHMEM)
 extern template class dist_embedding_layer<float,
                                            data_layout::DATA_PARALLEL,
                                            El::Device::GPU>;
+#ifdef LBANN_HAS_DOUBLE
 extern template class dist_embedding_layer<double,
                                            data_layout::DATA_PARALLEL,
                                            El::Device::GPU>;
+#endif // LBANN_HAS_DOUBLE
 #endif // defined(LBANN_HAS_GPU) && defined(LBANN_HAS_NVSHMEM)
 
 #define PROTO_DEVICE(T, Device)                                                \

--- a/src/layers/misc/misc_builders.cpp
+++ b/src/layers/misc/misc_builders.cpp
@@ -68,22 +68,26 @@ struct DFTTypeSupported<float, El::Device::CPU> : std::true_type
 {
 };
 #endif // LBANN_HAS_FFTW_FLOAT
+#ifdef LBANN_HAS_DOUBLE
 #ifdef LBANN_HAS_FFTW_DOUBLE
 template <>
 struct DFTTypeSupported<double, El::Device::CPU> : std::true_type
 {
 };
 #endif // LBANN_HAS_FFTW_DOUBLE
+#endif // LBANN_HAS_DOUBLE
 
 #ifdef LBANN_HAS_GPU
 template <>
 struct DFTTypeSupported<float, El::Device::GPU> : std::true_type
 {
 };
+#ifdef LBANN_HAS_DOUBLE
 template <>
 struct DFTTypeSupported<double, El::Device::GPU> : std::true_type
 {
 };
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 
 template <typename T,
@@ -141,6 +145,7 @@ struct UniformHashBuilder<float, L, El::Device::GPU>
 #endif // LBANN_HAS_GPU
 
 #ifdef LBANN_HAS_GPU
+#ifdef LBANN_HAS_DOUBLE
 template <data_layout L>
 struct UniformHashBuilder<double, L, El::Device::GPU>
 {
@@ -151,6 +156,7 @@ struct UniformHashBuilder<double, L, El::Device::GPU>
     return std::make_unique<LayerType>(std::forward<Args>(args)...);
   }
 };
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU
 
 } // namespace
@@ -218,12 +224,14 @@ std::unique_ptr<lbann::Layer> lbann::build_channelwise_softmax_layer_from_pbuf(
         comm,
         layer.dim(),
         layer.single_dim_mode());
+#ifdef LBANN_HAS_DOUBLE
     else if constexpr (std::is_same_v<T, double>)
       return std::make_unique<
         channelwise_softmax_layer<double, data_layout::DATA_PARALLEL, D>>(
         comm,
         layer.dim(),
         layer.single_dim_mode());
+#endif // LBANN_HAS_DOUBLE
   }
   (void)comm;
   LBANN_ERROR("Attempted to construct channelwise_softmax_layer ",

--- a/src/layers/regularizers/entrywise_batch_normalization_builder.cpp
+++ b/src/layers/regularizers/entrywise_batch_normalization_builder.cpp
@@ -43,10 +43,12 @@ lbann::build_entrywise_batch_normalization_layer_from_pbuf(
     return std::make_unique<entrywise_batch_normalization_layer<float, L, D>>(
       params.decay(),
       params.epsilon());
+#ifdef LBANN_HAS_DOUBLE
   else if constexpr (std::is_same_v<T, double>)
     return std::make_unique<entrywise_batch_normalization_layer<double, L, D>>(
       params.decay(),
       params.epsilon());
+#endif // LBANN_HAS_DOUBLE
   else
     LBANN_ERROR("entrywise_batch_normalization_layer is only supported for "
                 "\"float\" and \"double\".");

--- a/src/layers/regularizers/layer_norm_builder.cpp
+++ b/src/layers/regularizers/layer_norm_builder.cpp
@@ -43,10 +43,12 @@ lbann::build_layer_norm_layer_from_pbuf(lbann_comm* /*comm*/,
     return std::make_unique<layer_norm_layer<float, L, D>>(epsilon,
                                                            scale,
                                                            bias);
+#ifdef LBANN_HAS_DOUBLE
   else if constexpr (std::is_same_v<T, double>)
     return std::make_unique<layer_norm_layer<double, L, D>>(epsilon,
                                                             scale,
                                                             bias);
+#endif // LBANN_HAS_DOUBLE
   else {
     (void)scale;
     (void)bias;

--- a/src/layers/regularizers/unit_test/batch_normalization_test.cpp
+++ b/src/layers/regularizers/unit_test/batch_normalization_test.cpp
@@ -54,8 +54,11 @@ using LayerTypesAllDevices =
 #endif // LBANN_HAS_GPU
                >;
 
-using AllLayerTypes = h2::meta::tlist::Append<LayerTypesAllDevices<float>,
-                                              LayerTypesAllDevices<double>>;
+using AllLayerTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  LayerTypesAllDevices<float>>;
 
 using unit_test::utilities::IsValidPtr;
 TEMPLATE_LIST_TEST_CASE("Serializing batchnorm layer",

--- a/src/layers/transform/evaluation.cpp
+++ b/src/layers/transform/evaluation.cpp
@@ -338,10 +338,12 @@ LBANN_LAYER_DEFAULT_BUILDER(evaluation)
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 #undef PROTO
 #undef LBANN_INSTANTIATE_CPU_HALF
 #undef LBANN_INSTANTIATE_GPU_HALF
+#undef LBANN_INSTANTIATE_DOUBLE
 
 #define PROTO_DEVICE(T, Device)                                                \
   template class evaluation_layer<T, data_layout::DATA_PARALLEL, Device>;      \

--- a/src/layers/transform/unit_test/permute_layer_test.cpp
+++ b/src/layers/transform/unit_test/permute_layer_test.cpp
@@ -44,8 +44,10 @@ using TheTestTypes = h2::meta::TL<
 #ifdef LBANN_HAS_GPU_FP16
   ::lbann::fp16,
 #endif
-  float,
-  double>;
+#ifdef LBANN_HAS_DOUBLE
+  double,
+#endif // LBANN_HAS_DOUBLE
+  float>;
 
 static std::string to_str(::lbann::description const& d)
 {

--- a/src/layers/unit_test/operator_layer_test.cpp
+++ b/src/layers/unit_test/operator_layer_test.cpp
@@ -84,8 +84,10 @@ using AllLayerTypes = h2::meta::tlist::Append<
 #ifdef LBANN_HAS_HALF
   LayerTypeAllLayoutsAndDevice<FP16Type>,
 #endif // LBANN_HAS_HALF
-  LayerTypeAllLayoutsAndDevice<float>,
-  LayerTypeAllLayoutsAndDevice<double>>;
+#ifdef LBANN_HAS_DOUBLE
+  LayerTypeAllLayoutsAndDevice<double>,
+#endif // LBANN_HAS_DOUBLE
+  LayerTypeAllLayoutsAndDevice<float>>;
 
 template <typename LayerT>
 struct LayerTraits;

--- a/src/operators/math/cereal_registration/abs.cpp
+++ b/src/operators/math/cereal_registration/abs.cpp
@@ -51,9 +51,13 @@
 #define PROTO_DEVICE(T, D) LBANN_REGISTER_OPERATOR_WITH_CEREAL(T, D)
 
 PROTO_DEVICE(El::Complex<float>, El::Device::CPU);
+#ifdef LBANN_HAS_DOUBLE
 PROTO_DEVICE(El::Complex<double>, El::Device::CPU);
+#endif // LBANN_HAS_DOUBLE
 
 #ifdef LBANN_HAS_GPU
 PROTO_DEVICE(El::Complex<float>, El::Device::GPU);
+#ifdef LBANN_HAS_DOUBLE
 PROTO_DEVICE(El::Complex<double>, El::Device::GPU);
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_GPU

--- a/src/operators/math/math_builders.cpp
+++ b/src/operators/math/math_builders.cpp
@@ -26,16 +26,18 @@
 
 #include <lbann/operators/math/math_builders_impl.hpp>
 
-#define LBANN_ABS_OP_COMPLEX_ETI(D)                                            \
-  template std::unique_ptr<lbann::Operator<El::Complex<float>, float, D>>      \
-  lbann::build_abs_operator<El::Complex<float>, D>(                            \
-    lbann_data::Operator const&);                                              \
-  template std::unique_ptr<lbann::Operator<El::Complex<double>, double, D>>    \
-  lbann::build_abs_operator<El::Complex<double>, D>(                           \
-    lbann_data::Operator const&)
-LBANN_ABS_OP_COMPLEX_ETI(El::Device::CPU);
+#define LBANN_ABS_OP_COMPLEX_ETI(T, D)                                         \
+  template std::unique_ptr<lbann::Operator<El::Complex<T>, T, D>>              \
+  lbann::build_abs_operator<El::Complex<T>, D>(lbann_data::Operator const&);
+LBANN_ABS_OP_COMPLEX_ETI(float, El::Device::CPU);
+#ifdef LBANN_HAS_DOUBLE
+LBANN_ABS_OP_COMPLEX_ETI(double, El::Device::CPU);
+#endif // LBANN_HAS_DOUBLE
 #ifdef LBANN_HAS_GPU
-LBANN_ABS_OP_COMPLEX_ETI(El::Device::GPU);
+LBANN_ABS_OP_COMPLEX_ETI(float, El::Device::GPU);
+#ifdef LBANN_HAS_DOUBLE
+LBANN_ABS_OP_COMPLEX_ETI(double, El::Device::GPU);
+#endif // LBANN_HAS_DOUBLE
 #endif
 #undef LBANN_ABS_OP_COMPLEX_ETI
 

--- a/src/operators/math/unit_test/abs_test.cpp
+++ b/src/operators/math/unit_test/abs_test.cpp
@@ -64,10 +64,14 @@ using AbsOperatorAllDevices = h2::meta::TL<
 using AllAbsOpTypes = h2::meta::tlist::Append<
 #if !defined LBANN_HAS_ROCM
   AbsOperatorAllDevices<El::Complex<float>>,
+#ifdef LBANN_HAS_DOUBLE
   AbsOperatorAllDevices<El::Complex<double>>,
+#endif // LBANN_HAS_DOUBLE
 #endif // LBANN_HAS_ROCM
-  AbsOperatorAllDevices<float>,
-  AbsOperatorAllDevices<double>>;
+#ifdef LBANN_HAS_DOUBLE
+  AbsOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  AbsOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/add_constant_test.cpp
+++ b/src/operators/math/unit_test/add_constant_test.cpp
@@ -59,9 +59,11 @@ using AddConstantOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   AddConstantOperator<T, El::Device::CPU>>;
 
-using AllAddConstantOpTypes =
-  h2::meta::tlist::Append<AddConstantOperatorAllDevices<float>,
-                          AddConstantOperatorAllDevices<double>>;
+using AllAddConstantOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  AddConstantOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  AddConstantOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/add_test.cpp
+++ b/src/operators/math/unit_test/add_test.cpp
@@ -59,8 +59,11 @@ using AddOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   AddOperator<T, El::Device::CPU>>;
 
-using AllAddOpTypes = h2::meta::tlist::Append<AddOperatorAllDevices<float>,
-                                              AddOperatorAllDevices<double>>;
+using AllAddOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  AddOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  AddOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/clamp_test.cpp
+++ b/src/operators/math/unit_test/clamp_test.cpp
@@ -59,9 +59,11 @@ using ClampOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   ClampOperator<T, El::Device::CPU>>;
 
-using AllClampOpTypes =
-  h2::meta::tlist::Append<ClampOperatorAllDevices<float>,
-                          ClampOperatorAllDevices<double>>;
+using AllClampOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  ClampOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  ClampOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/constant_subtract_test.cpp
+++ b/src/operators/math/unit_test/constant_subtract_test.cpp
@@ -59,9 +59,11 @@ using ConstantSubtractOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   ConstantSubtractOperator<T, El::Device::CPU>>;
 
-using AllConstantSubtractOpTypes =
-  h2::meta::tlist::Append<ConstantSubtractOperatorAllDevices<float>,
-                          ConstantSubtractOperatorAllDevices<double>>;
+using AllConstantSubtractOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  ConstantSubtractOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  ConstantSubtractOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/cos_test.cpp
+++ b/src/operators/math/unit_test/cos_test.cpp
@@ -68,8 +68,11 @@ using CosOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   CosOperator<T, El::Device::CPU>>;
 
-using AllCosOpTypes = h2::meta::tlist::Append<CosOperatorAllDevices<float>,
-                                              CosOperatorAllDevices<double>>;
+using AllCosOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  CosOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  CosOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/equal_constant_test.cpp
+++ b/src/operators/math/unit_test/equal_constant_test.cpp
@@ -60,9 +60,11 @@ using EqualConstantOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   EqualConstantOperator<T, El::Device::CPU>>;
 
-using AllEqualConstantOpTypes =
-  h2::meta::tlist::Append<EqualConstantOperatorAllDevices<float>,
-                          EqualConstantOperatorAllDevices<double>>;
+using AllEqualConstantOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  EqualConstantOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  EqualConstantOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/multiply_test.cpp
+++ b/src/operators/math/unit_test/multiply_test.cpp
@@ -59,9 +59,11 @@ using MultiplyOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   MultiplyOperator<T, El::Device::CPU>>;
 
-using AllMultiplyOpTypes =
-  h2::meta::tlist::Append<MultiplyOperatorAllDevices<float>,
-                          MultiplyOperatorAllDevices<double>>;
+using AllMultiplyOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  MultiplyOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  MultiplyOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/not_equal_constant_test.cpp
+++ b/src/operators/math/unit_test/not_equal_constant_test.cpp
@@ -60,9 +60,11 @@ using NotEqualConstantOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   NotEqualConstantOperator<T, El::Device::CPU>>;
 
-using AllNotEqualConstantOpTypes =
-  h2::meta::tlist::Append<NotEqualConstantOperatorAllDevices<float>,
-                          NotEqualConstantOperatorAllDevices<double>>;
+using AllNotEqualConstantOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  NotEqualConstantOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  NotEqualConstantOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/scale_test.cpp
+++ b/src/operators/math/unit_test/scale_test.cpp
@@ -59,9 +59,11 @@ using ScaleOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   ScaleOperator<T, El::Device::CPU>>;
 
-using AllScaleOpTypes =
-  h2::meta::tlist::Append<ScaleOperatorAllDevices<float>,
-                          ScaleOperatorAllDevices<double>>;
+using AllScaleOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  ScaleOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  ScaleOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/sin_test.cpp
+++ b/src/operators/math/unit_test/sin_test.cpp
@@ -68,8 +68,11 @@ using SinOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   SinOperator<T, El::Device::CPU>>;
 
-using AllSinOpTypes = h2::meta::tlist::Append<SinOperatorAllDevices<float>,
-                                              SinOperatorAllDevices<double>>;
+using AllSinOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  SinOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  SinOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/subtract_constant_test.cpp
+++ b/src/operators/math/unit_test/subtract_constant_test.cpp
@@ -59,9 +59,11 @@ using SubtractConstantOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   SubtractConstantOperator<T, El::Device::CPU>>;
 
-using AllSubtractConstantOpTypes =
-  h2::meta::tlist::Append<SubtractConstantOperatorAllDevices<float>,
-                          SubtractConstantOperatorAllDevices<double>>;
+using AllSubtractConstantOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  SubtractConstantOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  SubtractConstantOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/operators/math/unit_test/subtract_test.cpp
+++ b/src/operators/math/unit_test/subtract_test.cpp
@@ -59,9 +59,11 @@ using SubtractOperatorAllDevices = h2::meta::TL<
 #endif // LBANN_HAS_GPU
   SubtractOperator<T, El::Device::CPU>>;
 
-using AllSubtractOpTypes =
-  h2::meta::tlist::Append<SubtractOperatorAllDevices<float>,
-                          SubtractOperatorAllDevices<double>>;
+using AllSubtractOpTypes = h2::meta::tlist::Append<
+#ifdef LBANN_HAS_DOUBLE
+  SubtractOperatorAllDevices<double>,
+#endif // LBANN_HAS_DOUBLE
+  SubtractOperatorAllDevices<float>>;
 
 namespace lbann {
 template <typename T, El::Device D>

--- a/src/optimizers/data_type_optimizer.cpp
+++ b/src/optimizers/data_type_optimizer.cpp
@@ -32,6 +32,7 @@
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 #define LBANN_CLASS_NAME data_type_optimizer

--- a/src/optimizers/optimizer.cpp
+++ b/src/optimizers/optimizer.cpp
@@ -57,7 +57,8 @@ void optimizer::finish_gradient_sync()
 }
 
 std::vector<std::reference_wrapper<El::BaseDistMatrix>>
-optimizer::get_raw_gradients() {
+optimizer::get_raw_gradients()
+{
   this->start_gradient_sync();
   this->finish_gradient_sync();
 
@@ -167,6 +168,7 @@ void optimizer::remove_gradient_source(const void* source)
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 #define LBANN_CLASS_NAME optimizer

--- a/src/optimizers/unit_test/optimizer_common.hpp
+++ b/src/optimizers/unit_test/optimizer_common.hpp
@@ -52,8 +52,11 @@ std::string desc_string(ObjectType const& opt)
 // archive, the cadr is the input archive. Accessor metafunctions are
 // defined below.
 
-using FpTypes = TL<float,
+using FpTypes = TL<float
+#ifdef LBANN_HAS_DOUBLE
+                   ,
                    double
+#endif // LBANN_HAS_DOUBLE
 #ifdef LBANN_HAS_HALF
                    ,
                    lbann::cpu_fp16

--- a/src/utils/amp.cpp
+++ b/src/utils/amp.cpp
@@ -25,26 +25,26 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/utils/amp.hpp"
-#include "lbann/utils/exception.hpp"
 #include "lbann/optimizers/optimizer.hpp"
+#include "lbann/utils/exception.hpp"
 
 #include <cmath>
 
 #ifdef LBANN_HAS_HALF
 namespace {
-bool isfinite(__half x) { return std::isfinite((float) x); }
-}
+bool isfinite(__half x) { return std::isfinite((float)x); }
+} // namespace
 #endif
 
 namespace lbann {
 namespace amp {
 
 template <typename TensorDataType>
-void is_finite_and_unscale(
-  El::AbstractDistMatrix<TensorDataType>& grads,
-  EvalType scale,
-  float* is_finite_cpu,
-  float* is_finite_gpu) {
+void is_finite_and_unscale(El::AbstractDistMatrix<TensorDataType>& grads,
+                           EvalType scale,
+                           float* is_finite_cpu,
+                           float* is_finite_gpu)
+{
   switch (grads.GetLocalDevice()) {
   case El::Device::CPU:
     is_finite_and_unscale_cpu(grads, scale, is_finite_cpu);
@@ -60,16 +60,16 @@ void is_finite_and_unscale(
   }
 }
 
-bool is_finite_and_unscale_all(
-  std::vector<optimizer*> optimizers,
-  EvalType scale) {
+bool is_finite_and_unscale_all(std::vector<optimizer*> optimizers,
+                               EvalType scale)
+{
   // Keep two separate pointers for CPU and GPU finiteness.
   float is_finite_cpu = 1.0f;
   float* is_finite_cpu_p = &is_finite_cpu;
 #ifdef LBANN_HAS_GPU
   El::Matrix<float, El::Device::GPU> is_finite_mat;
 #ifdef HYDROGEN_HAVE_CUB
-  is_finite_mat.SetMemoryMode(1);  // Use CUB memory pool.
+  is_finite_mat.SetMemoryMode(1); // Use CUB memory pool.
 #endif
   is_finite_mat.Resize(1, 1);
   El::Fill(is_finite_mat, El::TypeTraits<float>::One());
@@ -88,17 +88,27 @@ bool is_finite_and_unscale_all(
       // Attempt to convert from a BaseDistMatrix to an AbstractDistMatrix.
       if (auto* ptr_f = dynamic_cast<El::AbstractDistMatrix<float>*>(&grad)) {
         is_finite_and_unscale(*ptr_f, scale, is_finite_cpu_p, is_finite_gpu_p);
-      } else if (auto* ptr_d = dynamic_cast<El::AbstractDistMatrix<double>*>(&grad)) {
+      }
+      else if (auto* ptr_d =
+                 dynamic_cast<El::AbstractDistMatrix<double>*>(&grad)) {
         is_finite_and_unscale(*ptr_d, scale, is_finite_cpu_p, is_finite_gpu_p);
       }
 #ifdef LBANN_HAS_HALF
-      else if (auto* ptr_cpufp16 = dynamic_cast<El::AbstractDistMatrix<cpu_fp16>*>(&grad)) {
-        is_finite_and_unscale(*ptr_cpufp16, scale, is_finite_cpu_p, is_finite_gpu_p);
+      else if (auto* ptr_cpufp16 =
+                 dynamic_cast<El::AbstractDistMatrix<cpu_fp16>*>(&grad)) {
+        is_finite_and_unscale(*ptr_cpufp16,
+                              scale,
+                              is_finite_cpu_p,
+                              is_finite_gpu_p);
       }
 #endif
 #ifdef LBANN_HAS_GPU_FP16
-      else if (auto* ptr_fp16 = dynamic_cast<El::AbstractDistMatrix<fp16>*>(&grad)) {
-        is_finite_and_unscale(*ptr_fp16, scale, is_finite_cpu_p, is_finite_gpu_p);
+      else if (auto* ptr_fp16 =
+                 dynamic_cast<El::AbstractDistMatrix<fp16>*>(&grad)) {
+        is_finite_and_unscale(*ptr_fp16,
+                              scale,
+                              is_finite_cpu_p,
+                              is_finite_gpu_p);
       }
 #endif
       else {
@@ -109,7 +119,7 @@ bool is_finite_and_unscale_all(
 
   bool is_finite = is_finite_cpu == 1.0f;
 #ifdef LBANN_HAS_GPU
-  #pragma GCC diagnostic push
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   is_finite &= (is_finite_mat.Get(0, 0) == 1.0f);
 #pragma GCC diagnostic pop
@@ -118,10 +128,10 @@ bool is_finite_and_unscale_all(
 }
 
 template <typename TensorDataType>
-void is_finite_and_unscale_cpu(
-  El::AbstractDistMatrix<TensorDataType>& grads,
-  EvalType scale,
-  float* is_finite_p) {
+void is_finite_and_unscale_cpu(El::AbstractDistMatrix<TensorDataType>& grads,
+                               EvalType scale,
+                               float* is_finite_p)
+{
   const auto inv_scale = El::To<TensorDataType>(EvalType{1} / scale);
   auto* __restrict__ buf = grads.Buffer();
 
@@ -145,7 +155,7 @@ void is_finite_and_unscale_cpu(
     LBANN_OMP_PARALLEL_FOR_ARGS(reduction(&& : is_finite) collapse(2))
     for (size_t col = 0; col < width; ++col) {
       for (size_t row = 0; row < height; ++row) {
-        auto& val = buf[row + col*ldim];
+        auto& val = buf[row + col * ldim];
         if (!isfinite(val)) {
           is_finite = false;
         }
@@ -159,16 +169,16 @@ void is_finite_and_unscale_cpu(
   }
 }
 
-#define PROTO(T)                                \
-  template void is_finite_and_unscale<T>(       \
-    El::AbstractDistMatrix<T>&,                 \
-    EvalType,                                   \
-    float*,                                     \
-    float*);
+#define PROTO(T)                                                               \
+  template void is_finite_and_unscale<T>(El::AbstractDistMatrix<T>&,           \
+                                         EvalType,                             \
+                                         float*,                               \
+                                         float*);
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
-}  // namespace amp
-}  // namespace lbann
+} // namespace amp
+} // namespace lbann

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -510,6 +510,7 @@ int get_num_spatial_dims(const Layer& layer) { return get_num_dims(layer) - 2; }
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 } // namespace dc

--- a/src/utils/serialize_matrices.cpp
+++ b/src/utils/serialize_matrices.cpp
@@ -78,6 +78,7 @@
 
 // Enumerate all the valid data types.
 #define PROTO(T) REGISTER_ALL_DISTMATRIX_DEVICES(T)
+#define LBANN_INSTANTIATE_DOUBLE
 #include <lbann/macros/instantiate.hpp>
 
 CEREAL_REGISTER_DYNAMIC_INIT(DistMatrixTypes);

--- a/src/utils/serialize_matrices/common.hpp
+++ b/src/utils/serialize_matrices/common.hpp
@@ -27,6 +27,8 @@
 #include <cereal/types/polymorphic.hpp>
 #include <lbann/utils/serialization/serialize_matrices.hpp>
 
+#define LBANN_INSTANTIATE_DOUBLE
+
 // Register types outside Cereal's namespace.
 #define LBANN_COMMA ,
 

--- a/src/weights/data_type_weights.cpp
+++ b/src/weights/data_type_weights.cpp
@@ -599,6 +599,7 @@ void data_type_weights<TensorDataType>::do_steal_values_(weights& other)
 
 #define LBANN_INSTANTIATE_CPU_HALF
 #define LBANN_INSTANTIATE_GPU_HALF
+#define LBANN_INSTANTIATE_DOUBLE
 #include "lbann/macros/instantiate.hpp"
 
 #define LBANN_CLASS_NAME data_type_weights

--- a/src/weights/unit_test/weights_proxy_test.cpp
+++ b/src/weights/unit_test/weights_proxy_test.cpp
@@ -169,8 +169,12 @@ TEST_CASE("Empty WeightsProxy tests.", "[mpi][weights][proxy]")
 
 TEMPLATE_TEST_CASE("Weights proxy tests.",
                    "[mpi][weights][proxy]",
-                   (MasterProxyPair<float, float>),
-                   (MasterProxyPair<double, float>))
+                   (MasterProxyPair<float, float>)
+#ifdef LBANN_HAS_DOUBLE
+                     ,
+                   (MasterProxyPair<double, float>)
+#endif // LBANN_HAS_DOUBLE
+)
 {
   using MasterDataType = MasterType<TestType>;
   using DataType = ProxyType<TestType>;


### PR DESCRIPTION
Changing the core of LBANN to have double as a core data type for
layers, weights, and optimizers to be a build time option.  This will 
allow developers to reduce compilation time (minimizing template 
instantiation).