### PR TITLE
Remove some logic from the superbuild

### DIFF
--- a/.gitlab/build-and-test.sh
+++ b/.gitlab/build-and-test.sh
@@ -179,6 +179,10 @@ then
     cmake --build build-deps
     ninja -C build-deps gather-all
 
+    # Copy the suggested cmake prefix path to the install tree.
+    mkdir ${prefix}/logs
+    cp ${build_dir}/build-deps/lbann_sb_suggested_cmake_install_prefix.sh ${prefix}/logs
+
     # Stamp these commits
     cd ${build_dir}/build-deps/aluminum/src && git rev-parse HEAD > ${prefix}/al-prebuilt-hash.txt
     cd ${build_dir}/build-deps/hydrogen/src && git rev-parse HEAD > ${prefix}/h-prebuilt-hash.txt

--- a/scripts/superbuild/CMakeLists.txt
+++ b/scripts/superbuild/CMakeLists.txt
@@ -154,25 +154,8 @@ if (LBANN_SB_BUILD_AWS_OFI_RCCL)
   message("export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBARY_PATH\}\n")
   message("-----------------------------------------------------------------\n")
   file(APPEND "${CMAKE_BINARY_DIR}/lbann_sb_suggested_cmake_prefix_path.sh"
-    "export AWS_OFI_RCCL_LIBDIR=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib\n")
-  file(APPEND "${CMAKE_BINARY_DIR}/lbann_sb_suggested_cmake_prefix_path.sh"
-    "export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBRARY_PATH\}\n")
-  file(APPEND "${CMAKE_INSTALL_PREFIX}/logs/lbann_sb_suggested_cmake_prefix_path.sh"
-    "export AWS_OFI_RCCL_LIBDIR=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib\n")
-  file(APPEND "${CMAKE_INSTALL_PREFIX}/logs/lbann_sb_suggested_cmake_prefix_path.sh"
-    "export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBRARY_PATH\}\n")
-endif ()
-
-if (LBANN_SB_FWD_LBANN_LBANN_WITH_PYTHON_FRONTEND)
-  message("-----------------------------------------------------------------\n")
-  message("LBANN was built with support for the Python Front End (PFE) (If you need to install it via pip you can in the LBANN site-packages with):")
-  message("  python3 -m pip install --target \$\{LBANN_PYTHON_SITE_PACKAGES\} pytest")
-  message("  python3 -m pip install --target \$\{LBANN_PYTHON_SITE_PACKAGES\} protobuf")
-  if (LBANN_SB_FWD_LBANN_LBANN_WITH_CNPY)
-    message("\nLBANN was built with support for the NumPy (If you need to install it via pip you can in the LBANN site-packages with):")
-    message("  python3 -m pip install --target \$\{LBANN_PYTHON_SITE_PACKAGES\} numpy")
-  endif ()
-  message("\n-----------------------------------------------------------------\n")
+    "export AWS_OFI_RCCL_LIBDIR=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib\n
+    export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBRARY_PATH\}\n")
 endif ()
 
 # Add a custom target for bundling all things up

--- a/scripts/superbuild/CMakeLists.txt
+++ b/scripts/superbuild/CMakeLists.txt
@@ -154,8 +154,8 @@ if (LBANN_SB_BUILD_AWS_OFI_RCCL)
   message("export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBARY_PATH\}\n")
   message("-----------------------------------------------------------------\n")
   file(APPEND "${CMAKE_BINARY_DIR}/lbann_sb_suggested_cmake_prefix_path.sh"
-    "export AWS_OFI_RCCL_LIBDIR=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib\n
-    export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBRARY_PATH\}\n")
+    "export AWS_OFI_RCCL_LIBDIR=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib
+export LD_LIBRARY_PATH=${LBANN_SB_AWS_OFI_RCCL_PREFIX}/lib:\$\{LD_LIBRARY_PATH\}\n")
 endif ()
 
 # Add a custom target for bundling all things up

--- a/scripts/superbuild/ci/ci_core_dependencies.sh
+++ b/scripts/superbuild/ci/ci_core_dependencies.sh
@@ -162,6 +162,7 @@ if [ ! -e ${INSTALL_PREFIX}/logs ]; then
     mkdir -p ${INSTALL_PREFIX}/logs
 fi
 module -t list 2> ${INSTALL_PREFIX}/logs/modules.txt
+cp ${BUILD_DIR}/lbann_sb_suggested_cmake_prefix_path.sh ${INSTALL_PREFIX}/logs
 
 pushd ${BUILD_DIR}
 ninja


### PR DESCRIPTION
The Superbuild cannot write to `CMAKE_INSTALL_PREFIX` during configure time. There's no guarantee that this variable is even set, or that it's a valid and writeable path if it is set (indeed, the default path is likely not writeable by the average superbuild user). Moreover, even if it is set, each package maintains its own install prefix, which may be wholly unrelated to whatever is in the `CMAKE_INSTALL_PREFIX`. Finally, the superbuild doesn't define an `install` target at all, so we cannot simply copy the file at "superbuild install time" since such a thing doesn't exist (and this certainly is not a compelling reason to change that).

In spite of this seemingly bleak status quo, clients of the superbuild are much more empowered than the superbuild can inherently be, and they have access to all of the relevant information. In the case of LBANN's CI infrastructure, we _do_ choose to install all of the dependencies under a common prefix, so **we** can manually copy this file over to that prefix any time after configuration has completed.

As the last bit of cleanup, I removed a message about python something or another that's LBANN's problem and should go in **LBANN**'s CMake, not the superbuild's (the message had nothing to do with interactions with or among any of the packages known to the superbuild, and therefore it is irrelevant to the goals of the superbuild system). Also, as far as I know, CNPY has no dependence on Python or the `numpy` python module, so I also culled that message, also believing it to be irrelevant and/or erroneous (LBANN's dependence (or not) on `numpy` is a concern for the LBANN project and not the superbuild as [it is not a package manager](https://github.com/LLNL/lbann/blob/develop/scripts/superbuild/README.md?plain=1#L42-L43)).