### PR TITLE
Fix CosmoFlow Double-Reading

### DIFF
--- a/include/lbann/data_ingestion/readers/data_reader_hdf5_legacy.hpp
+++ b/include/lbann/data_ingestion/readers/data_reader_hdf5_legacy.hpp
@@ -143,11 +143,14 @@ protected:
                            TensorDataType* sample);
   void read_hdf5_sample(uint64_t data_id,
                         TensorDataType* sample,
-                        TensorDataType* labels);
+                        TensorDataType* labels,
+                        bool get_sample = true,
+                        bool get_labels = true,
+                        bool get_responses = true);
   // void set_defaults() override;
   void load_sample(conduit::Node& node, uint64_t data_id);
   bool fetch_datum(CPUMat& X, uint64_t data_id, uint64_t mb_idx) override;
-  void fetch_datum_conduit(Mat& X, uint64_t data_id);
+  void fetch_sample_conduit(Mat& X, uint64_t data_id, std::string field);
   bool fetch_data_field(data_field_type data_field,
                         CPUMat& Y,
                         uint64_t data_id,

--- a/src/data_ingestion/readers/data_reader_hdf5_legacy.cpp
+++ b/src/data_ingestion/readers/data_reader_hdf5_legacy.cpp
@@ -185,7 +185,8 @@ void hdf5_reader<TensorDataType>::read_hdf5_sample(uint64_t data_id,
   }
   else if (this->has_responses() && get_responses) {
     assert_always(labels == nullptr);
-    hid_t h_data = CHECK_HDF5(H5Dopen(h_file, m_key_responses.c_str(), H5P_DEFAULT));
+    hid_t h_data =
+      CHECK_HDF5(H5Dopen(h_file, m_key_responses.c_str(), H5P_DEFAULT));
     CHECK_HDF5(H5Dread(h_data,
                        H5T_NATIVE_FLOAT,
                        H5S_ALL,
@@ -398,14 +399,21 @@ bool hdf5_reader<TensorDataType>::fetch_datum(Mat& X,
     fetch_sample_conduit(X_v, data_id, "slab");
   }
   else {
-    read_hdf5_sample(data_id, (TensorDataType*)X_v.Buffer(), nullptr, true, false, false);
+    read_hdf5_sample(data_id,
+                     (TensorDataType*)X_v.Buffer(),
+                     nullptr,
+                     true,
+                     false,
+                     false);
   }
   prof_region_end("fetch_datum", false);
   return true;
 }
 
 template <typename TensorDataType>
-void hdf5_reader<TensorDataType>::fetch_sample_conduit(Mat& X, uint64_t data_id, std::string field)
+void hdf5_reader<TensorDataType>::fetch_sample_conduit(Mat& X,
+                                                       uint64_t data_id,
+                                                       std::string field)
 {
   const std::string conduit_key = LBANN_DATA_ID_STR(data_id);
   // Create a node to hold all of the data
@@ -456,7 +464,9 @@ bool hdf5_reader<TensorDataType>::fetch_response(Mat& Y,
     }
     else {
       read_hdf5_sample(data_id, nullptr, nullptr, false, false, true);
-      std::memcpy(Y_v.Buffer(), &m_all_responses[0], m_all_responses.size() * sizeof(DataType));
+      std::memcpy(Y_v.Buffer(),
+                  &m_all_responses[0],
+                  m_all_responses.size() * sizeof(DataType));
     }
   }
   prof_region_end("fetch_response", false);


### PR DESCRIPTION
Fixes double-reading of samples for cosmoflow when the datastore is disabled.
Before:
![image](https://github.com/LLNL/lbann/assets/117680821/fdb3a350-945a-40eb-bfb4-c6d414d7dba5)

After:
![image](https://github.com/LLNL/lbann/assets/117680821/7d32e700-1aa6-46d7-85fa-9c19c42d86d6)
