### PR TITLE
Force convolutions to be deterministic when LBANN_DETERMINISTIC

### DIFF
--- a/src/utils/miopen.cpp
+++ b/src/utils/miopen.cpp
@@ -562,8 +562,16 @@ void ConvolutionDescriptor::reset(DescriptorHandle_t desc)
 
 void ConvolutionDescriptor::create()
 {
-  if (!desc_)
+  if (!desc_) {
     CHECK_MIOPEN(miopenCreateConvolutionDescriptor(&desc_));
+#ifdef LBANN_DETERMINISTIC
+    CHECK_MIOPEN(
+      miopenSetConvolutionAttribute(
+        desc_,
+        MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC,
+        1));
+#endif // LBANN_DETERMINISTIC
+  }
 }
 
 void ConvolutionDescriptor::set(std::vector<int> const& pad,


### PR DESCRIPTION
Note that this uses an [undocumented API](https://github.com/ROCm/MIOpen/blob/develop/include/miopen/miopen.h#L1120-L1122) in MIOpen.