### PR TITLE
Use CUTENSOR for Tessellate backpropagation in supported cases

### DIFF
--- a/ci_test/unit_tests/test_unit_layer_tessellate_backprop.py
+++ b/ci_test/unit_tests/test_unit_layer_tessellate_backprop.py
@@ -1,0 +1,91 @@
+import lbann
+import numpy as np
+import test_util
+
+
+@test_util.lbann_test(check_gradients=True)
+def test_tessellate_pad():
+    # Prepare reference output
+    np.random.seed(20240627)
+    x = np.random.rand(37, 20, 1)
+    reference_numpy = np.tile(x, (1, 1, 5))
+
+    tester = test_util.ModelTester()
+
+    x = tester.inputs_like(x)
+    reference = tester.make_reference(reference_numpy)
+
+    # Test layer
+    y = lbann.Tessellate(x, dims=[20, 5])
+
+    # Set test loss
+    tester.set_loss(lbann.MeanSquaredError(y, reference))
+    tester.set_check_gradients_tensor(lbann.Square(y))
+
+    return tester
+
+
+@test_util.lbann_test(check_gradients=True)
+def test_tessellate_scalar():
+    # Prepare reference output
+    np.random.seed(20240627)
+    x = np.random.rand(37, 1, 1, 1)
+    reference_numpy = np.tile(x, (1, 5, 6, 7))
+
+    tester = test_util.ModelTester()
+
+    x = tester.inputs_like(x)
+    reference = tester.make_reference(reference_numpy)
+
+    # Test layer
+    y = lbann.Tessellate(x, dims=[5, 6, 7])
+
+    # Set test loss
+    tester.set_loss(lbann.MeanSquaredError(y, reference))
+    tester.set_check_gradients_tensor(lbann.Square(y))
+
+    return tester
+
+
+@test_util.lbann_test(check_gradients=True)
+def test_tessellate_repro1():
+    # Prepare reference output
+    np.random.seed(20240627)
+    x = np.random.rand(16, 3, 1, 1)
+    reference_numpy = np.tile(x, (1, 16, 3, 3))
+
+    tester = test_util.ModelTester()
+
+    x = tester.inputs_like(x)
+    reference = tester.make_reference(reference_numpy)
+
+    # Test layer
+    y = lbann.Tessellate(x, dims=[3 * 16, 3, 3])
+
+    # Set test loss
+    tester.set_loss(lbann.MeanSquaredError(y, reference))
+    tester.set_check_gradients_tensor(lbann.Square(y))
+
+    return tester
+
+
+@test_util.lbann_test(check_gradients=True)
+def test_tessellate_repro2():
+    # Prepare reference output
+    np.random.seed(20240627)
+    x = np.random.rand(37, 16, 1, 1)
+    reference_numpy = np.tile(x, (1, 1, 64, 64))
+
+    tester = test_util.ModelTester()
+
+    x = tester.inputs_like(x)
+    reference = tester.make_reference(reference_numpy)
+
+    # Test layer
+    y = lbann.Tessellate(x, dims=[16, 64, 64])
+
+    # Set test loss
+    tester.set_loss(lbann.MeanSquaredError(y, reference))
+    tester.set_check_gradients_tensor(lbann.Square(y))
+
+    return tester

--- a/include/lbann/utils/tensor_dims_utils.hpp
+++ b/include/lbann/utils/tensor_dims_utils.hpp
@@ -49,8 +49,8 @@ public:
   explicit NamedVector(std::vector<T> const& v) : m_data{v} {}
   explicit NamedVector(std::vector<T>&& v) : m_data{std::move(v)} {}
   template <typename U>
-  explicit NamedVector(std::vector<U> const& v) : m_data(v.begin(), v.end()) {}
-
+  explicit NamedVector(std::vector<U> const& v) : m_data(v.begin(), v.end())
+  {}
 
   NamedVector(NamedVector const& other) = default;
   NamedVector(NamedVector&& other) = default;
@@ -234,10 +234,12 @@ auto get_strides_as(ColMajorDims<DimT> const& dims)
   size_t const ndims = dim_vec.size();
 
   std::vector<StrideT> strides;
-  strides.reserve(ndims);
-  strides.push_back(StrideT{1});
-  for (size_t ii = 0UL; ii < ndims - 1; ++ii)
-    strides.push_back(strides[ii] * static_cast<StrideT>(dim_vec[ii]));
+  if (ndims > 0) {
+    strides.reserve(ndims);
+    strides.push_back(StrideT{1});
+    for (size_t ii = 0UL; ii < ndims - 1; ++ii)
+      strides.push_back(strides[ii] * static_cast<StrideT>(dim_vec[ii]));
+  }
   return ColMajorStrides<StrideT>(strides);
 }
 

--- a/src/layers/transform/tessellate.cpp
+++ b/src/layers/transform/tessellate.cpp
@@ -134,6 +134,7 @@ void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_3d(
   }
 }
 
+#ifdef LBANN_HAS_CUTENSOR
 template <typename TensorDataType, data_layout T_layout, El::Device Dev>
 void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_cutensor(
   const std::vector<int>& input_dims,
@@ -145,6 +146,7 @@ void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_cutensor(
   // regular backprop
   bp_compute_3d(input_dims, output_dims, output_grad, input_grad);
 }
+#endif
 
 // Explicit template instantiation
 #define PROTO(T)                                                               \

--- a/src/layers/transform/tessellate.cpp
+++ b/src/layers/transform/tessellate.cpp
@@ -134,6 +134,18 @@ void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_3d(
   }
 }
 
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_cutensor(
+  const std::vector<int>& input_dims,
+  const std::vector<int>& output_dims,
+  const El::AbstractDistMatrix<TensorDataType>& output_grad,
+  El::AbstractMatrix<TensorDataType>& input_grad)
+{
+  // Multi-dimensional reduction for CPU Tessellate backprop is the same as the
+  // regular backprop
+  bp_compute_3d(input_dims, output_dims, output_grad, input_grad);
+}
+
 // Explicit template instantiation
 #define PROTO(T)                                                               \
   template class tessellate_layer<T,                                           \

--- a/src/layers/transform/tessellate.cu
+++ b/src/layers/transform/tessellate.cu
@@ -28,6 +28,8 @@
 #include "lbann/layers/transform/tessellate.hpp"
 #include "lbann/utils/gpu/helpers.hpp"
 
+#include "tessellate_cutensor_impl.hpp"
+
 namespace lbann {
 
 namespace {

--- a/src/layers/transform/tessellate_cutensor_impl.hpp
+++ b/src/layers/transform/tessellate_cutensor_impl.hpp
@@ -1,0 +1,124 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2014-2024, Lawrence Livermore National Security, LLC.
+// Produced at the Lawrence Livermore National Laboratory.
+// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+//
+// LLNL-CODE-697807.
+// All rights reserved.
+//
+// This file is part of LBANN: Livermore Big Artificial Neural Network
+// Toolkit. For details, see http://software.llnl.gov/LBANN or
+// https://github.com/LLNL/LBANN.
+//
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// may not use this file except in compliance with the License.  You may
+// obtain a copy of the License at:
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the license.
+////////////////////////////////////////////////////////////////////////////////
+
+#include "lbann/layers/transform/tessellate.hpp"
+
+#ifdef LBANN_HAS_CUTENSOR
+#include "lbann/utils/cutensor_support.hpp"
+
+namespace lbann {
+
+template <typename TensorDataType, data_layout T_layout, El::Device Dev>
+void tessellate_layer<TensorDataType, T_layout, Dev>::bp_compute_cutensor(
+  const std::vector<int>& input_dims,
+  const std::vector<int>& output_dims,
+  const El::AbstractDistMatrix<TensorDataType>& output_grad,
+  El::AbstractMatrix<TensorDataType>& input_grad)
+{
+  LBANN_ASSERT(Dev == El::Device::GPU);
+
+  // Constants
+  const auto one = El::TypeTraits<TensorDataType>::One();
+  const auto zero = El::TypeTraits<TensorDataType>::Zero();
+
+  // Data matrices
+  using LocalMat = El::Matrix<TensorDataType, El::Device::GPU>;
+  LocalMat const& input =
+    static_cast<LocalMat const&>(output_grad.LockedMatrix());
+  LocalMat& output = static_cast<LocalMat&>(input_grad);
+
+  // Make dimensions and modes
+  int dims = static_cast<int>(output_dims.size());
+  auto input_modes = make_modes(dims);
+  auto output_modes = make_modes(dims);
+  for (int i = 0; i < dims; ++i) {
+    if (input_dims[i] == 1 && input_dims[i] != output_dims[i]) {
+      // Extra -1 skips mini batch dimension
+      output_modes.erase(output_modes.begin() + (dims - i - 1));
+    }
+  }
+  auto actual_output_dims = input_dims;
+  for (int i = dims - 1; i >= 0; --i) {
+    if (input_dims[i] == 1 && input_dims[i] != output_dims[i]) {
+      actual_output_dims.erase(actual_output_dims.begin() + i);
+    }
+  }
+
+  // Specify that the dimensions are given in row-major format
+  RowMajorDims<int64_t> ct_input_dims(output_dims);
+  RowMajorDims<int64_t> ct_output_dims(actual_output_dims);
+
+  auto input_desc = get_descriptor(input, ct_input_dims);
+  auto output_desc = get_descriptor(output, ct_output_dims);
+
+  // Create workspace buffers
+  LocalMat workspace;
+  workspace.SetMemoryMode(1);
+  auto handle = get_handle_ptr();
+  uint64_t wspsize = 0;
+  CHECK_CUTENSOR(
+    cutensorReductionGetWorkspaceSize(handle,
+                                      input.LockedBuffer(),
+                                      &input_desc,
+                                      input_modes.data(),
+                                      output.LockedBuffer(),
+                                      &output_desc,
+                                      output_modes.data(),
+                                      output.LockedBuffer(),
+                                      &output_desc,
+                                      output_modes.data(),
+                                      CUTENSOR_OP_ADD,
+                                      CUDATypeT<TensorDataType>::compute_type,
+                                      &wspsize));
+  workspace.Resize(wspsize, 1);
+
+  auto multisync = El::MakeMultiSync(gpu::get_sync_info(input_grad),
+                                     gpu::get_sync_info(output_grad));
+
+  // Compute reduction locally
+  CHECK_CUTENSOR(cutensorReduction(
+    handle,
+    &one,
+    input.LockedBuffer(),
+    &input_desc,
+    input_modes.data(),
+    &zero,
+    output.LockedBuffer(),
+    &output_desc,
+    output_modes.data(),
+    output.Buffer(),
+    &output_desc,
+    output_modes.data(),
+    CUTENSOR_OP_ADD,
+    CUDATypeT<TensorDataType>::compute_type,
+    workspace.Buffer(),
+    wspsize,
+    static_cast<El::SyncInfo<El::Device::GPU>>(multisync).Stream()));
+}
+
+} // namespace lbann
+
+#endif // LBANN_HAS_CUTENSOR


### PR DESCRIPTION
In cases where all dimensions are only extended (i.e., broadcast) from 1 to some value, backpropagation of Tessellate can be represented as a multi-dimensional reduction. This can yield potential performance improvements.
