### PR TITLE
Restore the superbuild

### DIFF
--- a/scripts/superbuild/CMakeLists.txt
+++ b/scripts/superbuild/CMakeLists.txt
@@ -1,0 +1,180 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+cmake_minimum_required(VERSION 3.22)
+project(LBANN_SuperBuild NONE)
+
+cmake_policy(SET CMP0097 NEW)
+
+message("\nWelcome to the LBANN SuperBuild system.\n\nGood luck!\n")
+
+if (PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  message(FATAL_ERROR "In-source builds are not permitted.")
+endif ()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
+include(LBANNSuperBuildAddCMakeExternPkg)
+include(LBANNSuperBuildAddPackages)
+include(LBANNSuperBuildCreateCMakeArguments)
+include(LBANNSuperBuildInitExternPkg)
+
+# SuperBuild options
+option(LBANN_SB_DEFAULT_CUDA_OPTS
+  "Set Tom's preferred default options for CUDA builds."
+  OFF)
+
+option(LBANN_SB_DEFAULT_ROCM_OPTS
+  "Set Tom's preferred default options for ROCm builds."
+  OFF)
+
+option(LBANN_SB_CLONE_VIA_SSH
+  "Use SSH protocol instead of HTTPS for github." OFF)
+
+set(LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY "COMMON"
+  CACHE STRING "Package prefix selection strategy. [COMMON, PKG, PKG_LC].")
+
+# List packages that we can build. The names are chosen first to align
+# with variables specific to the package (e.g., Aluminum uses
+# "ALUMINUM_" as its variable prefix, so we simplify our lives by
+# using "ALUMINUM" as the package name). When the variable names do
+# not include the package, we fall back on however the package refers
+# to itself.
+#
+# NOTE: This list is ORDERED. "Second-order" dependencies come before
+# "first-order" dependencies.
+#
+# FIXME: Address the above node so that the packages are known before
+# descending into subdirectories.
+lbann_sb_add_packages(
+  # Ack, a "third-order" dependency
+  RCCL
+
+  # These are "second-order" dependencies
+  adiak        # Caliper
+  Caliper      # Aluminum, LBANN
+  Aluminum     # Hydrogen, DiHydrogen
+  Catch2       # Hydrogen, DiHydrogen
+  HDF5         # Conduit
+  JPEG-TURBO   # OpenCV
+  OpenBLAS     # Hydrogen
+  spdlog       # DiHydrogen, LBANN
+
+  # These are the "first-order" dependencies
+  cereal
+  Clara
+  CNPY
+  Conduit
+  Hydrogen     # DiHydrogen depends on H.
+  DiHydrogen
+  OpenCV
+  protobuf
+  zstr
+
+  # And finally add the option to build LBANN
+  LBANN)
+
+# Note: This changes things around slightly from the original
+# version. I have flattened this list to IGNORE the dependency
+# graph. This makes it slightly more general-purpose (that is, I don't
+# care WHY you want to build {HDF5, JPEG-turbo, OpenBLAS} but not
+# {Conduit, OpenCV, Hydrogen}, so I'm just going to let you do that).
+
+# Add the TPL subdirectories
+set(_GIT_REPOSITORY_TAG "GIT_REPOSITORY")
+set(_GIT_TAG_TAG "GIT_TAG")
+foreach (pkg ${LBANN_SB_BUILD_PKGS})
+  if (LBANN_SB_BUILD_${pkg})
+    string(TOLOWER "${pkg}" pkg_lower)
+    add_subdirectory(${pkg_lower})
+  endif ()
+endforeach ()
+
+# Print a helpful(?) message
+set(LBANN_SB_SUGG_CMAKE_PREFIX_PATH_TMP "\$\{CMAKE_PREFIX_PATH\}")
+message("\n-----------------------------------------------------------------\n")
+message("LBANN SuperBuild will build the following packages:\n")
+foreach (pkg ${LBANN_SB_BUILD_PKGS})
+  if (${pkg}_CMAKE_INSTALL_PREFIX)
+    message("  -- ${pkg} (${${pkg}_CMAKE_INSTALL_PREFIX})")
+    list(PREPEND LBANN_SB_SUGG_CMAKE_PREFIX_PATH_TMP
+      "${${pkg}_CMAKE_INSTALL_PREFIX}")
+  elseif (LBANN_SB_${pkg}_PREFIX)
+    message("  -- ${pkg} (${LBANN_SB_${pkg}_PREFIX})")
+    list(PREPEND LBANN_SB_SUGG_CMAKE_PREFIX_PATH_TMP
+      "${LBANN_SB_${pkg}_PREFIX}")
+  else ()
+    message("  -- ${pkg} (??????)")
+  endif ()
+endforeach ()
+list(REMOVE_DUPLICATES LBANN_SB_SUGG_CMAKE_PREFIX_PATH_TMP)
+string(REPLACE ";" ":" LBANN_SB_SUGG_CMAKE_PREFIX_PATH
+  "${LBANN_SB_SUGG_CMAKE_PREFIX_PATH_TMP}")
+message("\nIt may be useful to do the following:\n")
+message("export CMAKE_PREFIX_PATH=${LBANN_SB_SUGG_CMAKE_PREFIX_PATH}\n")
+message("or\n")
+message("source lbann_sb_suggested_cmake_prefix_path.sh\n")
+message("Note that these assume a Bourne-compatible shell.")
+message("\n-----------------------------------------------------------------\n")
+file(WRITE "${CMAKE_BINARY_DIR}/lbann_sb_suggested_cmake_prefix_path.sh"
+  "export CMAKE_PREFIX_PATH=${LBANN_SB_SUGG_CMAKE_PREFIX_PATH}\n")
+
+# Add a custom target for bundling all things up
+if (UNIX)
+  find_program(__FIND_EXE find)
+  mark_as_advanced(__FIND_EXE)
+  set(__WORKING_DIR "${CMAKE_BINARY_DIR}")
+  if (__FIND_EXE)
+    set(__cmd "${__FIND_EXE};.;\(;-ipath;*/stamp/*.log;-o;-ipath;*/CMakeFiles/CMake*.log;-o;-name;CMakeCache.txt;\);-exec;${CMAKE_COMMAND};-E;tar;czf;all_output_logs.tar.gz;--;{};+")
+    add_custom_target(gather-logs
+      COMMAND "${__cmd}"
+      BYPRODUCTS "${__WORKING_DIR}/all_output_logs.tar.gz"
+      WORKING_DIRECTORY "${__WORKING_DIR}"
+      COMMENT "Gathering all output logs."
+      VERBATIM
+      COMMAND_EXPAND_LISTS
+      USES_TERMINAL)
+
+    add_custom_target(gather-all)
+    add_dependencies(gather-all gather-logs)
+    if (CMAKE_GENERATOR STREQUAL "Ninja")
+      set(__cmd "${__FIND_EXE};.;-name;*.ninja;-exec;${CMAKE_COMMAND};-E;tar;czf;all_build_files.tar.gz;{};+")
+    elseif (CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+      set(__cmd "${__FIND_EXE};.;\(;-name;link.txt;-o;-name;build.make;-o;-name;flags.make;\);-exec;${CMAKE_COMMAND};-E;tar;czf;all_build_files.tar.gz;{};+")
+    else ()
+      set(__cmd)
+    endif ()
+    if (__cmd)
+      add_custom_target(gather-build
+        COMMAND "${__cmd}"
+        BYPRODUCTS "${__WORKING_DIR}/all_build_files.tar.gz"
+        WORKING_DIRECTORY "${__WORKING_DIR}"
+        COMMENT "Gathering all build files."
+        VERBATIM
+        COMMAND_EXPAND_LISTS
+        USES_TERMINAL)
+      add_dependencies(gather-all gather-build)
+    endif ()
+  endif (__FIND_EXE)
+endif (UNIX)

--- a/scripts/superbuild/CMakeLists.txt
+++ b/scripts/superbuild/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/README.md
+++ b/scripts/superbuild/README.md
@@ -1,0 +1,326 @@
+# LBANN SuperBuild
+
+Welcome to the LBANN SuperBuild project. Let's begin by establishing
+some boundaries and expectations.
+
+## What this is
+
+This SuperBuild infrastructure was originally developed as part of the
+[LBANN Project](https://github.com/LLNL/LBANN) as a way to build the
+first-order third-party dependencies for LBANN. It existed for some
+time hidden behind the infamous and storied `build_lbann_lc.sh` shell
+script. However, it was deprecated when Spack was determined to be
+mature and capable enough to build LBANN. It was officially removed
+from LBANN when the development team at the time had embraced the
+Spack build.
+
+Under normal circumstances, the official position of the LBANN team
+(myself included) is that users and developers should use the LBANN
+build script (which uses Spack under the hood). If you're here, it's
+likely because the build script just isn't working for you, and
+hopefully this will get you started.
+
+The SuperBuild can build all of the first-order dependencies of LBANN
+(except Python, due to its ubiquity), as well as a select few of its
+second-order dependencies that are either deemed to have significant
+performance impact (JPEG-turbo, OpenBLAS) or subject to version
+constraints that are unlikely to be fulfilled by system defaults
+(HDF5). It can also build LBANN itself, either from scratch or from a
+source directory that a user provides. As long as you have a
+mostly-sane operating system, this should get you a working build of
+LBANN.
+
+Above all, bear in mind: this is a *build tool*. It builds stuff, and
+that's it.
+
+The primary build targets are developer workstations (Linux and macOS)
+and Department of Energy clusters/supercomputers. It is regularly
+tested on a variety of LLNL machines as well as Perlmutter at NERSC.
+
+## What this is NOT
+
+This is not a package manager. Use `pacman`, `dnf`, `apt`, etc. for
+that. Or use Spack if you're really desperate.
+
+In particular, I don't track versions all that closely, and I don't do
+anything to "update" packages beyond what CMake gives me for free.
+
+I don't do anything special with Python. If you use this to build
+LBANN and you can't run something due to a missing Python dependency,
+install it however you would normally install a Python package.
+
+The SuperBuild will do very little to babysit your build. It will
+happily let you metaphorically shoot yourself in the foot. It does
+exactly what you tell it to do.
+
+# Supported packages
+
+The following packages are known by the SuperBuild framework:
+
+- [Aluminum](https://github.com/LLNL/Aluminum) - High-performance
+  communication library that provides a stream-aware interface and
+  semantics.
+- [Catch2](https://github.com/catchorg/catch2) - A unit-testing
+  framework for C++ packages. (Mostly for developers; also used by
+  H2 and Hydrogen, if enabled.)
+- [cereal](https://github.com/uscilab/cereal) - C++ serialization
+  library.
+- [Clara](https://github.com/catchorg/clara) - Argument parser (yes,
+  it *is* deprecated, and no, I don't care. It works. It could be
+  replaced by cxxopts or something if that changes.)
+- [CNPY](https://github.com/rogersce/cnpy) - Read and write NumPy data
+  in C++.
+- [Conduit](https://github.com/LLNL/Conduit) - Yet another
+  serialization format. Apparently there aren't enough of these.
+- [DiHydrogen](https://github.com/LLNL/DiHydrogen) - Distributed
+  tensors and associated operations upon them. This is also the
+  current location of the legacy "DistConv" library used by LBANN.
+- [HDF5](https://github.com/HDFGroup/hdf5) - Hierarchical data format,
+  but for SCIENCE!
+- [Hydrogen](https://github.com/LLNL/Elemental) - GPU-aware matrix
+  algebra library.
+- [JPEG-TURBO](https://github.com/libjpeg-turbo/libjpeg-turbo) - JPEG
+  but in turbo mode. Zoom zoom zoom.
+- [OpenBLAS](https://github.com/xianyi/OpenBLAS.git) - BLAS library
+  for when your vendor doesn't do a good job.
+- [OpenCV](https://github.com/opencv/opencv) - Computer vision
+  library.
+- [protobuf](https://github.com/protocolbuffers/protobuf.git) - And
+  yet *another* serialization format that LBANN (and others) (ab)use
+  for model topology description and configuration.
+- [spdlog](https://github.com/gabime/spdlog) - Fast C++ logging
+  library.
+- [zstr](https://github.com/mateidavid/zstr) - C++ ZLib wrapper.
+
+The framework is "opt-in". No package will be built unless the user
+explicitly enables it when they configure the SuperBuild project.
+
+# CMake configuration
+
+The SuperBuild project is configured and run through
+[CMake](https://cmake.org). I personally advocate using the
+[Ninja](https://ninja-build.org/) generator, but they should
+work. Under the hood, the system works by defining a series of [CMake
+External
+Projects](https://cmake.org/cmake/help/git-stage/module/ExternalProject.html)
+that is controlled by special CMake arguments, documented below.
+
+An important bit to note is that `ExternalProject` generates the
+*infratructure* to configure, build and install other projects.
+*However*, these projects are *NOT* configured when the SuperBuild is
+generated. This implies that, for things like library- or package-
+finding in these projects, the environment that matters is *not* the
+environment that exists when `cmake` is run to configure the
+SuperBuild but rather the environment that is exported to the
+subsequent invocation of the generated build system (e.g., `ninja` or
+`make` or whatever). This should be borne in mind when thinking about
+how to ensure that packages are resolving dependencies appropriately.
+
+On this note, the SuperBuild only offers dependency-resolution
+assistance with packages built by the SuperBuild. For example, if a
+user builds HDF5 *and* Conduit with *the same* SuperBuild, the
+SuperBuild itself will attempt to forward the correct HDF5 directory
+to Conduit so that Conduit's configuration finds the HDF5 that was
+built by this SuperBuild build system. However, if some other HDF5 is
+to be used, the onus is on the user to forward the necessary
+information about its existence and location to the Conduit package in
+the SuperBuild (e.g., by setting
+`LBANN_SB_FWD_Conduit_HDF5_DIR=/path/to/hdf5/prefix` in the SuperBuild
+configuration line, [as described
+below](#passing-options-to-superbuild-packages).
+
+The main SuperBuild project is designed to be a passive task
+manager. In CMake-speak, the language is `NONE` and it never calls a
+`find_{path,package,executable,library}` function. It simply
+configures a system of `ExternalProject` calls that do ALL of the work
+of building these packages. This has the benefit that it's nearly
+impossible for the configuration of the SuperBuild project itself to
+fail. The downside is that it pushes all configuration issues to the
+individual packages being built.
+
+## SuperBuild CMake Options
+
+There are several options and variables that can be used to control
+the SuperBuild project itself. All arguments used by the SuperBuild
+package are either standard CMake options (prefixed with `CMAKE_`) or
+use the `LBANN_SB_` prefix.
+
+- `LBANN_SB_BUILD_<PKG>` enables the build for `<PKG>`, which must
+  match a package (case-sensitive) in the list of packages above.
+
+- `LBANN_SB_CLONE_VIA_SSH` switches HTTPS GitHub URLs for SSH-based
+  ones. The onus is on the user to ensure their SSH authentication
+  method is setup and working.
+
+- `LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY` defines how to modify the
+  top-level `CMAKE_INSTALL_PREFIX` at the package level. Acceptible
+  values are:
+  - `COMMON` (default): Any package that doesn't specify its own
+    prefix will install to the SuperBuild's `CMAKE_INSTALL_PREFIX` (if
+    set).
+  - `PKG`: Any package that doesn't specify its own prefix will
+    install to `CMAKE_INSTALL_PREFIX/<PKG>`, with the casing of `PKG`
+    matching that in the list of packages above.
+  - `PKG_LC`: Any package that doesn't specify its own prefix will
+    install to `CMAKE_INSTALL_PREFIX/<pkg>`, where `<pkg>` is the
+    lower-cased version of the package name in the list of packages
+    above.
+
+The following variables will be forwarded to all GPU-enabled packages
+if it can be detected that they are being built with GPU support. CUDA
+packages will inherit
+
+- `CMAKE_CUDA_ARCHITECTURES`
+
+ROCm packages will inherit all of
+
+- `CMAKE_HIP_ARCHITECTURES`
+- `AMDGPU_TARGETS`
+- `GPU_TARGETS`
+
+If any of those are set, all will inherit that value and be forwarded
+appropriately. (I have no explanation for why these are ALL needed,
+but I get sporadic and nonsensical failures if I omit any. It is
+zero-cost-to-me to forward them all, and therefore zero-value-to-me to
+diagnose this (non-)issue.)
+
+## Passing options to SuperBuild packages
+
+The SuperBuild project attempts to expose mechanisms to allow even
+fine-grained control over the build of its component packages. The
+level of control is much higher if the package uses a CMake build, but
+an effort is made for other types of projects. Packages have some
+common options that are used to configure the `ExternalProject`
+command in CMake. These are prefixed with `LBANN_SB_<PKG>_`, where
+`<PKG>` matches a package (case-sensitive) in the list of packages
+above. The mechanism for package-specific options are described in
+detail [below](#options-specific-to-a-package).
+
+### Common options
+
+The following options are available to any package in the SuperBuild
+system and may be used to customize the properties of the build of
+those packages. It is the user's responsibility to ensure no
+compatibility issues arise (e.g., using two different and incompatible
+compilers to build two different packages). The options that are tied
+to CMake options work by forwarding values to the
+`ExternalProject`. This is (usually) easy for CMake projects, and a
+"best effort" is made to map them to non-CMake-based build systems.
+
+- `LBANN_SB_<PKG>_PREFIX` - The installation prefix for the `<PKG>`
+  package. If not provided, this defaults to `CMAKE_INSTALL_PREFIX`
+  modified according to `LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY`.
+- `LBANN_SB_<PKG>_<LANG>_COMPILER` - The compiler for the `<LANG>`
+  language for the `<PKG>` package. The default is the top-level
+  `CMAKE_<LANG>_COMPILER`, if provided. Otherwise no value is
+  forwarded and it is left to the package configure stage to deduce.
+- `LBANN_SB_<PKG>_<LANG>_FLAGS` - The flags to pass to the compiler
+  for the `<LANG>` language for the `<PKG>` package. The default is
+  the top-level `CMAKE_<LANG>_FLAGS`, if provided. Otherwise no value
+  is forwarded and it is left to the package configure stage to
+  deduce.
+- `LBANN_SB_<PKG>_SOURCE_DIR` - Specify a local directory to use to
+  build the `<PKG>` package. If this is set, it must be the top-level
+  directory for the build system of `<PKG>` (for a CMake package, the
+  directory containing the top-level `CMakeLists.txt`). Using this
+  option will disable ALL automatic Git steps and the source code will
+  be built as-is.
+- `LBANN_SB_<PKG>_URL` - The URL from which to clone the `<PKG>`
+  package. This must be a Git repository. This defaults to some flavor
+  of the "official" project repository (with a preference toward
+  Github if multiple candidates exist). This is ignored if
+  `LBANN_SB_<PKG>_SOURCE_DIR` is set.
+- `LBANN_SB_<PKG>_TAG` - The Git tag to check out for the `<PKG>`
+  package. The SuperBuild specifies a default tag for each package
+  that is a version acceptible to use with the `develop` branch of
+  LBANN.
+- `LBANN_SB_<PKG>_CMAKE_GENERATOR` - Setup the CMake generator to use
+  for the `<PKG>` package. This has no effect if the package is not a
+  CMake package. It will fail at *SuperBuild build time* (during the
+  configure step for `<PKG>`) if this is not a valid CMake generator
+  string. The default value is the generator used to configure the
+  SuperBuild.
+- `LBANN_SB_<PKG>_BUILD_SHARED_LIBS` - Build shared libraries for the
+  `<PKG>` package. This may not have an effect if the package is not a
+  CMake package. The default value is the value of the top-level
+  `BUILD_SHARED_LIBS`.
+- `LBANN_SB_<PKG>_IPO` - Attempt to enable interprocedural
+  optimization for the `<PKG>` package. The default value is the value
+  of the top-level `CMAKE_INTERPROCEDURAL_OPTIMIZATION`. This only has
+  an effect in CMake packages. Non-CMake packages should use compiler
+  flags to manually specify IPO options.
+- `LBANN_SB_<PKG>_PIC` - Attempt to enable
+  position-independent code for the `<PKG>` package. This may override
+  any inherited behavior from `LBANN_SB_<PKG>_BUILD_SHARED_LIBS`. This
+  only has an effect in CMake packages. Non-CMake packages should use
+  compiler flags to manually specify PIC/PIE flags.
+
+### Options specific to a package
+
+Packages in the SuperBuild that use CMake may have other options
+forwarded to them by using a special variable syntax:
+`LBANN_SB_FWD_<PKG>_<VARIABLE_NAME>=value`. For a project named `Foo`,
+we could set a variable, `WITH_SOME_FEATURE=ON`, in the `Foo` build
+system by passing `LBANN_SB_FWD_Foo_WITH_SOME_FEATURE=ON` to the
+SuperBuild configuration. When the CMake `ExternalProject` is
+generated for `Foo`, the configuration step will include `cmake
+... -DWITH_SOME_FEATURE=ON ... /path/to/Foo/src` automatically.
+
+Packages that do NOT use CMake builds (notably OpenBLAS) may have
+additional options associated with them if they are coded into that
+package's `CMakeLists.txt` format. At this time, there's no "hard and
+fast rule" for the format of these options, and they may not follow
+the `LBANN_SB_FWD_` syntax. Indeed, the option may not be forwarding
+anything but rather manipulating the `ExternalProject_Add`
+specification, so `_FWD_` may be semantically inappropriate. I haven't
+decided yet if I want to push for it anyway for "consistency". In the
+meantime, users are encouraged to consult the corresponding
+`CMakeLists.txt` file or their CMake cache (`ccmake`, e.g.) for a list
+of exposed options for these packages.
+
+Some packages in the SuperBuild will have default settings that are
+configured to match the "usual usage" for LBANN. These are exposed by
+`CACHE` variables or explicit `option()` calls in the SuperBuild CMake
+configuration, and users will see these appear in their
+`CMakeCache.txt` even if they haven't explicitly set these
+variables. They generally follow the same variable name syntax as
+described above for consistency, though users are encouraged to verify
+this in the appropriate `CMakeLists.txt` files.
+
+# Debugging SuperBuild issues
+
+SuperBuild packages are all built with a common structure. Unless
+`LBANN_SB_<PKG>_SOURCE_DIR` was specified, the source clone will be
+located in `<build_root>/<pkg>/src` The scripts that the SuperBuild
+build stage will execute, as well as the log files generated by these
+commands, are located in `<build_root>/<pkg>/stamp`. Auxiliary scripts
+may be located in `<build_root>/<pkg>/tmp`. All CMake-based packages
+have their build directories located in `<build_root>/<pkg>/build`.
+Packages that build in the source tree (e.g., OpenBLAS) will not have
+such a directory.
+
+If configuration was successful, a fully-functional build system should
+be present in the `<build_root>/<pkg>/build` directory, and a user
+should be able to invoke `cmake --build <build_root>/<pkg>/build` to
+perform a standalone (re)build. This can be useful for incremental
+rebuilds while debugging and/or editing the package.
+
+(TODO: Finish this section.)
+
+# Getting help
+
+If something fails at SuperBuild configuration time (i.e., when you
+run `cmake` for this project), please [open an
+issue](https://github.com/llnl/lbann/issues/new) and begin the title
+with "[SuperBuild]" so I know to look. Please attach *THE WHOLE
+OUTPUT* of CMake. I may also ask you for the log files it notes at the
+end, usually `<BUILD_DIR>/CMakeFiles/CMake{Output,Error.log}`, so it's
+not a bad idea to send those along, too.
+
+If something fails in one of the package builds, and you're using the
+Ninja or Makefiles generators, there's a target called `gather-all`
+that will attempt to collect the relevant build system files and log
+files for every package that was enabled. I will probably ask for the
+tarballs generated by this target. When filing an issue, please
+indicate which package is failing and if you have uncovered any
+insight into why that's happening.

--- a/scripts/superbuild/adiak/CMakeLists.txt
+++ b/scripts/superbuild/adiak/CMakeLists.txt
@@ -1,0 +1,72 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# adiak-specific configuration options explicitly exposed
+lbann_sb_default_pkg_option(adiak
+  ENABLE_MPI
+  "Enable MPI support in adiak."
+  ON)
+
+lbann_sb_default_pkg_option(adiak
+  ENABLE_OPENMP
+  "Enable OpenMP support in adiak."
+  ON)
+
+lbann_sb_default_cuda_option(
+  adiak
+  ENABLE_CUDA
+  "Enable CUDA support in adiak."
+  ON)
+
+lbann_sb_default_rocm_option(
+  adiak
+  ENABLE_HIP
+  "Enable HIP support in adiak."
+  ON)
+
+lbann_sb_default_pkg_option(adiak
+  ENABLE_TESTS
+  "Build adiak unit tests."
+  OFF)
+
+lbann_sb_default_pkg_option(adiak
+  ENABLE_FORTRAN
+  "Build adiak with fortran support"
+  OFF)
+
+set(lbann_sb_ftn_lang)
+if (LBANN_SB_FWD_adiak_ENABLE_FORTRAN)
+  set(lbann_sb_ftn_lang Fortran)
+endif ()
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME adiak
+  LANGUAGES C CXX ${lbann_sb_ftn_lang}
+  GITHUB_URL llnl/adiak.git
+  GIT_TAG "master"
+)
+
+set(adiak_DIR ${LBANN_SB_adiak_PREFIX}
+  CACHE INTERNAL "The install prefix of adiak.")

--- a/scripts/superbuild/adiak/CMakeLists.txt
+++ b/scripts/superbuild/adiak/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/aluminum/CMakeLists.txt
+++ b/scripts/superbuild/aluminum/CMakeLists.txt
@@ -1,0 +1,67 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_default_pkg_option(
+  Aluminum
+  ALUMINUM_ENABLE_CALIPER
+  "Enable Caliper support in Aluminum"
+  ${LBANN_SB_BUILD_Caliper})
+
+lbann_sb_default_cuda_option(
+  Aluminum
+  ALUMINUM_ENABLE_CUDA
+  "Enable the base CUDA support in Aluminum"
+  ON)
+
+lbann_sb_default_rocm_option(
+  Aluminum
+  ALUMINUM_ENABLE_ROCM
+  "Enable the base ROCM support in Aluminum"
+  ON)
+
+lbann_sb_default_gpu_option(
+  Aluminum
+  ALUMINUM_ENABLE_HOST_TRANSFER
+  "Enable the host-transfer backend in Aluminum"
+  ON)
+
+if (LBANN_SB_BUILD_RCCL)
+  lbann_sb_default_rocm_option(
+    Aluminum
+    ALUMINUM_ENABLE_NCCL
+    "Enable RCCL support in Aluminum"
+    ON)
+endif ()
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME Aluminum
+  LANGUAGES CXX
+  OPTIONAL_LANGUAGES CUDA HIP
+  GITHUB_URL llnl/Aluminum.git
+  GIT_TAG "master"
+  DEPENDS_ON Caliper RCCL)
+
+set(Aluminum_DIR ${LBANN_SB_Aluminum_PREFIX}
+  CACHE INTERNAL "The install prefix of Aluminum.")

--- a/scripts/superbuild/aluminum/CMakeLists.txt
+++ b/scripts/superbuild/aluminum/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/caliper/CMakeLists.txt
+++ b/scripts/superbuild/caliper/CMakeLists.txt
@@ -1,0 +1,95 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# Caliper-specific configuration options explicitly exposed
+lbann_sb_default_pkg_option(
+  Caliper
+  WITH_ADIAK
+  "Enable adiak support in Caliper."
+  ${LBANN_SB_BUILD_adiak})
+
+lbann_sb_default_pkg_option(
+  Caliper
+  WITH_FORTRAN
+  "Enable fortran support in Caliper."
+  OFF)
+
+lbann_sb_default_pkg_option(
+  Caliper
+  WITH_OMPT
+  "Enable OMPT support in Caliper."
+  OFF)
+
+lbann_sb_default_pkg_option(
+  Caliper
+  WITH_MPI
+  "Enable MPI support in Caliper."
+  ON)
+
+lbann_sb_default_cuda_option(
+  Caliper
+  WITH_CUPTI
+  "Enable cupty support in Caliper."
+  ON)
+
+lbann_sb_default_cuda_option(
+  Caliper
+  WITH_NVTX
+  "Enable nvtx support in Caliper."
+  ON)
+
+lbann_sb_default_rocm_option(
+  Caliper
+  WITH_ROCM
+  "Enable ROCm support in Caliper."
+  ON)
+
+lbann_sb_default_rocm_option(
+  Caliper
+  WITH_ROCTRACER
+  "Enable roctracer support in Caliper."
+  ON)
+
+lbann_sb_default_rocm_option(
+  Caliper
+  WITH_ROCTX
+  "Enable roctx support in Caliper."
+  ON)
+
+set(lbann_sb_ftn_lang)
+if (LBANN_SB_FWD_Caliper_WITH_FORTRAN)
+  set(lbann_sb_ftn_lang Fortran)
+endif ()
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME Caliper
+  LANGUAGES C CXX ${lbann_sb_ftn_lang}
+  GITHUB_URL llnl/caliper.git
+  GIT_TAG "master"
+  DEPENDS_ON adiak
+)
+
+set(Caliper_DIR ${LBANN_SB_Caliper_PREFIX}
+  CACHE INTERNAL "The install prefix of Caliper.")

--- a/scripts/superbuild/caliper/CMakeLists.txt
+++ b/scripts/superbuild/caliper/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/catch2/CMakeLists.txt
+++ b/scripts/superbuild/catch2/CMakeLists.txt
@@ -1,0 +1,40 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+
+# This prefers Catch2 v3
+lbann_sb_add_cmake_extern_pkg(
+  NAME Catch2
+  LANGUAGES CXX
+  GITHUB_URL catchorg/catch2.git
+  GIT_TAG "devel"
+  EXTRA_CMAKE_ARGS
+  -DCATCH_BUILD_TESTING=OFF
+  -DCATCH_BUILD_EXAMPLES=OFF
+  -DCATCH_ENABLE_WERROR=OFF
+  )
+
+set(CATCH2_DIR ${LBANN_SB_Catch2_PREFIX}
+  CACHE INTERNAL "The install prefix of Catch2.")

--- a/scripts/superbuild/catch2/CMakeLists.txt
+++ b/scripts/superbuild/catch2/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cereal/CMakeLists.txt
+++ b/scripts/superbuild/cereal/CMakeLists.txt
@@ -1,0 +1,39 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+option(LBANN_SB_FWD_cereal_JUST_INSTALL_CEREAL
+  "cereal value-forward for JUST_INSTALL_CEREAL" ON)
+option(LBANN_SB_FWD_cereal_WITH_WERROR
+  "CEREAL value-forward for WITH_WERROR" OFF)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME cereal
+  LANGUAGES C CXX
+  GITHUB_URL uscilab/cereal.git
+  GIT_TAG v1.3.0
+)
+
+set(cereal_DIR ${LBANN_SB_cereal_PREFIX}
+  CACHE INTERNAL "The install prefix of cereal.")

--- a/scripts/superbuild/cereal/CMakeLists.txt
+++ b/scripts/superbuild/cereal/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/clara/CMakeLists.txt
+++ b/scripts/superbuild/clara/CMakeLists.txt
@@ -1,0 +1,61 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_init_extern_pkg(
+  NAME Clara
+  LANGUAGES CXX
+  GITHUB_URL catchorg/clara.git
+  GIT_TAG v1.1.5)
+
+# Manually spec the external project
+include(ExternalProject)
+ExternalProject_Add(Clara
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+  TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp
+  STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/stamp
+
+  SOURCE_DIR ${LBANN_SB_Clara_SOURCE_DIR}
+  INSTALL_DIR ${LBANN_SB_Clara_PREFIX}
+  BUILD_IN_SOURCE 1
+
+  ${_GIT_REPOSITORY_TAG} ${LBANN_SB_Clara_URL}
+  ${_GIT_TAG_TAG} ${LBANN_SB_Clara_TAG}
+
+  USES_TERMINAL_INSTALL 1
+  LOG_DOWNLOAD 1
+  LOG_UPDATE 1
+  LOG_INSTALL 1
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+
+  INSTALL_COMMAND
+  ${CMAKE_COMMAND} -E copy_directory
+  ${LBANN_SB_Clara_SOURCE_DIR}/single_include
+  ${LBANN_SB_Clara_PREFIX}/include
+)
+
+set(Clara_DIR ${LBANN_SB_Clara_PREFIX}
+  CACHE INTERNAL "The install prefix of Clara.")

--- a/scripts/superbuild/clara/CMakeLists.txt
+++ b/scripts/superbuild/clara/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildAddCMakeExternPkg.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildAddCMakeExternPkg.cmake
@@ -1,0 +1,339 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+function(lbann_sb_create_extern_pkg_cmake_args OUTPUT_VAR)
+  set(_fn_opts)
+  set(_fn_one_val PKG_NAME)
+  set(_fn_multi_val VARIABLES)
+  cmake_parse_arguments(lbann_sb_args
+    "${_fn_opts}"
+    "${_fn_one_val}"
+    "${_fn_multi_val}" ${ARGN})
+
+  set(lbann_sb_args_strip_regex "^LBANN_SB_FWD_${lbann_sb_args_PKG_NAME}_")
+
+  set(lbann_sb_args_arg_list)
+  foreach (var ${lbann_sb_args_VARIABLES})
+    string(REGEX REPLACE "${lbann_sb_args_strip_regex}" ""
+      lbann_sb_args_arg_name "${var}")
+    list(APPEND lbann_sb_args_arg_list
+      "-D${lbann_sb_args_arg_name}=${${var}}")
+  endforeach ()
+
+  # Return
+  set(${OUTPUT_VAR} "${lbann_sb_args_arg_list}" PARENT_SCOPE)
+endfunction ()
+
+function(lbann_sb_create_pkg_lang_cmake_args OUTPUT_VAR)
+  set(_fn_opts)
+  set(_fn_one_val PKG_NAME)
+  set(_fn_multi_val LANGUAGES)
+  cmake_parse_arguments(lbann_sb_args
+    "${_fn_opts}"
+    "${_fn_one_val}"
+    "${_fn_multi_val}" ${ARGN})
+
+  set(NAME "${lbann_sb_args_PKG_NAME}")
+  set(lbann_sb_args_arg_list)
+  foreach (lang ${lbann_sb_args_LANGUAGES})
+    if ("${lang}" STREQUAL "NONE")
+      continue()
+    endif ()
+    if (LBANN_SB_${NAME}_${lang}_COMPILER)
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_COMPILER:STRING=${LBANN_SB_${NAME}_${lang}_COMPILER}")
+    endif ()
+    if (LBANN_SB_${NAME}_${lang}_STANDARD)
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_STANDARD:STRING=${LBANN_SB_${NAME}_${lang}_STANDARD}")
+    endif ()
+    if (LBANN_SB_${NAME}_${lang}_FLAGS)
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_FLAGS:STRING=${LBANN_SB_${NAME}_${lang}_FLAGS}")
+    endif ()
+    if (LBANN_SB_${NAME}_${lang}_HOST_COMPILER)
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_HOST_COMPILER:STRING=${LBANN_SB_${NAME}_${lang}_HOST_COMPILER}")
+    endif ()
+    if ("${lang}" STREQUAL "CUDA")
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_ARCHITECTURES:STRING=${LBANN_SB_${NAME}_${lang}_ARCHITECTURES}")
+    endif ()
+    if ("${lang}" STREQUAL "HIP")
+      list(APPEND lbann_sb_args_arg_list
+        "-DCMAKE_${lang}_ARCHITECTURES:STRING=${LBANN_SB_${NAME}_${lang}_ARCHITECTURES}"
+        "-DAMDGPU_TARGETS:STRING=${LBANN_SB_${NAME}_${lang}_ARCHITECTURES}"
+        "-DGPU_TARGETS:STRING=${LBANN_SB_${NAME}_${lang}_ARCHITECTURES}")
+    endif ()
+
+    if (LBANN_SB_${PKG_NAME}_BUILD_TYPE)
+      string(TOUPPER "${LBANN_SB_${PKG_NAME}_BUILD_TYPE}" build_type)
+      if (LBANN_SB_${NAME}_${lang}_FLAGS_${build_type})
+        string(CONCAT _argstring
+          "-DCMAKE_${lang}_FLAGS_${build_type}:STRING="
+          "${LBANN_SB_${NAME}_${lang}_FLAGS_${build_type}}")
+        list(APPEND lbann_sb_args_arg_list "${_argstring}")
+      endif ()
+    endif ()
+  endforeach ()
+
+  # Not language-specific, but this seems like the best place for now.
+  if (LBANN_SB_${NAME}_SHARED_LINKER_FLAGS)
+    string(CONCAT _argstring
+      "-DCMAKE_SHARED_LINKER_FLAGS:STRING="
+      "${LBANN_SB_${NAME}_SHARED_LINKER_FLAGS}")
+    list(APPEND lbann_sb_args_arg_list "${_argstring}")
+  endif ()
+  if (LBANN_SB_${NAME}_STATIC_LINKER_FLAGS)
+    string(CONCAT _argstring
+      "-DCMAKE_STATIC_LINKER_FLAGS:STRING="
+      "${LBANN_SB_${NAME}_STATIC_LINKER_FLAGS}")
+    list(APPEND lbann_sb_args_arg_list "${_argstring}")
+  endif ()
+  if (LBANN_SB_${NAME}_EXE_LINKER_FLAGS)
+    string(CONCAT _argstring
+      "-DCMAKE_EXE_LINKER_FLAGS:STRING="
+      "${LBANN_SB_${NAME}_EXE_LINKER_FLAGS}")
+    list(APPEND lbann_sb_args_arg_list "${_argstring}")
+  endif ()
+  if (LBANN_SB_${PKG_NAME}_BUILD_TYPE)
+    string(TOUPPER "${LBANN_SB_${PKG_NAME}_BUILD_TYPE}" build_type)
+    if (LBANN_SB_${NAME}_SHARED_LINKER_FLAGS_${build_type})
+      string(CONCAT _argstring
+        "-DCMAKE_SHARED_LINKER_FLAGS_${build_type}:STRING="
+        "${LBANN_SB_${NAME}_SHARED_LINKER_FLAGS_${build_type}}")
+      list(APPEND lbann_sb_args_arg_list "${_argstring}")
+    endif ()
+    if (LBANN_SB_${NAME}_STATIC_LINKER_FLAGS_${build_type})
+      string(CONCAT _argstring
+        "-DCMAKE_STATIC_LINKER_FLAGS_${build_type}:STRING="
+        "${LBANN_SB_${NAME}_STATIC_LINKER_FLAGS_${build_type}}")
+      list(APPEND lbann_sb_args_arg_list "${_argstring}")
+    endif ()
+    if (LBANN_SB_${NAME}_EXE_LINKER_FLAGS_${build_type})
+      string(CONCAT _argstring
+        "-DCMAKE_EXE_LINKER_FLAGS_${build_type}:STRING="
+        "${LBANN_SB_${NAME}_EXE_LINKER_FLAGS_${build_type}}")
+      list(APPEND lbann_sb_args_arg_list "${_argstring}")
+    endif ()
+  endif ()
+
+  # RPATHs
+  if (LBANN_SB_${NAME}_BUILD_RPATH)
+    list(APPEND lbann_sb_args_arg_list
+      "-DCMAKE_BUILD_RPATH:STRING=${LBANN_SB_${NAME}_BUILD_RPATH}")
+  endif ()
+  if (LBANN_SB_${NAME}_INSTALL_RPATH)
+    list(APPEND lbann_sb_args_arg_list
+      "-DCMAKE_INSTALL_RPATH:STRING=${LBANN_SB_${NAME}_INSTALL_RPATH}")
+  endif ()
+
+  # Return
+  set(${OUTPUT_VAR} "${lbann_sb_args_arg_list}" PARENT_SCOPE)
+endfunction ()
+
+# Keywords:
+#   NAME -- the name of the package
+#
+#   LANGUAGES -- the languages for the package
+#
+#   DEPENDS_ON -- Any dependencies of the package. These are packages
+#                 known to the superbuild and MUST be initialized
+#                 prior to invoking this macro. NOTE: this is strictly
+#                 an ordering mechanism required for correct build
+#                 system generation! If detection is not automatic,
+#                 the user is responsible for ensuring this package
+#                 knows to find the dependencies at its build time
+#                 (e.g., by setting CMAKE_PREFIX_PATH or similar).
+#
+#   EXTRA_CMAKE_ARGS -- strings to be forwarded as arguments to
+#                       CMake for this package.
+#
+#   SOURCE_SUBDIR -- Path in the source directory to the toplevel
+#                    CMakeLists.txt file.
+#
+# This macro also accepts the following keywords, which are forwarded
+# directly to lbann_sb_init_extern_pkg:
+#
+#   GITHUB_URL -- the github URL for the package
+#   GIT_TAG -- the git tag to checkout for this package
+include(ExternalProject)
+macro(lbann_sb_add_cmake_extern_pkg)
+  set(_macro_opts)
+  set(_macro_one_val
+    NAME
+    GITHUB_URL
+    GIT_TAG
+    SOURCE_SUBDIR)
+  set(_macro_multi_val
+    LANGUAGES
+    EXTRA_CMAKE_ARGS
+    DEPENDS_ON
+    OPTIONAL_LANGUAGES)
+  cmake_parse_arguments(lbann_sb_add
+    "${_macro_opts}"
+    "${_macro_one_val}"
+    "${_macro_multi_val}" ${ARGN})
+
+  # Perform the common initialization tasks. A non-CMake package (or
+  # something with weird stuff going on such that they need to
+  # customize the ExternalProject_Add call) would just call this
+  # directly. The subset of arguments that it cares about are noted in
+  # that macro's documentation.
+  lbann_sb_init_extern_pkg(
+    NAME ${lbann_sb_add_NAME}
+    LANGUAGES ${lbann_sb_add_LANGUAGES}
+    OPTIONAL_LANGUAGES ${lbann_sb_add_OPTIONAL_LANGUAGES}
+    GITHUB_URL ${lbann_sb_add_GITHUB_URL}
+    GIT_TAG ${lbann_sb_add_GIT_TAG})
+
+  # Handle the DEPENDS_ON tag. This assumes that any package name
+  # passed here has already been initialized.
+  set(LBANN_SB_DEPENDS_TAG)
+  set(LBANN_SB_${PKG_NAME}_DEPENDS)
+  set(LBANN_SB_${PKG_NAME}_DEPENDS_PATHS)
+  foreach (pkg ${lbann_sb_add_DEPENDS_ON})
+    message(STATUS "${PKG_NAME}: Checking for ${pkg}")
+    if (TARGET ${pkg})
+      list(APPEND LBANN_SB_${PKG_NAME}_DEPENDS ${pkg})
+      list(APPEND
+        LBANN_SB_${PKG_NAME}_DEPENDS_PATHS
+        "${LBANN_SB_${pkg}_PREFIX}")
+      set(LBANN_SB_FWD_${PKG_NAME}_${pkg}_ROOT "${LBANN_SB_${pkg}_PREFIX}")
+    endif ()
+  endforeach ()
+  if (LBANN_SB_${PKG_NAME}_DEPENDS)
+    set(LBANN_SB_DEPENDS_TAG "DEPENDS")
+    string(REPLACE ";" "|"
+      LBANN_SB_FWD_${PKG_NAME}_CMAKE_PREFIX_PATH
+      "${LBANN_SB_${PKG_NAME}_DEPENDS_PATHS}")
+    message(STATUS "${PKG_NAME} depends on: ${LBANN_SB_${PKG_NAME}_DEPENDS}")
+  endif ()
+
+  # Get the variables to forward.
+  get_property(PKG_VARIABLES DIRECTORY PROPERTY VARIABLES)
+  set(lbann_sb_add_var_incl_regex "^LBANN_SB_FWD_${PKG_NAME}_.*")
+  list(FILTER PKG_VARIABLES INCLUDE REGEX "${lbann_sb_add_var_incl_regex}")
+  # Unlike previous versions of the code, we don't need the EXCLUDE
+  # REGEX clause because we now prefix any and all SuperBuild
+  # variables with "LBANN_SB". Of those, we only care about those
+  # followed by "_FWD_${PKG_NAME}", which we collect via the INCLUDE
+  # REGEX.
+
+  # This function will take the list of variables and copy them into a
+  # string of the form "-D${REAL_VAR_NAME}=${${VAR_NAME}}", where
+  # "${REAL_VAR_NAME}" is the name of the variable with
+  # "LBANN_SB_FWD_${PKG_NAME}_" stripped off.
+  lbann_sb_create_extern_pkg_cmake_args(
+    LBANN_SB_${PKG_NAME}_CMAKE_ARGS
+    PKG_NAME ${PKG_NAME}
+    VARIABLES ${PKG_VARIABLES})
+
+  # This uses the output variables of "lbann_sb_init_extern_pkg" to
+  # forward basic language compiler and flag information.
+  lbann_sb_create_pkg_lang_cmake_args(
+    LBANN_SB_${PKG_NAME}_CMAKE_LANG_ARGS
+    PKG_NAME ${PKG_NAME}
+    LANGUAGES ${lbann_sb_add_LANGUAGES} ${lbann_sb_add_OPTIONAL_LANGUAGES})
+
+  # Handle the SOURCE_SUBDIR tag.
+  set(LBANN_SB_SOURCE_SUBDIR_TAG)
+  set(LBANN_SB_${PKG_NAME}_SOURCE_SUBDIR)
+  if (lbann_sb_add_SOURCE_SUBDIR)
+    set(LBANN_SB_SOURCE_SUBDIR_TAG "SOURCE_SUBDIR")
+    set(LBANN_SB_${PKG_NAME}_SOURCE_SUBDIR "${lbann_sb_add_SOURCE_SUBDIR}")
+  endif ()
+
+  set(LBANN_SB_GIT_SUBMODULES_TAG)
+  set(LBANN_SB_GIT_SUBMODULES_VAL)
+  if ("${PKG_NAME}" STREQUAL "LBANN")
+    set(LBANN_SB_GIT_SUBMODULES_TAG "GIT_SUBMODULES")
+    set(LBANN_SB_GIT_SUBMODULES_VAL "")
+    message("\nLBANN!\n")
+  endif ()
+
+  # Finally add the project.
+  ExternalProject_Add(${PKG_NAME}
+    # Standard stuff; users shouldn't care.
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+    TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp
+    STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/stamp
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
+
+    # User-configured paths.
+    SOURCE_DIR ${LBANN_SB_${PKG_NAME}_SOURCE_DIR}
+    INSTALL_DIR ${LBANN_SB_${PKG_NAME}_PREFIX}
+
+    ${LBANN_SB_SOURCE_SUBDIR_TAG} ${LBANN_SB_${PKG_NAME}_SOURCE_SUBDIR}
+
+    # Hack to handle building from an existing source directory.
+    ${LBANN_SB_GIT_REPOSITORY_TAG} ${LBANN_SB_GIT_REPOSITORY}
+    ${LBANN_SB_GIT_TAG_TAG} ${LBANN_SB_GIT_TAG}
+
+    # Setup any dependencies
+    ${LBANN_SB_DEPENDS_TAG} ${LBANN_SB_${PKG_NAME}_DEPENDS}
+
+    # FIXME (trb 03/07/2023): This needs to be conditionally set!
+    #GIT_SUBMODULES ""
+    #${LBANN_SB_GIT_SUBMODULES_TAG} ${LBANN_SB_GIT_SUBMODULES_VAL}
+    GIT_SHALLOW 1
+
+    # Log everything.
+    LOG_DOWNLOAD 1
+    LOG_UPDATE 1
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_INSTALL 1
+    LOG_TEST 1
+
+    USES_TERMINAL_BUILD 1
+    LIST_SEPARATOR |
+
+    CMAKE_GENERATOR ${LBANN_SB_${PKG_NAME}_CMAKE_GENERATOR}
+    CMAKE_ARGS
+    # Compilers and flags
+    ${LBANN_SB_${PKG_NAME}_CMAKE_LANG_ARGS}
+
+    # Standard CMakery
+    -D BUILD_SHARED_LIBS=${LBANN_SB_${PKG_NAME}_BUILD_SHARED_LIBS}
+    -D CMAKE_INSTALL_PREFIX=${LBANN_SB_${PKG_NAME}_PREFIX}
+    -D CMAKE_BUILD_TYPE=${LBANN_SB_${PKG_NAME}_BUILD_TYPE}
+    -D CMAKE_POSITION_INDEPENDENT_CODE=${LBANN_SB_${PKG_NAME}_PIC}
+    -D CMAKE_INTERPROCEDURAL_OPTIMIZATION=${LBANN_SB_${PKG_NAME}_IPO}
+
+    -D CMAKE_INSTALL_RPATH_USE_LINK_PATH=${LBANN_SB_${PKG_NAME}_INSTALL_RPATH_USE_LINK_PATH}
+    -D CMAKE_SKIP_RPATH=${LBANN_SB_${PKG_NAME}_SKIP_RPATH}
+    -D CMAKE_BUILD_RPATH_USE_ORIGIN=${LBANN_SB_${PKG_NAME}_BUILD_RPATH_USE_ORIGIN}
+    -D CMAKE_BUILD_WITH_INSTALL_RPATH=${LBANN_SB_${PKG_NAME}_BUILD_WITH_INSTALL_RPATH}
+    -D CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH=${LBANN_SB_${PKG_NAME}_INSTALL_REMOVE_ENVIRONMENT_RPATH}
+    -D CMAKE_SKIP_BUILD_RPATH=${LBANN_SB_${PKG_NAME}_SKIP_BUILD_RPATH}
+    -D CMAKE_SKIP_INSTALL_RPATH=${LBANN_SB_${PKG_NAME}_SKIP_INSTALL_RPATH}
+
+    # Extra arguments for CMake
+    ${LBANN_SB_${PKG_NAME}_CMAKE_ARGS}
+    ${lbann_sb_add_EXTRA_CMAKE_ARGS}
+  )
+
+endmacro ()

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildAddCMakeExternPkg.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildAddCMakeExternPkg.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildAddPackages.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildAddPackages.cmake
@@ -1,0 +1,74 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+include(CMakeDependentOption)
+
+macro(lbann_sb_default_pkg_option PKG_NAME OPTION_NAME DOC_STR VALUE)
+  option(LBANN_SB_FWD_${PKG_NAME}_${OPTION_NAME}
+    "${DOC_STR}"
+    ${VALUE})
+endmacro ()
+
+macro(lbann_sb_default_cuda_option PKG_NAME OPTION_NAME DOC_STR VALUE)
+  cmake_dependent_option(
+    LBANN_SB_FWD_${PKG_NAME}_${OPTION_NAME}
+    "${DOC_STR}"
+    ${VALUE}
+    "LBANN_SB_DEFAULT_CUDA_OPTS"
+    OFF)
+endmacro ()
+
+macro(lbann_sb_default_rocm_option PKG_NAME OPTION_NAME DOC_STR VALUE)
+  cmake_dependent_option(
+    LBANN_SB_FWD_${PKG_NAME}_${OPTION_NAME}
+    "${DOC_STR}"
+    ${VALUE}
+    "LBANN_SB_DEFAULT_ROCM_OPTS"
+    OFF)
+endmacro ()
+
+macro(lbann_sb_default_gpu_option PKG_NAME OPTION_NAME DOC_STR VALUE)
+  cmake_dependent_option(
+    LBANN_SB_FWD_${PKG_NAME}_${OPTION_NAME}
+    "${DOC_STR}"
+    ${VALUE}
+    "LBANN_SB_DEFAULT_CUDA_OPTS OR LBANN_SB_DEFAULT_ROCM_OPTS"
+    OFF)
+endmacro ()
+
+macro(lbann_sb_add_package PKG_NAME)
+  option(LBANN_SB_BUILD_${PKG_NAME}
+    "Optionally download and build ${PKG_NAME}?"
+    OFF)
+  if (LBANN_SB_BUILD_${PKG_NAME})
+    list(APPEND LBANN_SB_BUILD_PKGS ${PKG_NAME})
+  endif ()
+endmacro ()
+
+macro(lbann_sb_add_packages)
+  foreach (pkg ${ARGN})
+    lbann_sb_add_package(${pkg})
+  endforeach ()
+endmacro ()

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildAddPackages.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildAddPackages.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildCreateCMakeArguments.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildCreateCMakeArguments.cmake
@@ -1,0 +1,124 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# This function takes a list of variables and writes a CMake argument string of the format:
+#   -DARGNAME:ARGTYPE=ARGVALUE ...
+#
+# Arguments:
+#   -- REMOVE_PKG_NAME: <PACKAGE_NAME>_<OPTION> gets written as -D<OPTION>=<...>
+#
+#   -- PACKAGE_NAME: The name of the package
+#   -- OUTPUT_VARIABLE: The list of CMake options
+#
+#   -- VARIABLES: The list of variable names to process
+#   -- EXTRA_REMOVE_PREFIXES: Also strip these prefixes. Takes
+#        precendence over SKIP_VARS_WITH_PREFIXES and PACKAGE_NAME.
+#   -- SKIP_VARS_WITH_PREFIXES: Skip a variable with this prefix
+#        unless caught by EXTRA_REMOVE_PREFIXES
+#
+function (create_cmake_arguments)
+  set(_OPTIONS REMOVE_PKG_NAME)
+  set(_ONE_VALUE_PARAMS PACKAGE_NAME OUTPUT_VARIABLE)
+  set(_MULTI_VALUE_PARAMS
+    VARIABLES SKIP_VARS_WITH_PREFIXES EXTRA_REMOVE_PREFIXES)
+
+  cmake_parse_arguments(_CREATEARGS
+    "${_OPTIONS}" "${_ONE_VALUE_PARAMS}" "${_MULTI_VALUE_PARAMS}" ${ARGN})
+
+  # Short-circuit. IDK if is the best decision...
+  if (${_CREATEARGS_OUTPUT_VARIABLE})
+    return()
+  endif ()
+
+  foreach (_variable ${_CREATEARGS_VARIABLES})
+
+    # Check the variable's type, if possible.
+    get_property(_CMAKE_ARG_TYPE CACHE ${_variable} PROPERTY TYPE)
+
+    if (_CMAKE_ARG_TYPE STREQUAL "STATIC"
+        OR _CMAKE_ARG_TYPE STREQUAL "INTERNAL")
+      continue()
+    endif ()
+
+    set(_variable_done FALSE)
+
+    # EXTRA_REMOVE_PREFIXES takes precedence over everything
+    foreach (_prefix ${_CREATEARGS_EXTRA_REMOVE_PREFIXES})
+      string(REGEX REPLACE "^${_prefix}_\(.+\)" "\\1"
+        _CMAKE_ARG_NAME ${_variable})
+      if (CMAKE_MATCH_COUNT GREATER 0)
+        set(_variable_done TRUE)
+        break ()
+      endif ()
+    endforeach ()
+
+    # Check for skips
+    if (NOT _variable_done AND _CREATEARGS_SKIP_VARS_WITH_PREFIXES)
+
+      foreach (_prefix ${_CREATEARGS_SKIP_VARS_WITH_PREFIXES})
+        string(REGEX MATCH "^${_prefix}_" _MATCH_FOUND ${_variable})
+        if (_MATCH_FOUND)
+          set(_variable_done TRUE)
+          break ()
+        endif ()
+      endforeach ()
+
+      if(_variable_done)
+        continue ()
+      endif ()
+    endif ()
+
+    if (NOT _variable_done)
+      # Cleanup the variable name
+      if (_CREATEARGS_REMOVE_PKG_NAME)
+        # We must be careful to only remove the first instance of the
+        # package name.
+        string(REGEX REPLACE "^${_CREATEARGS_PACKAGE_NAME}_\(.+\)" "\\1"
+          _CMAKE_ARG_NAME ${_variable})
+      else ()
+        # Handle CMake options
+        string(REGEX REPLACE "${_CREATEARGS_PACKAGE_NAME}_\(CMAKE_.+\)" "\\1"
+          _CMAKE_ARG_NAME ${_variable})
+      endif ()
+      set(_variable_done TRUE)
+    endif ()
+
+    # Add the variable to the CMake line
+    if (${_variable} MATCHES ".*\;.*") # If it's a list
+      string(REPLACE ";" "|" ${_variable} "${${_variable}}")
+    endif ()
+
+    if (NOT ${_CMAKE_ARG_TYPE} STREQUAL "UNINITIALIZED")
+      list(APPEND _output_string
+        "-D${_CMAKE_ARG_NAME}:${_CMAKE_ARG_TYPE}=${${_variable}}")
+    else ()
+      list(APPEND _output_string "-D${_CMAKE_ARG_NAME}=${${_variable}}")
+    endif ()
+  endforeach ()
+
+  # Return
+  set(${_CREATEARGS_OUTPUT_VARIABLE} ${_output_string} PARENT_SCOPE)
+
+endfunction(create_cmake_arguments)

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildCreateCMakeArguments.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildCreateCMakeArguments.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildInitExternPkg.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildInitExternPkg.cmake
@@ -1,0 +1,315 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# This should duplicate CMP0102 "NEW" behavior.
+function(lbann_sb_mark_as_advanced)
+  foreach (var ${ARGN})
+    if (DEFINED CACHE{${var}})
+      mark_as_advanced(${var})
+    endif ()
+  endforeach ()
+endfunction ()
+
+# This macro handles a lot of the boiler-plate associated with getting
+# a package configured.
+#
+# usage: lbann_sb_init_extern_pkg(PKG_NAME
+#                                 LANGUAGES [C,CXX,HIP,CUDA,etc]
+#                                 OPTIONAL_LANGUAGES [HIP,CUDA,etc])
+#
+# PKG_NAME: The name of the package as you'd like it to appear in the
+#           interface. E.g., "Protobuf" will setup variables like
+#           "LBANN_SB_Protobuf_C_COMPILER".
+#
+# LANGUAGES: The programming languages that should be enabled. Each
+#            language listed will be the argument to a call to
+#            enable_language(). Thus, the arguments here must be valid
+#            CMake languages. For each language, we setup the
+#            following variables:
+#
+#               LBANN_SB_${PKG_NAME}_${LANGUAGE}_COMPILER
+#                              (default: CMAKE_${LANG}_COMPILER)
+#               LBANN_SB_${PKG_NAME}_${LANGUAGE}_STANDARD
+#                              (default: CMAKE_${LANG}_STANDARD)
+#               LBANN_SB_${PKG_NAME}_${LANGUAGE}_FLAGS
+#                              (default: CMAKE_${LANG}_FLAGS)
+#
+#            Because CUDA is an epic pain, if CUDA is one of the
+#            required languages, we also consider
+#            LBANN_SB_${PKG_NAME}_CUDA_HOST_COMPILER. If this variable
+#            isn't explicitly set by the user but
+#            CMAKE_CUDA_HOST_COMPILER is set, we will set it to that
+#            value. Otherwise, we leave it unset.
+#
+# OPTIONAL_LANGUAGES:
+#                     The note about CUDA applies here as well.
+#
+# In addition to the language configuration described above, this
+# handles the default build type, whether to build shared libraries,
+# whether to use PIC, whether to use IPO, and installation prefix. The
+# variables are:
+#
+#     LBANN_SB_${PKG_NAME}_BUILD_TYPE (default: CMAKE_BUILD_TYPE)
+#     LBANN_SB_${PKG_NAME}_BUILD_SHARED_LIBS (default: BUILD_SHARED_LIBS)
+#     LBANN_SB_${PKG_NAME}_PIC (default: CMAKE_POSITION_INDEPENDENT_CODE)
+#     LBANN_SB_${PKG_NAME}_IPO (default: CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+#     LBANN_SB_${PKG_NAME}_PREFIX (default: CMAKE_INSTALL_PREFIX)
+#
+include(CheckLanguage)
+macro(lbann_sb_init_extern_pkg)
+  set(_macro_opts)
+  set(_macro_one_val NAME GITHUB_URL GIT_TAG)
+  set(_macro_multi_val LANGUAGES OPTIONAL_LANGUAGES)
+  cmake_parse_arguments(sb_init
+    "${_macro_opts}"
+    "${_macro_one_val}"
+    "${_macro_multi_val}" "${ARGN}")
+
+  # These are just convenience names. HOWEVER, they are left in the
+  # environment at the end of the macro. Thus, they are valid in
+  # downstream code (at least at the calling scope).
+  set(PKG_NAME ${sb_init_NAME})
+  set(PKG_LANGS ${sb_init_LANGUAGES} ${sb_init_OPTIONAL_LANGUAGES})
+
+  set(LBANN_SB_${PKG_NAME}_BUILD_TYPE
+    ${CMAKE_BUILD_TYPE} CACHE
+    STRING "The CMake build type for this build.")
+  string(TOUPPER "${LBANN_SB_${PKG_NAME}_BUILD_TYPE}" build_type)
+
+  # Setup the language-specific stuff (compiler/flags).
+  foreach (lang ${PKG_LANGS})
+    if ("${lang}" STREQUAL "NONE")
+      continue()
+    endif ()
+
+    # I'm not sure if this is worthwhile or not. It might give a user
+    # early feedback, but it doesn't take a custom compiler into
+    # account.
+    #
+    # TODO: Write some custom code to check that the given compiler
+    # exists. This shouldn't be TOO hard, especially if we assume
+    # we're NOT cross-compiling.
+    check_language(${lang})
+
+    # NOTE: These must be type STRING! If the COMPILER has type
+    # FILEPATH and is just an executable name (e.g., literally the
+    # string "g++"), CMake will force the string to an absolute path
+    # by prepending its working directory.
+    set(LBANN_SB_${PKG_NAME}_${lang}_COMPILER
+      ${CMAKE_${lang}_COMPILER} CACHE
+      STRING "The ${lang} compiler to use for ${PKG_NAME}.")
+
+    if (${lang} STREQUAL "CUDA")
+      set(LBANN_SB_${PKG_NAME}_${lang}_HOST_COMPILER
+        ${CMAKE_${lang}_HOST_COMPILER} CACHE
+        STRING "The ${lang} HOST compiler to use for ${PKG_NAME}.")
+      set(LBANN_SB_${PKG_NAME}_${lang}_ARCHITECTURES
+        ${CMAKE_${lang}_ARCHITECTURES} CACHE
+        STRING "The ${lang} architectures for ${PKG_NAME}.")
+    endif ()
+
+    if (${lang} STREQUAL "HIP")
+      set(LBANN_SB_${PKG_NAME}_${lang}_ARCHITECTURES
+        ${CMAKE_${lang}_ARCHITECTURES} CACHE
+        STRING "The ${lang} architectures for ${PKG_NAME}.")
+    endif ()
+
+    set(LBANN_SB_${PKG_NAME}_${lang}_STANDARD
+      ${CMAKE_${lang}_STANDARD} CACHE
+      STRING "The ${lang} standard to use for ${PKG_NAME}.")
+
+    set(LBANN_SB_${PKG_NAME}_${lang}_FLAGS
+      ${CMAKE_${lang}_FLAGS} CACHE
+      STRING "The ${lang} compiler flags to use for ${PKG_NAME}.")
+
+    set(LBANN_SB_${PKG_NAME}_${lang}_FLAGS_${build_type}
+      ${CMAKE_${lang}_FLAGS_${build_type}} CACHE
+      STRING
+      "The ${lang} compiler flags to use for ${PKG_NAME} in ${build_type} mode.")
+
+    lbann_sb_mark_as_advanced(
+      LBANN_SB_${PKG_NAME}_${lang}_COMPILER
+      LBANN_SB_${PKG_NAME}_${lang}_STANDARD
+      LBANN_SB_${PKG_NAME}_${lang}_FLAGS
+      LBANN_SB_${PKG_NAME}_${lang}_FLAGS_${build_type}
+      LBANN_SB_${PKG_NAME}_${lang}_HOST_COMPILER
+    )
+  endforeach()
+
+  set(LBANN_SB_${PKG_NAME}_BUILD_RPATH
+    "${CMAKE_BUILD_RPATH}"
+    CACHE STRING
+    "The build RPATHs to add to ${PKG_NAME}.")
+  set(LBANN_SB_${PKG_NAME}_INSTALL_RPATH
+    "${CMAKE_INSTALL_RPATH}"
+    CACHE STRING
+    "The install RPATHs to add to ${PKG_NAME}.")
+
+  set(LBANN_SB_${PKG_NAME}_SHARED_LINKER_FLAGS
+    "${CMAKE_SHARED_LINKER_FLAGS}"
+    CACHE STRING
+    "The shared linker flags for ${PKG_NAME}.")
+  set(LBANN_SB_${PKG_NAME}_STATIC_LINKER_FLAGS
+    "${CMAKE_STATIC_LINKER_FLAGS}"
+    CACHE STRING
+    "The static linker flags for ${PKG_NAME}.")
+  set(LBANN_SB_${PKG_NAME}_EXE_LINKER_FLAGS
+    "${CMAKE_EXE_LINKER_FLAGS}"
+    CACHE STRING
+    "The exe linker flags for ${PKG_NAME}.")
+
+  if (build_type)
+    set(LBANN_SB_${PKG_NAME}_SHARED_LINKER_FLAGS_${build_type}
+      "${CMAKE_SHARED_LINKER_FLAGS_${build_type}}"
+      CACHE STRING
+      "The shared linker flags for ${PKG_NAME} in ${build_type} mode.")
+    set(LBANN_SB_${PKG_NAME}_STATIC_LINKER_FLAGS_${build_type}
+      "${CMAKE_STATIC_LINKER_FLAGS_${build_type}}"
+      CACHE STRING
+      "The static linker flags for ${PKG_NAME} in ${build_type} mode.")
+    set(LBANN_SB_${PKG_NAME}_EXE_LINKER_FLAGS_${build_type}
+      "${CMAKE_EXE_LINKER_FLAGS_${build_type}}"
+      CACHE STRING
+      "The exe linker flags for ${PKG_NAME} in ${build_type} mode.")
+  endif ()
+
+
+  if (LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY STREQUAL "PKG")
+    set(LBANN_SB_${PKG_NAME}_PREFIX
+      ${CMAKE_INSTALL_PREFIX}/${PKG_NAME} CACHE
+      PATH "The CMake installation prefix for this build.")
+  elseif (LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY STREQUAL "PKG_LC")
+    string(TOLOWER "${PKG_NAME}" pkg_name_lower)
+    set(LBANN_SB_${PKG_NAME}_PREFIX
+      ${CMAKE_INSTALL_PREFIX}/${pkg_name_lower} CACHE
+      PATH "The CMake installation prefix for this build.")
+    set(pkg_name_lower)
+  else ()
+    set(LBANN_SB_${PKG_NAME}_PREFIX
+      ${CMAKE_INSTALL_PREFIX} CACHE
+      PATH "The CMake installation prefix for this build.")
+  endif ()
+
+  # TODO: Untangle the potential conflict between
+  # "BUILD_SHARED_LIBS=ON" and "CMAKE_POSITION_INDEPENDENT_CODE={OFF or
+  # unset}"
+  option(LBANN_SB_${PKG_NAME}_BUILD_SHARED_LIBS
+    "Build shared libraries for ${PKG_NAME}?" ${BUILD_SHARED_LIBS})
+  option(LBANN_SB_${PKG_NAME}_PIC
+    "Force PIC for ${PKG_NAME}?" ${CMAKE_POSITION_INDEPENDENT_CODE})
+  option(LBANN_SB_${PKG_NAME}_IPO
+    "Use interprocedural optimization for ${PKG_NAME}?"
+    ${CMAKE_INTERPROCEDURAL_OPTIMIZATION})
+
+  # RPATH stuff
+  option(LBANN_SB_${PKG_NAME}_INSTALL_RPATH_USE_LINK_PATH
+    "Add linker paths to install RPATH for ${PKG_NAME}"
+    ${CMAKE_INSTALL_RPATH_USE_LINK_PATH})
+  option(LBANN_SB_${PKG_NAME}_SKIP_RPATH
+    "If true, skip adding rpath info to ${PKG_NAME}"
+    ${CMAKE_SKIP_RPATH})
+  option(LBANN_SB_${PKG_NAME}_BUILD_RPATH_USE_ORIGIN
+    "Use ORIGIN in build RPATH for ${PKG_NAME}"
+    ${CMAKE_BUILD_RPATH_USE_ORIGIN})
+  option(LBANN_SB_${PKG_NAME}_BUILD_WITH_INSTALL_RPATH
+    "Use install rpath as build rpath for ${PKG_NAME}"
+    ${CMAKE_BUILD_WITH_INSTALL_RPATH})
+  option(LBANN_SB_${PKG_NAME}_INSTALL_REMOVE_ENVIRONMENT_RPATH
+    "Remove toolchain-specific paths from install RPATH for ${PKG_NAME}"
+    ${CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH})
+  option(LBANN_SB_${PKG_NAME}_SKIP_BUILD_RPATH
+    "If true, skip adding build rpath info to ${PKG_NAME}"
+    ${CMAKE_SKIP_BUILD_RPATH})
+  option(LBANN_SB_${PKG_NAME}_SKIP_INSTALL_RPATH
+    "If true, skip adding install rpath info to ${PKG_NAME}"
+    ${CMAKE_SKIP_INSTALL_RPATH})
+
+  if (sb_init_GITHUB_URL)
+    option(LBANN_SB_${PKG_NAME}_CLONE_VIA_SSH
+      "Use the SSH protocol to clone ${PKG_NAME}?"
+      ${LBANN_SB_CLONE_VIA_SSH})
+
+    set(LBANN_SB_${PKG_NAME}_HTTPS_URL
+      "https://github.com/${sb_init_GITHUB_URL}" CACHE
+      STRING "The HTTPS URL CMake installation prefix for ${PKG_NAME}.")
+    set(LBANN_SB_${PKG_NAME}_SSH_URL
+      "git@github.com:${sb_init_GITHUB_URL}" CACHE
+      STRING "The SSH URL CMake installation prefix for ${PKG_NAME}.")
+
+    if (LBANN_SB_${PKG_NAME}_CLONE_VIA_SSH)
+      set(LBANN_SB_${PKG_NAME}_URL
+        ${LBANN_SB_${PKG_NAME}_SSH_URL} CACHE
+        STRING "The URL to use to clone ${PKG_NAME}.")
+    else ()
+      set(LBANN_SB_${PKG_NAME}_URL
+        ${LBANN_SB_${PKG_NAME}_HTTPS_URL} CACHE
+        STRING "The URL to use to clone ${PKG_NAME}.")
+    endif ()
+  endif ()
+
+  set(LBANN_SB_${PKG_NAME}_TAG
+    ${sb_init_GIT_TAG} CACHE
+    STRING "The git tag to checkout for ${PKG_NAME}.")
+
+  set(LBANN_SB_${PKG_NAME}_CMAKE_GENERATOR
+    ${CMAKE_GENERATOR} CACHE
+    STRING "The CMake generator to use for ${PKG_NAME}.")
+
+  set(LBANN_SB_${PKG_NAME}_SOURCE_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/src" CACHE
+    PATH "The source directory for ${PKG_NAME}.")
+
+  if ("${LBANN_SB_${PKG_NAME}_SOURCE_DIR}"
+      STREQUAL
+      "${CMAKE_CURRENT_BINARY_DIR}/src")
+    set(LBANN_SB_GIT_REPOSITORY_TAG "GIT_REPOSITORY")
+    set(LBANN_SB_GIT_TAG_TAG "GIT_TAG")
+    set(LBANN_SB_GIT_REPOSITORY "${LBANN_SB_${PKG_NAME}_URL}")
+    set(LBANN_SB_GIT_TAG "${LBANN_SB_${PKG_NAME}_TAG}")
+  else ()
+    # If the user has provided some other dir, we need to disable the
+    # download/update stages. This is done by clearing the repository
+    # URL and tag.
+    set(LBANN_SB_GIT_REPOSITORY_TAG)
+    set(LBANN_SB_GIT_TAG_TAG)
+    set(LBANN_SB_GIT_REPOSITORY)
+    set(LBANN_SB_GIT_TAG)
+    message(STATUS
+      "Using ${PKG_NAME} source in: ${LBANN_SB_${PKG_NAME}_SOURCE_DIR}")
+  endif ()
+
+  lbann_sb_mark_as_advanced(
+    LBANN_SB_${PKG_NAME}_BUILD_SHARED_LIBS
+    LBANN_SB_${PKG_NAME}_BUILD_TYPE
+    LBANN_SB_${PKG_NAME}_CLONE_VIA_SSH
+    LBANN_SB_${PKG_NAME}_CMAKE_GENERATOR
+    LBANN_SB_${PKG_NAME}_HTTPS_URL
+    LBANN_SB_${PKG_NAME}_IPO
+    LBANN_SB_${PKG_NAME}_PIC
+    LBANN_SB_${PKG_NAME}_SOURCE_DIR
+    LBANN_SB_${PKG_NAME}_SSH_URL
+  )
+
+endmacro()

--- a/scripts/superbuild/cmake/modules/LBANNSuperBuildInitExternPkg.cmake
+++ b/scripts/superbuild/cmake/modules/LBANNSuperBuildInitExternPkg.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/cnpy/CMakeLists.txt
+++ b/scripts/superbuild/cnpy/CMakeLists.txt
@@ -1,0 +1,38 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# Match the CNPY default
+option(LBANN_SB_FWD_CNPY_ENABLE_STATIC "Enable the CNPY static linkage." ON)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME CNPY
+  LANGUAGES C CXX
+  GITHUB_URL rogersce/cnpy.git
+  GIT_TAG "4e8810b1a8637695171ed346ce68f6984e585ef4"
+  EXTRA_CMAKE_ARGS
+  -D CMAKE_MACOSX_RPATH=ON)
+
+set(CNPY_DIR ${LBANN_SB_CNPY_PREFIX}
+  CACHE INTERNAL "The install prefix of CNPY.")

--- a/scripts/superbuild/cnpy/CMakeLists.txt
+++ b/scripts/superbuild/cnpy/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/conduit/CMakeLists.txt
+++ b/scripts/superbuild/conduit/CMakeLists.txt
@@ -1,0 +1,61 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# CONDUIT-specific configuration options explicitly exposed
+option(LBANN_SB_FWD_Conduit_ENABLE_MPI
+  "Enable MPI support in CONDUIT."
+  ON)
+option(LBANN_SB_FWD_Conduit_ENABLE_PYTHON
+  "Enable CONDUIT Python module support."
+  OFF)
+option(LBANN_SB_FWD_Conduit_ENABLE_TESTS
+  "Build CONDUIT unit tests."
+  OFF)
+option(LBANN_SB_FWD_Conduit_ENABLE_FORTRAN
+  "Build CONDUIT with fortran support"
+  OFF)
+
+set(lbann_sb_ftn_lang)
+if (LBANN_SB_FWD_Conduit_ENABLE_FORTRAN)
+  set(lbann_sb_ftn_lang Fortran)
+endif ()
+
+# Conduit is "cute" about finding HDF5. It's not a CMake option() --
+# you opt in by setting HDF5_DIR explicitly. So let's do that.
+if (TARGET HDF5 AND NOT LBANN_SB_FWD_Conduit_HDF5_DIR)
+  set(LBANN_SB_FWD_Conduit_HDF5_DIR ${HDF5_DIR})
+endif ()
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME Conduit
+  LANGUAGES C CXX ${lbann_sb_ftn_lang}
+  GITHUB_URL llnl/conduit.git
+  GIT_TAG "develop"
+  SOURCE_SUBDIR src
+  DEPENDS_ON HDF5
+)
+
+set(Conduit_DIR ${LBANN_SB_Conduit_PREFIX}
+  CACHE INTERNAL "The install prefix of Conduit.")

--- a/scripts/superbuild/conduit/CMakeLists.txt
+++ b/scripts/superbuild/conduit/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/dihydrogen/CMakeLists.txt
+++ b/scripts/superbuild/dihydrogen/CMakeLists.txt
@@ -1,0 +1,63 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# Most of the folks using the superbuild are devs, and this has no
+# performance implications for those who aren't.
+lbann_sb_default_pkg_option(
+  DiHydrogen
+  H2_DEVELOPER_BUILD
+  "Enable developer warnings/features in H2"
+  ON)
+
+# Explicitly acknowledge DistConv
+lbann_sb_default_pkg_option(
+  DiHydrogen
+  H2_ENABLE_DISTCONV_LEGACY
+  "Enable legacy DistConv library in DiHydrogen"
+  OFF)
+
+lbann_sb_default_cuda_option(
+  DiHydrogen
+  H2_ENABLE_CUDA
+  "Enable CUDA support in DiHydrogen"
+  ON)
+
+lbann_sb_default_rocm_option(
+  DiHydrogen
+  H2_ENABLE_ROCM
+  "Enable HIP/ROCm support in DiHydrogen"
+  ON)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME DiHydrogen
+  LANGUAGES CXX
+  OPTIONAL_LANGUAGES CUDA HIP
+  GITHUB_URL LLNL/DiHydrogen.git
+  GIT_TAG "develop"
+  DEPENDS_ON Aluminum Catch2 spdlog Hydrogen
+)
+
+set(DiHydrogen_DIR ${LBANN_SB_DiHydrogen_PREFIX}
+  CACHE INTERNAL "The install prefix of DiHydrogen.")

--- a/scripts/superbuild/dihydrogen/CMakeLists.txt
+++ b/scripts/superbuild/dihydrogen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/examples/cuda-distconv.sh
+++ b/scripts/superbuild/examples/cuda-distconv.sh
@@ -1,0 +1,143 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+
+# Set to ON (or any CMake truthy value) to build all of the
+# dependencies of the LBANN stack
+BUILD_EXTERNAL_TPLS=ON
+
+# Set to ON to build Aluminum, Hydrogen, DiHydrogen, and LBANN
+BUILD_LBANN_STACK=ON
+
+# Set to ON to enable DistConv support. Only matters if building the
+# LBANN stack.
+BUILD_WITH_DISTCONV=ON
+
+# Improve debugging info and remove some misguided warnings. These are
+# passed only to the LBANN stack.
+EXTRA_CXX_FLAGS="-g3 -Wno-deprecated-declarations"
+EXTRA_CUDA_FLAGS="-g3 -Wno-deprecated-declarations"
+
+# Prefer RPATH to RUNPATH (stability over flexibility)
+EXTRA_LINK_FLAGS="-Wl,--disable-new-dtags"
+
+# Set this to the CUDA GPU arch(s) to support (example set for Lassen/Sierra)
+CUDA_GPU_ARCH=70
+
+# Set to the directory with the top-level CMakeLists.txt file for LBANN
+LBANN_SRC_DIR=$(git rev-parse --show-toplevel)
+
+# Set to the directory with the top-level SuperBuild CMakeLists.txt file
+SUPERBUILD_SRC_DIR=${LBANN_SRC_DIR}/scripts/superbuild
+
+# Set to the preferred install directory
+INSTALL_PREFIX=${PWD}/install-cuda-distconv
+
+# Set to the preferred build directory
+BUILD_DIR=${TMPDIR}/lbann-superbuild
+
+cmake \
+    -G Ninja \
+    -S ${SUPERBUILD_SRC_DIR} \
+    -B ${BUILD_DIR} \
+    \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=${INSTALL_TOP} \
+    \
+    -D CMAKE_C_COMPILER=$(command -v gcc) \
+    -D CMAKE_CXX_COMPILER=$(command -v g++) \
+    -D CMAKE_CUDA_COMPILER=$(command -v nvcc) \
+    -D CMAKE_CUDA_HOST_COMPILER=$(command -v g++) \
+    -D CMAKE_Fortran_COMPILER=$(command -v gfortran) \
+    \
+    -D CMAKE_CXX_STANDARD=17 \
+    -D CMAKE_CUDA_STANDARD=17 \
+    -D CMAKE_CUDA_ARCHITECTURES=${GPU_ARCH} \
+    \
+    -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
+    \
+    -D LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY="PKG_LC" \
+    -D LBANN_SB_DEFAULT_CUDA_OPTS=ON \
+    \
+    -D LBANN_SB_BUILD_Catch2=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_Catch2_TAG="devel" \
+    \
+    -D LBANN_SB_BUILD_adiak=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_Caliper=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_adiak_BUILD_SHARED_LIBS=ON \
+    -D LBANN_SB_Caliper_BUILD_SHARED_LIBS=ON \
+    \
+    -D LBANN_SB_BUILD_cereal=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_Clara=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_CNPY=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_protobuf=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_spdlog=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_zstr=${BUILD_EXTERNAL_TPLS} \
+    \
+    -D LBANN_SB_BUILD_Conduit=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_HDF5=${BUILD_EXTERNAL_TPLS} \
+    \
+    -D LBANN_SB_BUILD_JPEG-TURBO=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_OpenCV=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_FWD_OpenCV_WITH_IPP=OFF \
+    -D LBANN_SB_OpenCV_TAG=4.x \
+    \
+    -D LBANN_SB_BUILD_Aluminum=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_Aluminum_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_Aluminum_CUDA_FLAGS="${EXTRA_CUDA_FLAGS}" \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_CALIPER=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_NCCL=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_HOST_TRANSFER=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_TESTS=OFF \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_BENCHMARKS=OFF \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_THREAD_MULTIPLE=OFF \
+    \
+    -D LBANN_SB_BUILD_Hydrogen=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_Hydrogen_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_Hydrogen_CUDA_FLAGS="${EXTRA_CUDA_FLAGS}" \
+    -D LBANN_SB_FWD_Hydrogen_BLA_VENDOR="Generic" \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_GENERAL_LAPACK_FALLBACK=ON \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_HALF=OFF \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_TESTING=ON \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_UNIT_TESTS=OFF \
+    \
+    -D LBANN_SB_BUILD_DiHydrogen=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_DiHydrogen_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_DiHydrogen_CUDA_FLAGS="${EXTRA_CUDA_FLAGS}" \
+    -D LBANN_SB_FWD_DiHydrogen_BLA_VENDOR="Generic" \
+    -D LBANN_SB_FWD_DiHydrogen_H2_ENABLE_DISTCONV_LEGACY=${BUILD_WITH_DISTCONV} \
+    \
+    -D LBANN_SB_BUILD_LBANN=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_LBANN_SOURCE_DIR=$${LBANN_SRC_DIR} \
+    -D LBANN_SB_LBANN_BUILD_SHARED_LIBS=ON \
+    -D LBANN_SB_LBANN_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_LBANN_CUDA_FLAGS="${EXTRA_CUDA_FLAGS}" \
+    -D LBANN_SB_FWD_LBANN_BLA_VENDOR="Generic" \
+    -D LBANN_SB_FWD_LBANN_CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -D LBANN_SB_FWD_LBANN_LBANN_DATATYPE=float \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_CALIPER=ON \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_DISTCONV=${BUILD_WITH_DISTCONV} \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_TBINF=OFF \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_UNIT_TESTING=ON

--- a/scripts/superbuild/examples/cuda-distconv.sh
+++ b/scripts/superbuild/examples/cuda-distconv.sh
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/examples/rocm-distconv.sh
+++ b/scripts/superbuild/examples/rocm-distconv.sh
@@ -1,0 +1,137 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+
+# Set to ON (or any CMake truthy value) to build all of the
+# dependencies of the LBANN stack
+BUILD_EXTERNAL_TPLS=ON
+
+# Set to ON to build Aluminum, Hydrogen, DiHydrogen, and LBANN
+BUILD_LBANN_STACK=ON
+
+# Set to ON to enable DistConv support. Only matters if building the
+# LBANN stack.
+BUILD_WITH_DISTCONV=ON
+
+# Improve debugging info and remove some misguided warnings. These are
+# passed only to the LBANN stack.
+EXTRA_CXX_FLAGS="-g3 -Wno-deprecated-declarations"
+EXTRA_HIP_FLAGS="-g3 -Wno-deprecated-declarations"
+
+# Prefer RPATH to RUNPATH (stability over flexibility)
+EXTRA_LINK_FLAGS="-Wl,--disable-new-dtags"
+
+# Set this to the AMD GPU arch(s) to support (example set for Crusher/Frontier/Tioga)
+AMD_GPU_ARCH=gfx90a
+
+# Set to the directory with the top-level CMakeLists.txt file for LBANN
+LBANN_SRC_DIR=$(git rev-parse --show-toplevel)
+
+# Set to the directory with the top-level SuperBuild CMakeLists.txt file
+SUPERBUILD_SRC_DIR=${LBANN_SRC_DIR}/scripts/superbuild
+
+# Set to the preferred install directory
+INSTALL_PREFIX=${PWD}/install-rocm-distconv
+
+# Set to the preferred build directory
+BUILD_DIR=${TMPDIR}/lbann-superbuild
+
+cmake \
+    -G Ninja \
+    -S ${SUPERBUILD_SRC_DIR} \
+    -B ${BUILD_DIR} \
+    \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+    \
+    -D CMAKE_C_COMPILER=$(which amdclang) \
+    -D CMAKE_CXX_COMPILER=$(which amdclang++) \
+    -D CMAKE_Fortran_COMPILER=$(which gfortran) \
+    \
+    -D CMAKE_EXE_LINKER_FLAGS=${EXTRA_LINK_FLAGS} \
+    -D CMAKE_SHARED_LINKER_FLAGS=${EXTRA_LINK_FLAGS} \
+    \
+    -D CMAKE_CXX_STANDARD=17 \
+    -D CMAKE_HIP_STANDARD=17 \
+    -D CMAKE_HIP_ARCHITECTURES=${AMD_GPU_ARCH} \
+    \
+    -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
+    \
+    -D LBANN_SB_DEFAULT_INSTALL_PATH_STRATEGY="PKG_LC" \
+    -D LBANN_SB_DEFAULT_ROCM_OPTS=ON \
+    \
+    -D LBANN_SB_BUILD_adiak=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_Caliper=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_adiak_BUILD_SHARED_LIBS=ON \
+    -D LBANN_SB_Caliper_BUILD_SHARED_LIBS=ON \
+    \
+    -D LBANN_SB_BUILD_Catch2=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_cereal=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_Clara=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_CNPY=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_protobuf=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_spdlog=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_zstr=${BUILD_EXTERNAL_TPLS} \
+    \
+    -D LBANN_SB_BUILD_Conduit=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_HDF5=${BUILD_EXTERNAL_TPLS} \
+    \
+    -D LBANN_SB_BUILD_JPEG-TURBO=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_BUILD_OpenCV=${BUILD_EXTERNAL_TPLS} \
+    -D LBANN_SB_OpenCV_TAG=4.x \
+    \
+    -D LBANN_SB_BUILD_Aluminum=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_Aluminum_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_Aluminum_HIP_FLAGS="${EXTRA_HIP_FLAGS}" \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_CALIPER=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_NCCL=ON \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_HOST_TRANSFER=OFF \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_TESTS=OFF \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_BENCHMARKS=OFF \
+    -D LBANN_SB_FWD_Aluminum_ALUMINUM_ENABLE_THREAD_MULTIPLE=OFF \
+    \
+    -D LBANN_SB_BUILD_Hydrogen=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_Hydrogen_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_Hydrogen_HIP_FLAGS="${EXTRA_HIP_FLAGS}" \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_HALF=OFF \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_TESTING=ON \
+    -D LBANN_SB_FWD_Hydrogen_Hydrogen_ENABLE_UNIT_TESTS=OFF \
+    \
+    -D LBANN_SB_BUILD_DiHydrogen=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_DiHydrogen_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_DiHydrogen_HIP_FLAGS="${EXTRA_HIP_FLAGS}" \
+    -D LBANN_SB_FWD_DiHydrogen_H2_ENABLE_DISTCONV_LEGACY=${BUILD_WITH_DISTCONV} \
+    \
+    -D LBANN_SB_BUILD_LBANN=${BUILD_LBANN_STACK} \
+    -D LBANN_SB_LBANN_BUILD_SHARED_LIBS=ON \
+    -D LBANN_SB_LBANN_SOURCE_DIR=${LBANN_SRC_DIR} \
+    -D LBANN_SB_FWD_LBANN_CMAKE_EXPORT_COMPILE_COMMANDS=ON \
+    -D LBANN_SB_LBANN_CXX_FLAGS="${EXTRA_CXX_FLAGS}" \
+    -D LBANN_SB_LBANN_HIP_FLAGS="${EXTRA_HIP_FLAGS}" \
+    -D LBANN_SB_FWD_LBANN_LBANN_DATATYPE=float \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_CALIPER=ON \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_DISTCONV=${BUILD_WITH_DISTCONV} \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_TBINF=OFF \
+    -D LBANN_SB_FWD_LBANN_LBANN_WITH_UNIT_TESTING=ON

--- a/scripts/superbuild/examples/rocm-distconv.sh
+++ b/scripts/superbuild/examples/rocm-distconv.sh
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/hdf5/CMakeLists.txt
+++ b/scripts/superbuild/hdf5/CMakeLists.txt
@@ -1,0 +1,81 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# These defaults are set so as to be most amenable to LBANN(/Conduit).
+set(LBANN_SB_FWD_HDF5_DEFAULT_API_VERSION "v18"
+  CACHE BOOL "Default API version for HDF5")
+
+option(LBANN_SB_FWD_HDF5_BUILD_TESTING
+  "Build HDF5 tests."
+  OFF)
+
+# HDF5-specific configuration options explicitly exposed
+option(LBANN_SB_FWD_HDF5_HDF5_BUILD_EXAMPLES
+  "Build HDF5 examples." OFF)
+option(LBANN_SB_FWD_HDF5_HDF5_ENABLE_PARALLEL
+  "Build HDF5 with parallel (MPI) support." ON)
+
+option(LBANN_SB_FWD_HDF5_HDF5_USE_16_API_DEFAULT
+  "Use 1.6 API by default"
+  OFF)
+option(LBANN_SB_FWD_HDF5_HDF5_USE_18_API_DEFAULT
+  "Use 1.8 API by default"
+  ON)
+option(LBANN_SB_FWD_HDF5_HDF5_USE_110_API_DEFAULT
+  "Use 1.10 API by default"
+  OFF)
+option(LBANN_SB_FWD_HDF5_HDF5_USE_112_API_DEFAULT
+  "Use 1.12 API by default"
+  OFF)
+option(LBANN_SB_FWD_HDF5_HDF5_BUILD_FORTRAN
+  "Build HDF5 with fortran support"
+  OFF)
+option(LBANN_SB_FWD_HDF5_HDF5_GENERATE_HEADERS
+  "See HDF5 docs."
+  ON)
+
+# At present, this is required for LBANN/JAG use.
+option(LBANN_SB_FWD_HDF5_HDF5_ENABLE_Z_LIB_SUPPORT
+  "Build HDF5 with ZLIB support"
+  ON)
+
+set(MAYBE_HDF5_FORTRAN)
+if (LBANN_SB_FWD_HDF5_HDF5_BUILD_FORTRAN)
+  set(MAYBE_HDF5_FORTRAN Fortran)
+endif ()
+
+if (LBANN_SB_FWD_HDF5_HDF5_ENABLE_PARALLEL)
+  # The C++ and Parallel paths are mutually exclusive, apparently.
+  set(LBANN_SB_FWD_HDF5_HDF5_BUILD_CPP_LIB OFF CACHE BOOL "" FORCE)
+endif ()
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME HDF5
+  LANGUAGES C CXX ${MAYBE_HDF5_FORTRAN}
+  GITHUB_URL HDFGroup/hdf5
+  GIT_TAG "hdf5-1_10_9")
+
+set(HDF5_DIR ${LBANN_SB_HDF5_PREFIX}
+  CACHE INTERNAL "The install prefix of HDF5.")

--- a/scripts/superbuild/hdf5/CMakeLists.txt
+++ b/scripts/superbuild/hdf5/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/hydrogen/CMakeLists.txt
+++ b/scripts/superbuild/hydrogen/CMakeLists.txt
@@ -1,0 +1,76 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_default_pkg_option(
+  Hydrogen
+  Hydrogen_ENABLE_ALUMINUM
+  "Enable Aluminum-based communication in Hydrogen"
+  ${LBANN_SB_BUILD_Aluminum})
+
+lbann_sb_default_pkg_option(Hydrogen
+  Hydrogen_GENERAL_LAPACK_FALLBACK
+  "Allow a fallback search for system blas/lapack libraries in Hydrogen"
+  ON)
+
+lbann_sb_default_pkg_option(
+  Hydrogen
+  Hydrogen_ENABLE_OPENMP
+  "Use OpenMP threading (host code only) in Hydrogen"
+  ON)
+
+lbann_sb_default_pkg_option(
+  Hydrogen
+  Hydrogen_USE_64BIT_INTS
+  "Use 64-bit indexing in Hydrogen"
+  ON)
+
+lbann_sb_default_cuda_option(
+  Hydrogen
+  Hydrogen_ENABLE_CUDA
+  "Enable CUDA support in Hydrogen"
+  ON)
+
+lbann_sb_default_rocm_option(
+  Hydrogen
+  Hydrogen_ENABLE_ROCM
+  "Enable ROCm support in Hydrogen"
+  ON)
+
+lbann_sb_default_gpu_option(
+  Hydrogen
+  Hydrogen_ENABLE_CUB
+  "Enable (hip)CUB memory allocators in Hydrogen"
+  ON)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME Hydrogen
+  LANGUAGES CXX
+  OPTIONAL_LANGUAGES CUDA HIP
+  GITHUB_URL llnl/Elemental.git
+  GIT_TAG "hydrogen"
+  DEPENDS_ON Aluminum Catch2 OpenBLAS)
+
+set(Hydrogen_DIR ${LBANN_SB_Hydrogen_PREFIX}
+  CACHE INTERNAL "The install prefix of Hydrogen.")

--- a/scripts/superbuild/hydrogen/CMakeLists.txt
+++ b/scripts/superbuild/hydrogen/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/jpeg-turbo/CMakeLists.txt
+++ b/scripts/superbuild/jpeg-turbo/CMakeLists.txt
@@ -1,0 +1,40 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# Explicitly declare this option; set default to match expectation.
+option(LBANN_SB_FWD_JPEG-TURBO_ENABLE_STATIC
+  "Enable the jpeg-turbo static linkage." ON)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME JPEG-TURBO
+  LANGUAGES C CXX ASM_NASM
+  GITHUB_URL libjpeg-turbo/libjpeg-turbo
+  GIT_TAG "2.0.3"
+  EXTRA_CMAKE_ARGS
+  -DCMAKE_MACOSX_RPATH=ON
+)
+
+set(JPEG-TURBO_DIR ${LBANN_SB_JPEG-TURBO_PREFIX}
+  CACHE INTERNAL "The install prefix of JPEG-TURBO.")

--- a/scripts/superbuild/jpeg-turbo/CMakeLists.txt
+++ b/scripts/superbuild/jpeg-turbo/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/lbann/CMakeLists.txt
+++ b/scripts/superbuild/lbann/CMakeLists.txt
@@ -1,0 +1,92 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+option(LBANN_SB_LBANN_ENABLE_EXTRA_UTILS
+  "Enable the utility targets in LBANN"
+  OFF)
+
+option(LBANN_SB_FWD_LBANN_LBANN_WARNINGS_AS_ERRORS
+  "Build with -Werror"
+  OFF)
+
+option(LBANN_SB_FWD_LBANN_LBANN_WITH_CALIPER
+  "Build LBANN with Caliper support"
+  ${LBANN_SB_BUILD_Caliper})
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME LBANN
+  LANGUAGES C CXX
+  OPTIONAL_LANGUAGES CUDA HIP
+  GITHUB_URL LLNL/lbann.git
+  GIT_TAG "develop"
+  DEPENDS_ON
+  Aluminum DiHydrogen Hydrogen
+  Caliper
+  Catch2
+  Clara
+  CNPY
+  Conduit HDF5
+  hipTT
+  OpenCV JPEG-TURBO
+  OpenBLAS
+  cereal
+  protobuf
+  spdlog
+  zstr
+)
+
+if (LBANN_SB_LBANN_ENABLE_EXTRA_UTILS)
+
+  # Ensure the JAG utils are built
+  ExternalProject_Add_Step(LBANN build-jag-utils
+    COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target jag-utils
+    COMMENT "Performing building of JAG utils for 'LBANN'"
+    DEPENDEES build
+    DEPENDERS install
+    LOG 1
+    USES_TERMINAL 1)
+
+  # Ensure the ATOM utils are built
+  ExternalProject_Add_Step(LBANN build-atom-utils
+    COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target atom-utils
+    COMMENT "Performing building of ATOM tools for 'LBANN'"
+    DEPENDEES build
+    DEPENDERS install
+    LOG 1
+    USES_TERMINAL 1)
+
+  # Ensure the PILOT2 utils are built
+  ExternalProject_Add_Step(LBANN build-pilot2-utils
+    COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG> --target pilot2-utils
+    COMMENT "Performing building of PILOT2 tools for 'LBANN'"
+    DEPENDEES build
+    DEPENDERS install
+    LOG 1
+    USES_TERMINAL 1)
+
+endif ()
+
+set(LBANN_DIR ${LBANN_SB_LBANN_PREFIX}
+    CACHE INTERNAL "The install prefix of LBANN.")

--- a/scripts/superbuild/lbann/CMakeLists.txt
+++ b/scripts/superbuild/lbann/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/openblas/CMakeLists.txt
+++ b/scripts/superbuild/openblas/CMakeLists.txt
@@ -1,0 +1,117 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_init_extern_pkg(
+  NAME OpenBLAS
+  LANGUAGES C Fortran
+  GITHUB_URL xianyi/OpenBLAS.git
+  GIT_TAG "v0.3.6")
+
+option(OpenBLAS_USE_64_BIT_INDEX
+  "Whether OpenBLAS should use 64-bit indices" OFF)
+
+option(OpenBLAS_USE_OPENMP
+  "Whether OpenBLAS should make use of OpenMP" ON)
+
+set(OpenBLAS_MAX_MAKE_JOBS "4"
+  CACHE STRING "Number of 'make' jobs allowed for OpenBLAS build.")
+
+# Handle the options
+if (OpenBLAS_USE_64_BIT_INDEX)
+  set(_TMP_OpenBLAS_INTERFACE_COMMAND "INTERFACE64=1 SYMBOLSUFFIX=64")
+else()
+  set(_TMP_OpenBLAS_INTERFACE_COMMAND "INTERFACE64=0")
+endif()
+
+if (OpenBLAS_USE_OPENMP)
+  set(_TMP_OpenBLAS_THREAD_COMMAND USE_OPENMP=1)
+else()
+  set(_TMP_OpenBLAS_THREAD_COMMAND USE_THREAD=0)
+endif()
+
+# Arch flags
+#
+# FIXME: No longer relevant, I'm guessing...
+if(APPLE)
+  # This is a hack but is a good default for modern Mac's
+  set(_TMP_OpenBLAS_ARCH_COMMAND TARGET=SANDYBRIDGE)
+endif()
+
+set(OpenBLAS_INTERFACE_COMMAND "${_TMP_OpenBLAS_INTERFACE_COMMAND}"
+  CACHE STRING
+  "The command to be forwarded to OpenBLAS to control the index interface.")
+
+set(OpenBLAS_THREAD_COMMAND "${_TMP_OpenBLAS_THREAD_COMMAND}"
+  CACHE STRING
+  "The command to be forwarded to OpenBLAS to control threading.")
+
+set(OpenBLAS_ARCH_COMMAND "${_TMP_OpenBLAS_ARCH_COMMAND}"
+  CACHE STRING
+  "THe command to be forwarded to OpenBLAS to describe the CPU architecture.")
+
+# If not using the Makefile generator for CMake, using
+# CMAKE_MAKE_PROGRAM probably won't work here (in particular, ninja
+# cannot process Makefiles). So we go looking for plain ol' "make"
+# instead.
+find_program(GNU_MAKE_PROGRAM make)
+
+include (ExternalProject)
+ExternalProject_Add(OpenBLAS
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+  ${LBANN_SB_GIT_REPOSITORY_TAG} ${LBANN_SB_OpenBLAS_URL}
+  ${LBANN_SB_GIT_TAG_TAG} ${LBANN_SB_OpenBLAS_TAG}
+  TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp
+  STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/stamp
+
+  SOURCE_DIR ${LBANN_SB_OpenBLAS_SOURCE_DIR}
+  INSTALL_DIR ${LBANN_SB_OpenBLAS_PREFIX}
+
+  BUILD_IN_SOURCE 1
+
+  USES_TERMINAL_BUILD 1
+  LOG_DOWNLOAD 1
+  LOG_UPDATE 1
+  LOG_CONFIGURE 1
+  LOG_BUILD 1
+  LOG_INSTALL 1
+  LOG_TEST 1
+
+  CONFIGURE_COMMAND ""
+  UPDATE_COMMAND ""
+
+  BUILD_COMMAND
+  ${GNU_MAKE_PROGRAM} -j${OpenBLAS_MAX_MAKE_JOBS}
+  CC=${LBANN_SB_OpenBLAS_C_COMPILER}
+  FC=${LBANN_SB_OpenBLAS_Fortran_COMPILER}
+  ${OpenBLAS_THREAD_COMMAND}
+  ${OpenBLAS_ARCH_COMMAND}
+  ${OpenBLAS_INTERFACE_COMMAND}
+  libs netlib shared
+  INSTALL_COMMAND
+  ${GNU_MAKE_PROGRAM} install PREFIX=${LBANN_SB_OpenBLAS_PREFIX}
+)
+
+set(OpenBLAS_DIR ${LBANN_SB_OpenBLAS_PREFIX}
+  CACHE INTERNAL "The install prefix of OpenBLAS.")

--- a/scripts/superbuild/openblas/CMakeLists.txt
+++ b/scripts/superbuild/openblas/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/opencv/AddOpenCVOptions.cmake
+++ b/scripts/superbuild/opencv/AddOpenCVOptions.cmake
@@ -1,0 +1,238 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# OpenCV modules
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_core "OpenCV: Enable core module" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_flann "OpenCV: Enable flann module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_imgproc "OpenCV: Enable imgproc module" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_highgui "OpenCV: Enable highgui module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_features2d "OpenCV: Enable features2d module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_calib3d "OpenCV: Enable calib3d module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_ml "OpenCV: Enable ml module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_video "OpenCV: Enable video module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_legacy "OpenCV: Enable legacy module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_objdetect "OpenCV: Enable objdetect module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_photo "OpenCV: Enable photo module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_gpu "OpenCV: Enable gpu module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_nonfree "OpenCV: Enable nonfree module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_contrib "OpenCV: Enable contrib module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_java "OpenCV: Enable java module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_python "OpenCV: Enable python module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_python2 "OpenCV: Enable python2 module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_python3 "OpenCV: Enable python3 module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_stitching "OpenCV: Enable stitching module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_superres "OpenCV: Enable superres module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_ts "OpenCV: Enable ts module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_videostab "OpenCV: Enable videostab module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_world "OpenCV: Enable world module" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_NONFREE "OpenCV: Enable non-free algorithms" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_videoio "OpenCV: Enable videoio module" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_dnn "OpenCV: Build dnn module and protobuf" OFF)
+
+# Optional 3rd party components
+option(LBANN_SB_FWD_OpenCV_WITH_1394 "OpenCV: Include IEEE1394 support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_AVFOUNDATION
+  "OpenCV: Use AVFoundation for Video I/O (iOS/Mac)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CARBON "OpenCV: Use Carbon for UI instead of Cocoa" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CAROTENE
+  "OpenCV: Use NVidia carotene acceleration library for ARM platform" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CPUFEATURES "OpenCV: Use cpufeatures Android library" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_VTK
+  "OpenCV: Include VTK library support (and build opencv_viz module eiher)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CUDA "OpenCV: Include NVidia Cuda Runtime support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CUFFT
+  "OpenCV: Include NVidia cuFFT library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CUBLAS "OpenCV: Include NVidia cuBLAS library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_NVCUVID
+  "OpenCV: Include NVidia Video Decoding library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_EIGEN "OpenCV: Include Eigen2/Eigen3 support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_VFW "OpenCV: Include Video for Windows support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_FFMPEG "OpenCV: Include FFMPEG support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GSTREAMER "OpenCV: Include Gstreamer support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GSTREAMER_0_10
+  "OpenCV: Enable Gstreamer 0.10 support (instead of 1.x)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GTK "OpenCV: Include GTK support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GTK_2_X "OpenCV: Use GTK version 2" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_IMAGEIO "OpenCV: ImageIO support for OS X" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_IPP "OpenCV: Include Intel IPP support" ON)
+option(LBANN_SB_FWD_OpenCV_WITH_HALIDE "OpenCV: Include Halide support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_JASPER "OpenCV: Include JPEG2K support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_JPEG "OpenCV: Include JPEG support" ON)
+option(LBANN_SB_FWD_OpenCV_WITH_WEBP "OpenCV: Include WebP support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENEXR "OpenCV: Include ILM support via OpenEXR" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENGL "OpenCV: Include OpenGL support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENVX "OpenCV: Include OpenVX support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENNI "OpenCV: Include OpenNI support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENNI2 "OpenCV: Include OpenNI2 support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_PNG "OpenCV: Include PNG support" ON)
+option(LBANN_SB_FWD_OpenCV_WITH_GDCM "OpenCV: Include DICOM support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_PVAPI "OpenCV: Include Prosilica GigE support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GIGEAPI "OpenCV: Include Smartek GigE support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_ARAVIS "OpenCV: Include Aravis GigE support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_QT "OpenCV: Build with Qt Backend support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_WIN32UI "OpenCV: Build with Win32 UI Backend support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_QUICKTIME "OpenCV: Use QuickTime for Video I/O" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_QTKIT "OpenCV: Use QTKit Video I/O backend" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_TBB "OpenCV: Include Intel TBB support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENMP "OpenCV: Include OpenMP support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CSTRIPES "OpenCV: Include C= support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_PTHREADS_PF "OpenCV: Use pthreads-based parallel_for" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_TIFF "OpenCV: Include TIFF support" ON)
+option(LBANN_SB_FWD_OpenCV_WITH_UNICAP "OpenCV: Include Unicap support (GPL)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_V4L "OpenCV: Include Video 4 Linux support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_LIBV4L "OpenCV: Use libv4l for Video 4 Linux support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_DSHOW "OpenCV: Build VideoIO with DirectShow support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_MSMF
+  "OpenCV: Build VideoIO with Media Foundation support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_XIMEA "OpenCV: Include XIMEA cameras support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_XINE "OpenCV: Include Xine support (GPL)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_CLP "OpenCV: Include Clp support (EPL)" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENCL "OpenCV: Include OpenCL Runtime support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENCL_SVM
+  "OpenCV: Include OpenCL Shared Virtual Memory support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENCLAMDFFT
+  "OpenCV: Include AMD OpenCL FFT library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_OPENCLAMDBLAS
+  "OpenCV: Include AMD OpenCL BLAS library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_DIRECTX "OpenCV: Include DirectX support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_INTELPERC
+  "OpenCV: Include Intel Perceptual Computing support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_IPP_A "OpenCV: Include Intel IPP_A support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_MATLAB "OpenCV: Include Matlab support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_VA "OpenCV: Include VA support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_VA_INTEL "OpenCV: Include Intel VA-API/OpenCL support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_MFX "OpenCV: Include Intel Media SDK support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GDAL "OpenCV: Include GDAL Support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_GPHOTO2 "OpenCV: Include gPhoto2 library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_LAPACK "OpenCV: Include Lapack library support" OFF)
+option(LBANN_SB_FWD_OpenCV_WITH_ITT "OpenCV: Include Intel ITT support" ON)
+
+# OpenCV build components
+option(LBANN_SB_FWD_OpenCV_BUILD_SHARED_LIBS
+  "OpenCV: Build shared libraries instead of static ones" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_opencv_apps
+  "OpenCV: Build utility applications" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_ANDROID_EXAMPLES
+  "OpenCV: Build examples for Android platform" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_DOCS
+  "OpenCV: Create build rules for OpenCV Documentation" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_EXAMPLES "OpenCV: Build all examples" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_PACKAGE
+  "OpenCV: Create build rules for OpenCV Documentation" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_PERF_TESTS "OpenCV: Build performance tests" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_TESTS "OpenCV: Build accuracy & regression tests" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_WITH_DEBUG_INFO
+  "OpenCV: Include debug info into debug libs (not MSCV only)" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_WITH_STATIC_CRT
+  "OpenCV: Enables use of staticaly linked CRT for staticaly linked OpenCV" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_WITH_DYNAMIC_IPP
+  "OpenCV: Enables dynamic linking of IPP (only for standalone IPP)" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_FAT_JAVA_LIB
+  "OpenCV: Create fat java wrapper containing the whole OpenCV library" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_ANDROID_SERVICE
+  "OpenCV: Build OpenCV Manager for Google Play" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_ANDROID_PACKAGE
+  "OpenCV: Build platform-specific package for Google Play" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_TINY_GPU_MODULE
+  "OpenCV: Build tiny gpu module with limited image format support" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_CUDA_STUBS
+  "OpenCV: Build CUDA modules stubs when no CUDA SDK" OFF)
+
+# 3rd party libs
+option(LBANN_SB_FWD_OpenCV_WITH_LIBJPEG_TURBO "OpenCV: Should OpenCV use libjpeg" OFF)
+
+option(LBANN_SB_FWD_OpenCV_BUILD_ZLIB "OpenCV: Build zlib from source" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_TIFF "OpenCV: Build libtiff from source" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_JASPER "OpenCV: Build libjasper from source" OFF)
+if (LBANN_SB_FWD_OpenCV_WITH_LIBJPEG_TURBO)
+  option(LBANN_SB_FWD_OpenCV_BUILD_JPEG "OpenCV: Build libjpeg from source" OFF)
+else()
+  option(LBANN_SB_FWD_OpenCV_BUILD_JPEG "OpenCV: Build libjpeg from source" ON)
+endif()
+option(LBANN_SB_FWD_OpenCV_BUILD_PNG "OpenCV: Build libpng from source" ON)
+option(LBANN_SB_FWD_OpenCV_BUILD_OPENEXR "OpenCV: Build openexr from source" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_TBB "OpenCV: Download and build TBB from source" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_IPP_IW "OpenCV: Build IPP IW from source" OFF)
+option(LBANN_SB_FWD_OpenCV_BUILD_ITT "OpenCV: Build Intel ITT from source" ON)
+
+# OpenCV installation options
+option(LBANN_SB_FWD_OpenCV_INSTALL_CREATE_DISTRIB
+  "OpenCV: Change install rules to build the distribution package" OFF)
+option(LBANN_SB_FWD_OpenCV_INSTALL_C_EXAMPLES "OpenCV: Install C examples" OFF)
+option(LBANN_SB_FWD_OpenCV_INSTALL_PYTHON_EXAMPLES "OpenCV: Install Python examples" OFF)
+option(LBANN_SB_FWD_OpenCV_INSTALL_ANDROID_EXAMPLES "OpenCV: Install Android examples" OFF)
+option(LBANN_SB_FWD_OpenCV_INSTALL_TO_MANGLED_PATHS
+  "OpenCV: Enables mangled install paths" OFF)
+option(LBANN_SB_FWD_OpenCV_INSTALL_TESTS
+  "OpenCV: Install accuracy and performance test binaries and test data" OFF)
+
+# OpenCV build options
+option(LBANN_SB_FWD_OpenCV_ENABLE_CCACHE "OpenCV: Use ccache" OFF)
+option(LBANN_SB_FWD_OpenCV_DYNAMIC_CUDA "OpenCV: Enabled dynamic CUDA linkage" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_PRECOMPILED_HEADERS "OpenCV: Use precompiled headers" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_SOLUTION_FOLDERS
+  "OpenCV: Solution folder in Visual Studio or in other IDEs" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_PROFILING
+  "OpenCV: Enable profiling in the GCC compiler (Add flags: -g -pg)" ON)
+option(LBANN_SB_FWD_OpenCV_ENABLE_COVERAGE
+  "OpenCV: Enable coverage collection with  GCov" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_OMIT_FRAME_POINTER
+  "OpenCV: Enable -fomit-frame-pointer for GCC" ON)
+option(LBANN_SB_FWD_OpenCV_ENABLE_POWERPC "OpenCV: Enable PowerPC for GCC" ON)
+option(LBANN_SB_FWD_OpenCV_ENABLE_FAST_MATH
+  "OpenCV: Enable -ffast-math (not recommended for GCC 4.6.x)" ON)
+option(LBANN_SB_FWD_OpenCV_ENABLE_NEON "OpenCV: Enable NEON instructions" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_VFPV3 "OpenCV: Enable VFPv3-D32 instructions" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_NOISY_WARNINGS
+  "OpenCV: Show all warnings even if they are too noisy" OFF)
+option(LBANN_SB_FWD_OpenCV_WARNINGS_ARE_ERRORS "OpenCV: Treat warnings as errors" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_WINRT_MODE
+  "OpenCV: Build with Windows Runtime support" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_WINRT_MODE_NATIVE
+  "OpenCV: Build with Windows Runtime native C++ support" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_LIBVS2013
+  "OpenCV: Build VS2013 with Visual Studio 2013 libraries" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_WINSDK81 "OpenCV: Build VS2013 with Windows 8.1 SDK" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_WINPHONESDK80
+  "OpenCV: Build with Windows Phone 8.0 SDK" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_WINPHONESDK81
+  "OpenCV: Build VS2013 with Windows Phone 8.1 SDK" OFF)
+option(LBANN_SB_FWD_OpenCV_ANDROID_EXAMPLES_WITH_LIBS
+  "OpenCV: Build binaries of Android examples with native libraries" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_IMPL_COLLECTION
+  "OpenCV: Collect implementation data on function call" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_INSTRUMENTATION
+  "OpenCV: Instrument functions to collect calls trace and performance" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_GNU_STL_DEBUG
+  "OpenCV: Enable GNU STL Debug mode (defines _GLIBCXX_DEBUG)" OFF)
+option(LBANN_SB_FWD_OpenCV_ENABLE_BUILD_HARDENING
+  "OpenCV: Enable hardening of the resulting binaries" OFF)
+option(LBANN_SB_FWD_OpenCV_GENERATE_ABI_DESCRIPTOR
+  "OpenCV: Generate XML file for abi_compliance_checker tool" OFF)
+option(LBANN_SB_FWD_OpenCV_CV_ENABLE_INTRINSICS
+  "OpenCV: Use intrinsic-based optimized code" ON)
+option(LBANN_SB_FWD_OpenCV_CV_DISABLE_OPTIMIZATION
+  "OpenCV: Disable explicit optimized code" OFF)
+option(LBANN_SB_FWD_OpenCV_CV_TRACE "OpenCV: Enable OpenCV code trace" OFF)

--- a/scripts/superbuild/opencv/AddOpenCVOptions.cmake
+++ b/scripts/superbuild/opencv/AddOpenCVOptions.cmake
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/opencv/CMakeLists.txt
+++ b/scripts/superbuild/opencv/CMakeLists.txt
@@ -1,0 +1,49 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# OpenCV will default to using JPEG-TURBO if it's being built with the
+# superbuild at the same time.
+if (TARGET JPEG-TURBO)
+  set(LBANN_SB_FWD_OpenCV_WITH_LIBJPEG_TURBO ON)
+  set(LBANN_SB_FWD_OpenCV_BUILD_JPEG OFF)
+  set(LBANN_SB_FWD_OpenCV_CMAKE_PREFIX_PATH
+    ${CMAKE_PREFIX_PATH}
+    "${LBANN_SB_JPEG-TURBO_PREFIX}")
+endif ()
+
+# Add all the OpenCV options; this is just for the GUI, of course
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}")
+include(AddOpenCVOptions)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME OpenCV
+  LANGUAGES C CXX Fortran # WHY FORTRAN???
+  GITHUB_URL opencv/opencv
+  GIT_TAG "4.1.0"
+  DEPENDS_ON JPEG-TURBO
+)
+
+set(OpenCV_DIR ${LBANN_SB_OpenCV_PREFIX}
+  CACHE INTERNAL "The install prefix of OpenCV.")

--- a/scripts/superbuild/opencv/CMakeLists.txt
+++ b/scripts/superbuild/opencv/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/protobuf/CMakeLists.txt
+++ b/scripts/superbuild/protobuf/CMakeLists.txt
@@ -1,0 +1,39 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# Change a default by default
+option(LBANN_SB_FWD_protobuf_protobuf_BUILD_TESTS
+  "Build tests for protobuf?"
+  OFF)
+
+lbann_sb_add_cmake_extern_pkg(
+  NAME protobuf
+  LANGUAGES C CXX
+  GITHUB_URL protocolbuffers/protobuf.git
+  GIT_TAG "v21.5"
+  EXTRA_CMAKE_ARGS -DCMAKE_MACOSX_RPATH=ON)
+
+set(protobuf_DIR ${LBANN_SB_protobuf_PREFIX}
+  CACHE INTERNAL "The install prefix of Protobuf.")

--- a/scripts/superbuild/protobuf/CMakeLists.txt
+++ b/scripts/superbuild/protobuf/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/rccl/CMakeLists.txt
+++ b/scripts/superbuild/rccl/CMakeLists.txt
@@ -1,0 +1,34 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+# This probably won't build if the CXX compiler is not 'hipcc', but maybe? Good luck.
+lbann_sb_add_cmake_extern_pkg(
+  NAME RCCL
+  LANGUAGES C CXX HIP
+  GITHUB_URL ROCmSoftwarePlatform/rccl
+  GIT_TAG "develop")
+
+set(RCCL_DIR ${LBANN_SB_RCCL_PREFIX}
+  CACHE INTERNAL "The install prefix of RCCL.")

--- a/scripts/superbuild/rccl/CMakeLists.txt
+++ b/scripts/superbuild/rccl/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/spdlog/CMakeLists.txt
+++ b/scripts/superbuild/spdlog/CMakeLists.txt
@@ -1,0 +1,34 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_add_cmake_extern_pkg(
+  NAME spdlog
+  LANGUAGES CXX
+  GITHUB_URL gabime/spdlog
+  GIT_TAG v1.x
+)
+
+set(${PKG_NAME}_DIR ${LBANN_SB_${PKG_NAME}_PREFIX}
+  CACHE INTERNAL "The install prefix of ${PKG_NAME}.")

--- a/scripts/superbuild/spdlog/CMakeLists.txt
+++ b/scripts/superbuild/spdlog/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>

--- a/scripts/superbuild/zstr/CMakeLists.txt
+++ b/scripts/superbuild/zstr/CMakeLists.txt
@@ -1,0 +1,61 @@
+################################################################################
+## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Produced at the Lawrence Livermore National Laboratory.
+## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+## the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+##
+## LLNL-CODE-697807.
+## All rights reserved.
+##
+## This file is part of LBANN: Livermore Big Artificial Neural Network
+## Toolkit. For details, see http://software.llnl.gov/LBANN or
+## https://github.com/LLNL/LBANN.
+##
+## Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+## may not use this file except in compliance with the License.  You may
+## obtain a copy of the License at:
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+## implied. See the License for the specific language governing
+## permissions and limitations under the license.
+################################################################################
+lbann_sb_init_extern_pkg(
+  NAME zstr
+  LANGUAGES NONE
+  GITHUB_URL mateidavid/zstr
+  GIT_TAG master)
+
+# Now add the external project
+include(ExternalProject)
+ExternalProject_Add(zstr
+  PREFIX ${CMAKE_CURRENT_BINARY_DIR}
+  TMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/tmp
+  STAMP_DIR ${CMAKE_CURRENT_BINARY_DIR}/stamp
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build
+
+  SOURCE_DIR ${LBANN_SB_zstr_SOURCE_DIR}
+  INSTALL_DIR ${LBANN_SB_zstr_PREFIX}
+
+  ${LBANN_SB_GIT_REPOSITORY_TAG} ${LBANN_SB_zstr_URL}
+  ${LBANN_SB_GIT_TAG_TAG} ${LBANN_SB_zstr_TAG}
+
+  USES_TERMINAL_INSTALL 1
+  LOG_DOWNLOAD 1
+  LOG_UPDATE 1
+  LOG_INSTALL 1
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+
+  INSTALL_COMMAND
+  ${CMAKE_COMMAND} -E copy_directory
+  ${LBANN_SB_zstr_SOURCE_DIR}/src
+  ${LBANN_SB_zstr_PREFIX}/include
+)
+
+set(zstr_DIR ${LBANN_SB_zstr_PREFIX}
+  CACHE INTERNAL "The install prefix of zstr.")

--- a/scripts/superbuild/zstr/CMakeLists.txt
+++ b/scripts/superbuild/zstr/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-## Copyright (c) 2014-2022, Lawrence Livermore National Security, LLC.
+## Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
 ## Produced at the Lawrence Livermore National Laboratory.
 ## Written by the LBANN Research Team (B. Van Essen, et al.) listed in
 ## the CONTRIBUTORS file. <lbann-dev@llnl.gov>


### PR DESCRIPTION
It is with great sadness that this is done. The superbuild has been kept for internal use and for those situations in which real package managers prove inadequate, which were supposed to be few. Yet I have had to hand it out to nearly every user and/or developer of LBANN, because I guess our simple little package is too much for certain package managers to handle. Thus, here it is.

Do note that I do not want to spend any more of my life maintaining build systems or hand-holding developers (or users) than is programmatically necessary. Therefore this is presented as-is, with a couple of example scripts and a README. Good luck.

Finally, do continue to relentlessly hound the developers and/or maintainers of whichever package manager has failed to provide you with a working LBANN build so that this superbuild can fade away for a final time. It's not a hard package to build, and the dependencies are both quite few and quite common. So it's a real shame that there is so much trouble.