### PR TITLE
Fixes for half and CUDA 12.2

### DIFF
--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -299,7 +299,7 @@ private:
 
     // Check if LRN is using default beta parameter
     // std::fabs is not defined for GPU half.
-#ifdef LBANN_HAS_HALF
+#ifdef LBANN_HAS_GPU_FP16
     const bool default_beta = [&] {
       if constexpr (!std::is_same_v<TensorDataType, __half>) {
         return (std::fabs((m_beta - El::To<TensorDataType>(0.75)) /
@@ -316,7 +316,7 @@ private:
       (std::fabs((m_beta - El::To<TensorDataType>(0.75)) /
                  El::To<TensorDataType>(0.75)) <
        2 * std::numeric_limits<DataType>::epsilon());
-#endif // LBANN_HAS_HALF
+#endif // LBANN_HAS_GPU_FP16
 
     ////////////////////////////////////////////////////////////////
     // activations(i) = prev_activations(i) / scale_factor(i) ^ beta

--- a/include/lbann/layers/regularizers/local_response_normalization.hpp
+++ b/include/lbann/layers/regularizers/local_response_normalization.hpp
@@ -298,10 +298,25 @@ private:
     const int num_per_channel = this->get_output_size() / num_channels;
 
     // Check if LRN is using default beta parameter
+    // std::fabs is not defined for GPU half.
+#ifdef LBANN_HAS_HALF
+    const bool default_beta = [&] {
+      if constexpr (!std::is_same_v<TensorDataType, __half>) {
+        return (std::fabs((m_beta - El::To<TensorDataType>(0.75)) /
+                          El::To<TensorDataType>(0.75)) <
+                2 * std::numeric_limits<DataType>::epsilon());
+      }
+      else {
+        LBANN_ERROR("Cannot use GPU half on CPU for LRN");
+        return false;
+      }
+    }();
+#else
     const bool default_beta =
       (std::fabs((m_beta - El::To<TensorDataType>(0.75)) /
                  El::To<TensorDataType>(0.75)) <
        2 * std::numeric_limits<DataType>::epsilon());
+#endif // LBANN_HAS_HALF
 
     ////////////////////////////////////////////////////////////////
     // activations(i) = prev_activations(i) / scale_factor(i) ^ beta

--- a/src/callbacks/gradient_clipping.cpp
+++ b/src/callbacks/gradient_clipping.cpp
@@ -137,7 +137,7 @@ struct NormComputer
 
       // The following call may incur communication (e.g., with sharded weights)
       norm = El::Nrm2(grad);
-      if (norm > norm_value) {
+      if (norm > El::To<TensorDataType>(norm_value)) {
         El::Scale(El::To<TensorDataType>(norm_value) / norm, grad);
       }
     }
@@ -158,7 +158,7 @@ struct NormComputer
         }
 #else
         local_norm = El::Nrm2(gradmatrix);
-#endif
+#endif // LBANN_HAS_HALF
 #ifdef LBANN_HAS_GPU
       }
       else if ((gradmat.GetDevice() == El::Device::GPU)) {
@@ -179,20 +179,20 @@ struct NormComputer
       }
       if (dtw.is_sharded()) {
         // Summarize sharded norms separately (as they will be allreduced)
-        *global_sharded_norm_ptr += local_norm * local_norm;
+        *global_sharded_norm_ptr += El::To<DataType>(local_norm * local_norm);
         *any_weights_sharded = true;
       }
       else if (on_subgrid(grad)) {
         // If gradients live on a subgrid, also reduce them based on their size
-        *global_sharded_norm_ptr +=
+        *global_sharded_norm_ptr += El::To<DataType>(
           (local_norm * local_norm) /
-          El::To<TensorDataType>(grad.RedundantSize());
+          El::To<TensorDataType>(grad.RedundantSize()));
         *any_weights_sharded = true;
       }
       else {
         // As an optimization, weights that are shared across all ranks in a
         // trainer (i.e., STAR_STAR) don't need to be reduced
-        *global_norm_ptr += local_norm * local_norm;
+        *global_norm_ptr += El::To<DataType>(local_norm * local_norm);
       }
     }
   }

--- a/src/callbacks/gradient_clipping.cpp
+++ b/src/callbacks/gradient_clipping.cpp
@@ -149,7 +149,7 @@ struct NormComputer
           static_cast<const El::Matrix<TensorDataType, El::Device::CPU>&>(
             gradmat);
         // Nrm2 is not supported on CPU matrices with __half.
-#ifdef LBANN_HAS_HALF
+#ifdef LBANN_HAS_GPU_FP16
         if constexpr (!std::is_same_v<TensorDataType, __half>) {
           local_norm = El::Nrm2(gradmatrix);
         }
@@ -158,7 +158,7 @@ struct NormComputer
         }
 #else
         local_norm = El::Nrm2(gradmatrix);
-#endif // LBANN_HAS_HALF
+#endif // LBANN_HAS_GPU_FP16
 #ifdef LBANN_HAS_GPU
       }
       else if ((gradmat.GetDevice() == El::Device::GPU)) {

--- a/src/optimizers/adam.cpp
+++ b/src/optimizers/adam.cpp
@@ -34,7 +34,7 @@
 
 namespace lbann {
 
-#if defined(LBANN_HAS_ROCM) && defined(LBANN_HAS_GPU_FP16)
+#if defined(LBANN_HAS_GPU_FP16)
 namespace {
 bool isfinite(fp16 const& x) { return std::isfinite(float(x)); }
 } // namespace


### PR DESCRIPTION
Various fixes throughout the codebase to build properly with the changes to half in CUDA 12.2.

Mainly this is now better handling CPU code that is instantiated with the GPU half type (even if we never execute it).

(I will wait to merge this until CI can run.)