### PR TITLE
Patch things for Torch's 2.11 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,16 @@ elseif (TARGET torch_hip)
   endforeach()
   set_target_properties(torch_hip
     PROPERTIES INTERFACE_COMPILE_OPTIONS "${_torch_hip_compile_opts}")
+
+  # FIXME (trb): So I really, truly hate this, but this seems to be
+  # the shortest approach to dealing with version-based switches in
+  # the C++ code. Other approaches involve obscure preprocessor macros
+  # or long-winded SFINAE tricks, and because I want you, dear human
+  # reader, to be happy, I opted for this very simple, highly readable
+  # implementation instead.
+  if (Torch_VERSION VERSION_LESS "2.11.0")
+    set(LBANNV2_USE_C10_HIP_NAMESPACE_AND_SYMBOLS TRUE)
+  endif ()
 endif ()
 
 # We need to determine if we should be using a CXX11_ABI macro or not

--- a/cmake/lbannv2_config.h.in
+++ b/cmake/lbannv2_config.h.in
@@ -26,6 +26,8 @@
 #cmakedefine01 LBANNV2_WITHOUT_MI300A
 #cmakedefine01 LBANNV2_UNKNOWN_MI300A
 
+#cmakedefine01 LBANNV2_USE_C10_HIP_NAMESPACE_AND_SYMBOLS
+
 #ifndef SPDLOG_ACTIVE_LEVEL
 // This defaults to "TRACE" so that all messages are compiled and
 // available. Use the runtime environment variable to control which

--- a/src/lbannv2/memory/mi300a_allocator.cpp
+++ b/src/lbannv2/memory/mi300a_allocator.cpp
@@ -40,7 +40,7 @@ bool use_nonblocking_stream()
 
 struct StreamRAII
 {
-  lbannv2::c10_gpu::HIPStream stream;
+  ::lbannv2::TorchGPUStream_t stream;
 
   StreamRAII()
     : stream {lbannv2::c10_gpu::getStreamFromExternal(
@@ -60,7 +60,7 @@ struct StreamRAII
 };  // struct StreamRAII
 
 // Internal stream for managing "host" allocations through CUB
-lbannv2::c10_gpu::HIPStream host_allocation_stream(c10::DeviceIndex const idx)
+::lbannv2::TorchGPUStream_t host_allocation_stream(c10::DeviceIndex const idx)
 {
   static std::vector<StreamRAII> stream_raii(lbannv2::gpu::num_devices());
   LBANNV2_ASSERT_ALWAYS(idx >= 0 && idx < lbannv2::gpu::num_devices());
@@ -203,7 +203,7 @@ void lbannv2::migrate_ptr(c10::DataPtr& ptr,
   // Update the stream
   auto const new_stream = real_tgt_device.is_cpu()
                             ? host_allocation_stream(ptr_dev_idx)
-                            : c10_gpu::HIPStream(with_stream);
+                            : TorchGPUStream_t(with_stream);
 
   // UGH. Oh well.
   MI300Allocator().instance().alloc_->recordStream(ptr, new_stream);

--- a/src/lbannv2/memory/mi300a_allocator.hpp
+++ b/src/lbannv2/memory/mi300a_allocator.hpp
@@ -48,10 +48,10 @@ private:
   MI300Allocator& operator=(MI300Allocator const&) = delete;
   MI300Allocator& operator=(MI300Allocator&&) = delete;
 
-#if LBANNV2_HAS_CUDA
-  using DeviceAlloc_t = c10_gpu::CUDACachingAllocator::CUDAAllocator;
-#elif LBANNV2_HAS_ROCM
-  using DeviceAlloc_t = c10_gpu::HIPCachingAllocator::HIPAllocator;
+#if LBANNV2_USE_C10_HIP_NAMESPACE_AND_SYMBOLS
+  using DeviceAlloc_t = ::c10::hip::HIPCachingAllocator::HIPAllocator;
+#else
+  using DeviceAlloc_t = ::c10::cuda::CUDACachingAllocator::CUDAAllocator;
 #endif
   DeviceAlloc_t* alloc_;
 

--- a/src/lbannv2/ops/migrate.cpp
+++ b/src/lbannv2/ops/migrate.cpp
@@ -96,7 +96,7 @@ at::Tensor lbannv2::migrate(at::Tensor& t, c10::Device const& d)
   // We need to get the "real" "CUDA" target.
   c10::Device const real_tgt_d =
     (d.is_cuda() && !d.has_index())
-      ? c10::Device {c10::kCUDA, c10::hip::current_device()}
+      ? c10::Device {c10::kCUDA, gpu::current_device()}
       : d;
 
   // If the real_src_d is "cpu", it can be migrated to "cpu".
@@ -122,7 +122,8 @@ at::Tensor lbannv2::migrate(at::Tensor& t, c10::Device const& d)
   {
     c10::Stream stream = real_tgt_d.is_cpu()
                            ? c10::Stream {c10::Stream::DEFAULT, d}
-                           : c10::hip::getCurrentHIPStream(real_tgt_d.index());
+                           : getDeviceCurrentStream(real_tgt_d.index());
+
     lbannv2::migrate_ptr(t.storage().mutable_data_ptr(), d, stream);
 
     // Report the number of meaningful bytes migrated. This is
@@ -152,7 +153,7 @@ at::Tensor lbannv2::migrate(at::Tensor& t, c10::Device const& d)
 
     if (src_d.is_cuda())
     {
-      c10::hip::getCurrentHIPStream(src_d.index()).synchronize();
+      getDeviceCurrentStream(src_d.index()).synchronize();
     }
 
     return out;

--- a/src/lbannv2/ops/nonzero.hip
+++ b/src/lbannv2/ops/nonzero.hip
@@ -13,6 +13,13 @@
 #include <ATen/hip/HIPContext.h>
 #include <hipcub/hipcub.hpp>
 
+// Note (trb): UGH PyTorch 2.11
+#ifdef C10_HIP_KERNEL_LAUNCH_CHECK
+#define LBANNV2_KERNEL_LAUNCH_CHECK() C10_HIP_KERNEL_LAUNCH_CHECK()
+#else
+#define LBANNV2_KERNEL_LAUNCH_CHECK() C10_CUDA_KERNEL_LAUNCH_CHECK()
+#endif
+
 namespace
 {
 template <typename T>
@@ -216,7 +223,7 @@ void nonzero_out_mi300a_impl(at::Tensor const& self, at::Tensor& out)
       int const nblocks = (num_nonzeros_h + nthreads - 1) / nthreads;
       write_indices<<<nblocks, nthreads, 0, stream>>>(
         out_temp.mutable_data_ptr<int64_t>(), dims, self.dim(), num_nonzeros_h);
-      C10_HIP_KERNEL_LAUNCH_CHECK();
+      LBANNV2_KERNEL_LAUNCH_CHECK();
     }
   }
   if (need_to_copy)

--- a/src/lbannv2/utils/gpu_utils.hpp
+++ b/src/lbannv2/utils/gpu_utils.hpp
@@ -25,6 +25,7 @@
 #elif LBANNV2_HAS_ROCM
 
 #include <c10/hip/HIPFunctions.h>
+#include <c10/hip/HIPStream.h>
 
 #include <stdexcept>
 
@@ -45,10 +46,14 @@
 
 namespace lbannv2
 {
-#if LBANNV2_HAS_CUDA
-namespace c10_gpu = c10::cuda;
-#elif LBANNV2_HAS_ROCM
+#if LBANNV2_USE_C10_HIP_NAMESPACE_AND_SYMBOLS
 namespace c10_gpu = c10::hip;
+using TorchGPUStream_t = c10::hip::HIPStream;
+inline auto& getDeviceCurrentStream = c10::hip::getCurrentHIPStream;
+#elif LBANNV2_HAS_GPU
+namespace c10_gpu = c10::cuda;
+using TorchGPUStream_t = c10::cuda::CUDAStream;
+inline auto& getDeviceCurrentStream = c10::cuda::getCurrentCUDAStream;
 #endif
 
 inline constexpr bool has_cuda() noexcept


### PR DESCRIPTION
The main change is that they've moved hip support to just exist under "cuda"/"CUDA" names (namespaces or symbols). This likely isn't the best fix, but hopefully it's an understandable and maintainable one.