### PR TITLE
Accept any H2 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,7 +243,7 @@ endif ()
 
 # DiHydrogen and Distconv
 if (LBANN_WITH_DISTCONV)
-  find_package(DiHydrogen 0.3.0 CONFIG REQUIRED COMPONENTS Meta Patterns DistConv)
+  find_package(DiHydrogen CONFIG REQUIRED COMPONENTS Meta Patterns DistConv)
   set(LBANN_HAS_DISTCONV TRUE)
   set(LBANN_H2_LIBS
     H2::H2Meta


### PR DESCRIPTION
Alternatively we could bump this to 0.4.0, check for either 0.3.0 or 0.4.0, or do an extra explicit check for version >= 0.3.0 outside of the find_package syntax.