### PR TITLE
Do not backpropagate through layers without gradient sources

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -297,6 +297,8 @@ class Layer
   template <hydrogen::Device Device>
   friend class kfac_block_gru;
 
+  friend class model;
+
 public:
   /** @name Lifecycle */
   ///@{

--- a/include/lbann/models/model.hpp
+++ b/include/lbann/models/model.hpp
@@ -343,6 +343,11 @@ private:
    */
   void setup_weights();
 
+  /** @brief Tests whether a layer would be needed to compute through during
+   *  backpropagation
+   */
+  bool is_layer_needed_for_backprop(const Layer* l) const;
+
   ///@}
   /** @name Subgraph parallelism implementation */
   ///@{
@@ -560,6 +565,14 @@ private:
 
   /** @brief Current callbacks to process. */
   std::vector<std::shared_ptr<callback_base>> m_callbacks;
+
+  /** @brief A set of layers needed for backpropagation.
+   *  @details This set is populated by model::forward_prop and controls
+   *  which layers will be computed during backpropagation. If the
+   *  `NO_BACKPROP_DISABLE` option is enabled, this set will not change the
+   *  behavior of backpropagation.
+   */
+  std::unordered_set<const Layer*> m_needed_for_backprop;
 
   /** @brief Is the model setup
    *  @details Flag to indicate if the setup function has been called
@@ -793,10 +806,7 @@ model::set_current_mini_batch_size(uint64_t mini_batch_size) noexcept
   return;
 }
 
-inline bool model::is_amp_enabled() const noexcept
-{
-  return m_amp_enabled;
-}
+inline bool model::is_amp_enabled() const noexcept { return m_amp_enabled; }
 
 inline EvalType model::get_amp_scale_factor() const noexcept
 {

--- a/src/callbacks/check_gradients.cpp
+++ b/src/callbacks/check_gradients.cpp
@@ -273,8 +273,8 @@ void check_gradients::do_check_gradients(model& m) const
   m.get_objective_function()->differentiate();
   m.get_objective_function()->compute_weight_regularization();
 
-  // Compute analytical gradients through model
-  m.backward_prop(false, /*skip_callbacks=*/true);
+  // Compute all analytical gradients through model
+  m.backward_prop(/*compute_weight_grads_only=*/false, /*skip_callbacks=*/true);
 
   // Choose finite difference step
   // Note: Consider a central difference scheme:

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -480,7 +480,7 @@ bool model::is_layer_needed_for_backprop(const Layer* l) const
 
   // Second, check the layer itself. If frozen, backprop is not necessary.
   if (l->is_frozen()) {
-    return true;
+    return false;
   }
 
   // Otherwise, check weight optimizers. If one of the associated optimizers


### PR DESCRIPTION
This PR tracks layers that do not need to be computed on backpropagation and skips those. Disable with `LBANN_NO_BACKPROP_DISABLE=1`.