### PR TITLE
Use Hydrogen for MPI Calls

### DIFF
--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -67,6 +67,7 @@
 #cmakedefine LBANN_HAS_SHMEM
 #cmakedefine LBANN_HAS_LARGESCALE_NODE2VEC
 #cmakedefine LBANN_HAS_ONNX
+#cmakedefine LBANN_BUILT_WITH_SPECTRUM
 
 #cmakedefine LBANN_DETERMINISTIC
 


### PR DESCRIPTION
Uses Hydrogen for MPI calls except in the case of doing a send with Spectrum MPI.