### PR TITLE
fix missing header for dump_model_graph

### DIFF
--- a/src/callbacks/dump_model_graph.cpp
+++ b/src/callbacks/dump_model_graph.cpp
@@ -25,6 +25,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "lbann/callbacks/dump_model_graph.hpp"
+#include "lbann/models/model.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann_config.hpp"
 


### PR DESCRIPTION
fixes "invalid use of incomplete type lbann::model" when compiling with LBANN_HAS_BOOST.