### PR TITLE
Fix Hang in Python Dataset Reader with DistConv

### DIFF
--- a/include/lbann/data_ingestion/readers/data_reader_python_dataset.hpp
+++ b/include/lbann/data_ingestion/readers/data_reader_python_dataset.hpp
@@ -111,6 +111,8 @@ private:
   El::Int m_num_responses;
   /** @brief Number of data samples in data set. */
   El::Int m_num_samples;
+  /** @brief Current mini batch index in the data set. */
+  uint64_t m_current_mini_batch_index{0};
 
   /** @brief User-provided Python dataset object.
    *

--- a/include/lbann/data_ingestion/readers/data_reader_python_dataset.hpp
+++ b/include/lbann/data_ingestion/readers/data_reader_python_dataset.hpp
@@ -111,8 +111,6 @@ private:
   El::Int m_num_responses;
   /** @brief Number of data samples in data set. */
   El::Int m_num_samples;
-  /** @brief Current mini batch index in the data set. */
-  uint64_t m_current_mini_batch_index{0};
 
   /** @brief User-provided Python dataset object.
    *

--- a/src/data_ingestion/readers/data_reader_python_dataset.cpp
+++ b/src/data_ingestion/readers/data_reader_python_dataset.cpp
@@ -162,6 +162,8 @@ bool python_dataset_reader::fetch_data_block(
 
   // Prefetch the next minibatch asynchronously
   this->queue_samples(mb_size);
+  
+  m_current_mini_batch_index++;
 
   return true;
 }
@@ -186,7 +188,12 @@ void python_dataset_reader::shuffle_responses(DataType* responses_ptr)
 
   execution_mode mode = exec_mode_from_string(get_role());
   dataset& ds = get_trainer().get_data_coordinator().get_dataset(mode);
-  uint64_t global_mb_size = ds.get_current_mini_batch_size();
+  uint64_t global_mb_size{};
+  if (m_current_mini_batch_index < (ds.get_num_iterations_per_epoch() - 1)) {
+    global_mb_size = ds.get_mini_batch_size();
+  }else if (m_current_mini_batch_index == (ds.get_num_iterations_per_epoch() - 1)){
+    global_mb_size = ds.get_last_mini_batch_size();
+  }
 
   uint64_t local_mb_size = global_mb_size / nprocs;
   uint64_t extra_samples = global_mb_size % nprocs;
@@ -427,8 +434,10 @@ void python_dataset_reader::update(bool epoch_complete)
 {
   generic_data_reader::update(epoch_complete);
 
-  if (epoch_complete)
+  if (epoch_complete) {
     queue_epoch();
+    m_current_mini_batch_index = 0;
+  }
 }
 
 } // namespace lbann

--- a/src/data_ingestion/readers/data_reader_python_dataset.cpp
+++ b/src/data_ingestion/readers/data_reader_python_dataset.cpp
@@ -162,8 +162,6 @@ bool python_dataset_reader::fetch_data_block(
 
   // Prefetch the next minibatch asynchronously
   this->queue_samples(mb_size);
-  
-  m_current_mini_batch_index++;
 
   return true;
 }
@@ -189,9 +187,11 @@ void python_dataset_reader::shuffle_responses(DataType* responses_ptr)
   execution_mode mode = exec_mode_from_string(get_role());
   dataset& ds = get_trainer().get_data_coordinator().get_dataset(mode);
   uint64_t global_mb_size{};
-  if (m_current_mini_batch_index < (ds.get_num_iterations_per_epoch() - 1)) {
+  if (m_dataset_minibatch_offset < (ds.get_num_iterations_per_epoch() - 1)) {
     global_mb_size = ds.get_mini_batch_size();
-  }else if (m_current_mini_batch_index == (ds.get_num_iterations_per_epoch() - 1)){
+  }
+  else if (m_dataset_minibatch_offset ==
+           (ds.get_num_iterations_per_epoch() - 1)) {
     global_mb_size = ds.get_last_mini_batch_size();
   }
 
@@ -434,10 +434,8 @@ void python_dataset_reader::update(bool epoch_complete)
 {
   generic_data_reader::update(epoch_complete);
 
-  if (epoch_complete) {
+  if (epoch_complete)
     queue_epoch();
-    m_current_mini_batch_index = 0;
-  }
 }
 
 } // namespace lbann


### PR DESCRIPTION
Fixes a bug where shuffling responses for DistConv can hang when the last mini batch is incomplete. Due to asynchronous IO, the reader thread may request the current mini batch index from the LBANN dataset object before it has been properly updated by the training algorithm thread. This is solved by internally tracking the mini batch index.