### PR TITLE
Fix FP16 support on ROCm platforms

### DIFF
--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -399,11 +399,10 @@ private:
     const int num_per_channel = this->get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter
+    typedef TensorDataType T;
     const bool default_beta =
-      (std::fabs((m_beta - El::To<TensorDataType>(0.75)) /
-                 El::To<TensorDataType>(0.75)) <
-       El::To<TensorDataType>(2) *
-         std::numeric_limits<TensorDataType>::epsilon());
+      (El::Abs((m_beta - El::To<T>(0.75)) / El::To<T>(0.75)) <
+       El::To<T>(2) * std::numeric_limits<T>::epsilon());
 
     ////////////////////////////////////////////////////////////////
     // error_signal(i)

--- a/include/lbann/layers/transform/constant.hpp
+++ b/include/lbann/layers/transform/constant.hpp
@@ -77,7 +77,7 @@ protected:
 
   void fp_compute() override
   {
-    if (m_value == EvalType(0)) {
+    if (m_value == El::To<TensorDataType>(0.0)) {
       El::Zero(this->get_activations());
     }
     else {

--- a/include/lbann/utils/impl/cuda.hpp
+++ b/include/lbann/utils/impl/cuda.hpp
@@ -149,7 +149,7 @@ __device__ __forceinline__ T gpu_lib::block_reduce(T val)
 template <>
 __device__ __forceinline__ bool gpu_lib::isfinite(__half const& x)
 {
-  return !(::__isnan(x) || ::__hisinf(x));
+  return !(::__hisnan(x) || ::__hisinf(x));
 }
 template <>
 __device__ __forceinline__ bool gpu_lib::isinf(__half const& x)

--- a/include/lbann/utils/impl/rocm.hpp
+++ b/include/lbann/utils/impl/rocm.hpp
@@ -155,7 +155,7 @@ __device__ __forceinline__ T gpu_lib::block_reduce(T val)
 #define WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(func)                 \
   __device__ __forceinline__ __half gpu_lib::func(__half const& x)             \
   {                                                                            \
-    return ::func(float(x));                                                   \
+    return gpu_lib::func(float(x));                                            \
   }
 
 WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(round)
@@ -197,7 +197,28 @@ WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(tanh)
 WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(acosh)
 WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(asinh)
 WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(atanh)
+
+WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(erf)
+WRAP_UNARY_ROCM_HALF_CAST_TO_FLOAT_MATH_FUNCTION(erfinv)
 #undef WRAP_UNARY_ROCM_HALF_MATH_FUNCTION
+
+template <>
+__device__ __forceinline__ bool gpu_lib::isnan(__half const& x)
+{
+  return __hisnan(x);
+}
+
+template <>
+__device__ __forceinline__ bool gpu_lib::isinf(__half const& x)
+{
+  return __hisinf(x);
+}
+
+template <>
+__device__ __forceinline__ bool gpu_lib::isfinite(__half const& x)
+{
+  return !(__hisnan(x) || __hisinf(x));
+}
 
 // Binary math functions
 __device__ __forceinline__ __half gpu_lib::min(const __half& x, const __half& y)

--- a/src/layers/regularizers/selu_dropout.cpp
+++ b/src/layers/regularizers/selu_dropout.cpp
@@ -167,7 +167,7 @@ void selu_dropout<T, L, D>::fp_compute()
 {
   if (this->m_model->get_execution_context().get_execution_mode() !=
         execution_mode::training ||
-      m_keep_prob < 0.0f) {
+      m_keep_prob < El::To<T>(0.0f)) {
     // Do nothing if dropout is disabled
     El::Copy(this->get_prev_activations(), this->get_activations());
   }
@@ -203,7 +203,7 @@ void selu_dropout<T, L, D>::bp_compute()
 {
   if (this->m_model->get_execution_context().get_execution_mode() !=
         execution_mode::training ||
-      m_keep_prob < 0.0f) {
+      m_keep_prob < El::To<T>(0.0f)) {
     El::Copy(this->get_prev_error_signals(), this->get_error_signals());
   }
   else {

--- a/src/layers/transform/reduction.cpp
+++ b/src/layers/transform/reduction.cpp
@@ -125,7 +125,7 @@ void reduction_layer<TensorDataType, Layout, Device>::fp_compute()
     break;
   case reduction_mode::AVERAGE:
     El::Gemv(El::TRANSPOSE,
-             one / El::To<TensorDataType>(input.Height()),
+             El::To<TensorDataType>(one / El::To<TensorDataType>(input.Height())),
              input.LockedMatrix(),
              ones,
              zero,
@@ -186,7 +186,7 @@ void reduction_layer<TensorDataType, Layout, Device>::bp_compute()
   case reduction_mode::AVERAGE:
     El::Gemm(El::NORMAL,
              El::NORMAL,
-             one / El::To<TensorDataType>(input_grad.Height()),
+             El::To<TensorDataType>(one / El::To<TensorDataType>(input_grad.Height())),
              ones,
              local_output_grad,
              zero,

--- a/src/layers/transform/uniform.cpp
+++ b/src/layers/transform/uniform.cpp
@@ -37,8 +37,8 @@ namespace lbann {
 template <typename TensorDataType, data_layout L, El::Device D>
 void uniform_layer<TensorDataType, L, D>::fp_compute()
 {
-  const auto& mean = (m_max + m_min) / El::To<TensorDataType>(2);
-  const auto& radius = (m_max - m_min) / El::To<TensorDataType>(2);
+  TensorDataType const mean = (m_max + m_min) / El::To<TensorDataType>(2);
+  TensorDataType const radius = (m_max - m_min) / El::To<TensorDataType>(2);
   auto& output = this->get_activations();
   const auto& mode =
     this->m_model->get_execution_context().get_execution_mode();

--- a/src/weights/initializer.cpp
+++ b/src/weights/initializer.cpp
@@ -272,11 +272,12 @@ description uniform_initializer<TensorDataType>::get_description() const
 template <typename TensorDataType>
 void uniform_initializer<TensorDataType>::fill(AbsDistMatrixType& matrix)
 {
+  typedef TensorDataType T;
   uniform_fill(matrix,
                matrix.Height(),
                matrix.Width(),
-               (m_max + m_min) / El::To<TensorDataType>(2),
-               (m_max - m_min) / El::To<TensorDataType>(2));
+               El::To<T>((m_max + m_min) / El::To<T>(2)),
+               El::To<T>((m_max - m_min) / El::To<T>(2)));
 }
 
 template <typename TensorDataType>
@@ -365,7 +366,7 @@ build_uniform_initializer_from_pbuf(google::protobuf::Message const& msg)
     dynamic_cast<lbann_data::Initializer::UniformInitializer const&>(msg);
   const auto& min = El::To<TensorDataType>(params.min());
   const auto& max = El::To<TensorDataType>(params.max());
-  if (min != 0.0 || max != 0.0) {
+  if (min != El::To<TensorDataType>(0.0) || max != El::To<TensorDataType>(0.0)) {
     return std::make_unique<uniform_initializer<TensorDataType>>(min, max);
   }
   else {
@@ -377,12 +378,13 @@ template <typename TensorDataType>
 std::unique_ptr<weights_initializer>
 build_normal_initializer_from_pbuf(google::protobuf::Message const& msg)
 {
+  typedef TensorDataType T;
   const auto& params =
     dynamic_cast<lbann_data::Initializer::NormalInitializer const&>(msg);
   const auto& mean = El::To<TensorDataType>(params.mean());
   const auto& standard_deviation =
     El::To<TensorDataType>(params.standard_deviation());
-  if (mean != 0.0 || standard_deviation != 0.0) {
+  if (mean != El::To<T>(0.0) || standard_deviation != El::To<T>(0.0)) {
     return std::make_unique<normal_initializer<TensorDataType>>(
       mean,
       standard_deviation);


### PR DESCRIPTION
This requires LLNL/Elemental#109.

This does NOT impact DistConv codepaths -- fp16 is still not supported in DistConv on any platform.

@ndryden will likely care about this for testing AMP (#2359).